### PR TITLE
Simplify RPCManager and RPC module to implement other clients

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -304,9 +304,9 @@ class RPC(object):
 
         return '*Status:* `already stopped`'
 
-    def rpc_reload_conf(self) -> str:
+    def _rpc_reload_conf(self) -> str:
         """ Handler for reload_conf. """
-        self.freqtrade.state = State.RELOAD_CONF
+        self._freqtrade.state = State.RELOAD_CONF
         return '*Status:* `Reloading config ...`'
 
     # FIX: no test for this!!!!

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 
 
 class RPCException(Exception):
+    """
+    Should be raised with a rpc-formatted message in an _rpc_* method
+    if the required state is wrong, i.e.:
+
+    raise RPCException('*Status:* `no active trade`')
+    """
     pass
 
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -2,20 +2,20 @@
 This module contains class to define a RPC communications
 """
 import logging
+from abc import abstractmethod
 from datetime import datetime, timedelta, date
 from decimal import Decimal
 from typing import Dict, Tuple, Any
 
 import arrow
 import sqlalchemy as sql
-from pandas import DataFrame
 from numpy import mean, nan_to_num
+from pandas import DataFrame
 
 from freqtrade import exchange
 from freqtrade.misc import shorten_date
 from freqtrade.persistence import Trade
 from freqtrade.state import State
-
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,19 @@ class RPC(object):
         :return: None
         """
         self.freqtrade = freqtrade
+
+    @abstractmethod
+    def cleanup(self) -> str:
+        """ Cleanup pending module resources """
+
+    @property
+    @abstractmethod
+    def name(self) -> None:
+        """ Returns the lowercase name of this module """
+
+    @abstractmethod
+    def send_msg(self, msg: str) -> None:
+        """ Sends a message to all registered rpc modules """
 
     def rpc_trade_status(self) -> Tuple[bool, Any]:
         """

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -25,8 +25,9 @@ class RPCManager(object):
 
     def cleanup(self) -> None:
         """ Stops all enabled rpc modules """
+        logger.info('Cleaning up rpc modules ...')
         for mod in self.registered_modules:
-            logger.info('Cleaning up rpc.%s ...', mod.name)
+            logger.debug('Cleaning up rpc.%s ...', mod.name)
             mod.cleanup()
 
         self.registered_modules = []

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -26,11 +26,11 @@ class RPCManager(object):
     def cleanup(self) -> None:
         """ Stops all enabled rpc modules """
         logger.info('Cleaning up rpc modules ...')
-        for mod in self.registered_modules:
+        while self.registered_modules:
+            mod = self.registered_modules.pop()
             logger.debug('Cleaning up rpc.%s ...', mod.name)
             mod.cleanup()
-
-        self.registered_modules = []
+            del mod
 
     def send_msg(self, msg: str) -> None:
         """

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -1,11 +1,11 @@
 """
 This module contains class to manage RPC communications (Telegram, Slack, ...)
 """
-from typing import Any, List
 import logging
+from typing import List
 
+from freqtrade.rpc.rpc import RPC
 from freqtrade.rpc.telegram import Telegram
-
 
 logger = logging.getLogger(__name__)
 
@@ -15,36 +15,21 @@ class RPCManager(object):
     Class to manage RPC objects (Telegram, Slack, ...)
     """
     def __init__(self, freqtrade) -> None:
-        """
-        Initializes all enabled rpc modules
-        :param config: config to use
-        :return: None
-        """
-        self.freqtrade = freqtrade
+        """ Initializes all enabled rpc modules """
+        self.registered_modules: List[RPC] = []
 
-        self.registered_modules: List[str] = []
-        self.telegram: Any = None
-        self._init()
-
-    def _init(self) -> None:
-        """
-        Init RPC modules
-        :return:
-        """
-        if self.freqtrade.config['telegram'].get('enabled', False):
+        # Enable telegram
+        if freqtrade.config['telegram'].get('enabled', False):
             logger.info('Enabling rpc.telegram ...')
-            self.registered_modules.append('telegram')
-            self.telegram = Telegram(self.freqtrade)
+            self.registered_modules.append(Telegram(freqtrade))
 
     def cleanup(self) -> None:
-        """
-        Stops all enabled rpc modules
-        :return: None
-        """
-        if 'telegram' in self.registered_modules:
-            logger.info('Cleaning up rpc.telegram ...')
-            self.registered_modules.remove('telegram')
-            self.telegram.cleanup()
+        """ Stops all enabled rpc modules """
+        for mod in self.registered_modules:
+            logger.info('Cleaning up rpc.%s ...', mod.name)
+            mod.cleanup()
+
+        self.registered_modules = []
 
     def send_msg(self, msg: str) -> None:
         """
@@ -52,6 +37,7 @@ class RPCManager(object):
         :param msg: message
         :return: None
         """
-        logger.info(msg)
-        if 'telegram' in self.registered_modules:
-            self.telegram.send_msg(msg)
+        logger.info('Sending rpc message: %s', msg)
+        for mod in self.registered_modules:
+            logger.debug('Forwarding message to rpc.%s', mod.name)
+            mod.send_msg(msg)

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -5,7 +5,6 @@ import logging
 from typing import List
 
 from freqtrade.rpc.rpc import RPC
-from freqtrade.rpc.telegram import Telegram
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +20,7 @@ class RPCManager(object):
         # Enable telegram
         if freqtrade.config['telegram'].get('enabled', False):
             logger.info('Enabling rpc.telegram ...')
+            from freqtrade.rpc.telegram import Telegram
             self.registered_modules.append(Telegram(freqtrade))
 
     def cleanup(self) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -16,6 +16,8 @@ from freqtrade.rpc.rpc import RPC, RPCException
 
 logger = logging.getLogger(__name__)
 
+logger.debug('Included module rpc.telegram ...')
+
 
 def authorized_only(command_handler: Callable[[Any, Bot, Update], None]) -> Callable[..., Any]:
     """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -26,9 +26,7 @@ def authorized_only(command_handler: Callable[[Any, Bot, Update], None]) -> Call
     :return: decorated function
     """
     def wrapper(self, *args, **kwargs):
-        """
-        Decorator logic
-        """
+        """ Decorator logic """
         update = kwargs.get('update') or args[1]
 
         # Reject unauthorized messages
@@ -55,9 +53,7 @@ def authorized_only(command_handler: Callable[[Any, Bot, Update], None]) -> Call
 
 
 class Telegram(RPC):
-    """
-    Telegram, this class send messages to Telegram
-    """
+    """  This class handles all telegram communication """
 
     @property
     def name(self) -> str:
@@ -241,9 +237,7 @@ class Telegram(RPC):
 
     @authorized_only
     def _balance(self, bot: Bot, update: Update) -> None:
-        """
-        Handler for /balance
-        """
+        """ Handler for /balance """
         try:
             currencys, total, symbol, value = \
                 self._rpc_balance(self._config['fiat_display_currency'])

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -289,8 +289,8 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        msg = self.rpc_reload_conf()
-        self.send_msg(msg, bot=bot)
+        msg = self._rpc_reload_conf()
+        self._send_msg(msg, bot=bot)
 
     @authorized_only
     def _forcesell(self, bot: Bot, update: Update) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -12,7 +12,7 @@ from telegram.error import NetworkError, TelegramError
 from telegram.ext import CommandHandler, Updater
 
 from freqtrade.__init__ import __version__
-from freqtrade.rpc.rpc import RPC
+from freqtrade.rpc.rpc import RPC, RPCException
 
 logger = logging.getLogger(__name__)
 
@@ -151,13 +151,11 @@ class Telegram(RPC):
             self._status_table(bot, update)
             return
 
-        # Fetch open trade
-        (error, trades) = self.rpc_trade_status()
-        if error:
-            self._send_msg(trades, bot=bot)
-        else:
-            for trademsg in trades:
-                self._send_msg(trademsg, bot=bot)
+        try:
+            for trade_msg in self._rpc_trade_status():
+                self._send_msg(trade_msg, bot=bot)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _status_table(self, bot: Bot, update: Update) -> None:
@@ -168,15 +166,12 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        # Fetch open trade
-        (err, df_statuses) = self.rpc_status_table()
-        if err:
-            self._send_msg(df_statuses, bot=bot)
-        else:
+        try:
+            df_statuses = self._rpc_status_table()
             message = tabulate(df_statuses, headers='keys', tablefmt='simple')
-            message = "<pre>{}</pre>".format(message)
-
-            self._send_msg(message, parse_mode=ParseMode.HTML)
+            self._send_msg("<pre>{}</pre>".format(message), parse_mode=ParseMode.HTML)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _daily(self, bot: Bot, update: Update) -> None:
@@ -191,14 +186,12 @@ class Telegram(RPC):
             timescale = int(update.message.text.replace('/daily', '').strip())
         except (TypeError, ValueError):
             timescale = 7
-        (error, stats) = self.rpc_daily_profit(
-            timescale,
-            self._config['stake_currency'],
-            self._config['fiat_display_currency']
-        )
-        if error:
-            self._send_msg(stats, bot=bot)
-        else:
+        try:
+            stats = self._rpc_daily_profit(
+                timescale,
+                self._config['stake_currency'],
+                self._config['fiat_display_currency']
+            )
             stats = tabulate(stats,
                              headers=[
                                  'Day',
@@ -207,11 +200,10 @@ class Telegram(RPC):
                              ],
                              tablefmt='simple')
             message = '<b>Daily Profit over the last {} days</b>:\n<pre>{}</pre>'\
-                      .format(
-                          timescale,
-                          stats
-                      )
+                      .format(timescale, stats)
             self._send_msg(message, bot=bot, parse_mode=ParseMode.HTML)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _profit(self, bot: Bot, update: Update) -> None:
@@ -222,67 +214,65 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        (error, stats) = self.rpc_trade_statistics(
-            self._config['stake_currency'],
-            self._config['fiat_display_currency']
-        )
-        if error:
-            self._send_msg(stats, bot=bot)
-            return
+        try:
+            stats = self._rpc_trade_statistics(
+                self._config['stake_currency'],
+                self._config['fiat_display_currency'])
 
-        # Message to display
-        markdown_msg = "*ROI:* Close trades\n" \
-                       "∙ `{profit_closed_coin:.8f} {coin} ({profit_closed_percent:.2f}%)`\n" \
-                       "∙ `{profit_closed_fiat:.3f} {fiat}`\n" \
-                       "*ROI:* All trades\n" \
-                       "∙ `{profit_all_coin:.8f} {coin} ({profit_all_percent:.2f}%)`\n" \
-                       "∙ `{profit_all_fiat:.3f} {fiat}`\n" \
-                       "*Total Trade Count:* `{trade_count}`\n" \
-                       "*First Trade opened:* `{first_trade_date}`\n" \
-                       "*Latest Trade opened:* `{latest_trade_date}`\n" \
-                       "*Avg. Duration:* `{avg_duration}`\n" \
-                       "*Best Performing:* `{best_pair}: {best_rate:.2f}%`"\
-                       .format(
-                           coin=self._config['stake_currency'],
-                           fiat=self._config['fiat_display_currency'],
-                           profit_closed_coin=stats['profit_closed_coin'],
-                           profit_closed_percent=stats['profit_closed_percent'],
-                           profit_closed_fiat=stats['profit_closed_fiat'],
-                           profit_all_coin=stats['profit_all_coin'],
-                           profit_all_percent=stats['profit_all_percent'],
-                           profit_all_fiat=stats['profit_all_fiat'],
-                           trade_count=stats['trade_count'],
-                           first_trade_date=stats['first_trade_date'],
-                           latest_trade_date=stats['latest_trade_date'],
-                           avg_duration=stats['avg_duration'],
-                           best_pair=stats['best_pair'],
-                           best_rate=stats['best_rate']
-                       )
-        self._send_msg(markdown_msg, bot=bot)
+            # Message to display
+            markdown_msg = "*ROI:* Close trades\n" \
+                           "∙ `{profit_closed_coin:.8f} {coin} ({profit_closed_percent:.2f}%)`\n" \
+                           "∙ `{profit_closed_fiat:.3f} {fiat}`\n" \
+                           "*ROI:* All trades\n" \
+                           "∙ `{profit_all_coin:.8f} {coin} ({profit_all_percent:.2f}%)`\n" \
+                           "∙ `{profit_all_fiat:.3f} {fiat}`\n" \
+                           "*Total Trade Count:* `{trade_count}`\n" \
+                           "*First Trade opened:* `{first_trade_date}`\n" \
+                           "*Latest Trade opened:* `{latest_trade_date}`\n" \
+                           "*Avg. Duration:* `{avg_duration}`\n" \
+                           "*Best Performing:* `{best_pair}: {best_rate:.2f}%`"\
+                           .format(
+                               coin=self._config['stake_currency'],
+                               fiat=self._config['fiat_display_currency'],
+                               profit_closed_coin=stats['profit_closed_coin'],
+                               profit_closed_percent=stats['profit_closed_percent'],
+                               profit_closed_fiat=stats['profit_closed_fiat'],
+                               profit_all_coin=stats['profit_all_coin'],
+                               profit_all_percent=stats['profit_all_percent'],
+                               profit_all_fiat=stats['profit_all_fiat'],
+                               trade_count=stats['trade_count'],
+                               first_trade_date=stats['first_trade_date'],
+                               latest_trade_date=stats['latest_trade_date'],
+                               avg_duration=stats['avg_duration'],
+                               best_pair=stats['best_pair'],
+                               best_rate=stats['best_rate']
+                           )
+            self._send_msg(markdown_msg, bot=bot)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _balance(self, bot: Bot, update: Update) -> None:
         """
         Handler for /balance
         """
-        (error, result) = self.rpc_balance(self._config['fiat_display_currency'])
-        if error:
-            self._send_msg('`All balances are zero.`')
-            return
+        try:
+            currencys, total, symbol, value = \
+                self._rpc_balance(self._config['fiat_display_currency'])
+            output = ''
+            for currency in currencys:
+                output += "*{currency}:*\n" \
+                          "\t`Available: {available: .8f}`\n" \
+                          "\t`Balance: {balance: .8f}`\n" \
+                          "\t`Pending: {pending: .8f}`\n" \
+                          "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
 
-        (currencys, total, symbol, value) = result
-        output = ''
-        for currency in currencys:
-            output += "*{currency}:*\n" \
-                      "\t`Available: {available: .8f}`\n" \
-                      "\t`Balance: {balance: .8f}`\n" \
-                      "\t`Pending: {pending: .8f}`\n" \
-                      "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
-
-        output += "\n*Estimated Value*:\n" \
-                  "\t`BTC: {0: .8f}`\n" \
-                  "\t`{1}: {2: .2f}`\n".format(total, symbol, value)
-        self._send_msg(output)
+            output += "\n*Estimated Value*:\n" \
+                      "\t`BTC: {0: .8f}`\n" \
+                      "\t`{1}: {2: .2f}`\n".format(total, symbol, value)
+            self._send_msg(output, bot=bot)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _start(self, bot: Bot, update: Update) -> None:
@@ -293,9 +283,8 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        (error, msg) = self.rpc_start()
-        if error:
-            self._send_msg(msg, bot=bot)
+        msg = self._rpc_start()
+        self._send_msg(msg, bot=bot)
 
     @authorized_only
     def _stop(self, bot: Bot, update: Update) -> None:
@@ -306,7 +295,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        (error, msg) = self.rpc_stop()
+        msg = self._rpc_stop()
         self._send_msg(msg, bot=bot)
 
     @authorized_only
@@ -332,10 +321,10 @@ class Telegram(RPC):
         """
 
         trade_id = update.message.text.replace('/forcesell', '').strip()
-        (error, message) = self.rpc_forcesell(trade_id)
-        if error:
-            self._send_msg(message, bot=bot)
-            return
+        try:
+            self._rpc_forcesell(trade_id)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _performance(self, bot: Bot, update: Update) -> None:
@@ -346,19 +335,18 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        (error, trades) = self.rpc_performance()
-        if error:
-            self._send_msg(trades, bot=bot)
-            return
-
-        stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
-            index=i + 1,
-            pair=trade['pair'],
-            profit=trade['profit'],
-            count=trade['count']
-        ) for i, trade in enumerate(trades))
-        message = '<b>Performance:</b>\n{}'.format(stats)
-        self._send_msg(message, parse_mode=ParseMode.HTML)
+        try:
+            trades = self._rpc_performance()
+            stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
+                index=i + 1,
+                pair=trade['pair'],
+                profit=trade['profit'],
+                count=trade['count']
+            ) for i, trade in enumerate(trades))
+            message = '<b>Performance:</b>\n{}'.format(stats)
+            self._send_msg(message, parse_mode=ParseMode.HTML)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _count(self, bot: Bot, update: Update) -> None:
@@ -369,19 +357,18 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        (error, trades) = self.rpc_count()
-        if error:
-            self._send_msg(trades, bot=bot)
-            return
-
-        message = tabulate({
-            'current': [len(trades)],
-            'max': [self._config['max_open_trades']],
-            'total stake': [sum((trade.open_rate * trade.amount) for trade in trades)]
-        }, headers=['current', 'max', 'total stake'], tablefmt='simple')
-        message = "<pre>{}</pre>".format(message)
-        logger.debug(message)
-        self._send_msg(message, parse_mode=ParseMode.HTML)
+        try:
+            trades = self._rpc_count()
+            message = tabulate({
+                'current': [len(trades)],
+                'max': [self._config['max_open_trades']],
+                'total stake': [sum((trade.open_rate * trade.amount) for trade in trades)]
+            }, headers=['current', 'max', 'total stake'], tablefmt='simple')
+            message = "<pre>{}</pre>".format(message)
+            logger.debug(message)
+            self._send_msg(message, parse_mode=ParseMode.HTML)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
 
     @authorized_only
     def _help(self, bot: Bot, update: Update) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -14,7 +14,6 @@ from telegram.ext import CommandHandler, Updater
 from freqtrade.__init__ import __version__
 from freqtrade.rpc.rpc import RPC
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -57,6 +56,11 @@ class Telegram(RPC):
     """
     Telegram, this class send messages to Telegram
     """
+
+    @property
+    def name(self) -> str:
+        return "telegram"
+
     def __init__(self, freqtrade) -> None:
         """
         Init the Telegram call, and init the super class RPC
@@ -120,6 +124,10 @@ class Telegram(RPC):
 
         self._updater.stop()
 
+    def send_msg(self, msg: str) -> None:
+        """ Send a message to telegram channel """
+        self._send_msg(msg)
+
     def is_enabled(self) -> bool:
         """
         Returns True if the telegram module is activated, False otherwise
@@ -146,10 +154,10 @@ class Telegram(RPC):
         # Fetch open trade
         (error, trades) = self.rpc_trade_status()
         if error:
-            self.send_msg(trades, bot=bot)
+            self._send_msg(trades, bot=bot)
         else:
             for trademsg in trades:
-                self.send_msg(trademsg, bot=bot)
+                self._send_msg(trademsg, bot=bot)
 
     @authorized_only
     def _status_table(self, bot: Bot, update: Update) -> None:
@@ -163,12 +171,12 @@ class Telegram(RPC):
         # Fetch open trade
         (err, df_statuses) = self.rpc_status_table()
         if err:
-            self.send_msg(df_statuses, bot=bot)
+            self._send_msg(df_statuses, bot=bot)
         else:
             message = tabulate(df_statuses, headers='keys', tablefmt='simple')
             message = "<pre>{}</pre>".format(message)
 
-            self.send_msg(message, parse_mode=ParseMode.HTML)
+            self._send_msg(message, parse_mode=ParseMode.HTML)
 
     @authorized_only
     def _daily(self, bot: Bot, update: Update) -> None:
@@ -189,7 +197,7 @@ class Telegram(RPC):
             self._config['fiat_display_currency']
         )
         if error:
-            self.send_msg(stats, bot=bot)
+            self._send_msg(stats, bot=bot)
         else:
             stats = tabulate(stats,
                              headers=[
@@ -203,7 +211,7 @@ class Telegram(RPC):
                           timescale,
                           stats
                       )
-            self.send_msg(message, bot=bot, parse_mode=ParseMode.HTML)
+            self._send_msg(message, bot=bot, parse_mode=ParseMode.HTML)
 
     @authorized_only
     def _profit(self, bot: Bot, update: Update) -> None:
@@ -219,7 +227,7 @@ class Telegram(RPC):
             self._config['fiat_display_currency']
         )
         if error:
-            self.send_msg(stats, bot=bot)
+            self._send_msg(stats, bot=bot)
             return
 
         # Message to display
@@ -250,7 +258,7 @@ class Telegram(RPC):
                            best_pair=stats['best_pair'],
                            best_rate=stats['best_rate']
                        )
-        self.send_msg(markdown_msg, bot=bot)
+        self._send_msg(markdown_msg, bot=bot)
 
     @authorized_only
     def _balance(self, bot: Bot, update: Update) -> None:
@@ -259,7 +267,7 @@ class Telegram(RPC):
         """
         (error, result) = self.rpc_balance(self._config['fiat_display_currency'])
         if error:
-            self.send_msg('`All balances are zero.`')
+            self._send_msg('`All balances are zero.`')
             return
 
         (currencys, total, symbol, value) = result
@@ -274,7 +282,7 @@ class Telegram(RPC):
         output += "\n*Estimated Value*:\n" \
                   "\t`BTC: {0: .8f}`\n" \
                   "\t`{1}: {2: .2f}`\n".format(total, symbol, value)
-        self.send_msg(output)
+        self._send_msg(output)
 
     @authorized_only
     def _start(self, bot: Bot, update: Update) -> None:
@@ -287,7 +295,7 @@ class Telegram(RPC):
         """
         (error, msg) = self.rpc_start()
         if error:
-            self.send_msg(msg, bot=bot)
+            self._send_msg(msg, bot=bot)
 
     @authorized_only
     def _stop(self, bot: Bot, update: Update) -> None:
@@ -299,7 +307,7 @@ class Telegram(RPC):
         :return: None
         """
         (error, msg) = self.rpc_stop()
-        self.send_msg(msg, bot=bot)
+        self._send_msg(msg, bot=bot)
 
     @authorized_only
     def _reload_conf(self, bot: Bot, update: Update) -> None:
@@ -326,7 +334,7 @@ class Telegram(RPC):
         trade_id = update.message.text.replace('/forcesell', '').strip()
         (error, message) = self.rpc_forcesell(trade_id)
         if error:
-            self.send_msg(message, bot=bot)
+            self._send_msg(message, bot=bot)
             return
 
     @authorized_only
@@ -340,7 +348,7 @@ class Telegram(RPC):
         """
         (error, trades) = self.rpc_performance()
         if error:
-            self.send_msg(trades, bot=bot)
+            self._send_msg(trades, bot=bot)
             return
 
         stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
@@ -350,7 +358,7 @@ class Telegram(RPC):
             count=trade['count']
         ) for i, trade in enumerate(trades))
         message = '<b>Performance:</b>\n{}'.format(stats)
-        self.send_msg(message, parse_mode=ParseMode.HTML)
+        self._send_msg(message, parse_mode=ParseMode.HTML)
 
     @authorized_only
     def _count(self, bot: Bot, update: Update) -> None:
@@ -363,7 +371,7 @@ class Telegram(RPC):
         """
         (error, trades) = self.rpc_count()
         if error:
-            self.send_msg(trades, bot=bot)
+            self._send_msg(trades, bot=bot)
             return
 
         message = tabulate({
@@ -373,7 +381,7 @@ class Telegram(RPC):
         }, headers=['current', 'max', 'total stake'], tablefmt='simple')
         message = "<pre>{}</pre>".format(message)
         logger.debug(message)
-        self.send_msg(message, parse_mode=ParseMode.HTML)
+        self._send_msg(message, parse_mode=ParseMode.HTML)
 
     @authorized_only
     def _help(self, bot: Bot, update: Update) -> None:
@@ -399,7 +407,7 @@ class Telegram(RPC):
                   "*/help:* `This help message`\n" \
                   "*/version:* `Show version`"
 
-        self.send_msg(message, bot=bot)
+        self._send_msg(message, bot=bot)
 
     @authorized_only
     def _version(self, bot: Bot, update: Update) -> None:
@@ -410,10 +418,10 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        self.send_msg('*Version:* `{}`'.format(__version__), bot=bot)
+        self._send_msg('*Version:* `{}`'.format(__version__), bot=bot)
 
-    def send_msg(self, msg: str, bot: Bot = None,
-                 parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:
+    def _send_msg(self, msg: str, bot: Bot = None,
+                  parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:
         """
         Send given markdown message
         :param msg: message

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -80,12 +80,7 @@ class Telegram(RPC):
         Initializes this module with the given config,
         registers all known command handlers
         and starts polling for message updates
-        :param config: config to use
-        :return: None
         """
-        if not self.is_enabled():
-            return
-
         self._updater = Updater(token=self._config['telegram']['token'], workers=0)
 
         # Register command handler and start telegram message polling
@@ -121,20 +116,11 @@ class Telegram(RPC):
         Stops all running telegram threads.
         :return: None
         """
-        if not self.is_enabled():
-            return
-
         self._updater.stop()
 
     def send_msg(self, msg: str) -> None:
         """ Send a message to telegram channel """
         self._send_msg(msg)
-
-    def is_enabled(self) -> bool:
-        """
-        Returns True if the telegram module is activated, False otherwise
-        """
-        return bool(self._config.get('telegram', {}).get('enabled', False))
 
     @authorized_only
     def _status(self, bot: Bot, update: Update) -> None:
@@ -418,9 +404,6 @@ class Telegram(RPC):
         :param parse_mode: telegram parse mode
         :return: None
         """
-        if not self.is_enabled():
-            return
-
         bot = bot or self._updater.bot
 
         keyboard = [['/daily', '/profit', '/balance'],

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -31,7 +31,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -77,7 +77,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -110,7 +110,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker, value={'price_usd': 15000.0})
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -165,7 +165,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
         ticker=MagicMock(return_value={'price_usd': 15000.0}),
     )
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -241,7 +241,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
         ticker=MagicMock(return_value={'price_usd': 15000.0}),
     )
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -312,7 +312,7 @@ def test_rpc_balance_handle(default_conf, mocker):
         ticker=MagicMock(return_value={'price_usd': 15000.0}),
     )
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -340,7 +340,7 @@ def test_rpc_start(mocker, default_conf) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -366,7 +366,7 @@ def test_rpc_stop(mocker, default_conf) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -392,7 +392,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
 
     cancel_order_mock = MagicMock()
     mocker.patch.multiple(
@@ -495,7 +495,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
@@ -533,7 +533,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     """
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),

--- a/freqtrade/tests/rpc/test_rpc_manager.py
+++ b/freqtrade/tests/rpc/test_rpc_manager.py
@@ -104,7 +104,7 @@ def test_send_msg_telegram_disabled(mocker, default_conf, caplog) -> None:
     rpc_manager = RPCManager(freqtradebot)
     rpc_manager.send_msg('test')
 
-    assert log_has('test', caplog.record_tuples)
+    assert log_has('Sending rpc message: test', caplog.record_tuples)
     assert telegram_mock.call_count == 0
 
 
@@ -119,5 +119,5 @@ def test_send_msg_telegram_enabled(mocker, default_conf, caplog) -> None:
     rpc_manager = RPCManager(freqtradebot)
     rpc_manager.send_msg('test')
 
-    assert log_has('test', caplog.record_tuples)
+    assert log_has('Sending rpc message: test', caplog.record_tuples)
     assert telegram_mock.call_count == 1

--- a/freqtrade/tests/rpc/test_rpc_manager.py
+++ b/freqtrade/tests/rpc/test_rpc_manager.py
@@ -7,49 +7,35 @@ from copy import deepcopy
 from unittest.mock import MagicMock
 
 from freqtrade.rpc.rpc_manager import RPCManager
-from freqtrade.rpc.telegram import Telegram
 from freqtrade.tests.conftest import log_has, get_patched_freqtradebot
 
 
 def test_rpc_manager_object() -> None:
-    """
-    Test the Arguments object has the mandatory methods
-    :return: None
-    """
-    assert hasattr(RPCManager, '_init')
+    """ Test the Arguments object has the mandatory methods """
     assert hasattr(RPCManager, 'send_msg')
     assert hasattr(RPCManager, 'cleanup')
 
 
 def test__init__(mocker, default_conf) -> None:
-    """
-    Test __init__() method
-    """
-    init_mock = mocker.patch('freqtrade.rpc.rpc_manager.RPCManager._init', MagicMock())
-    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+    """ Test __init__() method """
+    conf = deepcopy(default_conf)
+    conf['telegram']['enabled'] = False
 
-    rpc_manager = RPCManager(freqtradebot)
-    assert rpc_manager.freqtrade == freqtradebot
+    rpc_manager = RPCManager(get_patched_freqtradebot(mocker, conf))
     assert rpc_manager.registered_modules == []
-    assert rpc_manager.telegram is None
-    assert init_mock.call_count == 1
 
 
 def test_init_telegram_disabled(mocker, default_conf, caplog) -> None:
-    """
-    Test _init() method with Telegram disabled
-    """
+    """ Test _init() method with Telegram disabled """
     caplog.set_level(logging.DEBUG)
 
     conf = deepcopy(default_conf)
     conf['telegram']['enabled'] = False
 
-    freqtradebot = get_patched_freqtradebot(mocker, conf)
-    rpc_manager = RPCManager(freqtradebot)
+    rpc_manager = RPCManager(get_patched_freqtradebot(mocker, conf))
 
     assert not log_has('Enabling rpc.telegram ...', caplog.record_tuples)
     assert rpc_manager.registered_modules == []
-    assert rpc_manager.telegram is None
 
 
 def test_init_telegram_enabled(mocker, default_conf, caplog) -> None:
@@ -59,14 +45,12 @@ def test_init_telegram_enabled(mocker, default_conf, caplog) -> None:
     caplog.set_level(logging.DEBUG)
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
 
-    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
-    rpc_manager = RPCManager(freqtradebot)
+    rpc_manager = RPCManager(get_patched_freqtradebot(mocker, default_conf))
 
     assert log_has('Enabling rpc.telegram ...', caplog.record_tuples)
     len_modules = len(rpc_manager.registered_modules)
     assert len_modules == 1
-    assert 'telegram' in rpc_manager.registered_modules
-    assert isinstance(rpc_manager.telegram, Telegram)
+    assert 'telegram' in [mod.name for mod in rpc_manager.registered_modules]
 
 
 def test_cleanup_telegram_disabled(mocker, default_conf, caplog) -> None:
@@ -99,11 +83,11 @@ def test_cleanup_telegram_enabled(mocker, default_conf, caplog) -> None:
     rpc_manager = RPCManager(freqtradebot)
 
     # Check we have Telegram as a registered modules
-    assert 'telegram' in rpc_manager.registered_modules
+    assert 'telegram' in [mod.name for mod in rpc_manager.registered_modules]
 
     rpc_manager.cleanup()
     assert log_has('Cleaning up rpc.telegram ...', caplog.record_tuples)
-    assert 'telegram' not in rpc_manager.registered_modules
+    assert 'telegram' not in [mod.name for mod in rpc_manager.registered_modules]
     assert telegram_mock.call_count == 1
 
 

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -706,7 +706,7 @@ def test_reload_conf_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -60,9 +60,7 @@ def test__init__(default_conf, mocker) -> None:
 
 
 def test_init(default_conf, mocker, caplog) -> None:
-    """
-    Test _init() method
-    """
+    """ Test _init() method """
     start_polling = MagicMock()
     mocker.patch('freqtrade.rpc.telegram.Updater', MagicMock(return_value=start_polling))
 
@@ -256,7 +254,7 @@ def test_status(default_conf, update, mocker, fee, ticker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        rpc_trade_status=MagicMock(return_value=(False, [1, 2, 3])),
+        _rpc_trade_status=MagicMock(return_value=[1, 2, 3]),
         _status_table=status_table,
         _send_msg=msg_mock
     )
@@ -667,7 +665,7 @@ def test_start_handle(default_conf, update, mocker) -> None:
     assert freqtradebot.state == State.STOPPED
     telegram._start(bot=MagicMock(), update=update)
     assert freqtradebot.state == State.RUNNING
-    assert msg_mock.call_count == 0
+    assert msg_mock.call_count == 1
 
 
 def test_start_handle_already_running(default_conf, update, mocker) -> None:

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -258,7 +258,7 @@ def test_status(default_conf, update, mocker, fee, ticker) -> None:
         _init=MagicMock(),
         rpc_trade_status=MagicMock(return_value=(False, [1, 2, 3])),
         _status_table=status_table,
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -296,7 +296,7 @@ def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
         _status_table=status_table,
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -341,7 +341,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -397,7 +397,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -465,7 +465,7 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -506,7 +506,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -604,7 +604,7 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -634,7 +634,7 @@ def test_zero_balance_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -656,7 +656,7 @@ def test_start_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -680,7 +680,7 @@ def test_start_handle_already_running(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -705,7 +705,7 @@ def test_stop_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -730,7 +730,7 @@ def test_stop_handle_already_stopped(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
@@ -898,7 +898,7 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.exchange.validate_pairs', MagicMock())
 
@@ -940,7 +940,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
@@ -981,7 +981,7 @@ def test_performance_handle_invalid(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch('freqtrade.freqtradebot.exchange.validate_pairs', MagicMock())
     freqtradebot = FreqtradeBot(default_conf)
@@ -1004,7 +1004,7 @@ def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
@@ -1047,7 +1047,7 @@ def test_help_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
@@ -1067,7 +1067,7 @@ def test_version_handle(default_conf, update, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
         _init=MagicMock(),
-        send_msg=msg_mock
+        _send_msg=msg_mock
     )
     freqtradebot = FreqtradeBot(default_conf)
     telegram = Telegram(freqtradebot)
@@ -1090,12 +1090,12 @@ def test_send_msg(default_conf, mocker) -> None:
     telegram = Telegram(freqtradebot)
 
     telegram._config['telegram']['enabled'] = False
-    telegram.send_msg('test', bot)
+    telegram._send_msg('test', bot)
     assert not bot.method_calls
     bot.reset_mock()
 
     telegram._config['telegram']['enabled'] = True
-    telegram.send_msg('test', bot)
+    telegram._send_msg('test', bot)
     assert len(bot.method_calls) == 1
 
 
@@ -1113,7 +1113,7 @@ def test_send_msg_network_error(default_conf, mocker, caplog) -> None:
     telegram = Telegram(freqtradebot)
 
     telegram._config['telegram']['enabled'] = True
-    telegram.send_msg('test', bot)
+    telegram._send_msg('test', bot)
 
     # Bot should've tried to send it twice
     assert len(bot.method_calls) == 2

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -57,7 +57,7 @@ def patch_RPCManager(mocker) -> MagicMock:
     :param mocker: mocker to patch RPCManager class
     :return: RPCManager.send_msg MagicMock to track if this method is called
     """
-    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     rpc_mock = mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
     return rpc_mock
 

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -57,7 +57,7 @@ def patch_RPCManager(mocker) -> MagicMock:
     :param mocker: mocker to patch RPCManager class
     :return: RPCManager.send_msg MagicMock to track if this method is called
     """
-    mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
+    mocker.patch('freqtrade.rpc.rpc_manager.Telegram', MagicMock())
     rpc_mock = mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
     return rpc_mock
 


### PR DESCRIPTION
## Summary

I would like to implement a discord RPC client. This PR is the first step in this direction. It contains mostly code cleanups and preparations for that. No breaking changes.

#### Simplifies RPCManager:
* Removed telegram member variable (a instance of each running module is now in `self.registered_modules`)
* Make `cleanup` and `send_msg` more abstract to handle all modules in `self.registered modules`

#### Refactor RPC:
* Add some abstract methods to call `name`, `cleanup` and `send_msg` via RPCManager in a more abstract way.
* Refactored tuple return madness (this is now handled via RPCException)

#### EDIT:
* python-telegram-bot is no longer imported at runtime if telegram has been disabled in config.

