### PR TITLE
Reduce time taken for backtest.py - def backtest by 60%

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -221,7 +221,21 @@ class Backtesting(object):
 
             # Convert from Pandas to list for performance reasons
             # (Looping Pandas is slow.)
-            ticker = [x for x in ticker_data.itertuples()]
+
+            #ticker = [x for x in ticker_data.itertuples()]
+            """
+            Use faster numpy to mask out rows we will not use in slower itertuples loop
+
+            Filter rows that are buy or sell to be processed
+            Also keep the last row from in any state for open trades
+            """
+            mask = (ticker_data['buy'].values != 0) | (ticker_data['sell'].values != 0)
+            ticker_loop_data=ticker_data[mask]
+
+            end_row = DataFrame(ticker_data[-1:].values, columns=ticker_data.columns)
+            ticker_loop_data = ticker_loop_data.append(end_row)
+
+            ticker = [x for x in ticker_loop_data.itertuples()]
 
             lock_pair_until = None
             for index, row in enumerate(ticker):


### PR DESCRIPTION
Performs bitwise filter on buy/sell rows in the df
before passing to the slower itertuples loop

The larger the dataset the greater the performance gain

Tested for absence of malice with before/after diffs on output of 60 pairs with 24,000 candles. 
No delta on any trades closed or open.  (223 closed trades 19 open)

Diff available here: http://www.mergely.com/EoGF9SST/

Profile traces before and after: 

Before: 4.7 seconds
```
*** PROFILER RESULTS ***
backtest (/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/optimize/backtesting.py:189)
function called 1 times

         3274636 function calls (3261140 primitive calls) in 4.780 seconds
```

After: 2.09 seconds
```
*** PROFILER RESULTS ***
backtest (/Users/creslin/PycharmProjects/freqtrade_new/freqtrade/optimize/backtesting.py:189)
function called 1 times

         1977916 function calls (1961960 primitive calls) in 2.097 seconds


```