### PR TITLE
Choose tickers to download

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -117,6 +117,7 @@ This will download ticker data for all the currency pairs you defined in `pairs.
 - To change the exchange used to download the tickers, use `--exchange`. Default is `bittrex`.
 - To use `pairs.json` from some other folder, use `--pairs-file some_other_dir/pairs.json`.
 - To download ticker data for only 10 days, use `--days 10`.
+- Use `--timeframes` to specify which tickers to download. Default is `--timeframes 1m 5m` which will download 1-minute and 5-minute tickers.
 
 
 For help about backtesting usage, please refer to 

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -317,7 +317,7 @@ class Arguments(object):
             '-t', '--timeframes',
             help='Specify which tickers to download. Space separated list. \
                   Default: %(default)s',
-            choices=['5m', '15m', '30m', '1h', '2h', '4h',
+            choices=['1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h',
                      '6h', '8h', '12h', '1d', '3d', '1w', '1M'],
             default=['1m', '5m'],
             nargs='+',

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -312,3 +312,14 @@ class Arguments(object):
             dest='exchange',
             type=str,
             default='bittrex')
+
+        self.parser.add_argument(
+            '-t', '--timeframes',
+            help='Specify which tickers to download. Space separated list. \
+                  Default: %(default)s',
+            choices=['5m', '15m', '30m', '1h', '2h', '4h',
+                     '6h', '8h', '12h', '1d', '3d', '1w', '1M'],
+            default=['1m', '5m'],
+            nargs='+',
+            dest='timeframes',
+        )

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -14,7 +14,7 @@ arguments = arguments.Arguments(sys.argv[1:], 'download utility')
 arguments.testdata_dl_options()
 args = arguments.parse_args()
 
-TICKER_INTERVALS = ['1m', '5m']
+timeframes = args.timeframes
 
 dl_path = os.path.join(DEFAULT_DL_PATH, args.exchange)
 if args.export:
@@ -44,7 +44,7 @@ exchange._API = exchange.init_ccxt({'key': '',
 
 
 for pair in PAIRS:
-    for tick_interval in TICKER_INTERVALS:
+    for tick_interval in timeframes:
         print(f'downloading pair {pair}, interval {tick_interval}')
 
         data = exchange.get_ticker_history(pair, tick_interval, since_ms=since_time)


### PR DESCRIPTION

## Summary

`download_backtest_data.py` previously always downloaded 1minute and 5min tickers. Now you can choose timeframes with `--timeframes`.

## Quick changelog

Add `--timeframes` flag which takes space-separated list of tickers, like `--timeframes 5m 1h 4h`.

Merge this only after #840 .