### PR TITLE
Add cumulative profit to backtest result table

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -88,9 +88,9 @@ class Backtesting(object):
         """
         stake_currency = str(self.config.get('stake_currency'))
 
-        floatfmt = ('s', 'd', '.2f', '.8f', '.1f')
+        floatfmt = ('s', 'd', '.2f', '.2f', '.8f', '.1f')
         tabular_data = []
-        headers = ['pair', 'buy count', 'avg profit %',
+        headers = ['pair', 'buy count', 'avg profit %', 'cum profit %',
                    'total profit ' + stake_currency, 'avg duration', 'profit', 'loss']
         for pair in data:
             result = results[results.pair == pair]
@@ -98,6 +98,7 @@ class Backtesting(object):
                 pair,
                 len(result.index),
                 result.profit_percent.mean() * 100.0,
+                result.profit_percent.sum() * 100.0,
                 result.profit_abs.sum(),
                 result.trade_duration.mean(),
                 len(result[result.profit_abs > 0]),
@@ -109,6 +110,7 @@ class Backtesting(object):
             'TOTAL',
             len(results.index),
             results.profit_percent.mean() * 100.0,
+            result.profit_percent.sum() * 100.0,
             results.profit_abs.sum(),
             results.trade_duration.mean(),
             len(results[results.profit_abs > 0]),

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -391,15 +391,16 @@ def test_generate_text_table(default_conf, mocker):
     )
 
     result_str = (
-        '| pair    |   buy count |   avg profit % |   '
+        '| pair    |   buy count |   avg profit % |   cum profit % |   '
         'total profit BTC |   avg duration |   profit |   loss |\n'
-        '|:--------|------------:|---------------:|'
+        '|:--------|------------:|---------------:|---------------:|'
         '-------------------:|---------------:|---------:|-------:|\n'
-        '| ETH/BTC |           2 |          15.00 |         '
+        '| ETH/BTC |           2 |          15.00 |          30.00 |         '
         '0.60000000 |           20.0 |        2 |      0 |\n'
-        '| TOTAL   |           2 |          15.00 |         '
+        '| TOTAL   |           2 |          15.00 |          30.00 |         '
         '0.60000000 |           20.0 |        2 |      0 |'
     )
+    print(result_str)
     assert backtesting._generate_text_table(data={'ETH/BTC': {}}, results=results) == result_str
 
 


### PR DESCRIPTION
## Summary
Add cumulative profit to backtest result table. This can give another view into how a strategy performs.

## results before
```
======================================== BACKTESTING REPORT =========================================
| pair      |   buy count |   avg profit % |   total profit ETH |   avg duration |   profit |   loss |
|:----------|------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| LTC/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| IOTA/ETH  |           1 |           1.73 |         0.00173121 |          250.0 |        1 |      0 |
| XMR/ETH   |           1 |          -4.47 |        -0.00445209 |          170.0 |        0 |      1 |
| XRP/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| NCASH/ETH |           1 |           1.79 |         0.00179266 |          590.0 |        1 |      0 |
| MTH/ETH   |           1 |           1.72 |         0.00170960 |          270.0 |        1 |      0 |
| AST/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| TNT/ETH   |           1 |          -5.34 |        -0.00534723 |          360.0 |        0 |      1 |
| ETC/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| TOTAL     |           5 |          -0.91 |        -0.00456585 |          328.0 |        3 |      2 |
2018-07-08 19:57:31,816 - freqtrade.optimize.backtesting - INFO - 
====================================== LEFT OPEN TRADES REPORT ======================================
| pair      |   buy count |   avg profit % |   total profit ETH |   avg duration |   profit |   loss |
|:----------|------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| LTC/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| IOTA/ETH  |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| XMR/ETH   |           1 |          -4.47 |        -0.00445209 |          170.0 |        0 |      1 |
| XRP/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| NCASH/ETH |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| MTH/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| AST/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| TNT/ETH   |           1 |          -5.34 |        -0.00534723 |          360.0 |        0 |      1 |
| ETC/ETH   |           0 |         nan    |         0.00000000 |          nan   |        0 |      0 |
| TOTAL     |           2 |          -4.90 |        -0.00979932 |          265.0 |        0 |      2 |

```
## results now
```
======================================== BACKTESTING REPORT =========================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH |   avg duration |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| LTC/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| IOTA/ETH  |           1 |           1.73 |           1.73 |         0.00173121 |          250.0 |        1 |      0 |
| XMR/ETH   |           1 |          -4.47 |          -4.47 |        -0.00445209 |          170.0 |        0 |      1 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| NCASH/ETH |           1 |           1.79 |           1.79 |         0.00179266 |          590.0 |        1 |      0 |
| MTH/ETH   |           1 |           1.72 |           1.72 |         0.00170960 |          270.0 |        1 |      0 |
| AST/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| TNT/ETH   |           1 |          -5.34 |          -5.34 |        -0.00534723 |          360.0 |        0 |      1 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| TOTAL     |           5 |          -0.91 |           0.00 |        -0.00456585 |          328.0 |        3 |      2 |
2018-07-08 19:55:50,183 - freqtrade.optimize.backtesting - INFO - 
====================================== LEFT OPEN TRADES REPORT ======================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH |   avg duration |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|---------------:|---------:|-------:|
| LTC/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| XMR/ETH   |           1 |          -4.47 |          -4.47 |        -0.00445209 |          170.0 |        0 |      1 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| NCASH/ETH |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| MTH/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| AST/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| TNT/ETH   |           1 |          -5.34 |          -5.34 |        -0.00534723 |          360.0 |        0 |      1 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 |          nan   |        0 |      0 |
| TOTAL     |           2 |          -4.90 |           0.00 |        -0.00979932 |          265.0 |        0 |      2 |
```