### PR TITLE
To be able to start with USDT in fiat_display_currency in config.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,8 +92,10 @@ The bot was tested with the following exchanges:
 Feel free to test other exchanges and submit your PR to improve the bot.
 
 ### What values for fiat_display_currency?
-`fiat_display_currency` set the fiat to use for the conversion form coin to fiat in Telegram. 
-The valid value are: "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD".
+`fiat_display_currency` set the base currency to use for the conversion form coin to fiat in Telegram.
+The valid values are: "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD".
+In addition to central bank currencies, a range of cryto currencies are supported.
+The valid values are: "BTC", "ETH", "XRP", "LTC", "BCH", "USDT".
 
 ## Switch to dry-run mode
 We recommend starting the bot in dry-run mode to see how your bot will

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ The bot was tested with the following exchanges:
 Feel free to test other exchanges and submit your PR to improve the bot.
 
 ### What values for fiat_display_currency?
-`fiat_display_currency` set the base currency to use for the conversion form coin to fiat in Telegram.
+`fiat_display_currency` set the base currency to use for the conversion from coin to fiat in Telegram.
 The valid values are: "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD".
 In addition to central bank currencies, a range of cryto currencies are supported.
 The valid values are: "BTC", "ETH", "XRP", "LTC", "BCH", "USDT".

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -28,7 +28,8 @@ SUPPORTED_FIAT = [
     "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK",
     "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY",
     "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN",
-    "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD"
+    "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD",
+    "USDT"
     ]
 
 # Required json-schema for user specified config

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -29,7 +29,7 @@ SUPPORTED_FIAT = [
     "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY",
     "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN",
     "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD",
-    "USDT"
+    "BTC", "ETH", "XRP", "LTC", "BCH", "USDT"
     ]
 
 # Required json-schema for user specified config


### PR DESCRIPTION
There are use-cases that need to build the base pair to consider price of whitelist pairs. 

On Binance the base pair is USDT not USD. 
USDT cannot be set in conifg.json as a fiat_display_currency as constants.py blocks it. 
This change does not break existing functionality as coinmarket allows conversion to USDT price. 

As example use-case here I use BTC/USDT to compare price gains for whitelist pairs. 

> /Users/creslin/PycharmProjects/freqtrade_new/scripts/report_correlation.py --timerange=1527595200-1527618600
> 2018-06-04 16:41:27,088 - freqtrade.configuration - INFO - Log level set to INFO
> 2018-06-04 16:41:27,088 - freqtrade.configuration - INFO - Using max_open_trades: 200 ...
> 2018-06-04 16:41:27,088 - freqtrade.configuration - INFO - Parameter --timerange detected: 1527595200-1527618600 ...
> 2018-06-04 16:41:27,089 - freqtrade.configuration - INFO - Using data folder: user_data/data/binance ...
> 2018-06-04 16:41:27,103 - freqtrade.optimize - INFO - Download the pair: "BTC/USDT", Interval: 5m
> dumping json to "/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/tests/testdata/BTC_USDT-5m.json"
> 2018-06-04 16:41:30,779 - freqtrade.optimize - INFO - Download the pair: "SNT/BTC", Interval: 5m
> dumping json to "/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/tests/testdata/SNT_BTC-5m.json"
> 2018-06-04 16:41:31,750 - freqtrade.optimize - INFO - Download the pair: "ETC/BTC", Interval: 5m
> dumping json to "/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/tests/testdata/ETC_BTC-5m.json"
> 2018-06-04 16:41:33,497 - freqtrade.optimize - INFO - Download the pair: "MTH/BTC", Interval: 5m
> dumping json to "/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/tests/testdata/MTH_BTC-5m.json"
>    
> 
> BasePair     Pair  Correlation  BTC % Change  Pair % USD Ch  Pair % BTC Ch  Gain % on BTC        Start         Stop  BTC Volume
> 2  BTC_USDT  MTH_USD        0.602         0.793          5.374          4.545       4.581493  05-29 12:00  05-29 18:30       25.53
> 0  BTC_USDT  SNT_USD        0.670         0.793          0.402         -0.388      -0.391277  05-29 12:00  05-29 18:30      206.07
> 1  BTC_USDT  ETC_USD        0.855         0.793          0.002         -0.785      -0.790920  05-29 12:00  05-29 18:30      180.34
> 
> 
> 

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
