### PR TITLE
add offset for positive trailing stop loss

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -7,6 +7,7 @@
     "ticker_interval": "5m",
     "trailing_stop": false,
     "trailing_stop_positive": 0.005,
+    "trailing_stop_positive_offset": 0.0051,
     "minimal_roi": {
         "40":  0.0,
         "30":  0.01,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ The table below will list all configuration parameters.
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file. 
 | `trailing_stoploss` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file).
 | `trailing_stoploss_positve` | 0 | No | Changes stop-loss once profit has been reached.
+| `trailing_stoploss_positve_offset` | 0 | No | Offset on when to apply `trailing_stoploss_positive`. Percentage value which should be positive.
 | `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
 | `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -35,14 +35,17 @@ basically what this means is that your stop loss will be adjusted to be always b
 
 ### Custom positive loss
 
-Due to demand, it is possible to have a default stop loss, when you are in the red with your buy, but once your buy turns positive,
-the system will utilize a new stop loss, which can be a different value. For example your default stop loss is 5%, but once you are in the
-black, it will be changed to be only a 1% stop loss
+Due to demand, it is possible to have a default stop loss, when you are in the red with your buy, but once your profit surpasses a certain percentage,
+the system will utilize a new stop loss, which can be a different value. For example your default stop loss is 5%, but once you have 1.1% profit,
+it will be changed to be only a 1% stop loss, which trails the green candles until it goes below them.
 
-This can be configured in the main configuration file and requires `"trailing_stop": true` to be set to true.
+Both values can be configured in the main configuration file and requires `"trailing_stop": true` to be set to true.
 
 ``` json
     "trailing_stop_positive":  0.01,
+    "trailing_stop_positive_offset":  0.011,
 ```
 
-The 0.01 would translate to a 1% stop loss, once you hit profit.
+The 0.01 would translate to a 1% stop loss, once you hit 1.1% profit.
+
+You should also make sure to have this value higher than your minimal ROI, otherwise minimal ROI will apply first and sell your trade.

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -63,6 +63,7 @@ CONF_SCHEMA = {
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
         'trailing_stop': {'type': 'boolean'},
         'trailing_stop_positive': {'type': 'number', 'minimum': 0, 'maximum': 1},
+        'trailing_stop_positive_offset': {'type': 'number', 'minimum': 0, 'maximum': 1},
         'unfilledtimeout': {
             'type': 'object',
             'properties': {

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -174,6 +174,7 @@ class IStrategy(ABC):
         """
         Based on current profit of the trade and configured (trailing) stoploss,
         decides to sell or not
+        :param current_profit: current profit in percent
         """
 
         trailing_stop = self.config.get('trailing_stop', False)
@@ -199,13 +200,16 @@ class IStrategy(ABC):
 
             # check if we have a special stop loss for positive condition
             # and if profit is positive
-            stop_loss_value = self.stoploss
-            if 'trailing_stop_positive' in self.config and current_profit > 0:
+            stop_loss_value = self.strategy.stoploss
+            sl_offset = self.config.get('trailing_stop_positive_offset', 0.0)
+
+            if 'trailing_stop_positive' in self.config and current_profit > sl_offset:
 
                 # Ignore mypy error check in configuration that this is a float
                 stop_loss_value = self.config.get('trailing_stop_positive')  # type: ignore
                 logger.debug(f"using positive stop loss mode: {stop_loss_value} "
-                             f"since we have profit {current_profit}")
+                             f"with offset {sl_offset:.4g} "
+                             f"since we have profit {current_profit:.4f}%")
 
             trade.adjust_stop_loss(current_rate, stop_loss_value)
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -200,7 +200,7 @@ class IStrategy(ABC):
 
             # check if we have a special stop loss for positive condition
             # and if profit is positive
-            stop_loss_value = self.strategy.stoploss
+            stop_loss_value = self.stoploss
             sl_offset = self.config.get('trailing_stop_positive_offset', 0.0)
 
             if 'trailing_stop_positive' in self.config and current_profit > sl_offset:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -45,7 +45,7 @@ def patch_get_signal(freqtrade: FreqtradeBot, value=(True, False)) -> None:
     :param value: which value IStrategy.get_signal() must return
     :return: None
     """
-    freqtrade.get_signal = lambda e, s, t: value
+    freqtrade.strategy.get_signal = lambda e, s, t: value
 
 
 def patch_RPCManager(mocker) -> MagicMock:
@@ -1830,7 +1830,6 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee, caplog, m
     Test sell_profit_only feature when enabled and we have a loss
     """
     buy_price = limit_buy_order['price']
-    patch_get_signal(mocker)
     patch_RPCManager(mocker)
     patch_coinmarketcap(mocker)
     mocker.patch.multiple(
@@ -1850,8 +1849,8 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee, caplog, m
     conf['trailing_stop_positive'] = 0.01
     conf['trailing_stop_positive_offset'] = 0.011
     freqtrade = FreqtradeBot(conf)
-    freqtrade.strategy.min_roi_reached = lambda trade, current_profit, current_time: True
-
+    patch_get_signal(freqtrade)
+    freqtrade.strategy.min_roi_reached = lambda trade, current_profit, current_time: False
     freqtrade.create_trade()
 
     trade = Trade.query.first()

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -45,7 +45,7 @@ def patch_get_signal(freqtrade: FreqtradeBot, value=(True, False)) -> None:
     :param value: which value IStrategy.get_signal() must return
     :return: None
     """
-    freqtrade.strategy.get_signal = lambda e, s, t: value
+    freqtrade.get_signal = lambda e, s, t: value
 
 
 def patch_RPCManager(mocker) -> MagicMock:
@@ -1833,7 +1833,6 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee, caplog, m
     patch_get_signal(mocker)
     patch_RPCManager(mocker)
     patch_coinmarketcap(mocker)
-    mocker.patch('freqtrade.freqtradebot.Analyze.min_roi_reached', return_value=False)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         validate_pairs=MagicMock(),
@@ -1851,6 +1850,8 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee, caplog, m
     conf['trailing_stop_positive'] = 0.01
     conf['trailing_stop_positive_offset'] = 0.011
     freqtrade = FreqtradeBot(conf)
+    freqtrade.strategy.min_roi_reached = lambda trade, current_profit, current_time: True
+
     freqtrade.create_trade()
 
     trade = Trade.query.first()


### PR DESCRIPTION

## Summary
add offset to trailing stop loss positive - otherwise it stops trailing with -1% (for example) once the profit is 0 - which is still a red trade.

Solve the issue: #1020 

## Quick changelog

- introduce new parameter for trailing stop loss Positive
