### PR TITLE
Partial candle removal

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -62,6 +62,7 @@ class Analyze(object):
             'close': 'last',
             'volume': 'max',
         })
+        frame.drop(frame.tail(1).index, inplace=True) # eliminate partial candle
         return frame
 
     def populate_indicators(self, dataframe: DataFrame) -> DataFrame:

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -62,7 +62,7 @@ class Analyze(object):
             'close': 'last',
             'volume': 'max',
         })
-        frame.drop(frame.tail(1).index, inplace=True) # eliminate partial candle
+        frame.drop(frame.tail(1).index, inplace=True)     # eliminate partial candle
         return frame
 
     def populate_indicators(self, dataframe: DataFrame) -> DataFrame:

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -317,7 +317,7 @@ def test_tickerdata_to_dataframe(default_conf, mocker) -> None:
 
     backtesting = Backtesting(default_conf)
     data = backtesting.tickerdata_to_dataframe(tickerlist)
-    assert len(data['UNITTEST/BTC']) == 100
+    assert len(data['UNITTEST/BTC']) == 99
 
     # Load Analyze to compare the result between Backtesting function and Analyze are the same
     analyze = Analyze(default_conf)
@@ -341,7 +341,7 @@ def test_get_timeframe(default_conf, mocker) -> None:
     )
     min_date, max_date = backtesting.get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
-    assert max_date.isoformat() == '2017-11-14T22:59:00+00:00'
+    assert max_date.isoformat() == '2017-11-14T22:58:00+00:00'
 
 
 def test_generate_text_table(default_conf, mocker):
@@ -478,7 +478,7 @@ def test_processed(default_conf, mocker) -> None:
 
 def test_backtest_pricecontours(default_conf, fee, mocker) -> None:
     mocker.patch('freqtrade.optimize.backtesting.exchange.get_fee', fee)
-    tests = [['raise', 17], ['lower', 0], ['sine', 17]]
+    tests = [['raise', 17], ['lower', 0], ['sine', 16]]
     for [contour, numres] in tests:
         simple_backtest(default_conf, contour, numres, mocker)
 

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -46,7 +46,7 @@ def test_analyze_object() -> None:
 
 def test_dataframe_correct_length(result):
     dataframe = Analyze.parse_ticker_dataframe(result)
-    assert len(result.index) == len(dataframe.index)
+    assert len(result.index) - 1 == len(dataframe.index)    # last partial candle removed
 
 
 def test_dataframe_correct_columns(result):
@@ -188,4 +188,4 @@ def test_tickerdata_to_dataframe(default_conf) -> None:
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m', timerange=timerange)
     tickerlist = {'UNITTEST/BTC': tick}
     data = analyze.tickerdata_to_dataframe(tickerlist)
-    assert len(data['UNITTEST/BTC']) == 100
+    assert len(data['UNITTEST/BTC']) == 99 # partial candle was removed

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -188,4 +188,4 @@ def test_tickerdata_to_dataframe(default_conf) -> None:
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m', timerange=timerange)
     tickerlist = {'UNITTEST/BTC': tick}
     data = analyze.tickerdata_to_dataframe(tickerlist)
-    assert len(data['UNITTEST/BTC']) == 99 # partial candle was removed
+    assert len(data['UNITTEST/BTC']) == 99       # partial candle was removed

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -39,7 +39,7 @@ def test_datesarray_to_datetimearray(ticker_history):
     assert dates[0].minute == 50
 
     date_len = len(dates)
-    assert date_len == 3
+    assert date_len == 2
 
 
 def test_common_datearray(default_conf) -> None:


### PR DESCRIPTION
Continuing the efforts towards fixing https://github.com/freqtrade/freqtrade/issues/746 . After merging the look-ahead fix for backtesting in #855 , this PR continues by disabling similar behaviour in live operations by removing the last candle which almost always is a partial candle from the indicator calculations so that strategies do not get thrown off by the intra-candle fluctuations of a partial candle.
