### PR TITLE
Update plotly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ coinmarketcap==5.0.3
 scikit-optimize==0.5.2
 
 # Required for plotting data
-#plotly==2.7.0
+#plotly==3.0.0

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -271,7 +271,7 @@ def generate_graph(pair, trades: pd.DataFrame, data: pd.DataFrame, args) -> tool
             x=data.date,
             y=data.bb_lowerband,
             name='BB lower',
-            line={'color': "transparent"},
+            line={'color': 'rgba(255,255,255,0)'},
         )
         bb_upper = go.Scatter(
             x=data.date,
@@ -279,7 +279,7 @@ def generate_graph(pair, trades: pd.DataFrame, data: pd.DataFrame, args) -> tool
             name='BB upper',
             fill="tonexty",
             fillcolor="rgba(0,176,246,0.2)",
-            line={'color': "transparent"},
+            line={'color': 'rgba(255,255,255,0)'},
         )
         fig.append_trace(bb_lower, 1, 1)
         fig.append_trace(bb_upper, 1, 1)


### PR DESCRIPTION
## Summary
Update plotly to version 3.0.0.

## Quick changelog

`"transparent"` is not supported anymore it appears - use `rgba(x,x,x,255)` to get transparent colors.

visually there is no change ... but here is a screenshot showing that ...

![2018-07-10-195557_1914x899_scrot](https://user-images.githubusercontent.com/5024695/42528291-4fc3fd64-847b-11e8-8d7a-b352239cb8de.png)
