### PR TITLE
Add Hibtc2 exchange in README and configuration.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ strategy parameters with real exchange data.
 ### Exchange marketplaces supported
 - [X] [Bittrex](https://bittrex.com/)
 - [X] [Binance](https://www.binance.com/)
-- [ ] [113 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
+- [X] [HitBTC v2](https://hitbtc.com/)
+- [ ] [112 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
+You have tried an exchange not listed here and it is working here?
+[Let us know](https://github.com/freqtrade/freqtrade/issues ).
 
 ## Quick start
 This quick start section is a very short explanation on how to test the 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,11 +83,12 @@ end up paying more then would probably have been necessary.
 Freqtrade is based on [CCXT library](https://github.com/ccxt/ccxt) that supports 115 cryptocurrency
 exchange markets and trading APIs. The complete up-to-date list can be found in the
 [CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python). However, the bot was tested
-with only Bittrex and Binance.
+with the exchange listed below.
 
 The bot was tested with the following exchanges:
 - [Bittrex](https://bittrex.com/): "bittrex"
 - [Binance](https://www.binance.com/): "binance"
+- [HitBTC v2](https://hitbtc.com/): "hitbtc2"
 
 Feel free to test other exchanges and submit your PR to improve the bot.
 


### PR DESCRIPTION
## Summary
Since HitBTC v2 was successfully tested by @ZeroCool940711. This PR add the exchange in the README and configuration.md.

Solve the issue: #842

## Quick changelog

- Add HitBTC v2 in the doc

