### PR TITLE
allow export of backtesting-results to different files

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -62,6 +62,12 @@ Where `-s TestStrategy` refers to the class name within the strategy file `test_
 python3 ./freqtrade/main.py backtesting --export trades
 ```
 
+**Exporting trades to file specifying a custom filename**
+```bash
+python3 ./freqtrade/main.py backtesting --export trades --export-filename=backtest_teststrategy.json
+```
+
+
 **Running backtest with smaller testset**  
 Use the `--timerange` argument to change how much of the testset
 you want to use. The last N ticks/timeframes will be used.

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -120,6 +120,8 @@ Backtesting also uses the config specified via `-c/--config`.
 ```
 usage: main.py backtesting [-h] [-i TICKER_INTERVAL] [--realistic-simulation]
                            [--timerange TIMERANGE] [-l] [-r] [--export EXPORT]
+                           [--export-filename EXPORTFILENAME]
+
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -137,6 +139,11 @@ optional arguments:
                         run your backtesting with up-to-date data.
   --export EXPORT       export backtest results, argument are: trades Example
                         --export=trades
+  --export-filename EXPORTFILENAME
+                        Save backtest results to this filename requires
+                        --export to be set as well Example --export-
+                        filename=backtest_today.json (default: backtest-
+                        result.json
 ```
 
 ### How to use --refresh-pairs-cached parameter?

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -137,6 +137,16 @@ class Arguments(object):
             default=None,
             dest='export',
         )
+        parser.add_argument(
+            '--export-filename',
+            help='Save backtest results to this filename \
+                  requires --export to be set as well\
+                  Example --export-filename=backtest_today.json\
+                  (default: %(default)s',
+            type=str,
+            default='backtest-result.json',
+            dest='exportfilename',
+        )
 
     @staticmethod
     def optimizer_shared_options(parser: argparse.ArgumentParser) -> None:

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -157,6 +157,11 @@ class Configuration(object):
             config.update({'export': self.args.export})
             logger.info('Parameter --export detected: %s ...', self.args.export)
 
+        # If --export-filename is used we add it to the configuration
+        if 'export' in config and 'exportfilename' in self.args and self.args.exportfilename:
+            config.update({'exportfilename': self.args.exportfilename})
+            logger.info('Storing backtest results to %s ...', self.args.exportfilename)
+
         return config
 
     def _load_hyperopt_config(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -154,6 +154,7 @@ class Backtesting(object):
         max_open_trades = args.get('max_open_trades', 0)
         realistic = args.get('realistic', False)
         record = args.get('record', None)
+        recordfilename = args.get('recordfn', 'backtest-result.json')
         records = []
         trades = []
         trade_count_lock: Dict = {}
@@ -196,8 +197,8 @@ class Backtesting(object):
         # For now export inside backtest(), maybe change so that backtest()
         # returns a tuple like: (dataframe, records, logs, etc)
         if record and record.find('trades') >= 0:
-            logger.info('Dumping backtest results')
-            file_dump_json('backtest-result.json', records)
+            logger.info('Dumping backtest results to %s', recordfilename)
+            file_dump_json(recordfilename, records)
         labels = ['currency', 'profit_percent', 'profit_BTC', 'duration']
         return DataFrame.from_records(trades, columns=labels)
 
@@ -257,7 +258,8 @@ class Backtesting(object):
                 'realistic': self.config.get('realistic_simulation', False),
                 'sell_profit_only': sell_profit_only,
                 'use_sell_signal': use_sell_signal,
-                'record': self.config.get('export')
+                'record': self.config.get('export'),
+                'recordfn': self.config.get('exportfilename'),
             }
         )
         logger.info(

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -218,7 +218,8 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         '--realistic-simulation',
         '--refresh-pairs-cached',
         '--timerange', ':100',
-        '--export', '/bar/foo'
+        '--export', '/bar/foo',
+        '--export-filename', 'foo_bar.json'
     ]
 
     config = setup_configuration(get_args(args))
@@ -257,6 +258,11 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'export' in config
     assert log_has(
         'Parameter --export detected: {} ...'.format(config['export']),
+        caplog.record_tuples
+    )
+    assert 'exportfilename' in config
+    assert log_has(
+        'Storing backtest results to {} ...'.format(config['exportfilename']),
         caplog.record_tuples
     )
 


### PR DESCRIPTION
## Summary
allow export of backtesting-results to different files

Currently, we need to run backtest  with `--export=trades` - move the resulting json to another folder and rerun backtest for another strategy to be able to compare the results.

This PR will allow specifying a different filename per backtest-run by specifying 
`--export=trades --export-filename=Standardstrat_binance.json` in backtest arguments.

## Quick changelog

- add --export-filename for backtesting


** Note**
why do we need to specify `--export=trades` and not just `--export` (as bollean)? the possibility to export is backtesting trades, so it seems kind of pointless ...
Is the intend here to export more detailed stuff in the future?
