### PR TITLE
fix /profit percentage calculation

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -9,6 +9,7 @@ from typing import Dict, Tuple, Any
 import arrow
 import sqlalchemy as sql
 from pandas import DataFrame
+from numpy import mean, nan_to_num
 
 from freqtrade import exchange
 from freqtrade.misc import shorten_date
@@ -209,14 +210,14 @@ class RPC(object):
         fiat = self.freqtrade.fiat_converter
         # Prepare data to display
         profit_closed_coin = round(sum(profit_closed_coin), 8)
-        profit_closed_percent = round(sum(profit_closed_percent) * 100, 2)
+        profit_closed_percent = round(nan_to_num(mean(profit_closed_percent)) * 100, 2)
         profit_closed_fiat = fiat.convert_amount(
             profit_closed_coin,
             stake_currency,
             fiat_display_currency
         )
         profit_all_coin = round(sum(profit_all_coin), 8)
-        profit_all_percent = round(sum(profit_all_percent) * 100, 2)
+        profit_all_percent = round(nan_to_num(mean(profit_all_percent)) * 100, 2)
         profit_all_fiat = fiat.convert_amount(
             profit_all_coin,
             stake_currency,

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -206,15 +206,30 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     trade.close_date = datetime.utcnow()
     trade.is_open = False
 
+    freqtradebot.create_trade()
+    trade = Trade.query.first()
+    # Simulate fulfilled LIMIT_BUY order for trade
+    trade.update(limit_buy_order)
+
+    # Update the ticker with a market going up
+    mocker.patch.multiple(
+        'freqtrade.freqtradebot.exchange',
+        validate_pairs=MagicMock(),
+        get_ticker=ticker_sell_up
+    )
+    trade.update(limit_sell_order)
+    trade.close_date = datetime.utcnow()
+    trade.is_open = False
+
     (error, stats) = rpc.rpc_trade_statistics(stake_currency, fiat_display_currency)
     assert not error
     assert prec_satoshi(stats['profit_closed_coin'], 6.217e-05)
     assert prec_satoshi(stats['profit_closed_percent'], 6.2)
     assert prec_satoshi(stats['profit_closed_fiat'], 0.93255)
-    assert prec_satoshi(stats['profit_all_coin'], 6.217e-05)
-    assert prec_satoshi(stats['profit_all_percent'], 6.2)
-    assert prec_satoshi(stats['profit_all_fiat'], 0.93255)
-    assert stats['trade_count'] == 1
+    assert prec_satoshi(stats['profit_all_coin'], 5.632e-05)
+    assert prec_satoshi(stats['profit_all_percent'], 2.81)
+    assert prec_satoshi(stats['profit_all_fiat'], 0.8448)
+    assert stats['trade_count'] == 2
     assert stats['first_trade_date'] == 'just now'
     assert stats['latest_trade_date'] == 'just now'
     assert stats['avg_duration'] == '0:00:00'


### PR DESCRIPTION
## Summary
Currently, the bot sums the percentage as well as the absolute profit when `/profit` is called.

for Profit, this is fine, however percentage should not be summed up.

Solve the issue: #629

## Quick changelog

- use mean for percentage (aligend with backtesting)

backtesting example:
https://github.com/freqtrade/freqtrade/blob/ad510b8b5f259efc1b730d397dc86e351bba9461/freqtrade/optimize/backtesting.py#L80

## What's new?

before on a well-worn database of a now stopped testing bot
```
ROI: Close trades
∙ -0.12266488 ETH (-122.54%)
∙ -74.616 USD
ROI: All trades
∙ -0.14937144 ETH (-149.22%)
∙ -90.861 USD
Total Trade Count: 142
First Trade opened: 23 days ago
Latest Trade opened: 2 days ago
Avg. Duration: 1 day, 11:55:55
Best Performing: VEN/ETH: 10.08%
```

after: 
```
ROI: Close trades
∙ -0.12266488 ETH (-0.90%)
∙ -74.616 USD
ROI: All trades
∙ -0.14933654 ETH (-1.05%)
∙ -90.840 USD
Total Trade Count: 142
First Trade opened: 23 days ago
Latest Trade opened: 2 days ago
Avg. Duration: 1 day, 11:55:55
Best Performing: VEN/ETH: 10.08%
```