### PR TITLE
fix default datadir not working in plot-script

### DIFF
--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -91,7 +91,7 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
         tickers[pair] = exchange.get_ticker_history(pair, tick_interval)
     else:
         tickers = optimize.load_data(
-            datadir=args.datadir,
+            datadir=_CONF.get("datadir"),
             pairs=[pair],
             ticker_interval=tick_interval,
             refresh_pairs=_CONF.get('refresh_pairs', False),

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -121,7 +121,7 @@ def plot_profit(args: Namespace) -> None:
         logger.info('Filter, keep pairs %s' % pairs)
 
     tickers = optimize.load_data(
-        datadir=args.datadir,
+        datadir=config.get('datadir'),
         pairs=pairs,
         ticker_interval=tick_interval,
         refresh_pairs=False,


### PR DESCRIPTION
## Summary
running the plot-profit script without supplying --datadir resulted in an error as args.datadir is empty in that case.

use the default supplied by the configuration-object instead (can be overwritten by `--datadir abcd`.

**update**
was broken in plot_dataframe too...