### PR TITLE
Add support for more timeframes

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -318,7 +318,7 @@ class Arguments(object):
             help='Specify which tickers to download. Space separated list. \
                   Default: %(default)s',
             choices=['1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h',
-                     '6h', '8h', '12h', '1d', '3d', '1w', '1M'],
+                     '6h', '8h', '12h', '1d', '3d', '1w'],
             default=['1m', '5m'],
             nargs='+',
             dest='timeframes',

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -12,6 +12,7 @@ DEFAULT_STRATEGY = 'DefaultStrategy'
 
 TICKER_INTERVAL_MINUTES = {
     '1m': 1,
+    '3m': 3,
     '5m': 5,
     '15m': 15,
     '30m': 30,
@@ -19,8 +20,10 @@ TICKER_INTERVAL_MINUTES = {
     '2h': 120,
     '4h': 240,
     '6h': 360,
+    '8h': 480,
     '12h': 720,
     '1d': 1440,
+    '3d': 4320,
     '1w': 10080,
 }
 


### PR DESCRIPTION
- Add constants for 3 minute, 8 hour and 3 day tickers.
- Remove support for 1 month ticker.
