### PR TITLE
Watchdog for bot process

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ optional arguments:
   --dry-run-db          Force dry run to use a local DB
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
+  -w, --watchdog        Run under watchdog (restart process if main loop is
+                        stalled)
 ```
 More details on:
 - [How to run the bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#bot-commands)

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -399,12 +399,10 @@ def cleanup() -> None:
     exit(0)
 
 
-def main(sysargv=sys.argv[1:]) -> None:
-    """
-    Loads and validates the config and handles the main loop
-    :return: None
-    """
+def init_args(sysargv) -> Watchdog:
+
     global _CONF
+
     args = parse_args(sysargv,
                       'Simple High Frequency Trading Bot for crypto currencies')
 
@@ -441,13 +439,24 @@ def main(sysargv=sys.argv[1:]) -> None:
             )
         else:
             logger.info('Dry run is disabled. (--dry_run_db ignored)')
-
     watchdog = Watchdog()
 
     if args.watchdog_enable:
         logger.info('Using watchdog to monitor process (--watchdog)')
         if not watchdog.start():
-            return
+            exit(0)
+
+    return args, watchdog
+
+
+def main(sysargv=sys.argv[1:]) -> None:
+    """
+    Loads and validates the config and handles the main loop
+    :return: None
+    """
+    global _CONF
+
+    args, watchdog = init_args(sysargv)
 
     try:
         init(_CONF)

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -142,6 +142,12 @@ def parse_args(args: List[str], description: str):
         metavar='INT',
         nargs='?',
     )
+    parser.add_argument(
+        '-w', '--watchdog',
+        help='Run under watchdog (restart process if main loop is stalled)',  # noqa
+        action='store_true',
+        dest='watchdog_enable',
+    )
 
     build_subcommands(parser)
     return parser.parse_args(args)

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -37,6 +37,14 @@ def test_parse_args_backtesting(mocker):
     assert call_args.ticker_interval == 5
 
 
+def test_init_args():
+    sysargv = ['--config', 'config.json.example']
+    args, watchdog = main.init_args(sysargv)
+    assert args.config == 'config.json.example'
+    assert main._CONF['stake_currency'] == 'BTC'
+    assert watchdog.timeout == 300
+
+
 def test_main_start_hyperopt(mocker):
     hyperopt_mock = mocker.patch(
         'freqtrade.optimize.hyperopt.start', MagicMock())

--- a/freqtrade/tests/test_watchdog.py
+++ b/freqtrade/tests/test_watchdog.py
@@ -16,3 +16,24 @@ def test_watchdog_kill(caplog):
     log = ["Watchdog started", "Watchdog stopped"]
     for line in log:
         assert line in caplog.text
+
+
+def test_try_kill_failed(mocker):
+    mocker.patch("os.kill")
+    mocker.patch("os.waitpid", return_value=(0, 0))
+    watchdog = Watchdog(1, 1)
+    assert watchdog.try_kill(0) is False
+
+
+def test_try_kill_success(mocker):
+    mocker.patch("os.kill")
+    mocker.patch("os.waitpid", return_value=(0, 1))
+    watchdog = Watchdog(1, 1)
+    assert watchdog.try_kill(0) is True
+
+
+def test_try_kill_error(mocker):
+    mocker.patch("os.kill")
+    mocker.patch("os.waitpid", side_effect=OSError)
+    watchdog = Watchdog(1, 1)
+    assert watchdog.try_kill(0) is True

--- a/freqtrade/tests/test_watchdog.py
+++ b/freqtrade/tests/test_watchdog.py
@@ -1,0 +1,18 @@
+from freqtrade.watchdog import Watchdog
+
+
+def test_watchdog_timeout(caplog):
+    watchdog = Watchdog(1)
+    assert(watchdog.run(0) is False)
+    log = ["Watchdog started", "Kill process due to timeout"]
+    for line in log:
+        assert line in caplog.text
+
+
+def test_watchdog_kill(caplog):
+    watchdog = Watchdog(1)
+    watchdog.exit_gracefully(1, 0)
+    assert(watchdog.run(0) is False)
+    log = ["Watchdog started", "Watchdog stopped"]
+    for line in log:
+        assert line in caplog.text

--- a/freqtrade/watchdog.py
+++ b/freqtrade/watchdog.py
@@ -12,10 +12,9 @@ KILL_TIMEOUT = 60
 
 class Watchdog:
 
-    shared_heartbeat = Value('d', 0.0)
-    kill_signal = None
-
     def __init__(self, timeout=WATCHDOG_TIMEOUT, kill_timeout=KILL_TIMEOUT):
+        self.shared_heartbeat = Value('d', 0.0)
+        self.kill_signal = None
         self.timeout = timeout
         self.kill_timeout = kill_timeout
         self.heartbeat()

--- a/freqtrade/watchdog.py
+++ b/freqtrade/watchdog.py
@@ -7,6 +7,7 @@ from multiprocessing import Value
 logger = logging.getLogger('freqtrade.watchdog')
 
 WATCHDOG_TIMEOUT = 300
+KILL_TIMEOUT = 60
 
 
 class Watchdog:
@@ -14,8 +15,9 @@ class Watchdog:
     shared_heartbeat = Value('d', 0.0)
     kill_signal = None
 
-    def __init__(self, timeout=WATCHDOG_TIMEOUT):
+    def __init__(self, timeout=WATCHDOG_TIMEOUT, kill_timeout=KILL_TIMEOUT):
         self.timeout = timeout
+        self.kill_timeout = kill_timeout
         self.heartbeat()
 
     def heartbeat(self) -> None:
@@ -26,11 +28,27 @@ class Watchdog:
         logger.warning("Kill signal: {}".format(signum))
         self.kill_signal = signum
 
+    def try_kill(self, pid):
+        os.kill(pid, signal.SIGINT)
+        for count in range(0, self.kill_timeout):
+            try:
+                pid, err_code = os.waitpid(pid, os.WNOHANG)
+                if pid != 0 or err_code != 0:
+                    return True
+                time.sleep(1)
+            except OSError:
+                return True
+        return False
+
     def kill(self, pid):
         logger.info("Stopping pid {}".format(pid))
         if pid:
-            os.kill(pid, signal.SIGTERM)  # Better use sigint and then sigterm?
-            os.wait()
+            if self.try_kill(pid):
+                logger.info("Process finished gracefully")
+            else:
+                logger.warning("Process not responded, kill by SIGTERM")
+                os.kill(pid, signal.SIGTERM)
+                os.wait()
 
     def start(self) -> bool:
         pid = os.fork()

--- a/freqtrade/watchdog.py
+++ b/freqtrade/watchdog.py
@@ -1,0 +1,79 @@
+import os
+import signal
+import time
+import logging
+from multiprocessing import Value
+
+logger = logging.getLogger('freqtrade.watchdog')
+
+WATCHDOG_TIMEOUT = 300
+
+
+class Watchdog:
+
+    shared_heartbeat = Value('d', 0.0)
+    kill_signal = None
+
+    def heartbeat(self) -> None:
+        logger.debug("Heartbeat")
+        self.shared_heartbeat.value = time.time()
+
+    def exit_gracefully(self, signum, frame):
+        logger.warning("Kill signal: {}".format(signum))
+        self.kill_signal = signum
+
+    def kill(self, pid):
+        logger.info("Stopping pid {}".format(pid))
+        os.kill(pid, signal.SIGTERM)  # Better use sigint and then sigterm?
+        os.wait()
+
+    def start(self) -> bool:
+        self.heartbeat()
+        pid = os.fork()
+        if pid != 0:
+            # In watchdog proces, run it
+            if not self.run(pid):
+                # Got exit signal
+                return False
+            else:
+                # Forked new children, continue to main
+                self.heartbeat()
+                return True
+        else:
+            # In children process, continue to main
+            return True
+
+    def run(self, pid) -> bool:
+        logger.info("Watchdog started")
+        self.orig_SIGINT = signal.signal(signal.SIGINT, self.exit_gracefully)
+        self.orig_SIGTERM = signal.signal(signal.SIGTERM, self.exit_gracefully)
+        try:
+            while True:
+                if self.kill_signal:
+                    raise KeyboardInterrupt()
+
+                timeout = time.time() - self.shared_heartbeat.value
+
+                if timeout > WATCHDOG_TIMEOUT:
+                    logger.warning("Kill process due to timeout: {}".format(timeout))
+                    self.kill(pid)
+                    new_pid = os.fork()
+                    if new_pid == 0:
+                        logger.info("New children forked")
+                        signal.signal(signal.SIGINT, self.orig_SIGINT)
+                        signal.signal(signal.SIGTERM, self.orig_SIGTERM)
+                        return True
+                    else:
+                        pid = new_pid
+
+                time.sleep(1)
+
+        except Exception as ex:
+            logger.exception(ex)
+            self.kill(pid)
+            return False
+
+        except KeyboardInterrupt:
+            logger.info("Watchdog stopped")
+            self.kill(pid)
+            return False


### PR DESCRIPTION
## Summary
Use watchdog process to monitor (forked) bot process 

Solve the issue: #127

## What's new?
If bot is died or main loop is halted, watchdog will kill & restart it
Enable by --watchdog option
