### PR TITLE
update windows install documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,6 @@ To understand how to set up the bot please read the [Bot Configuration](https://
 	- [MacOS](#macos)
 	- [Setup Config and virtual env](#setup-config-and-virtual-env)
 * [Windows](#windows)
-	
 
 <!-- /TOC -->
 
@@ -35,7 +34,9 @@ usage:
 ```
 
 ### --install
+
 This script will install everything you need to run the bot:
+
 * Mandatory software as: `Python3`, `ta-lib`, `wget`
 * Setup your virtualenv
 * Configure your `config.json` file
@@ -43,12 +44,15 @@ This script will install everything you need to run the bot:
 This script is a combination of `install script` `--reset`, `--config`
 
 ### --update
+
 Update parameter will pull the last version of your current branch and update your virtualenv.
 
 ### --reset
+
 Reset parameter will hard reset your branch (only if you are on `master` or `develop`) and recreate your virtualenv.
 
 ### --config
+
 Config parameter is a `config.json` configurator. This script will ask you questions to setup your bot and create your `config.json`.
 
 ------
@@ -62,7 +66,6 @@ Start by downloading Docker for your platform:
 * [Linux](https://www.docker.com/products/docker#/linux)
 
 Once you have Docker installed, simply create the config file (e.g. `config.json`) and then create a Docker image for `freqtrade` using the Dockerfile in this repo.
-
 
 ### 1. Prepare the Bot
 
@@ -95,15 +98,16 @@ cp -n config.json.example config.json
 #### 1.5. Create your database file *(optional - the bot will create it if it is missing)*
 
 Production
+
 ```bash
 touch tradesv3.sqlite
 ````
 
 Dry-Run
+
 ```bash
 touch tradesv3.dryrun.sqlite
 ```
-
 
 ### 2. Build the Docker image
 
@@ -114,7 +118,6 @@ docker build -t freqtrade .
 
 For security reasons, your configuration file will not be included in the image, you will need to bind mount it. It is also advised to bind mount an SQLite database file (see the "5. Run a restartable docker image" section) to keep it between  updates.
 
-
 ### 3. Verify the Docker image
 
 After the build process you can verify that the image was created with:
@@ -122,7 +125,6 @@ After the build process you can verify that the image was created with:
 ```bash
 docker images
 ```
-
 
 ### 4. Run the Docker image
 
@@ -132,15 +134,15 @@ You can run a one-off container that is immediately deleted upon exiting with th
 docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
 
-There is known issue in OSX Docker versions after 17.09.1, whereby /etc/localtime cannot be shared causing Docker to not start. A work-around for this is to start with the following cmd. 
+There is known issue in OSX Docker versions after 17.09.1, whereby /etc/localtime cannot be shared causing Docker to not start. A work-around for this is to start with the following cmd.
 
 ```bash
 docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
-More information on this docker issue and work-around can be read here: https://github.com/docker/for-mac/issues/2396
+
+More information on this docker issue and work-around can be read [here](https://github.com/docker/for-mac/issues/2396)
 
 In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
-
 
 ### 5. Run a restartable docker image
 
@@ -164,6 +166,7 @@ docker run -d \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
   freqtrade --db-url sqlite:///tradesv3.sqlite
 ```
+
 NOTE: db-url defaults to `sqlite:///tradesv3.sqlite` but it defaults to `sqlite://` if `dry_run=True` is being used.
 To override this behaviour use a custom db-url value: i.e.: `--db-url sqlite:///tradesv3.dryrun.sqlite`
 
@@ -190,12 +193,12 @@ We've included/collected install instructions for Ubuntu 16.04, MacOS, and Windo
 ### Requirements
 
 Click each one for install guide:
+
 * [Python 3.6.x](http://docs.python-guide.org/en/latest/starting/installation/), note the bot was not tested on Python >= 3.7.x
 * [pip](https://pip.pypa.io/en/stable/installing/)
 * [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
 * [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html)
-
 
 ### Linux - Ubuntu 16.04
 
@@ -240,17 +243,12 @@ Clone the git repository:
 git clone https://github.com/freqtrade/freqtrade.git
 ```
 
-Optionally checkout the develop branch:
-
-```bash
-git checkout develop
-```
-
 #### 5. Configure `freqtrade` as a `systemd` service
 
 From the freqtrade repo... copy `freqtrade.service` to your systemd user directory (usually `~/.config/systemd/user`) and update `WorkingDirectory` and `ExecStart` to match your setup.
 
 After that you can start the daemon with:
+
 ```bash
 systemctl --user start freqtrade
 ```
@@ -260,7 +258,6 @@ For this to be persistent (run when user is logged out) you'll need to enable `l
 ```bash
 sudo loginctl enable-linger "$USER"
 ```
-
 
 ### MacOS
 
@@ -296,7 +293,6 @@ Optionally checkout the develop branch:
 git checkout develop
 ```
 
-
 ### Setup Config and virtual env
 
 #### 1. Initialize the configuration
@@ -307,7 +303,6 @@ cp config.json.example config.json
 ```
 
 > *To edit the config please refer to [Bot Configuration](https://github.com/freqtrade/freqtrade/blob/develop/docs/configuration.md).*
-
 
 #### 2. Setup your Python virtual environment (virtualenv)
 
@@ -331,12 +326,26 @@ python3.6 ./freqtrade/main.py -c config.json
 
 ## Windows
 
-We recommend that Windows users use [Docker](#docker) as this will work
-much easier and smoother (also more secure).
+We recommend that Windows users use [Docker](#docker) as this will work much easier and smoother (also more secure).
 
-### Install freqtrade
+If that is not possible, try using the Windows Linux subsystem (WSL) - for which the Ubuntu instructions should work.
+If that is not available on your system, feel free to try the instructions below, which led to success for some.
+
+### Install freqtrade manually
+
+#### Clone the git repository
+
+```bash
+git clone https://github.com/freqtrade/freqtrade.git
+```
 
 copy paste `config.json` to ``\path\freqtrade-develop\freqtrade`
+
+#### install ta-lib
+
+Install ta-lib according to the [ta-lib documentation](https://github.com/mrjbq7/ta-lib#windows).
+
+As compiling from source on windows has heavy dependencies (requires a partial visual studio installation), there is also a repository of inofficial precompiled windows Wheels [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#ta-lib), which needs to be downloaded and installed using `pip install TA_Lib‑0.4.17‑cp36‑cp36m‑win32.whl` (make sure to use the version matching your python version)
 
 ```cmd
 >cd \path\freqtrade-develop
@@ -344,14 +353,14 @@ copy paste `config.json` to ``\path\freqtrade-develop\freqtrade`
 >cd .env\Scripts
 >activate.bat
 >cd \path\freqtrade-develop
+REM optionally install ta-lib from wheel
+REM >pip install TA_Lib‑0.4.17‑cp36‑cp36m‑win32.whl
 >pip install -r requirements.txt
 >pip install -e .
->cd freqtrade
->python main.py
+>python freqtrade\main.py
 ```
 
 > Thanks [Owdr](https://github.com/Owdr) for the commands. Source: [Issue #222](https://github.com/freqtrade/freqtrade/issues/222)
-
 
 Now you have an environment ready, the next step is
 [Bot Configuration](https://github.com/freqtrade/freqtrade/blob/develop/docs/configuration.md)...


### PR DESCRIPTION
## Summary
this is after i struggled with it myself.
improve windows installation documentation (mainly regarding ta-lib installation)


* removed a reference to checkout the develop-branch - which has become the default branch - so this step was unnecessary.
* improved steps for windows install
* referenced ta-lib wheel installation (as does the official documentation)
* make markdownlint a "little" happier ... (even though not all issues are fixed since we don't test for it anyway

