### PR TITLE
Use open-rates for backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -134,7 +134,7 @@ class Backtesting(object):
         stake_amount = args['stake_amount']
         max_open_trades = args.get('max_open_trades', 0)
         trade = Trade(
-            open_rate=buy_row.close,
+            open_rate=buy_row.open,
             open_date=buy_row.date,
             stake_amount=stake_amount,
             amount=stake_amount / buy_row.open,
@@ -149,35 +149,35 @@ class Backtesting(object):
                 trade_count_lock[sell_row.date] = trade_count_lock.get(sell_row.date, 0) + 1
 
             buy_signal = sell_row.buy
-            if self.analyze.should_sell(trade, sell_row.close, sell_row.date, buy_signal,
+            if self.analyze.should_sell(trade, sell_row.open, sell_row.date, buy_signal,
                                         sell_row.sell):
 
                 return BacktestResult(pair=pair,
-                                      profit_percent=trade.calc_profit_percent(rate=sell_row.close),
-                                      profit_abs=trade.calc_profit(rate=sell_row.close),
+                                      profit_percent=trade.calc_profit_percent(rate=sell_row.open),
+                                      profit_abs=trade.calc_profit(rate=sell_row.open),
                                       open_time=buy_row.date,
                                       close_time=sell_row.date,
                                       trade_duration=(sell_row.date - buy_row.date).seconds // 60,
                                       open_index=buy_row.Index,
                                       close_index=sell_row.Index,
                                       open_at_end=False,
-                                      open_rate=buy_row.close,
-                                      close_rate=sell_row.close
+                                      open_rate=buy_row.open,
+                                      close_rate=sell_row.open
                                       )
         if partial_ticker:
             # no sell condition found - trade stil open at end of backtest period
             sell_row = partial_ticker[-1]
             btr = BacktestResult(pair=pair,
-                                 profit_percent=trade.calc_profit_percent(rate=sell_row.close),
-                                 profit_abs=trade.calc_profit(rate=sell_row.close),
+                                 profit_percent=trade.calc_profit_percent(rate=sell_row.open),
+                                 profit_abs=trade.calc_profit(rate=sell_row.open),
                                  open_time=buy_row.date,
                                  close_time=sell_row.date,
                                  trade_duration=(sell_row.date - buy_row.date).seconds // 60,
                                  open_index=buy_row.Index,
                                  close_index=sell_row.Index,
                                  open_at_end=True,
-                                 open_rate=buy_row.close,
-                                 close_rate=sell_row.close
+                                 open_rate=buy_row.open,
+                                 close_rate=sell_row.open
                                  )
             logger.debug('Force_selling still open trade %s with %s perc - %s', btr.pair,
                          btr.profit_percent, btr.profit_abs)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -502,28 +502,28 @@ def test_backtest(default_conf, fee, mocker) -> None:
 
     expected = pd.DataFrame(
         {'pair': [pair, pair],
-         'profit_percent': [0.00148826, 0.00075313],
+         'profit_percent': [0.00029975, 0.00056708],
          'profit_abs': [1.49e-06, 7.6e-07],
          'open_time': [Arrow(2018, 1, 29, 18, 40, 0).datetime,
                        Arrow(2018, 1, 30, 3, 30, 0).datetime],
-         'close_time': [Arrow(2018, 1, 29, 23, 15, 0).datetime,
+         'close_time': [Arrow(2018, 1, 29, 22, 40, 0).datetime,
                         Arrow(2018, 1, 30, 4, 20, 0).datetime],
          'open_index': [77, 183],
-         'close_index': [132, 193],
-         'trade_duration': [275, 50],
+         'close_index': [125, 193],
+         'trade_duration': [240, 50],
          'open_at_end': [False, False],
-         'open_rate': [0.10432, 0.103364],
-         'close_rate': [0.104999, 0.10396]})
+         'open_rate': [0.104445, 0.10302485],
+         'close_rate': [0.105, 0.10359999]})
     pd.testing.assert_frame_equal(results, expected)
     data_pair = data_processed[pair]
     for _, t in results.iterrows():
         ln = data_pair.loc[data_pair["date"] == t["open_time"]]
-        # Check open trade
+        # Check open trade rate alignes to open rate
         assert ln is not None
-        assert round(ln.iloc[0]["close"], 6) == round(t["open_rate"], 6)
-        # check close trade
+        assert round(ln.iloc[0]["open"], 6) == round(t["open_rate"], 6)
+        # check close trade rate alignes to close rate
         ln = data_pair.loc[data_pair["date"] == t["close_time"]]
-        assert round(ln.iloc[0]["close"], 6) == round(t["close_rate"], 6)
+        assert round(ln.iloc[0]["open"], 6) == round(t["close_rate"], 6)
 
 
 def test_backtest_1min_ticker_interval(default_conf, fee, mocker) -> None:


### PR DESCRIPTION
## Summary
Use Open-rate for backtesting.
For an explanation as to why, se either ticket or the explanation below.

TL,DR: we use buy/sell signals from ticker the previous ticker - so we need to use open-rate, otherwise we use a different price (eventually a few hours later - when using hour/2h tickers).

Solve the issue: #961

## Quick changelog

- Use open as trade-open / close rate while backtesting

## Explanation - logic:
thanks to @creslinux for the great paper he wrote explaining this issue, i will shamelessly copy/paste his report below

<img width="511" alt="42368021-7917b1b2-80f5-11e8-8fba-13c616d1bb94" src="https://user-images.githubusercontent.com/5024695/42422755-a00f3c60-82ec-11e8-8672-04d36f6a3954.png">
