### PR TITLE
exclude networkx from pyup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytest-mock==1.10.0
 pytest-cov==2.5.1
 hyperopt==0.1
 # do not upgrade networkx before this is fixed https://github.com/hyperopt/hyperopt/issues/325
-networkx==1.11
+networkx==1.11 # pyup: ignore
 tabulate==0.8.2
 coinmarketcap==5.0.3
 


### PR DESCRIPTION
## Summary
Use pyup filter to exclude `networkx==1.11` from updates.

Solve the issue: #853
