### PR TITLE
separating unfulfilled timeouts for buy and sell

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,7 +5,10 @@
     "fiat_display_currency": "USD",
     "ticker_interval" : "5m",
     "dry_run": false,
-    "unfilledtimeout": 600,
+    "unfilledtimeout": {
+        "buy":10,
+        "sell":30
+    }
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/config.json.example
+++ b/config.json.example
@@ -8,7 +8,7 @@
     "unfilledtimeout": {
         "buy":10,
         "sell":30
-    }
+    },
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/config.json.example
+++ b/config.json.example
@@ -6,8 +6,8 @@
     "ticker_interval" : "5m",
     "dry_run": false,
     "unfilledtimeout": {
-        "buy":10,
-        "sell":30
+        "buy": 10,
+        "sell": 30
     },
     "bid_strategy": {
         "ask_last_balance": 0.0

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -15,7 +15,7 @@
     "unfilledtimeout": {
         "buy":10,
         "sell":30
-    }
+    },
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -12,7 +12,10 @@
         "0":  0.04
     },
     "stoploss": -0.10,
-    "unfilledtimeout": 600,
+    "unfilledtimeout": {
+        "buy":10,
+        "sell":30
+    }
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -13,8 +13,8 @@
     },
     "stoploss": -0.10,
     "unfilledtimeout": {
-        "buy":10,
-        "sell":30
+        "buy": 10,
+        "sell": 30
     },
     "bid_strategy": {
         "ask_last_balance": 0.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ The table below will list all configuration parameters.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file. 
-| `unfilledtimeout` | 0 | No | How long (in minutes) the bot will wait for an unfilled order to complete, after which the order will be cancelled.
+| `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
+| `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename).
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -61,7 +61,14 @@ CONF_SCHEMA = {
             'minProperties': 1
         },
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
-        'unfilledtimeout': {'type': 'integer', 'minimum': 0},
+        'unfilledtimeout': {
+            'type': 'object',
+            'properties': {
+                'use_book_order': {'type': 'boolean'},
+                'buy': {'type': 'number', 'minimum': 3},
+                'sell': {'type': 'number', 'minimum': 10}
+            }
+        },
         'bid_strategy': {
             'type': 'object',
             'properties': {

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -64,7 +64,6 @@ CONF_SCHEMA = {
         'unfilledtimeout': {
             'type': 'object',
             'properties': {
-                'use_book_order': {'type': 'boolean'},
                 'buy': {'type': 'number', 'minimum': 3},
                 'sell': {'type': 'number', 'minimum': 10}
             }

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -525,7 +525,7 @@ with limit `{buy_limit:.8f} ({stake_amount:.6f} \
                 continue
 
             # Check if trade is still actually open
-            if (order['status'] == 'open'):
+            if order['status'] == 'open':
                 if order['side'] == 'buy' and ordertime < buy_timeoutthreashold:
                     self.handle_timedout_limit_buy(trade, order)
                 elif order['side'] == 'sell' and ordertime < sell_timeoutthreashold:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -160,7 +160,7 @@ class FreqtradeBot(object):
 
             if 'unfilledtimeout' in self.config:
                 # Check and handle any timed out open orders
-                self.check_handle_timedout(self.config['unfilledtimeout'])
+                self.check_handle_timedout()
                 Trade.session.flush()
 
         except TemporaryError as error:
@@ -492,13 +492,16 @@ with limit `{buy_limit:.8f} ({stake_amount:.6f} \
         logger.info('Found no sell signals for whitelisted currencies. Trying again..')
         return False
 
-    def check_handle_timedout(self, timeoutvalue: int) -> None:
+    def check_handle_timedout(self) -> None:
         """
         Check if any orders are timed out and cancel if neccessary
         :param timeoutvalue: Number of minutes until order is considered timed out
         :return: None
         """
-        timeoutthreashold = arrow.utcnow().shift(minutes=-timeoutvalue).datetime
+        buy_timeout = self.config['unfilledtimeout']['buy']
+        sell_timeout = self.config['unfilledtimeout']['sell']
+        buy_timeoutthreashold = arrow.utcnow().shift(minutes=-buy_timeout).datetime
+        sell_timeoutthreashold = arrow.utcnow().shift(minutes=-sell_timeout).datetime
 
         for trade in Trade.query.filter(Trade.open_order_id.isnot(None)).all():
             try:
@@ -521,10 +524,12 @@ with limit `{buy_limit:.8f} ({stake_amount:.6f} \
             if int(order['remaining']) == 0:
                 continue
 
-            if order['side'] == 'buy' and ordertime < timeoutthreashold:
-                self.handle_timedout_limit_buy(trade, order)
-            elif order['side'] == 'sell' and ordertime < timeoutthreashold:
-                self.handle_timedout_limit_sell(trade, order)
+            # Check if trade is still actually open
+            if (order['status'] == 'open'):
+                if order['side'] == 'buy' and ordertime < buy_timeoutthreashold:
+                    self.handle_timedout_limit_buy(trade, order)
+                elif order['side'] == 'sell' and ordertime < sell_timeoutthreashold:
+                    self.handle_timedout_limit_sell(trade, order)
 
     # FIX: 20180110, why is cancel.order unconditionally here, whereas
     #                it is conditionally called in the

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -100,7 +100,10 @@ def default_conf():
             "0": 0.04
         },
         "stoploss": -0.10,
-        "unfilledtimeout": 600,
+        "unfilledtimeout": {
+            "buy": 10,
+            "sell": 30
+        },
         "bid_strategy": {
             "ask_last_balance": 0.0
         },

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1124,7 +1124,7 @@ def test_check_handle_timedout_buy(default_conf, ticker, limit_buy_order_old, fe
     Trade.session.add(trade_buy)
 
     # check it does cancel buy orders over the time limit
-    freqtrade.check_handle_timedout(600)
+    freqtrade.check_handle_timedout()
     assert cancel_order_mock.call_count == 1
     assert rpc_mock.call_count == 1
     trades = Trade.query.filter(Trade.open_order_id.is_(trade_buy.open_order_id)).all()
@@ -1165,7 +1165,7 @@ def test_check_handle_timedout_sell(default_conf, ticker, limit_sell_order_old, 
     Trade.session.add(trade_sell)
 
     # check it does cancel sell orders over the time limit
-    freqtrade.check_handle_timedout(600)
+    freqtrade.check_handle_timedout()
     assert cancel_order_mock.call_count == 1
     assert rpc_mock.call_count == 1
     assert trade_sell.is_open is True
@@ -1205,7 +1205,7 @@ def test_check_handle_timedout_partial(default_conf, ticker, limit_buy_order_old
 
     # check it does cancel buy orders over the time limit
     # note this is for a partially-complete buy order
-    freqtrade.check_handle_timedout(600)
+    freqtrade.check_handle_timedout()
     assert cancel_order_mock.call_count == 1
     assert rpc_mock.call_count == 1
     trades = Trade.query.filter(Trade.open_order_id.is_(trade_buy.open_order_id)).all()
@@ -1256,7 +1256,7 @@ def test_check_handle_timedout_exception(default_conf, ticker, mocker, caplog) -
         'recent call last):\n.*'
     )
 
-    freqtrade.check_handle_timedout(600)
+    freqtrade.check_handle_timedout()
     assert filter(regexp.match, caplog.record_tuples)
 
 


### PR DESCRIPTION
Based on work from @nullart (and with his agreement), i extracted the separated unfilled timeout.

This is part of #968, which i feel will be very difficult to merge as it mixes a ton of different features, so extracting them one by one should make merging easier.

## Summary
* allow configuration of separate timeouts for buy and sell.
* reduce the default config to something more reasonable




