### PR TITLE
StrategyResolver: Don't fail if user_data isn't present

### DIFF
--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -81,10 +81,13 @@ class StrategyResolver(object):
             abs_paths.insert(0, extra_dir)
 
         for path in abs_paths:
-            strategy = self._search_strategy(path, strategy_name)
-            if strategy:
-                logger.info('Using resolved strategy %s from \'%s\'', strategy_name, path)
-                return import_strategy(strategy)
+            try:
+                strategy = self._search_strategy(path, strategy_name)
+                if strategy:
+                    logger.info('Using resolved strategy %s from \'%s\'', strategy_name, path)
+                    return import_strategy(strategy)
+            except FileNotFoundError:
+                logger.warning('Path "%s" does not exist', path)
 
         raise ImportError(
             "Impossible to load Strategy '{}'. This class does not exist"

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -72,7 +72,7 @@ class StrategyResolver(object):
         """
         current_path = os.path.dirname(os.path.realpath(__file__))
         abs_paths = [
-            os.path.join(current_path, '..', '..', 'user_data', 'strategies'),
+            os.path.join(os.getcwd(), 'user_data', 'strategies'),
             current_path,
         ]
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -50,13 +50,16 @@ def test_load_strategy(result):
     assert 'adx' in resolver.strategy.populate_indicators(result)
 
 
-def test_load_strategy_custom_directory(result):
+def test_load_strategy_invalid_directory(result, caplog):
     resolver = StrategyResolver()
     extra_dir = os.path.join('some', 'path')
-    with pytest.raises(
-            FileNotFoundError,
-            match=r".*No such file or directory: '{}'".format(extra_dir)):
-        resolver._load_strategy('TestStrategy', extra_dir)
+    resolver._load_strategy('TestStrategy', extra_dir)
+
+    assert (
+        'freqtrade.strategy.resolver',
+        logging.WARNING,
+        'Path "{}" does not exist'.format(extra_dir),
+    ) in caplog.record_tuples
 
     assert hasattr(resolver.strategy, 'populate_indicators')
     assert 'adx' in resolver.strategy.populate_indicators(result)


### PR DESCRIPTION
## Summary
Fixes a FileNotFoundError in StrategyResolver if user_data wasn't found (a warning is printed instead). Also it uses the bot invocation path to find `user_data` instead of script path.

This should yield a working install with `python setup.py install`

Solve the issue: #435
