### PR TITLE
added support for showing the exposed real value on the count table

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -357,8 +357,9 @@ class Telegram(RPC):
 
         message = tabulate({
             'current': [len(trades)],
-            'max': [self._config['max_open_trades']]
-        }, headers=['current', 'max'], tablefmt='simple')
+            'max': [self._config['max_open_trades']],
+            'total stake': [sum((trade.open_rate * trade.amount) for trade in trades)]
+        }, headers=['current', 'max', 'total stake'], tablefmt='simple')
         message = "<pre>{}</pre>".format(message)
         logger.debug(message)
         self.send_msg(message, parse_mode=ParseMode.HTML)

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -1001,9 +1001,12 @@ def test_count_handle(default_conf, update, ticker, mocker) -> None:
     msg_mock.reset_mock()
     telegram._count(bot=MagicMock(), update=update)
 
-    msg = '<pre>  current    max\n---------  -----\n        1      {}</pre>'.format(
-        default_conf['max_open_trades']
-    )
+    msg = '<pre>  current    max    total stake\n---------  -----  -------------\n' \
+          '        1      {}          {}</pre>'\
+        .format(
+            default_conf['max_open_trades'],
+            default_conf['stake_amount']
+        )
     assert msg in msg_mock.call_args_list[0][0][0]
 
 


### PR DESCRIPTION
## Summary

Added a simple column to the count table, to show the total current exposure of all active trades.

## What's new?

count table now shows the complete exposure of all trades. Makes it easier to quickly check how much money has been exposed to the market.
```
  current    max    total stake
---------  -----  -------------
       30     30      0.0299934
```