### PR TITLE
ujson to load ticker files 30% faster in BT

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -2,6 +2,7 @@
 
 import gzip
 import json
+import ujson
 import logging
 import os
 from typing import Optional, List, Dict, Tuple, Any
@@ -67,7 +68,7 @@ def load_tickerdata_file(
     elif os.path.isfile(file):
         logger.debug('Loading ticker data from file %s', file)
         with open(file) as tickerdata:
-            pairdata = json.load(tickerdata)
+            pairdata = ujson.load(tickerdata)
     else:
         return None
 
@@ -163,7 +164,7 @@ def load_cached_data_for_updating(filename: str,
     # read the cached file
     if os.path.isfile(filename):
         with open(filename, "rt") as file:
-            data = json.load(file)
+            data = ujson.load(file)
             # remove the last item, because we are not sure if it is correct
             # it could be fetched when the candle was incompleted
             if data:

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -10,14 +10,16 @@ import arrow
 from freqtrade import misc, constants, OperationalException
 from freqtrade.exchange import Exchange
 from freqtrade.arguments import TimeRange
-
-logger = logging.getLogger(__name__)
-
 import importlib
 ujson_found = importlib.util.find_spec("ujson")
 if ujson_found is not None:
     import ujson
+
+logger = logging.getLogger(__name__)
+
+if ujson_found is not None:
     logger.debug('Loaded UltraJson ujson in optimize.py')
+
 
 def trim_tickerlist(tickerlist: List[Dict], timerange: TimeRange) -> List[Dict]:
     if not tickerlist:

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -2,7 +2,6 @@
 
 import gzip
 import json
-import ujson
 import logging
 import os
 from typing import Optional, List, Dict, Tuple, Any
@@ -11,6 +10,11 @@ import arrow
 from freqtrade import misc, constants, OperationalException
 from freqtrade.exchange import Exchange
 from freqtrade.arguments import TimeRange
+
+import importlib
+ujson_found = importlib.util.find_spec("ujson")
+if ujson_found is not None:
+    import ujson
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +72,10 @@ def load_tickerdata_file(
     elif os.path.isfile(file):
         logger.debug('Loading ticker data from file %s', file)
         with open(file) as tickerdata:
-            pairdata = ujson.load(tickerdata)
+            if ujson_found is not None:
+                pairdata = ujson.load(tickerdata)
+            else:
+                pairdata = json.load(tickerdata)
     else:
         return None
 

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -164,7 +164,7 @@ def load_cached_data_for_updating(filename: str,
     # read the cached file
     if os.path.isfile(filename):
         with open(filename, "rt") as file:
-            data = ujson.load(file)
+            data = json.load(file)
             # remove the last item, because we are not sure if it is correct
             # it could be fetched when the candle was incompleted
             if data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,10 @@ pytest-mock==1.10.0
 pytest-cov==2.5.1
 tabulate==0.8.2
 coinmarketcap==5.0.3
-ujson==1.35
+
+# Optional, speeds up ticker load
+# Requires visual studio in windows.
+#ujson==1.35
 
 # Required for hyperopt
 scikit-optimize==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ tabulate==0.8.2
 coinmarketcap==5.0.3
 
 # Optional, speeds up ticker load
-# Requires visual studio in windows.
+# Requires visual studio if on windows.
 #ujson==1.35
 
 # Required for hyperopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytest-mock==1.10.0
 pytest-cov==2.5.1
 tabulate==0.8.2
 coinmarketcap==5.0.3
+ujson==1.35
 
 # Required for hyperopt
 scikit-optimize==0.5.2


### PR DESCRIPTION
ujson loads ticker files 30% quicker in backest 
This can accumulate to many second as exchanges host 150+ pairs and users backtest longer data

In a test on 60 pairs with 2 weeks back data profile demonstrates load ticker time reduced from 
over 5 to 3.5 seconds. 

<img width="754" alt="screen shot 2018-07-12 at 12 05 28 pm" src="https://user-images.githubusercontent.com/34645187/42633100-eee52fe0-85ce-11e8-83e1-022ee6298d09.png">

<img width="741" alt="screen shot 2018-07-12 at 12 04 09 pm" src="https://user-images.githubusercontent.com/34645187/42633103-f356a8b0-85ce-11e8-9c03-bc13b2c46929.png">

the change has been tech tested to show no impact to trades in backtest with stop/roi and buy/sell 1
no detla witnessed, diff linked

http://www.mergely.com/0qwuibQH/
