### PR TITLE
Check if no backtest data is found and fail gracefully

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -237,6 +237,9 @@ class Backtesting(object):
                 timerange=timerange
             )
 
+        if not data:
+            logger.critical("No data found. Terminating.")
+            return
         # Ignore max_open_trades in backtesting, except realistic flag was passed
         if self.config.get('realistic_simulation', False):
             max_open_trades = self.config['max_open_trades']

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -437,7 +437,7 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
 
     conf = deepcopy(default_conf)
     conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
-    conf['ticker_interval'] = 1
+    conf['ticker_interval'] = "1m"
     conf['live'] = False
     conf['datadir'] = None
     conf['export'] = None
@@ -446,14 +446,8 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
     backtesting = Backtesting(conf)
     backtesting.start()
     # check the logs, that will contain the backtest result
-    exists = [
-        'Using local backtesting data (using whitelist in given config) ...',
-        'Using stake_currency: BTC ...',
-        'Using stake_amount: 0.001 ...',
-        'No data found. Terminating.'
-    ]
-    for line in exists:
-        assert log_has(line, caplog.record_tuples)
+
+    assert log_has('No data found. Terminating.', caplog.record_tuples)
 
 
 def test_backtest(default_conf, fee, mocker) -> None:


### PR DESCRIPTION
## Summary
Fix ungracefull termination (-> crash) when no backtest data is found and `--refresh-pairs-cached` is not supplied.
added test for this specific condition (which is not that uncommon i think).

## fixes the following error

fix ungracefull termination:
```
2018-06-10 22:21:33,694 - freqtrade.optimize.backtesting - INFO - Ignoring max_open_trades (realistic_simulation not set) ...
Traceback (most recent call last):
  File "/home/xmatt/development/pythonvirtenv/trade/bin/freqtrade", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/xmatt/development/python/cryptos/freqtrade/bin/freqtrade", line 7, in <module>
    main(sys.argv[1:])
  File "/home/xmatt/development/python/cryptos/freqtrade/freqtrade/main.py", line 32, in main
    args.func(args)
  File "/home/xmatt/development/python/cryptos/freqtrade/freqtrade/optimize/backtesting.py", line 313, in start
    backtesting.start()
  File "/home/xmatt/development/python/cryptos/freqtrade/freqtrade/optimize/backtesting.py", line 250, in start
    min_date, max_date = self.get_timeframe(preprocessed)
  File "/home/xmatt/development/python/cryptos/freqtrade/freqtrade/optimize/backtesting.py", line 61, in get_timeframe
    return min(timeframe, key=operator.itemgetter(0))[0], \
ValueError: min() arg is an empty sequence

```