### PR TITLE
update issue template to include ccxt version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,10 +6,12 @@ If it hasn't been reported, please create a new issue.
 ## Step 2: Describe your environment
 
   * Python Version: _____ (`python -V`)
+  * CCXT version: _____ (`pip freeze | grep ccxt`)
   * Branch: Master | Develop
   * Last Commit ID: _____ (`git log --format="%H" -n 1`)
- 
+  
 ## Step 3: Describe the problem:
+
 *Explain the problem you have encountered*
 
 ### Steps to reproduce:


### PR DESCRIPTION
## Summary
Since we receive many issues related to ccxt lately, i would suggest to include the ccxt version in the issue template. this will help debugging eventual crashes resulting from ccxt as well as opening an eventual upstream bug.

## Quick changelog

- Ask for ccxt version in issue template
