### PR TITLE
Remove global config from persistence module

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -21,7 +21,6 @@ from freqtrade import OperationalException
 
 logger = logging.getLogger(__name__)
 
-_CONF = {}
 _DECL_BASE: Any = declarative_base()
 
 
@@ -33,9 +32,7 @@ def init(config: Dict) -> None:
     :param config: config to use
     :return: None
     """
-    _CONF.update(config)
-
-    db_url = _CONF.get('db_url', None)
+    db_url = config.get('db_url', None)
     kwargs = {}
 
     # Take care of thread ownership if in-memory db
@@ -61,7 +58,7 @@ def init(config: Dict) -> None:
     check_migrate(engine)
 
     # Clean dry_run DB if the db is not in-memory
-    if _CONF.get('dry_run', False) and db_url != 'sqlite://':
+    if config.get('dry_run', False) and db_url != 'sqlite://':
         clean_dry_run_db()
 
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -510,7 +510,6 @@ def test_cancel_order_dry_run(default_conf, mocker):
 # Ensure that if not dry_run, we should call API
 def test_cancel_order(default_conf, mocker):
     default_conf['dry_run'] = False
-    # mocker.patch.dict('freqtrade.exchange.._CONF', default_conf)
     api_mock = MagicMock()
     api_mock.cancel_order = MagicMock(return_value=123)
     exchange = get_patched_exchange(mocker, default_conf, api_mock)

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -14,9 +14,7 @@ def init_persistence(default_conf):
     init(default_conf)
 
 
-def test_init_create_session(default_conf, mocker):
-    mocker.patch.dict('freqtrade.persistence._CONF', default_conf)
-
+def test_init_create_session(default_conf):
     # Check if init create a session
     init(default_conf)
     assert hasattr(Trade, 'session')
@@ -29,20 +27,17 @@ def test_init_custom_db_url(default_conf, mocker):
     # Update path to a value other than default, but still in-memory
     conf.update({'db_url': 'sqlite:///tmp/freqtrade2_test.sqlite'})
     create_engine_mock = mocker.patch('freqtrade.persistence.create_engine', MagicMock())
-    mocker.patch.dict('freqtrade.persistence._CONF', conf)
 
     init(conf)
     assert create_engine_mock.call_count == 1
     assert create_engine_mock.mock_calls[0][1][0] == 'sqlite:///tmp/freqtrade2_test.sqlite'
 
 
-def test_init_invalid_db_url(default_conf, mocker):
+def test_init_invalid_db_url(default_conf):
     conf = deepcopy(default_conf)
 
     # Update path to a value other than default, but still in-memory
     conf.update({'db_url': 'unknown:///some.url'})
-    mocker.patch.dict('freqtrade.persistence._CONF', conf)
-
     with pytest.raises(OperationalException, match=r'.*no valid database URL*'):
         init(conf)
 
@@ -53,7 +48,6 @@ def test_init_prod_db(default_conf, mocker):
     conf.update({'db_url': constants.DEFAULT_DB_PROD_URL})
 
     create_engine_mock = mocker.patch('freqtrade.persistence.create_engine', MagicMock())
-    mocker.patch.dict('freqtrade.persistence._CONF', conf)
 
     init(conf)
     assert create_engine_mock.call_count == 1
@@ -66,7 +60,6 @@ def test_init_dryrun_db(default_conf, mocker):
     conf.update({'db_url': constants.DEFAULT_DB_DRYRUN_URL})
 
     create_engine_mock = mocker.patch('freqtrade.persistence.create_engine', MagicMock())
-    mocker.patch.dict('freqtrade.persistence._CONF', conf)
 
     init(conf)
     assert create_engine_mock.call_count == 1


### PR DESCRIPTION
## Summary
Remove global config `_CONF` from `freqtrade.persistence` because it is no longer needed.
