### PR TITLE
Allow custom sqlite database path

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -45,6 +45,7 @@
         "token": "your_telegram_token",
         "chat_id": "your_telegram_chat_id"
     },
+    "db_url": "sqlite:///tradesv3.sqlite",
     "initial_state": "running",
     "internals": {
         "process_throttle_secs": 5

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -9,10 +9,10 @@ it.
 
 ## Bot commands
 ```
-usage: main.py [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
-               [--strategy-path PATH] [--dynamic-whitelist [INT]]
-               [--dry-run-db]
-               {backtesting,hyperopt} ...
+usage: freqtrade [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
+                 [--strategy-path PATH] [--dynamic-whitelist [INT]]
+                 [--db-url PATH]
+                 {backtesting,hyperopt} ...
 
 Simple High Frequency Trading Bot for crypto currencies
 
@@ -28,17 +28,16 @@ optional arguments:
   -c PATH, --config PATH
                         specify configuration file (default: config.json)
   -d PATH, --datadir PATH
-                        path to backtest data (default:
-                        freqtrade/tests/testdata
+                        path to backtest data
   -s NAME, --strategy NAME
                         specify strategy class name (default: DefaultStrategy)
   --strategy-path PATH  specify additional strategy lookup path
   --dynamic-whitelist [INT]
                         dynamically generate and update whitelist based on 24h
-                        BaseVolume (Default 20 currencies)
-  --dry-run-db          Force dry run to use a local DB
-                        "tradesv3.dry_run.sqlite" instead of memory DB. Work
-                        only if dry_run is enabled.
+                        BaseVolume (default: 20)
+  --db-url PATH         Override trades database URL, this is useful if
+                        dry_run is enabled or in custom deployments (default:
+                        sqlite:///tradesv3.sqlite)
 ```
 
 ### How to use a different config file?
@@ -102,14 +101,14 @@ python3 ./freqtrade/main.py --dynamic-whitelist 30
 negative value (e.g -2), `--dynamic-whitelist` will use the default
 value (20).
 
-### How to use --dry-run-db?
+### How to use --db-url?
 When you run the bot in Dry-run mode, per default no transactions are 
 stored in a database. If you want to store your bot actions in a DB 
-using `--dry-run-db`. This command will use a separate database file 
-`tradesv3.dry_run.sqlite`
+using `--db-url`. This can also be used to specify a custom database
+in production mode. Example command:
 
 ```bash
-python3 ./freqtrade/main.py -c config.json --dry-run-db
+python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 ```
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ The table below will list all configuration parameters.
 | `telegram.enabled` | true | Yes | Enable or not the usage of Telegram.
 | `telegram.token` | token | No | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
 | `telegram.chat_id` | chat_id | No | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.
+| `db_url` | `sqlite:///tradesv3.sqlite` | No | Declares database URL to use. NOTE: This defaults to `sqlite://` if `dry_run` is `True`.
 | `initial_state` | running | No | Defines the initial application state. More information below.
 | `strategy` | DefaultStrategy | No | Defines Strategy class to use.
 | `strategy_path` | null | No | Adds an additional strategy lookup path (must be a folder).
@@ -111,9 +112,10 @@ creating trades.
 
 ### To switch your bot in Dry-run mode:
 1. Edit your `config.json`  file
-2. Switch dry-run to true
+2. Switch dry-run to true and specify db_url for a persistent db
 ```json
 "dry_run": true,
+"db_url": "sqlite///tradesv3.dryrun.sqlite",
 ```
 
 3. Remove your Exchange API key (change them by fake api credentials)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ you run it in production mode.
 ### To switch your bot in production mode:
 1. Edit your `config.json`  file
 
-2. Switch dry-run to false
+2. Switch dry-run to false and don't forget to adapt your database URL if set
 ```json
 "dry_run": false,
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,10 +162,10 @@ docker run -d \
   -v /etc/localtime:/etc/localtime:ro \
   -v ~/.freqtrade/config.json:/freqtrade/config.json \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
-  freqtrade
+  freqtrade --db-url sqlite:///tradesv3.sqlite
 ```
-
-If you are using `dry_run=True` it's not necessary to mount `tradesv3.sqlite`, but you can mount `tradesv3.dryrun.sqlite` if you plan to use the dry run mode with the param `--dry-run-db`.
+NOTE: db-url defaults to `sqlite:///tradesv3.sqlite` but it defaults to `sqlite://` if `dry_run=True` is being used.
+To override this behaviour use a custom db-url value: i.e.: `--db-url sqlite:///tradesv3.dryrun.sqlite`
 
 ### 6. Monitor your Docker instance
 

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -12,7 +12,8 @@ class DependencyException(BaseException):
 class OperationalException(BaseException):
     """
     Requires manual intervention.
-    This happens when an exchange returns an unexpected error during runtime.
+    This happens when an exchange returns an unexpected error during runtime
+    or given configuration is invalid.
     """
 
 

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -95,20 +95,23 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '--dynamic-whitelist',
-            help='dynamically generate and update whitelist \
-                                  based on 24h BaseVolume (Default 20 currencies)',  # noqa
+            help='dynamically generate and update whitelist'
+                 ' based on 24h BaseVolume (default: %(default)s)',
             dest='dynamic_whitelist',
             const=constants.DYNAMIC_WHITELIST,
+            default=constants.DYNAMIC_WHITELIST,
             type=int,
             metavar='INT',
             nargs='?',
         )
         self.parser.add_argument(
-            '--dry-run-db',
-            help='Force dry run to use a local DB "tradesv3.dry_run.sqlite" \
-                                  instead of memory DB. Work only if dry_run is enabled.',
-            action='store_true',
-            dest='dry_run_db',
+            '--db-url',
+            help='Override trades database URL, this is useful if dry_run is enabled'
+                 ' or in custom deployments (default: %(default)s)',
+            dest='db_url',
+            default=constants.DEFAULT_DB_URL,
+            type=str,
+            metavar='PATH',
         )
 
     @staticmethod
@@ -274,13 +277,6 @@ class Arguments(object):
             '-p', '--pair',
             help='Show profits for only this pairs. Pairs are comma-separated.',
             dest='pair',
-            default=None
-        )
-
-        self.parser.add_argument(
-            '-db', '--db-url',
-            help='Show trades stored in database.',
-            dest='db_url',
             default=None
         )
 

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -96,10 +96,9 @@ class Arguments(object):
         self.parser.add_argument(
             '--dynamic-whitelist',
             help='dynamically generate and update whitelist'
-                 ' based on 24h BaseVolume (default: %(default)s)',
+                 ' based on 24h BaseVolume (default: %(const)s)',
             dest='dynamic_whitelist',
             const=constants.DYNAMIC_WHITELIST,
-            default=constants.DYNAMIC_WHITELIST,
             type=int,
             metavar='INT',
             nargs='?',

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -108,7 +108,7 @@ class Arguments(object):
             help='Override trades database URL, this is useful if dry_run is enabled'
                  ' or in custom deployments (default: %(default)s)',
             dest='db_url',
-            default=constants.DEFAULT_DB_URL,
+            default=constants.DEFAULT_DB_PROD_URL,
             type=str,
             metavar='PATH',
         )

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -103,12 +103,12 @@ class Configuration(object):
 
         if config.get('dry_run', False):
             logger.info('Dry run is enabled')
-            if config.get('db_url') in [None, constants.DEFAULT_DB_URL]:
+            if config.get('db_url') in [None, constants.DEFAULT_DB_PROD_URL]:
                 # Default to in-memory db for dry_run if not specified
-                config['db_url'] = 'sqlite://'
+                config['db_url'] = constants.DEFAULT_DB_DRYRUN_URL
         else:
             if not config.get('db_url', None):
-                config['db_url'] = constants.DEFAULT_DB_URL
+                config['db_url'] = constants.DEFAULT_DB_PROD_URL
             logger.info('Dry run is disabled')
 
         logger.info('Using DB: "{}"'.format(config['db_url']))

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -97,16 +97,21 @@ class Configuration(object):
                 '(not applicable with Backtesting and Hyperopt)'
             )
 
-        # Add dry_run_db if found and the bot in dry run
-        if self.args.dry_run_db and config.get('dry_run', False):
-            config.update({'dry_run_db': True})
-            logger.info('Parameter --dry-run-db detected ...')
+        if self.args.db_url and config.get('db_url', None):
+            config.update({'db_url': self.args.db_url})
+            logger.info('Parameter --db-url detected ...')
 
-        if config.get('dry_run_db', False):
-            if config.get('dry_run', False):
-                logger.info('Dry_run will use the DB file: "tradesv3.dry_run.sqlite"')
-            else:
-                logger.info('Dry run is disabled. (--dry_run_db ignored)')
+        if config.get('dry_run', False):
+            logger.info('Dry run is enabled')
+            if config.get('db_url') in [None, constants.DEFAULT_DB_URL]:
+                # Default to in-memory db for dry_run if not specified
+                config['db_url'] = 'sqlite://'
+        else:
+            if not config.get('db_url', None):
+                config['db_url'] = constants.DEFAULT_DB_URL
+            logger.info('Dry run is disabled')
+
+        logger.info('Using DB: "{}"'.format(config['db_url']))
 
         # Check if the exchange set by the user is supported
         self.check_exchange(config)

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -97,7 +97,7 @@ class Configuration(object):
                 '(not applicable with Backtesting and Hyperopt)'
             )
 
-        if self.args.db_url and config.get('db_url', None):
+        if self.args.db_url != constants.DEFAULT_DB_PROD_URL:
             config.update({'db_url': self.args.db_url})
             logger.info('Parameter --db-url detected ...')
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -9,6 +9,7 @@ TICKER_INTERVAL = 5  # min
 HYPEROPT_EPOCH = 100  # epochs
 RETRY_TIMEOUT = 30  # sec
 DEFAULT_STRATEGY = 'DefaultStrategy'
+DEFAULT_DB_URL = 'sqlite:///tradesv3.sqlite'
 
 TICKER_INTERVAL_MINUTES = {
     '1m': 1,
@@ -83,6 +84,7 @@ CONF_SCHEMA = {
             },
             'required': ['enabled', 'token', 'chat_id']
         },
+        'db_url': {'type': 'string'},
         'initial_state': {'type': 'string', 'enum': ['running', 'stopped']},
         'internals': {
             'type': 'object',

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -9,7 +9,8 @@ TICKER_INTERVAL = 5  # min
 HYPEROPT_EPOCH = 100  # epochs
 RETRY_TIMEOUT = 30  # sec
 DEFAULT_STRATEGY = 'DefaultStrategy'
-DEFAULT_DB_URL = 'sqlite:///tradesv3.sqlite'
+DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'
+DEFAULT_DB_DRYRUN_URL = 'sqlite://'
 
 TICKER_INTERVAL_MINUTES = {
     '1m': 1,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -33,12 +33,11 @@ class FreqtradeBot(object):
     This is from here the bot start its logic.
     """
 
-    def __init__(self, config: Dict[str, Any], db_url: Optional[str] = None)-> None:
+    def __init__(self, config: Dict[str, Any])-> None:
         """
         Init all variables and object the bot need to work
         :param config: configuration dict, you can use the Configuration.get_config()
         method to get the config dict.
-        :param db_url: database connector string for sqlalchemy (Optional)
         """
 
         logger.info(
@@ -57,17 +56,16 @@ class FreqtradeBot(object):
         self.persistence = None
         self.exchange = None
 
-        self._init_modules(db_url=db_url)
+        self._init_modules()
 
-    def _init_modules(self, db_url: Optional[str] = None) -> None:
+    def _init_modules(self) -> None:
         """
         Initializes all modules and updates the config
-        :param db_url: database connector string for sqlalchemy (Optional)
         :return: None
         """
         # Initialize all modules
 
-        persistence.init(self.config, db_url)
+        persistence.init(self.config)
         exchange.init(self.config)
 
         # Set initial application state

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from typing import List
 
+from freqtrade import OperationalException
 from freqtrade.arguments import Arguments
 from freqtrade.configuration import Configuration
 from freqtrade.freqtradebot import FreqtradeBot
@@ -47,6 +48,9 @@ def main(sysargv: List[str]) -> None:
     except KeyboardInterrupt:
         logger.info('SIGINT received, aborting ...')
         return_code = 0
+    except OperationalException as e:
+        logger.error(str(e))
+        return_code = 2
     except BaseException:
         logger.exception('Fatal exception!')
     finally:

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -10,13 +10,11 @@ from typing import Dict, Optional, Any
 import arrow
 from sqlalchemy import (Boolean, Column, DateTime, Float, Integer, String,
                         create_engine)
-from sqlalchemy.engine import Engine
+from sqlalchemy import inspect
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlalchemy.pool import StaticPool
-from sqlalchemy import inspect
-
 
 logger = logging.getLogger(__name__)
 
@@ -24,30 +22,30 @@ _CONF = {}
 _DECL_BASE: Any = declarative_base()
 
 
-def init(config: dict, engine: Optional[Engine] = None) -> None:
+def init(config: Dict) -> None:
     """
     Initializes this module with the given config,
     registers all known command handlers
     and starts polling for message updates
     :param config: config to use
-    :param engine: database engine for sqlalchemy (Optional)
     :return: None
     """
     _CONF.update(config)
-    if not engine:
-        if _CONF.get('dry_run', False):
-            # the user wants dry run to use a DB
-            if _CONF.get('dry_run_db', False):
-                engine = create_engine('sqlite:///tradesv3.dry_run.sqlite')
-            # Otherwise dry run will store in memory
-            else:
-                engine = create_engine('sqlite://',
-                                       connect_args={'check_same_thread': False},
-                                       poolclass=StaticPool,
-                                       echo=False)
-        else:
-            engine = create_engine('sqlite:///tradesv3.sqlite')
 
+    db_url = _CONF.get('db_url', None)
+    kwargs = {}
+
+    if not db_url and _CONF.get('dry_run', False):
+        # Default to in-memory db if not specified
+        # and take care of thread ownership if in-memory db
+        db_url = 'sqlite://'
+        kwargs.update({
+            'connect_args': {'check_same_thread': False},
+            'poolclass': StaticPool,
+            'echo': False,
+        })
+
+    engine = create_engine(db_url, **kwargs)
     session = scoped_session(sessionmaker(bind=engine, autoflush=True, autocommit=True))
     Trade.session = session()
     Trade.query = session.query_property()
@@ -55,7 +53,7 @@ def init(config: dict, engine: Optional[Engine] = None) -> None:
     check_migrate(engine)
 
     # Clean dry_run DB
-    if _CONF.get('dry_run', False) and _CONF.get('dry_run_db', False):
+    if _CONF.get('dry_run', False) and db_url != 'sqlite://':
         clean_dry_run_db()
 
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -16,8 +16,6 @@ from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from freqtrade import constants
-
 logger = logging.getLogger(__name__)
 
 _CONF = {}
@@ -37,8 +35,8 @@ def init(config: Dict) -> None:
     db_url = _CONF.get('db_url', None)
     kwargs = {}
 
-    if db_url == constants.DEFAULT_DB_DRYRUN_URL:
-        # Take care of thread ownership if in-memory db
+    # Take care of thread ownership if in-memory db
+    if db_url == 'sqlite://':
         kwargs.update({
             'connect_args': {'check_same_thread': False},
             'poolclass': StaticPool,
@@ -52,8 +50,8 @@ def init(config: Dict) -> None:
     _DECL_BASE.metadata.create_all(engine)
     check_migrate(engine)
 
-    # Clean dry_run DB
-    if _CONF.get('dry_run', False) and db_url != constants.DEFAULT_DB_DRYRUN_URL:
+    # Clean dry_run DB if the db is not in-memory
+    if _CONF.get('dry_run', False) and db_url != 'sqlite://':
         clean_dry_run_db()
 
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from freqtrade import constants
+
 logger = logging.getLogger(__name__)
 
 _CONF = {}
@@ -35,10 +37,8 @@ def init(config: Dict) -> None:
     db_url = _CONF.get('db_url', None)
     kwargs = {}
 
-    if not db_url and _CONF.get('dry_run', False):
-        # Default to in-memory db if not specified
-        # and take care of thread ownership if in-memory db
-        db_url = 'sqlite://'
+    if db_url == constants.DEFAULT_DB_DRYRUN_URL:
+        # Take care of thread ownership if in-memory db
         kwargs.update({
             'connect_args': {'check_same_thread': False},
             'poolclass': StaticPool,
@@ -53,7 +53,7 @@ def init(config: Dict) -> None:
     check_migrate(engine)
 
     # Clean dry_run DB
-    if _CONF.get('dry_run', False) and db_url != 'sqlite://':
+    if _CONF.get('dry_run', False) and db_url != constants.DEFAULT_DB_DRYRUN_URL:
         clean_dry_run_db()
 
 

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 import arrow
 import pytest
 from jsonschema import validate
-from sqlalchemy import create_engine
 from telegram import Chat, Message, Update
 
 from freqtrade.analyze import Analyze
@@ -45,7 +44,7 @@ def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
     mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
     mocker.patch('freqtrade.freqtradebot.Analyze.get_signal', MagicMock())
 
-    return FreqtradeBot(config, create_engine('sqlite://'))
+    return FreqtradeBot(config)
 
 
 def patch_coinmarketcap(mocker, value: Optional[Dict[str, float]] = None) -> None:
@@ -108,7 +107,8 @@ def default_conf():
             "chat_id": "0"
         },
         "initial_state": "running",
-        "loglevel": logging.DEBUG
+        "db_url": "sqlite://",
+        "loglevel": logging.DEBUG,
     }
     validate(configuration, constants.CONF_SCHEMA)
     return configuration

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -7,8 +7,6 @@ Unit test file for rpc/rpc.py
 from datetime import datetime
 from unittest.mock import MagicMock
 
-from sqlalchemy import create_engine
-
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Trade
 from freqtrade.rpc.rpc import RPC
@@ -39,7 +37,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -88,7 +86,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -123,7 +121,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     stake_currency = default_conf['stake_currency']
     fiat_display_currency = default_conf['fiat_display_currency']
 
@@ -180,7 +178,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     stake_currency = default_conf['stake_currency']
     fiat_display_currency = default_conf['fiat_display_currency']
 
@@ -243,7 +241,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     stake_currency = default_conf['stake_currency']
     fiat_display_currency = default_conf['fiat_display_currency']
 
@@ -314,7 +312,7 @@ def test_rpc_balance_handle(default_conf, mocker):
         get_balances=MagicMock(return_value=mock_balance)
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     (error, res) = rpc.rpc_balance(default_conf['fiat_display_currency'])
@@ -344,7 +342,7 @@ def test_rpc_start(mocker, default_conf) -> None:
         get_ticker=MagicMock()
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
     freqtradebot.state = State.STOPPED
 
@@ -372,7 +370,7 @@ def test_rpc_stop(mocker, default_conf) -> None:
         get_ticker=MagicMock()
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
     freqtradebot.state = State.RUNNING
 
@@ -411,7 +409,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
         get_fee=fee,
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -521,7 +519,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     # Create some test data
@@ -560,7 +558,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
         get_fee=fee,
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
 
     (error, trades) = rpc.rpc_count()

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from random import randint
 from unittest.mock import MagicMock
 
-from sqlalchemy import create_engine
 from telegram import Update, Message, Chat
 from telegram.error import NetworkError
 
@@ -156,7 +155,7 @@ def test_authorized_only(default_conf, mocker, caplog) -> None:
 
     conf = deepcopy(default_conf)
     conf['telegram']['enabled'] = False
-    dummy = DummyCls(FreqtradeBot(conf, create_engine('sqlite://')))
+    dummy = DummyCls(FreqtradeBot(conf))
     dummy.dummy_handler(bot=MagicMock(), update=update)
     assert dummy.state['called'] is True
     assert log_has(
@@ -187,7 +186,7 @@ def test_authorized_only_unauthorized(default_conf, mocker, caplog) -> None:
 
     conf = deepcopy(default_conf)
     conf['telegram']['enabled'] = False
-    dummy = DummyCls(FreqtradeBot(conf, create_engine('sqlite://')))
+    dummy = DummyCls(FreqtradeBot(conf))
     dummy.dummy_handler(bot=MagicMock(), update=update)
     assert dummy.state['called'] is False
     assert not log_has(
@@ -217,7 +216,7 @@ def test_authorized_only_exception(default_conf, mocker, caplog) -> None:
 
     conf = deepcopy(default_conf)
     conf['telegram']['enabled'] = False
-    dummy = DummyCls(FreqtradeBot(conf, create_engine('sqlite://')))
+    dummy = DummyCls(FreqtradeBot(conf))
     dummy.dummy_exception(bot=MagicMock(), update=update)
     assert dummy.state['called'] is False
     assert not log_has(
@@ -263,7 +262,7 @@ def test_status(default_conf, update, mocker, fee, ticker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -301,7 +300,7 @@ def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -348,7 +347,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
 
     conf = deepcopy(default_conf)
     conf['stake_amount'] = 15.0
-    freqtradebot = FreqtradeBot(conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -402,7 +401,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -470,7 +469,7 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Try invalid data
@@ -511,7 +510,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     telegram._profit(bot=MagicMock(), update=update)
@@ -608,7 +607,7 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
         send_msg=msg_mock
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     telegram._balance(bot=MagicMock(), update=update)
@@ -638,7 +637,7 @@ def test_zero_balance_handle(default_conf, update, mocker) -> None:
         send_msg=msg_mock
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     telegram._balance(bot=MagicMock(), update=update)
@@ -661,7 +660,7 @@ def test_start_handle(default_conf, update, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -685,7 +684,7 @@ def test_start_handle_already_running(default_conf, update, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.RUNNING
@@ -710,7 +709,7 @@ def test_stop_handle(default_conf, update, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.RUNNING
@@ -735,7 +734,7 @@ def test_stop_handle_already_stopped(default_conf, update, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -762,7 +761,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee, ticker_sell_up, moc
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -802,7 +801,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee, ticker_sell_do
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -847,7 +846,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None
         get_fee=fee
     )
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -880,7 +879,7 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.exchange.validate_pairs', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Trader is not running
@@ -927,7 +926,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
         get_fee=fee
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Create some test data
@@ -962,7 +961,7 @@ def test_performance_handle_invalid(default_conf, update, mocker) -> None:
         send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.exchange.validate_pairs', MagicMock())
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     # Trader is not running
@@ -991,7 +990,7 @@ def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
         buy=MagicMock(return_value={'id': 'mocked_order_id'})
     )
     mocker.patch('freqtrade.optimize.backtesting.exchange.get_fee', fee)
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
@@ -1027,7 +1026,7 @@ def test_help_handle(default_conf, update, mocker) -> None:
         _init=MagicMock(),
         send_msg=msg_mock
     )
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     telegram._help(bot=MagicMock(), update=update)
@@ -1047,7 +1046,7 @@ def test_version_handle(default_conf, update, mocker) -> None:
         _init=MagicMock(),
         send_msg=msg_mock
     )
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
 
     telegram._version(bot=MagicMock(), update=update)
@@ -1064,7 +1063,7 @@ def test_send_msg(default_conf, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
     conf = deepcopy(default_conf)
     bot = MagicMock()
-    freqtradebot = FreqtradeBot(conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(conf)
     telegram = Telegram(freqtradebot)
 
     telegram._config['telegram']['enabled'] = False
@@ -1087,7 +1086,7 @@ def test_send_msg_network_error(default_conf, mocker, caplog) -> None:
     conf = deepcopy(default_conf)
     bot = MagicMock()
     bot.send_message = MagicMock(side_effect=NetworkError('Oh snap'))
-    freqtradebot = FreqtradeBot(conf, create_engine('sqlite://'))
+    freqtradebot = FreqtradeBot(conf)
     telegram = Telegram(freqtradebot)
 
     telegram._config['telegram']['enabled'] = True

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -46,6 +46,11 @@ def test_parse_args_config() -> None:
     assert args.config == '/dev/null'
 
 
+def test_parse_args_db_url() -> None:
+    args = Arguments(['--db-url', 'sqlite:///test.sqlite'], '').get_parsed_arg()
+    assert args.db_url == 'sqlite:///test.sqlite'
+
+
 def test_parse_args_verbose() -> None:
     args = Arguments(['-v'], '').get_parsed_arg()
     assert args.loglevel == logging.DEBUG

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -118,7 +118,6 @@ def test_load_config(default_conf, mocker) -> None:
     assert validated_conf.get('strategy') == 'DefaultStrategy'
     assert validated_conf.get('strategy_path') is None
     assert 'dynamic_whitelist' not in validated_conf
-    assert 'dry_run_db' not in validated_conf
 
 
 def test_load_config_with_params(default_conf, mocker) -> None:
@@ -133,7 +132,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
         '--dynamic-whitelist', '10',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path',
-        '--dry-run-db',
+        '--db-url', 'sqlite:///someurl',
     ]
     args = Arguments(arglist, '').get_parsed_arg()
 
@@ -143,7 +142,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     assert validated_conf.get('dynamic_whitelist') == 10
     assert validated_conf.get('strategy') == 'TestStrategy'
     assert validated_conf.get('strategy_path') == '/some/path'
-    assert validated_conf.get('dry_run_db') is True
+    assert validated_conf.get('db_url') == 'sqlite:///someurl'
 
 
 def test_load_custom_strategy(default_conf, mocker) -> None:
@@ -178,7 +177,7 @@ def test_show_info(default_conf, mocker, caplog) -> None:
     arglist = [
         '--dynamic-whitelist', '10',
         '--strategy', 'TestStrategy',
-        '--dry-run-db'
+        '--db-url', 'sqlite:///tmp/testdb',
     ]
     args = Arguments(arglist, '').get_parsed_arg()
 
@@ -192,23 +191,8 @@ def test_show_info(default_conf, mocker, caplog) -> None:
         caplog.record_tuples
     )
 
-    assert log_has(
-        'Parameter --dry-run-db detected ...',
-        caplog.record_tuples
-    )
-
-    assert log_has(
-        'Dry_run will use the DB file: "tradesv3.dry_run.sqlite"',
-        caplog.record_tuples
-    )
-
-    # Test the Dry run condition
-    configuration.config.update({'dry_run': False})  # type: ignore
-    configuration._load_common_config(configuration.config)  # type: ignore
-    assert log_has(
-        'Dry run is disabled. (--dry_run_db ignored)',
-        caplog.record_tuples
-    )
+    assert log_has('Using DB: "sqlite:///tmp/testdb"', caplog.record_tuples)
+    assert log_has('Dry run is enabled', caplog.record_tuples)
 
 
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -406,9 +406,9 @@ def test_migrate_new(mocker, default_conf, fee):
                                      stake=default_conf.get("stake_amount"),
                                      amount=amount
                                      )
+    engine = create_engine('sqlite://')
     mocker.patch('freqtrade.persistence.create_engine', lambda *args, **kwargs: engine)
 
-    engine = create_engine('sqlite://')
     # Create table using the old format
     engine.execute(create_table_old)
     engine.execute(insert_table_old)

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -1,5 +1,5 @@
 # pragma pylint: disable=missing-docstring, C0103
-import os
+from copy import deepcopy
 
 import pytest
 from sqlalchemy import create_engine
@@ -21,77 +21,22 @@ def test_init_create_session(default_conf, mocker):
     assert 'Session' in type(Trade.session).__name__
 
 
-def test_init_dry_run_db(default_conf, mocker):
-    default_conf.update({'dry_run_db': True})
-    mocker.patch.dict('freqtrade.persistence._CONF', default_conf)
+def test_init_custom_db_url(default_conf, mocker):
+    conf = deepcopy(default_conf)
 
-    # First, protect the existing 'tradesv3.dry_run.sqlite' (Do not delete user data)
-    dry_run_db = 'tradesv3.dry_run.sqlite'
-    dry_run_db_swp = dry_run_db + '.swp'
-
-    if os.path.isfile(dry_run_db):
-        os.rename(dry_run_db, dry_run_db_swp)
+    # Update path to a value other than default, but still in-memory
+    conf.update({'db_url': 'sqlite:///'})
+    mocker.patch.dict('freqtrade.persistence._CONF', conf)
 
     # Check if the new tradesv3.dry_run.sqlite was created
-    init(default_conf)
-    assert os.path.isfile(dry_run_db) is True
-
-    # Delete the file made for this unitest and rollback to the previous
-    # tradesv3.dry_run.sqlite file
-
-    # 1. Delete file from the test
-    if os.path.isfile(dry_run_db):
-        os.remove(dry_run_db)
-
-    # 2. Rollback to the initial file
-    if os.path.isfile(dry_run_db_swp):
-        os.rename(dry_run_db_swp, dry_run_db)
-
-
-def test_init_dry_run_without_db(default_conf, mocker):
-    default_conf.update({'dry_run_db': False})
-    mocker.patch.dict('freqtrade.persistence._CONF', default_conf)
-
-    # First, protect the existing 'tradesv3.dry_run.sqlite' (Do not delete user data)
-    dry_run_db = 'tradesv3.dry_run.sqlite'
-    dry_run_db_swp = dry_run_db + '.swp'
-
-    if os.path.isfile(dry_run_db):
-        os.rename(dry_run_db, dry_run_db_swp)
-
-    # Check if the new tradesv3.dry_run.sqlite was created
-    init(default_conf)
-    assert os.path.isfile(dry_run_db) is False
-
-    # Rollback to the initial 'tradesv3.dry_run.sqlite' file
-    if os.path.isfile(dry_run_db_swp):
-        os.rename(dry_run_db_swp, dry_run_db)
+    init(conf)
 
 
 def test_init_prod_db(default_conf, mocker):
     default_conf.update({'dry_run': False})
     mocker.patch.dict('freqtrade.persistence._CONF', default_conf)
 
-    # First, protect the existing 'tradesv3.sqlite' (Do not delete user data)
-    prod_db = 'tradesv3.sqlite'
-    prod_db_swp = prod_db + '.swp'
-
-    if os.path.isfile(prod_db):
-        os.rename(prod_db, prod_db_swp)
-
-    # Check if the new tradesv3.sqlite was created
     init(default_conf)
-    assert os.path.isfile(prod_db) is True
-
-    # Delete the file made for this unitest and rollback to the previous tradesv3.sqlite file
-
-    # 1. Delete file from the test
-    if os.path.isfile(prod_db):
-        os.remove(prod_db)
-
-    # Rollback to the initial 'tradesv3.sqlite' file
-    if os.path.isfile(prod_db_swp):
-        os.rename(prod_db_swp, prod_db)
 
 
 @pytest.mark.usefixtures("init_persistence")
@@ -328,7 +273,7 @@ def test_calc_profit_percent(limit_buy_order, limit_sell_order, fee):
 
 
 def test_clean_dry_run_db(default_conf, fee):
-    init(default_conf, create_engine('sqlite://'))
+    init(default_conf)
 
     # Simulate dry_run entries
     trade = Trade(
@@ -377,7 +322,7 @@ def test_clean_dry_run_db(default_conf, fee):
     assert len(Trade.query.filter(Trade.open_order_id.isnot(None)).all()) == 1
 
 
-def test_migrate_old(default_conf, fee):
+def test_migrate_old(mocker, default_conf, fee):
     """
     Test Database migration(starting with old pairformat)
     """
@@ -409,11 +354,13 @@ def test_migrate_old(default_conf, fee):
                                      amount=amount
                                      )
     engine = create_engine('sqlite://')
+    mocker.patch('freqtrade.persistence.create_engine', lambda *args, **kwargs: engine)
+
     # Create table using the old format
     engine.execute(create_table_old)
     engine.execute(insert_table_old)
     # Run init to test migration
-    init(default_conf, engine)
+    init(default_conf)
 
     assert len(Trade.query.filter(Trade.id == 1).all()) == 1
     trade = Trade.query.filter(Trade.id == 1).first()
@@ -428,7 +375,7 @@ def test_migrate_old(default_conf, fee):
     assert trade.exchange == "bittrex"
 
 
-def test_migrate_new(default_conf, fee):
+def test_migrate_new(mocker, default_conf, fee):
     """
     Test Database migration (starting with new pairformat)
     """
@@ -459,12 +406,14 @@ def test_migrate_new(default_conf, fee):
                                      stake=default_conf.get("stake_amount"),
                                      amount=amount
                                      )
+    mocker.patch('freqtrade.persistence.create_engine', lambda *args, **kwargs: engine)
+
     engine = create_engine('sqlite://')
     # Create table using the old format
     engine.execute(create_table_old)
     engine.execute(insert_table_old)
     # Run init to test migration
-    init(default_conf, engine)
+    init(default_conf)
 
     assert len(Trade.query.filter(Trade.id == 1).all()) == 1
     trade = Trade.query.filter(Trade.id == 1).first()


### PR DESCRIPTION
## Summary
This PR removes `--dry-run-db` flag and replaces it with `--db-url`.
This argument takes a string and defaults to `sqlite:///tradesv3.sqlite` if not specified. It still defaults to `sqlite://` if dry_run is enabled.

The motivation for this change it to allow more flexible deployments.

To get a persistent db in dry_run the new command would look like this:
```
$ freqtrade --db-url sqlite:///tradesv3.dryrun.sqlite
```


Solve the issue: #274

## Quick changelog

- drop `--dry-run-db` and replace it with `--db-url`

## What's new?

### New Usage:
```
usage: freqtrade [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
                 [--strategy-path PATH] [--dynamic-whitelist [INT]]
                 [--db-url PATH]
                 {backtesting,hyperopt} ...

Simple High Frequency Trading Bot for crypto currencies

positional arguments:
  {backtesting,hyperopt}
    backtesting         backtesting module
    hyperopt            hyperopt module

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         be verbose
  --version             show program's version number and exit
  -c PATH, --config PATH
                        specify configuration file (default: config.json)
  -d PATH, --datadir PATH
                        path to backtest data
  -s NAME, --strategy NAME
                        specify strategy class name (default: DefaultStrategy)
  --strategy-path PATH  specify additional strategy lookup path
  --dynamic-whitelist [INT]
                        dynamically generate and update whitelist based on 24h
                        BaseVolume (default: 20)
  --db-url PATH         Override trades database URL, this is useful if
                        dry_run is enabled or in custom deployments (default:
                        sqlite:///tradesv3.sqlite)
```