### PR TITLE
fix hyperopt test when no config.json exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,16 @@ install:
 - pip install --upgrade flake8 coveralls pytest-random-order mypy
 - pip install -r requirements.txt
 - pip install -e .
-- cp config.json.example config.json
 jobs:
   include:
     - script: 
       - pytest --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
       - coveralls
     - script:
+      - cp config.json.example config.json
       - python freqtrade/main.py --datadir freqtrade/tests/testdata backtesting
     - script:
+      - cp config.json.example config.json
       - python freqtrade/main.py --datadir freqtrade/tests/testdata hyperopt -e 5
     - script: flake8 freqtrade
     - script: mypy freqtrade

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -61,6 +61,10 @@ def test_start(mocker, default_conf, caplog) -> None:
     Test start() function
     """
     start_mock = MagicMock()
+    mocker.patch(
+        'freqtrade.configuration.Configuration._load_config_file',
+        lambda *args, **kwargs: default_conf
+    )
     mocker.patch('freqtrade.optimize.hyperopt.Hyperopt.start', start_mock)
     mocker.patch('freqtrade.freqtradebot.exchange.validate_pairs', MagicMock())
 


### PR DESCRIPTION
## Summary
fix hyperopt test when no `config.json` exists.

travis does not complain as the example-file was copied beforehand, but my pc did as i don't have a plain `config.json`.