### PR TITLE
Update config dict with attributes loaded from strategy

### DIFF
--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -41,12 +41,16 @@ class StrategyResolver(object):
         if 'minimal_roi' in config:
             self.strategy.minimal_roi = config['minimal_roi']
             logger.info("Override strategy \'minimal_roi\' with value in config file.")
+        else:
+            config['minimal_roi'] = self.strategy.minimal_roi
 
         if 'stoploss' in config:
             self.strategy.stoploss = config['stoploss']
             logger.info(
                 "Override strategy \'stoploss\' with value in config file: %s.", config['stoploss']
             )
+        else:
+            config['stoploss'] = self.strategy.stoploss
 
         if 'ticker_interval' in config:
             self.strategy.ticker_interval = config['ticker_interval']
@@ -54,6 +58,8 @@ class StrategyResolver(object):
                 "Override strategy \'ticker_interval\' with value in config file: %s.",
                 config['ticker_interval']
             )
+        else:
+            config['ticker_interval'] = self.strategy.ticker_interval
 
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -74,13 +74,21 @@ def test_load_not_found_strategy():
 
 
 def test_strategy(result):
-    resolver = StrategyResolver({'strategy': 'DefaultStrategy'})
+    config = {'strategy': 'DefaultStrategy'}
+
+    resolver = StrategyResolver(config)
 
     assert hasattr(resolver.strategy, 'minimal_roi')
     assert resolver.strategy.minimal_roi[0] == 0.04
+    assert config.get("minimal_roi")['0'] == 0.04
 
     assert hasattr(resolver.strategy, 'stoploss')
     assert resolver.strategy.stoploss == -0.10
+    assert config['stoploss'] == -0.10
+
+    assert hasattr(resolver.strategy, 'ticker_interval')
+    assert resolver.strategy.ticker_interval == '5m'
+    assert config['ticker_interval'] == '5m'
 
     assert hasattr(resolver.strategy, 'populate_indicators')
     assert 'adx' in resolver.strategy.populate_indicators(result)

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -80,7 +80,7 @@ def test_strategy(result):
 
     assert hasattr(resolver.strategy, 'minimal_roi')
     assert resolver.strategy.minimal_roi[0] == 0.04
-    assert config.get("minimal_roi")['0'] == 0.04
+    assert config["minimal_roi"]['0'] == 0.04
 
     assert hasattr(resolver.strategy, 'stoploss')
     assert resolver.strategy.stoploss == -0.10


### PR DESCRIPTION
## Summary
Update the config-dict with values loaded from the strategy.
This should allow consistent use of the config object without the need to check if the attribute is not configured and came from the Strategy.

Solve the issue: #998, helps #979 which relies on having ticker_interval in the config dict after loading.

## Quick changelog

- Updates the config dictionary