### PR TITLE
Auto stake amount 

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -33,6 +33,7 @@
     },
     "experimental": {
         "use_sell_signal": false
+        "auto_stake_amount": false
     },
     "telegram": {
         "enabled": true,

--- a/config.json.example
+++ b/config.json.example
@@ -32,7 +32,7 @@
         ]
     },
     "experimental": {
-        "use_sell_signal": false
+        "use_sell_signal": false,
         "auto_stake_amount": false
     },
     "telegram": {

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -77,8 +77,10 @@ def _process(dynamic_whitelist: Optional[int] = 0) -> bool:
                 if _CONF.get('experimental', {}).get('auto_stake_amount'):
                     #Numbers of trading slots available
                     nb_trades_left = float(_CONF['max_open_trades'] - len (trades))
+                    print("nb_trades_left "+str(nb_trades_left))
                     #stake_amount in the conf is being used as the max value authorized 
                     stake_amount = min(_CONF['stake_amount'], balance / nb_trades_left)
+                    print("stake amount "+str(_CONF['stake_amount'])+" "+str(balance))
                 # Create entity and execute trade
                 state_changed = create_trade(stake_amount, balance)
                 if not state_changed:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -75,10 +75,10 @@ def _process(dynamic_whitelist: Optional[int] = 0) -> bool:
                 balance = exchange.get_balance(_CONF['stake_currency'])
                 stake_amount = float(_CONF['stake_amount'])
                 if _CONF.get('experimental', {}).get('auto_stake_amount', False):
-                    #Numbers of trading slots available
+                    # Numbers of trading slots available
                     nb_trades_left = float(_CONF['max_open_trades'] - len (trades))
                     print("nb_trades_left "+str(nb_trades_left))
-                    #stake_amount in the conf is being used as the max value authorized 
+                    # Stake_amount in the conf is being used as the max value authorized 
                     stake_amount = min(_CONF['stake_amount'], balance / nb_trades_left)
                     print("stake amount "+str(_CONF['stake_amount'])+" "+str(balance))
                 # Create entity and execute trade

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -76,11 +76,9 @@ def _process(dynamic_whitelist: Optional[int] = 0) -> bool:
                 stake_amount = float(_CONF['stake_amount'])
                 if _CONF.get('experimental', {}).get('auto_stake_amount', False):
                     # Numbers of trading slots available
-                    nb_trades_left = float(_CONF['max_open_trades'] - len (trades))
-                    print("nb_trades_left "+str(nb_trades_left))
-                    # Stake_amount in the conf is being used as the max value authorized 
+                    nb_trades_left = float(_CONF['max_open_trades'] - len(trades))
+                    # Stake_amount in the conf is being used as the max value authorized
                     stake_amount = min(_CONF['stake_amount'], balance / nb_trades_left)
-                    print("stake amount "+str(_CONF['stake_amount'])+" "+str(balance))
                 # Create entity and execute trade
                 state_changed = create_trade(stake_amount, balance)
                 if not state_changed:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -74,7 +74,7 @@ def _process(dynamic_whitelist: Optional[int] = 0) -> bool:
             try:
                 balance = exchange.get_balance(_CONF['stake_currency'])
                 stake_amount = float(_CONF['stake_amount'])
-                if _CONF.get('experimental', {}).get('auto_stake_amount'):
+                if _CONF.get('experimental', {}).get('auto_stake_amount', False):
                     #Numbers of trading slots available
                     nb_trades_left = float(_CONF['max_open_trades'] - len (trades))
                     print("nb_trades_left "+str(nb_trades_left))

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -234,7 +234,8 @@ CONF_SCHEMA = {
         'experimental': {
             'type': 'object',
             'properties': {
-                'use_sell_signal': {'type': 'boolean'}
+                'use_sell_signal': {'type': 'boolean'},
+                'auto_stake_amount': {'type': 'boolean'}
             }
         },
         'telegram': {

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -116,7 +116,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker):
     whitelist = copy.deepcopy(default_conf['exchange']['pair_whitelist'])
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     assert trade is not None
@@ -146,7 +146,7 @@ def test_create_trade_minimal_amount(default_conf, ticker, mocker):
                           get_ticker=ticker)
     init(default_conf, create_engine('sqlite://'))
     min_stake_amount = 0.0005
-    create_trade(min_stake_amount)
+    create_trade(min_stake_amount, 1)
     rate, amount = buy_mock.call_args[0][1], buy_mock.call_args[0][2]
     assert rate * amount >= min_stake_amount
 
@@ -161,7 +161,7 @@ def test_create_trade_no_stake_amount(default_conf, ticker, mocker):
                           buy=MagicMock(return_value='mocked_limit_buy'),
                           get_balance=MagicMock(return_value=default_conf['stake_amount'] * 0.5))
     with pytest.raises(DependencyException, match=r'.*stake amount.*'):
-        create_trade(default_conf['stake_amount'])
+        create_trade(default_conf['stake_amount'], default_conf['stake_amount'] - 0.0001)
 
 
 def test_create_trade_no_pairs(default_conf, ticker, mocker):
@@ -177,7 +177,7 @@ def test_create_trade_no_pairs(default_conf, ticker, mocker):
         conf = copy.deepcopy(default_conf)
         conf['exchange']['pair_whitelist'] = []
         mocker.patch.dict('freqtrade.main._CONF', conf)
-        create_trade(default_conf['stake_amount'])
+        create_trade(default_conf['stake_amount'], default_conf['stake_amount'])
 
 
 def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, mocker):
@@ -197,7 +197,7 @@ def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, mocker):
                           ticker=MagicMock(return_value={'price_usd': 15000.0}),
                           _cache_symbols=MagicMock(return_value={'BTC': 1}))
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     assert trade
@@ -230,7 +230,7 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog)
     mocker.patch('freqtrade.main.min_roi_reached', return_value=True)
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     trade.is_open = True
@@ -262,7 +262,7 @@ def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker
     mocker.patch('freqtrade.main.min_roi_reached', return_value=False)
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     trade.is_open = True
@@ -288,7 +288,7 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mo
 
     # Create trade and sell it
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     assert trade

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -116,7 +116,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker):
     whitelist = copy.deepcopy(default_conf['exchange']['pair_whitelist'])
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     assert trade is not None
@@ -250,7 +250,7 @@ def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, mocker):
                           ticker=MagicMock(return_value={'price_usd': 15000.0}),
                           _cache_symbols=MagicMock(return_value={'BTC': 1}))
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     assert trade
@@ -283,7 +283,7 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog)
     mocker.patch('freqtrade.main.min_roi_reached', return_value=True)
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     trade.is_open = True
@@ -315,7 +315,7 @@ def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker
     mocker.patch('freqtrade.main.min_roi_reached', return_value=False)
 
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     trade.is_open = True
@@ -341,7 +341,7 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mo
 
     # Create trade and sell it
     init(default_conf, create_engine('sqlite://'))
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     assert trade

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -190,6 +190,7 @@ def test_create_trade_dynamic_stake_amount_under_maximum(default_conf, ticker, m
     assert trade.stake_amount == float(0.0015)/default_conf['max_open_trades']
     assert trade.is_open
 
+
 def test_create_trade_dynamic_dynamic_stake_amount_over_maximum(default_conf, ticker, mocker):
     default_conf.update({'experimental': {'auto_stake_amount': True}})
     default_conf.update({'max_open_trades': 2})

--- a/freqtrade/tests/test_rpc_telegram.py
+++ b/freqtrade/tests/test_rpc_telegram.py
@@ -102,7 +102,7 @@ def test_status_handle(default_conf, update, ticker, mocker):
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
     # Trigger status while we have a fulfilled order for the open trade
     _status(bot=MagicMock(), update=update)
 
@@ -138,7 +138,7 @@ def test_status_table_handle(default_conf, update, ticker, mocker):
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(15.0)
+    create_trade(15.0,15.0)
 
     _status_table(bot=MagicMock(), update=update)
 
@@ -175,7 +175,7 @@ def test_profit_handle(
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -224,7 +224,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     trade = Trade.query.first()
     assert trade
@@ -261,7 +261,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
 
     # Decrease the price and sell it
     mocker.patch.multiple('freqtrade.main.exchange',
@@ -323,7 +323,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, mocker):
 
     # Create some test data
     for _ in range(4):
-        create_trade(0.001)
+        create_trade(0.001, 1)
     rpc_mock.reset_mock()
 
     update.message.text = '/forcesell all'
@@ -388,7 +388,7 @@ def test_performance_handle(
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
     trade = Trade.query.first()
     assert trade
 
@@ -426,7 +426,7 @@ def test_daily_handle(
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
     trade = Trade.query.first()
     assert trade
 
@@ -479,7 +479,7 @@ def test_count_handle(default_conf, update, ticker, mocker):
     update_state(State.RUNNING)
 
     # Create some test data
-    create_trade(0.001)
+    create_trade(0.001,1)
     msg_mock.reset_mock()
     _count(bot=MagicMock(), update=update)
 

--- a/freqtrade/tests/test_rpc_telegram.py
+++ b/freqtrade/tests/test_rpc_telegram.py
@@ -102,7 +102,7 @@ def test_status_handle(default_conf, update, ticker, mocker):
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
     # Trigger status while we have a fulfilled order for the open trade
     _status(bot=MagicMock(), update=update)
 
@@ -138,7 +138,7 @@ def test_status_table_handle(default_conf, update, ticker, mocker):
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(15.0,15.0)
+    create_trade(15.0, 15.0)
 
     _status_table(bot=MagicMock(), update=update)
 
@@ -175,7 +175,7 @@ def test_profit_handle(
     msg_mock.reset_mock()
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -224,7 +224,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     trade = Trade.query.first()
     assert trade
@@ -261,7 +261,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
 
     # Decrease the price and sell it
     mocker.patch.multiple('freqtrade.main.exchange',
@@ -388,7 +388,7 @@ def test_performance_handle(
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
     trade = Trade.query.first()
     assert trade
 
@@ -426,7 +426,7 @@ def test_daily_handle(
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
     trade = Trade.query.first()
     assert trade
 
@@ -479,7 +479,7 @@ def test_count_handle(default_conf, update, ticker, mocker):
     update_state(State.RUNNING)
 
     # Create some test data
-    create_trade(0.001,1)
+    create_trade(0.001, 1)
     msg_mock.reset_mock()
     _count(bot=MagicMock(), update=update)
 


### PR DESCRIPTION
The aim of this PR is to allow the bot to change the stake_amount by himself

A new flag "auto_stake_amount" has been added in the "experimental" dictionary

When setting auto_stake_amount to true, the stake_amount is being used has a maximum value never to go over.

This allow the bot to automatically used earnings made in previous closed trades.
