### PR TITLE
Moved registering application urls out of the run def

### DIFF
--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -37,14 +37,16 @@ class ApiServerSuperWrap(RPC):
     def register_rest_other(self):
         #Added as a placeholder for app URLs that are not implemented in rpc.rpc
         app.register_error_handler(404, self.page_not_found)
+        app.add_url_rule('/', 'hello', view_func=self.hello, methods=['GET'])
 
     def register_rest_rpc_urls(self):
         # register the url rules available on the api server
+        # This is where to register rest urls that make use of
+        # rpc.rpc functions
         '''
         First two arguments passed are /URL and 'Label'
         Label can be used as a shortcut when refactoring
         '''
-        app.add_url_rule('/', 'hello', view_func=self.hello, methods=['GET'])
         app.add_url_rule('/stop', 'stop', view_func=self.stop, methods=['GET'])
         app.add_url_rule('/start', 'start', view_func=self.start, methods=['GET'])
         app.add_url_rule('/daily', 'daily', view_func=self.daily, methods=['GET'])

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -35,7 +35,7 @@ class ApiServerSuperWrap(RPC):
         thread.start()
 
     def register_rest_other(self):
-        #Added as a placeholder for app URLs that are not implemented in rpc.rpc
+        # Added as a placeholder for app URLs that are not implemented in rpc.rpc
         app.register_error_handler(404, self.page_not_found)
         app.add_url_rule('/', 'hello', view_func=self.hello, methods=['GET'])
 

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -27,13 +27,19 @@ class ApiServerSuperWrap(RPC):
 
         self._config = freqtrade.config
 
+        # Register application handling
+        self.register_rest_other()
+        self.register_rest_rpc_urls()
+
         thread = threading.Thread(target=self.run, daemon=True)
         thread.start()
 
-    def run(self):
-        """ Method that runs forever """
+    def register_rest_other(self):
+        #Added as a placeholder for app URLs that are not implemented in rpc.rpc
+        app.register_error_handler(404, self.page_not_found)
 
-        # defines the url rules available on the api server
+    def register_rest_rpc_urls(self):
+        # register the url rules available on the api server
         '''
         First two arguments passed are /URL and 'Label'
         Label can be used as a shortcut when refactoring
@@ -42,6 +48,9 @@ class ApiServerSuperWrap(RPC):
         app.add_url_rule('/stop', 'stop', view_func=self.stop, methods=['GET'])
         app.add_url_rule('/start', 'start', view_func=self.start, methods=['GET'])
         app.add_url_rule('/daily', 'daily', view_func=self.daily, methods=['GET'])
+
+    def run(self):
+        """ Method that runs forever """
 
         """
         Section to handle configuration and running of the Rest server
@@ -80,6 +89,12 @@ class ApiServerSuperWrap(RPC):
     Define the application methods here, called by app.add_url_rule
     each Telegram command should have a like local substitute
     """
+
+    def page_not_found(self, error):
+        # return "404 not found", 404
+        return jsonify({'status': 'error',
+                        'reason': '''There's no API call for %s''' % request.base_url,
+                        'code': 404}), 404
 
     def hello(self):
         # For simple rest server testing via browser

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -35,24 +35,27 @@ class ApiServerSuperWrap(RPC):
         thread.start()
 
     def register_rest_other(self):
-        # Added as a placeholder for app URLs that are not implemented in rpc.rpc
+        """
+        Registers flask app URLs that are not calls to functionality in rpc.rpc.
+        :return:
+        """
         app.register_error_handler(404, self.page_not_found)
         app.add_url_rule('/', 'hello', view_func=self.hello, methods=['GET'])
 
     def register_rest_rpc_urls(self):
-        # register the url rules available on the api server
-        # This is where to register rest urls that make use of
-        # rpc.rpc functions
-        '''
+        """
+        Registers flask app URLs that are calls to functonality in rpc.rpc.
+
         First two arguments passed are /URL and 'Label'
         Label can be used as a shortcut when refactoring
-        '''
+        :return:
+        """
         app.add_url_rule('/stop', 'stop', view_func=self.stop, methods=['GET'])
         app.add_url_rule('/start', 'start', view_func=self.start, methods=['GET'])
         app.add_url_rule('/daily', 'daily', view_func=self.daily, methods=['GET'])
 
     def run(self):
-        """ Method that runs forever """
+        """ Method that runs flask app in its own thread forever """
 
         """
         Section to handle configuration and running of the Rest server
@@ -93,17 +96,19 @@ class ApiServerSuperWrap(RPC):
     """
 
     def page_not_found(self, error):
-        # return "404 not found", 404
+        # Return "404 not found", 404.
         return jsonify({'status': 'error',
                         'reason': '''There's no API call for %s''' % request.base_url,
                         'code': 404}), 404
 
     def hello(self):
-        # For simple rest server testing via browser
-        # cmds = 'Try uri:/daily?timescale=7 /profit /balance /status
-        #         /status /table /performance /count,
-        #         /start /stop /help'
+        """
+        None critical but helpful default index page.
 
+        That lists URLs added to the flask server.
+        This may be deprecated at any time.
+        :return: index.html
+        """
         rest_cmds = 'Commands implemented: <br>' \
                     '<a href=/daily?timescale=7>/daily?timescale=7</a>' \
                     '<br>' \
@@ -113,6 +118,11 @@ class ApiServerSuperWrap(RPC):
         return rest_cmds
 
     def daily(self):
+        """
+        Returns the last X days trading stats summary.
+
+        :return: stats
+        """
         try:
             timescale = request.args.get('timescale')
             logger.info("LocalRPC - Daily Command Called")
@@ -131,7 +141,8 @@ class ApiServerSuperWrap(RPC):
     def start(self):
         """
         Handler for /start.
-        Starts TradeThread
+
+        Starts TradeThread in bot if stopped.
         """
         msg = self._rpc_start()
         return jsonify(msg)
@@ -139,7 +150,8 @@ class ApiServerSuperWrap(RPC):
     def stop(self):
         """
         Handler for /stop.
-        Stops TradeThread
+
+        Stops TradeThread in bot if running
         """
         msg = self._rpc_stop()
         return jsonify(msg)


### PR DESCRIPTION
Moved registering application urls out of the app run def and into their own defs.

Added 404 handling

Split registration of URLs that use rpc.rpc and others into
own defs. Seems logical to be able to register separately for later hygiene.

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
