### PR TITLE
Store and read ticker files in and from test/testdata/<exchange> sub directories.

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -4,7 +4,6 @@ This module contains the argument manager class
 
 import argparse
 import logging
-import os
 import re
 import arrow
 from typing import List, Tuple, Optional
@@ -70,12 +69,16 @@ class Arguments(object):
             type=str,
             metavar='PATH',
         )
+        # default to none, if none passed we build a default
+        # which includes exchange as a subdir in config
+        # has to be this way around as config.json is not read yet to capture
+        # exchange value
         self.parser.add_argument(
             '-d', '--datadir',
-            help='path to backtest data (default: %(default)s',
+            help='path to backtest data (help_hints',
             dest='datadir',
-            default=os.path.join('freqtrade', 'tests', 'testdata'),
             type=str,
+            default=None,
             metavar='PATH',
         )
         self.parser.add_argument(

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -4,7 +4,7 @@ This module contains the configuration class
 
 import json
 import logging
-import os
+from os import path, makedirs
 from argparse import Namespace
 from typing import Optional, Dict, Any
 from jsonschema import Draft4Validator, validate
@@ -150,15 +150,15 @@ class Configuration(object):
         else:
             exchange = config.get('exchange', {}).get('name').lower()
             if exchange:
-                default = os.path.join('freqtrade', 'tests', 'testdata', exchange)
+                default = path.join('freqtrade', 'tests', 'testdata', exchange)
                 config.update({'datadir': default})
             # What if user has no exchange as arg or in file - set catchall
             else:
                 logger.info("No exchange set")
-                default = os.path.join('freqtrade', 'tests', 'testdata', 'catchall')
+                default = path.join('freqtrade', 'tests', 'testdata', 'catchall')
 
-        if not os.path.exists(config['datadir']):
-            os.makedirs(config['datadir'])
+        if not path.exists(config['datadir']):
+            makedirs(config['datadir'])
             logger.info("Made directory: %s", config['datadir'])
 
         logger.info('Using data folder: %s ...', config['datadir'])

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -4,6 +4,7 @@ This module contains the configuration class
 
 import json
 import logging
+import os
 from argparse import Namespace
 from typing import Optional, Dict, Any
 from jsonschema import Draft4Validator, validate
@@ -143,9 +144,24 @@ class Configuration(object):
             logger.info('Parameter --timerange detected: %s ...', self.args.timerange)
 
         # If --datadir is used we add it to the configuration
+        # If not passed as an arg, we build testdata path including 'exchange' as a sub dir
         if 'datadir' in self.args and self.args.datadir:
             config.update({'datadir': self.args.datadir})
-            logger.info('Using data folder: %s ...', self.args.datadir)
+        else:
+            exchange = config.get('exchange', {}).get('name').lower()
+            if exchange:
+                default = os.path.join('freqtrade', 'tests', 'testdata', exchange)
+                config.update({'datadir': default})
+            # What if user has no exchange as arg or in file - set catchall
+            else:
+                logger.info("No exchange set")
+                default = os.path.join('freqtrade', 'tests', 'testdata', 'catchall')
+
+        if not os.path.exists(config['datadir']):
+            os.makedirs(config['datadir'])
+            logger.info("Made directory: %s", config['datadir'])
+
+        logger.info('Using data folder: %s ...', config['datadir'])
 
         # If -r/--refresh-pairs-cached is used we add it to the configuration
         if 'refresh_pairs' in self.args and self.args.refresh_pairs:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -266,14 +266,14 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     arglist = [
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        '--datadir', '/foo/bar',
+        '--datadir', 'freqtrade/tests/testdata/',
         'backtesting',
         '--ticker-interval', '1m',
         '--live',
         '--realistic-simulation',
         '--refresh-pairs-cached',
         '--timerange', ':100',
-        '--export', '/bar/foo'
+        '--export', 'user_data/data'
     ]
 
     args = Arguments(arglist, '').get_parsed_arg()

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -8,18 +8,26 @@ import arrow
 
 from freqtrade import (exchange, arguments, misc)
 
-DEFAULT_DL_PATH = 'freqtrade/tests/testdata'
-
 arguments = arguments.Arguments(sys.argv[1:], 'download utility')
 arguments.testdata_dl_options()
 args = arguments.parse_args()
 
+# Added exchange as a subdirectory to download into
+# as Freqtrad now supports multiple exchanges.
+DEFAULT_DL_PATH = 'freqtrade/tests/testdata/' + args.exchange
+DEFAULT_PAIR_FILE = DEFAULT_DL_PATH + "/" + "pairs.json"
+
 TICKER_INTERVALS = ['1m', '5m']
 PAIRS = []
 
+# Added a check for a default pairs file in per exchange specific dir
 if args.pairs_file:
     with open(args.pairs_file) as file:
         PAIRS = json.load(file)
+elif os.path.isfile(DEFAULT_PAIR_FILE) is True:
+    with open(DEFAULT_PAIR_FILE) as file:
+        PAIRS = json.load(file)
+
 PAIRS = list(set(PAIRS))
 
 dl_path = DEFAULT_DL_PATH


### PR DESCRIPTION
Im uploading this PR for feedback. 
I understand I'm now to look at unit tests to support the change.

The PR is to store ticker data from exchanges in their own sub directory
> tests/testdata/"exchange"

This seems a better way to manage ticker records now the bot is supports multiple exchanges. 
It ensures backtest is against the right tickerfile data files from the same exchange, not old data from another exchange.
Also tickerfiles do not need to be deleted between backtests across exchanges, also this opens the opportunity to backtest strategies across multiple exchanges, or use averaged price movements.

The change is functional backtesting works for bittrex and binnance and should work for any exchange enabled on the bot without code change. It has been tested with numerous config files using default and as a -c argument also --refresh flags. 

The change also updates the download_backtest_data script to support the directory structure. 
Also this script will now look for pairs.json file in the exchange specific testdata directory as a default to use if no argument. 

Some output from backtesting from binance and bittrex, also download script.
```
python3 ./freqtrade/main.py -c config.json.bin backtesting  --refresh-pairs-cached --timerange=20180529-20180530
2018-06-03 20:38:01,128 - freqtrade.configuration - INFO - Log level set to INFO
2018-06-03 20:38:01,129 - freqtrade.configuration - INFO - Using max_open_trades: 200 ...
2018-06-03 20:38:01,130 - freqtrade.configuration - INFO - Parameter --timerange detected: 20180529-20180530 ...
2018-06-03 20:38:01,131 - freqtrade.configuration - INFO - Using data folder: freqtrade/tests/testdata/binance ...
2018-06-03 20:38:01,131 - freqtrade.configuration - INFO - Parameter -r/--refresh-pairs-cached detected ...
2018-06-03 20:38:01,131 - freqtrade.optimize.backtesting - INFO - Starting freqtrade in Backtesting mode
2018-06-03 20:38:01,153 - freqtrade.strategy.resolver - INFO - Using resolved strategy DefaultStrategy from '/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/strategy'
2018-06-03 20:38:01,153 - freqtrade.strategy.resolver - INFO - Override strategy 'ticker_interval' with value in config file: 5m.
2018-06-03 20:38:01,153 - freqtrade.exchange - INFO - Instance is running with dry_run enabled
2018-06-03 20:38:01,156 - freqtrade.exchange - INFO - Using Exchange "Binance"
2018-06-03 20:38:01,763 - freqtrade.optimize.backtesting - INFO - Using stake_currency: BTC ...
2018-06-03 20:38:01,764 - freqtrade.optimize.backtesting - INFO - Using stake_amount: 0.015 ...
2018-06-03 20:38:01,764 - freqtrade.optimize.backtesting - INFO - Using local backtesting data (using whitelist in given config) ...
2018-06-03 20:38:01,768 - freqtrade.optimize - INFO - Download data for all pairs and store them in freqtrade/tests/testdata/binance
2018-06-03 20:38:01,768 - freqtrade.optimize - INFO - Download the pair: "SNT/BTC", Interval: 5m
dumping json to "freqtrade/tests/testdata/binance/SNT_BTC-5m.json"
2018-06-03 20:38:02,136 - freqtrade.optimize - INFO - Download the pair: "ETC/BTC", Interval: 5m
dumping json to "freqtrade/tests/testdata/binance/ETC_BTC-5m.json"
2018-06-03 20:38:02,637 - freqtrade.optimize - INFO - Download the pair: "SKY/BTC", Interval: 5m
dumping json to "freqtrade/tests/testdata/binance/SKY_BTC-5m.json"
2018-06-03 20:38:03,158 - freqtrade.optimize.backtesting - INFO - Ignoring max_open_trades (realistic_simulation not set) ...
2018-06-03 20:38:03,303 - freqtrade.optimize.backtesting - INFO - Measuring data from 2018-05-29T00:00:00+00:00 up to 2018-05-30T00:00:00+00:00 (1 days)..
2018-06-03 20:38:03,372 - freqtrade.optimize.backtesting - INFO - 
==================================== BACKTESTING REPORT ====================================
| pair    |   buy count |   avg profit % |   total profit BTC |   avg duration |   profit |   loss |
|:--------|------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| SNT/BTC |           1 |           0.04 |         0.00000637 |           85.0 |        1 |      0 |
| ETC/BTC |           2 |           0.32 |         0.00009572 |           45.0 |        2 |      0 |
| SKY/BTC |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| TOTAL   |           3 |           0.23 |         0.00010209 |           58.3 |        3 |      0 |
```
Bittrex
```
(.env) DannyMBP:freqtrade_new creslin$ python3 ./freqtrade/main.py backtesting  --refresh-pairs-cached --timerange=20180529-20180530
2018-06-03 20:38:19,489 - freqtrade.configuration - INFO - Log level set to INFO
2018-06-03 20:38:19,490 - freqtrade.configuration - INFO - Using max_open_trades: 3 ...
2018-06-03 20:38:19,490 - freqtrade.configuration - INFO - Parameter --timerange detected: 20180529-20180530 ...
2018-06-03 20:38:19,491 - freqtrade.configuration - INFO - Using data folder: freqtrade/tests/testdata/bittrex ...
2018-06-03 20:38:19,491 - freqtrade.configuration - INFO - Parameter -r/--refresh-pairs-cached detected ...
2018-06-03 20:38:19,491 - freqtrade.optimize.backtesting - INFO - Starting freqtrade in Backtesting mode
2018-06-03 20:38:19,499 - freqtrade.strategy.resolver - INFO - Using resolved strategy DefaultStrategy from '/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/strategy'
2018-06-03 20:38:19,499 - freqtrade.strategy.resolver - INFO - Override strategy 'ticker_interval' with value in config file: 5m.
2018-06-03 20:38:19,499 - freqtrade.exchange - INFO - Instance is running with dry_run enabled
2018-06-03 20:38:19,501 - freqtrade.exchange - INFO - Using Exchange "Bittrex"
2018-06-03 20:38:21,036 - freqtrade.optimize.backtesting - INFO - Using stake_currency: BTC ...
2018-06-03 20:38:21,037 - freqtrade.optimize.backtesting - INFO - Using stake_amount: 0.05 ...
2018-06-03 20:38:21,037 - freqtrade.optimize.backtesting - INFO - Using local backtesting data (using whitelist in given config) ...
2018-06-03 20:38:21,041 - freqtrade.optimize - INFO - Download data for all pairs and store them in freqtrade/tests/testdata/bittrex
2018-06-03 20:38:21,041 - freqtrade.optimize - INFO - Download the pair: "LTC/BTC", Interval: 5m
dumping json to "freqtrade/tests/testdata/bittrex/LTC_BTC-5m.json"
2018-06-03 20:38:22,834 - freqtrade.optimize - INFO - Download the pair: "BCH/BTC", Interval: 5m
dumping json to "freqtrade/tests/testdata/bittrex/BCH_BTC-5m.json"
2018-06-03 20:38:24,576 - freqtrade.optimize.backtesting - INFO - Ignoring max_open_trades (realistic_simulation not set) ...
2018-06-03 20:38:24,752 - freqtrade.optimize.backtesting - INFO - Measuring data from 2018-05-29T00:00:00+00:00 up to 2018-05-30T00:00:00+00:00 (1 days)..
2018-06-03 20:38:24,838 - freqtrade.optimize.backtesting - INFO - 
==================================== BACKTESTING REPORT ====================================
| pair    |   buy count |   avg profit % |   total profit BTC |   avg duration |   profit |   loss |
|:--------|------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| LTC/BTC |           4 |           0.12 |         0.00024209 |           62.5 |        4 |      0 |
| BCH/BTC |           3 |           0.85 |         0.00126887 |           45.0 |        3 |      0 |
| TOTAL   |           7 |           0.43 |         0.00151096 |           55.0 |        7 |      0 | 

```
Also the download script: 
```
python3 scripts/download_backtest_data.py --exchange=binance --days=10
About to download pairs: ['LTC/USDT', 'POWR/BTC', 'XRP/BTC', 'XVG/BTC', 'ADA/BTC', 'LTC/BTC', 'ETH/USDT', 'VTC/BTC', 'NXT/BTC', 'WAVES/BTC', 'LSK/BTC', 'BAT/BTC', 'DASH/BTC', 'ETC/BTC', 'NEO/BTC', 'BTC/USDT', 'STORJ/BTC', 'ETH/BTC', 'XLM/BTC', 'ZEC/BTC', 'QTUM/BTC', 'XMR/BTC'] to freqtrade/tests/testdata/binance
downloading pair LTC/USDT, interval 1m
	Data was downloaded for period 2018-05-24 17:51:00+00:00 - 2018-06-03 17:50:00+00:00
dumping json to "freqtrade/tests/testdata/binance/LTC_USDT-1m.json"
downloading pair LTC/USDT, interval 5m
	Data was downloaded for period 2018-05-24 17:55:00+00:00 - 2018-06-03 17:50:00+00:00
dumping json to "freqtrade/tests/testdata/binance/LTC_USDT-5m.json"

```
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
