### PR TITLE
slight rework of download script

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -334,3 +334,10 @@ class Arguments(object):
             nargs='+',
             dest='timeframes',
         )
+
+        self.parser.add_argument(
+            '--erase',
+            help='Clean all existing data for the selected exchange/pairs/timeframes',
+            dest='erase',
+            action='store_true'
+        )


### PR DESCRIPTION
## Summary
Don't automatically delete data when downloading a shorter period

Fixes the following case (which happened to me today)
* data exists from 2018-01-01 - 2018-06-01
* run script with --days 24 (today is the 24th)
* wait for download
* check timerange - now i only got data form 2018-06-01 to 2018-06-24 - data from January til June has been deleted

## Quick changelog

- don't automatically delete existing backtest data
- introduce --erase option to delete existing pair data
- removal of duplicated code by calling the same method than `backtesting --refresh-pairs-cached`
