### PR TITLE
Avoid look-ahead in backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -162,6 +162,10 @@ class Backtesting(object):
             pair_data['buy'], pair_data['sell'] = 0, 0  # cleanup from previous run
 
             ticker_data = self.populate_sell_trend(self.populate_buy_trend(pair_data))[headers]
+
+            # to avoid using data from future, we buy/sell with signal from previous candle, not current
+            ticker_data.buy = ticker_data.buy.shift(1)
+            ticker_data.sell = ticker_data.sell.shift(1)
             ticker = [x for x in ticker_data.itertuples()]
 
             lock_pair_until = None

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -161,11 +161,15 @@ class Backtesting(object):
         for pair, pair_data in processed.items():
             pair_data['buy'], pair_data['sell'] = 0, 0  # cleanup from previous run
 
-            ticker_data = self.populate_sell_trend(self.populate_buy_trend(pair_data))[headers]
+            ticker_data = self.populate_sell_trend(
+                self.populate_buy_trend(pair_data))[headers].copy()
 
-            # to avoid using data from future, we buy/sell with signal from previous candle, not current
-            ticker_data.buy = ticker_data.buy.shift(1)
-            ticker_data.sell = ticker_data.sell.shift(1)
+            # to avoid using data from future, we buy/sell with signal from previous candle
+            ticker_data.loc[:, 'buy'] = ticker_data['buy'].shift(1)
+            ticker_data.loc[:, 'sell'] = ticker_data['sell'].shift(1)
+
+            ticker_data.drop(ticker_data.head(1).index, inplace=True)
+
             ticker = [x for x in ticker_data.itertuples()]
 
             lock_pair_until = None

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -30,7 +30,7 @@ def trim_dictlist(dict_list, num):
 
 
 def load_data_test(what):
-    timerange = TimeRange(None, 'line', 0, -100)
+    timerange = TimeRange(None, 'line', 0, -101)
     data = optimize.load_data(None, ticker_interval='1m',
                               pairs=['UNITTEST/BTC'], timerange=timerange)
     pair = data['UNITTEST/BTC']
@@ -110,14 +110,14 @@ def mocked_load_data(datadir, pairs=[], ticker_interval='0m', refresh_pairs=Fals
 # use for mock freqtrade.exchange.get_ticker_history'
 def _load_pair_as_ticks(pair, tickfreq):
     ticks = optimize.load_data(None, ticker_interval=tickfreq, pairs=[pair])
-    ticks = trim_dictlist(ticks, -200)
+    ticks = trim_dictlist(ticks, -201)
     return ticks[pair]
 
 
 # FIX: fixturize this?
 def _make_backtest_conf(mocker, conf=None, pair='UNITTEST/BTC', record=None):
     data = optimize.load_data(None, ticker_interval='8m', pairs=[pair])
-    data = trim_dictlist(data, -200)
+    data = trim_dictlist(data, -201)
     mocker.patch('freqtrade.exchange.validate_pairs', MagicMock(return_value=True))
     backtesting = Backtesting(conf)
     return {


### PR DESCRIPTION
Use buy/sell signal from previous candle, not current to avoid seeing to the future. Quick improvement to one issue mentioned in https://github.com/freqtrade/freqtrade/issues/746 

I will update/fix tests only if we decide to go with this change.