### PR TITLE
don't flag data as outdated which isn't

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -2,7 +2,7 @@
 Functions to analyze ticker data with indicators and produce buy and sell signals
 """
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Tuple
 
@@ -154,7 +154,7 @@ class Analyze(object):
         # Check if dataframe is out of date
         signal_date = arrow.get(latest['date'])
         interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        if signal_date < (arrow.utcnow() - timedelta(minutes=(interval_minutes + 5))):
+        if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + 5))):
             logger.warning(
                 'Outdated history for pair %s. Last tick is %s minutes old',
                 pair,


### PR DESCRIPTION
## Summary
Fix `Outdated history for pair` message when using longer timeframes (longer than 5m!!)

Solve the issue: #995

The best explanation is probably in the ticket, but to summarize assume the following:

it's now 9:55am (utc), we use 2h candles.

my last valid candle is the one from 6am (6am -8am).
the candle which opens at 8am will be closed in 5 minutes.

The current logic will flag this as "outdated" 99% of the time - as it goes back 2h+5m. (to 7:50am).
However, my valid candle starts at 6am. So we go back twice the tickerframe (in this case 4 hours) + a window of 5 minutes.


## Quick changelog

- increase allowed "non-available" time.
- use `arrow.shift()` instead of timedelta - to reduce necessary imports and code complexity 