### PR TITLE
replace --realistic with 2 separate flags

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -29,25 +29,25 @@ The backtesting is very easy with freqtrade.
 #### With 5 min tickers (Per default)
 
 ```bash
-python3 ./freqtrade/main.py backtesting --realistic-simulation
+python3 ./freqtrade/main.py backtesting
 ```
 
 #### With 1 min tickers
 
 ```bash
-python3 ./freqtrade/main.py backtesting --realistic-simulation --ticker-interval 1m
+python3 ./freqtrade/main.py backtesting --ticker-interval 1m
 ```
 
 #### Update cached pairs with the latest data
 
 ```bash
-python3 ./freqtrade/main.py backtesting --realistic-simulation --refresh-pairs-cached
+python3 ./freqtrade/main.py backtesting --refresh-pairs-cached
 ```
 
 #### With live data (do not alter your testdata files)
 
 ```bash
-python3 ./freqtrade/main.py backtesting --realistic-simulation --live
+python3 ./freqtrade/main.py backtesting --live
 ```
 
 #### Using a different on-disk ticker-data source

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -126,7 +126,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --realistic-simulation
+  --enable-position-tracking
                         Disables buying the same pair multiple times to 
                         simulate real world limitations
   --timerange TIMERANGE
@@ -164,7 +164,7 @@ To optimize your strategy, you can use hyperopt parameter hyperoptimization
 to find optimal parameter values for your stategy.
 
 ```
-usage: main.py hyperopt [-h] [-i TICKER_INTERVAL] [--realistic-simulation]
+usage: main.py hyperopt [-h] [-i TICKER_INTERVAL] [--enable-position-tracking]
                         [--timerange TIMERANGE] [-e INT]
                         [-s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]]
 
@@ -172,7 +172,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --realistic-simulation
+  --enable-position-tracking
                         Disables buying the same pair multiple times to 
                         simulate real world limitations
   --timerange TIMERANGE specify what timerange of data to use.

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -127,8 +127,8 @@ optional arguments:
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
   --realistic-simulation
-                        uses max_open_trades from config to simulate real
-                        world limitations
+                        Disables buying the same pair multiple times to 
+                        simulate real world limitations
   --timerange TIMERANGE
                         specify what timerange of data to use.
   -l, --live            using live data
@@ -173,8 +173,8 @@ optional arguments:
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
   --realistic-simulation
-                        uses max_open_trades from config to simulate real
-                        world limitations
+                        Disables buying the same pair multiple times to 
+                        simulate real world limitations
   --timerange TIMERANGE specify what timerange of data to use.
   -e INT, --epochs INT  specify number of epochs (default: 100)
   -s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...], --spaces {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -117,9 +117,7 @@ python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.s
 Backtesting also uses the config specified via `-c/--config`.
 
 ```
-usage: main.py backtesting [-h] [-i TICKER_INTERVAL]
-                             [--enable-position-stacking]
-                             [--disable-max-market-positions]
+usage: main.py backtesting [-h] [-i TICKER_INTERVAL] [--eps] [--dmmp]
                              [--timerange TIMERANGE] [-l] [-r]
                              [--export EXPORT] [--export-filename PATH]
 
@@ -127,9 +125,10 @@ optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --enable-position-stacking
-                        Allow buying the same pair twice (position stacking)
-  --disable-max-market-positions
+  --eps, --enable-position-stacking
+                        Allow buying the same pair multiple times (position
+                        stacking)
+  --dmmp, --disable-max-market-positions
                         Disable applying `max_open_trades` during backtest
                         (same as setting `max_open_trades` to a very high
                         number)
@@ -170,9 +169,7 @@ To optimize your strategy, you can use hyperopt parameter hyperoptimization
 to find optimal parameter values for your stategy.
 
 ```
-usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL]
-                          [--enable-position-stacking]
-                          [--disable-max-market-positions]
+usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--eps] [--dmmp]
                           [--timerange TIMERANGE] [-e INT]
                           [-s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]]
 
@@ -180,9 +177,10 @@ optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --enable-position-stacking
-                        Allow buying the same pair twice (position stacking)
-  --disable-max-market-positions
+  --eps, --enable-position-stacking
+                        Allow buying the same pair multiple times (position
+                        stacking)
+  --dmmp, --disable-max-market-positions
                         Disable applying `max_open_trades` during backtest
                         (same as setting `max_open_trades` to a very high
                         number)

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -117,18 +117,22 @@ python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.s
 Backtesting also uses the config specified via `-c/--config`.
 
 ```
-usage: main.py backtesting [-h] [-i TICKER_INTERVAL] [--realistic-simulation]
-                           [--timerange TIMERANGE] [-l] [-r] [--export EXPORT]
-                           [--export-filename EXPORTFILENAME]
-
+usage: main.py backtesting [-h] [-i TICKER_INTERVAL]
+                             [--enable-position-stacking]
+                             [--disable-max-market-positions]
+                             [--timerange TIMERANGE] [-l] [-r]
+                             [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --enable-position-tracking
-                        Disables buying the same pair multiple times to 
-                        simulate real world limitations
+  --enable-position-stacking
+                        Allow buying the same pair twice (position stacking)
+  --disable-max-market-positions
+                        Disable applying `max_open_trades` during backtest
+                        (same as setting `max_open_trades` to a very high
+                        number)
   --timerange TIMERANGE
                         specify what timerange of data to use.
   -l, --live            using live data
@@ -138,11 +142,13 @@ optional arguments:
                         run your backtesting with up-to-date data.
   --export EXPORT       export backtest results, argument are: trades Example
                         --export=trades
-  --export-filename EXPORTFILENAME
+  --export-filename PATH
                         Save backtest results to this filename requires
                         --export to be set as well Example --export-
-                        filename=backtest_today.json (default: backtest-
-                        result.json
+                        filename=user_data/backtest_data/backtest_today.json
+                        (default: user_data/backtest_data/backtest-
+                        result.json)
+
 ```
 
 ### How to use --refresh-pairs-cached parameter?
@@ -164,22 +170,29 @@ To optimize your strategy, you can use hyperopt parameter hyperoptimization
 to find optimal parameter values for your stategy.
 
 ```
-usage: main.py hyperopt [-h] [-i TICKER_INTERVAL] [--enable-position-tracking]
-                        [--timerange TIMERANGE] [-e INT]
-                        [-s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]]
+usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL]
+                          [--enable-position-stacking]
+                          [--disable-max-market-positions]
+                          [--timerange TIMERANGE] [-e INT]
+                          [-s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
                         specify ticker interval (1m, 5m, 30m, 1h, 1d)
-  --enable-position-tracking
-                        Disables buying the same pair multiple times to 
-                        simulate real world limitations
-  --timerange TIMERANGE specify what timerange of data to use.
+  --enable-position-stacking
+                        Allow buying the same pair twice (position stacking)
+  --disable-max-market-positions
+                        Disable applying `max_open_trades` during backtest
+                        (same as setting `max_open_trades` to a very high
+                        number)
+  --timerange TIMERANGE
+                        specify what timerange of data to use.
   -e INT, --epochs INT  specify number of epochs (default: 100)
   -s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...], --spaces {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]
                         Specify which parameters to hyperopt. Space separate
                         list. Default: all
+
 ```
 
 ## A parameter missing in the configuration?

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -188,7 +188,7 @@ class Arguments(object):
         parser.add_argument(
             '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '
-                  '(same as setting `max_open_trades` to a very high number)',
+                 '(same as setting `max_open_trades` to a very high number)',
             action='store_false',
             dest='use_max_market_positions',
             default=True

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -184,6 +184,16 @@ class Arguments(object):
             dest='position_stacking',
             default=False
         )
+
+        parser.add_argument(
+            '--disable-max-market-positions',
+            help='Disable applying `max_open_trades` during backtest '
+                  '(same as setting `max_open_trades` to a very high number)',
+            action='store_false',
+            dest='use_max_market_positions',
+            default=True
+        )
+
         parser.add_argument(
             '--timerange',
             help='specify what timerange of data to use.',

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -178,10 +178,11 @@ class Arguments(object):
             type=str,
         )
         parser.add_argument(
-            '--realistic-simulation',
-            help='uses max_open_trades from config to simulate real world limitations',
+            '--enable-position-stacking',
+            help='Allow buying the same pair twice (position stacking)',
             action='store_true',
-            dest='realistic_simulation',
+            dest='position_stacking',
+            default=False
         )
         parser.add_argument(
             '--timerange',

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -178,15 +178,15 @@ class Arguments(object):
             type=str,
         )
         parser.add_argument(
-            '--enable-position-stacking',
-            help='Allow buying the same pair twice (position stacking)',
+            '--eps', '--enable-position-stacking',
+            help='Allow buying the same pair multiple times (position stacking)',
             action='store_true',
             dest='position_stacking',
             default=False
         )
 
         parser.add_argument(
-            '--disable-max-market-positions',
+            '--dmmp', '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '
                  '(same as setting `max_open_trades` to a very high number)',
             action='store_false',

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -147,7 +147,13 @@ class Configuration(object):
             config.update({'position_stacking': True})
             logger.info('Parameter --enable-position-stacking detected ...')
 
-        logger.info('Using max_open_trades: %s ...', config.get('max_open_trades'))
+        # If --disable-max-market-positions is used we add it to the configuration
+        if 'use_max_market_positions' in self.args and not self.args.use_max_market_positions:
+            config.update({'use_max_market_positions': False})
+            logger.info('Parameter --disable-max-market-positions detected ...')
+            logger.info('max_open_trades set to unlimited ...')
+        else:
+            logger.info('Using max_open_trades: %s ...', config.get('max_open_trades'))
 
         # If --timerange is used we add it to the configuration
         if 'timerange' in self.args and self.args.timerange:

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -142,10 +142,11 @@ class Configuration(object):
             config.update({'live': True})
             logger.info('Parameter -l/--live detected ...')
 
-        # If --realistic-simulation is used we add it to the configuration
-        if 'realistic_simulation' in self.args and self.args.realistic_simulation:
-            config.update({'realistic_simulation': True})
-            logger.info('Parameter --realistic-simulation detected ...')
+        # If --enable-position-stacking is used we add it to the configuration
+        if 'position_stacking' in self.args and self.args.position_stacking:
+            config.update({'position_stacking': True})
+            logger.info('Parameter --enable-position-stacking detected ...')
+
         logger.info('Using max_open_trades: %s ...', config.get('max_open_trades'))
 
         # If --timerange is used we add it to the configuration
@@ -182,7 +183,7 @@ class Configuration(object):
         Extract information for sys.argv and load Hyperopt configuration
         :return: configuration as dictionary
         """
-        # If --realistic-simulation is used we add it to the configuration
+        # If --epochs is used we add it to the configuration
         if 'epochs' in self.args and self.args.epochs:
             config.update({'epochs': self.args.epochs})
             logger.info('Parameter --epochs detected ...')

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -282,12 +282,11 @@ class Backtesting(object):
         if not data:
             logger.critical("No data found. Terminating.")
             return
-        # Ignore max_open_trades in backtesting, except realistic flag was passed
-        # TODO: this is not position stacking!!
-        if self.config.get('position_stacking', False):
+        # Use max_open_trades in backtesting, except --disable-max-market-positions is set
+        if self.config.get('use_max_market_positions', True):
             max_open_trades = self.config['max_open_trades']
         else:
-            logger.info('Ignoring max_open_trades (position_stacking not set) ...')
+            logger.info('Ignoring max_open_trades (--disable-max-market-positions was used) ...')
             max_open_trades = 0
 
         preprocessed = self.tickerdata_to_dataframe(data)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -280,7 +280,7 @@ class Hyperopt(Backtesting):
             {
                 'stake_amount': self.config['stake_amount'],
                 'processed': processed,
-                'realistic': self.config.get('realistic_simulation', False),
+                'position_stacking': self.config.get('position_stacking', False),
             }
         )
         result_explanation = self.format_results(results)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -280,7 +280,7 @@ class Hyperopt(Backtesting):
             {
                 'stake_amount': self.config['stake_amount'],
                 'processed': processed,
-                'position_stacking': self.config.get('position_stacking', False),
+                'position_stacking': self.config.get('position_stacking', True),
             }
         )
         result_explanation = self.format_results(results)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -219,6 +219,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         '--ticker-interval', '1m',
         '--live',
         '--enable-position-stacking',
+        '--disable-max-market-positions',
         '--refresh-pairs-cached',
         '--timerange', ':100',
         '--export', '/bar/foo',
@@ -248,7 +249,10 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
 
     assert 'position_stacking' in config
     assert log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
-    assert log_has('Using max_open_trades: 1 ...', caplog.record_tuples)
+
+    assert 'use_max_market_positions' in config
+    assert log_has('Parameter --disable-max-market-positions detected ...', caplog.record_tuples)
+    assert log_has('max_open_trades set to unlimited ...', caplog.record_tuples)
 
     assert 'refresh_pairs' in config
     assert log_has('Parameter -r/--refresh-pairs-cached detected ...', caplog.record_tuples)
@@ -718,7 +722,8 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         '--ticker-interval', '1m',
         '--live',
         '--timerange', '-100',
-        '--enable-position-stacking'
+        '--enable-position-stacking',
+        '--disable-max-market-positions'
     ]
     args = get_args(args)
     start(args)
@@ -727,7 +732,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         'Parameter -i/--ticker-interval detected ...',
         'Using ticker_interval: 1m ...',
         'Parameter -l/--live detected ...',
-        'Using max_open_trades: 1 ...',
+        'Ignoring max_open_trades (--disable-max-market-positions was used) ...',
         'Parameter --timerange detected: -100 ...',
         'Using data folder: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -96,7 +96,7 @@ def simple_backtest(config, contour, num_results, mocker) -> None:
             'stake_amount': config['stake_amount'],
             'processed': processed,
             'max_open_trades': 1,
-            'realistic': True
+            'position_stacking': False
         }
     )
     # results :: <class 'pandas.core.frame.DataFrame'>
@@ -127,7 +127,7 @@ def _make_backtest_conf(mocker, conf=None, pair='UNITTEST/BTC', record=None):
         'stake_amount': conf['stake_amount'],
         'processed': backtesting.tickerdata_to_dataframe(data),
         'max_open_trades': 10,
-        'realistic': True,
+        'position_stacking': False,
         'record': record
     }
 
@@ -193,8 +193,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'live' not in config
     assert not log_has('Parameter -l/--live detected ...', caplog.record_tuples)
 
-    assert 'realistic_simulation' not in config
-    assert not log_has('Parameter --realistic-simulation detected ...', caplog.record_tuples)
+    assert 'position_stacking' not in config
+    assert not log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
 
     assert 'refresh_pairs' not in config
     assert not log_has('Parameter -r/--refresh-pairs-cached detected ...', caplog.record_tuples)
@@ -218,7 +218,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         'backtesting',
         '--ticker-interval', '1m',
         '--live',
-        '--realistic-simulation',
+        '--enable-position-stacking',
         '--refresh-pairs-cached',
         '--timerange', ':100',
         '--export', '/bar/foo',
@@ -246,8 +246,8 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'live' in config
     assert log_has('Parameter -l/--live detected ...', caplog.record_tuples)
 
-    assert 'realistic_simulation' in config
-    assert log_has('Parameter --realistic-simulation detected ...', caplog.record_tuples)
+    assert 'position_stacking' in config
+    assert log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
     assert log_has('Using max_open_trades: 1 ...', caplog.record_tuples)
 
     assert 'refresh_pairs' in config
@@ -495,7 +495,7 @@ def test_backtest(default_conf, fee, mocker) -> None:
             'stake_amount': default_conf['stake_amount'],
             'processed': data_processed,
             'max_open_trades': 10,
-            'realistic': True
+            'position_stacking': False
         }
     )
     assert not results.empty
@@ -543,7 +543,7 @@ def test_backtest_1min_ticker_interval(default_conf, fee, mocker) -> None:
             'stake_amount': default_conf['stake_amount'],
             'processed': backtesting.tickerdata_to_dataframe(data),
             'max_open_trades': 1,
-            'realistic': True
+            'position_stacking': False
         }
     )
     assert not results.empty
@@ -718,7 +718,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         '--ticker-interval', '1m',
         '--live',
         '--timerange', '-100',
-        '--realistic-simulation'
+        '--enable-position-stacking'
     ]
     args = get_args(args)
     start(args)
@@ -734,7 +734,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         'Using stake_amount: 0.001 ...',
         'Downloading data for all pairs in whitelist ...',
         'Measuring data from 2017-11-14T19:31:00+00:00 up to 2017-11-14T22:58:00+00:00 (0 days)..',
-        'Parameter --realistic-simulation detected ...'
+        'Parameter --enable-position-stacking detected ...'
     ]
 
     for line in exists:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -275,8 +275,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'live' not in config
     assert not log_has('Parameter -l/--live detected ...', caplog.record_tuples)
 
-    assert 'realistic_simulation' not in config
-    assert not log_has('Parameter --realistic-simulation detected ...', caplog.record_tuples)
+    assert 'position_stacking' not in config
+    assert not log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
 
     assert 'refresh_pairs' not in config
     assert not log_has('Parameter -r/--refresh-pairs-cached detected ...', caplog.record_tuples)
@@ -300,7 +300,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         'backtesting',
         '--ticker-interval', '1m',
         '--live',
-        '--realistic-simulation',
+        '--enable-position-stacking',
         '--refresh-pairs-cached',
         '--timerange', ':100',
         '--export', '/bar/foo'
@@ -330,8 +330,8 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'live' in config
     assert log_has('Parameter -l/--live detected ...', caplog.record_tuples)
 
-    assert 'realistic_simulation'in config
-    assert log_has('Parameter --realistic-simulation detected ...', caplog.record_tuples)
+    assert 'position_stacking'in config
+    assert log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
     assert log_has('Using max_open_trades: 1 ...', caplog.record_tuples)
 
     assert 'refresh_pairs'in config

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -301,6 +301,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         '--ticker-interval', '1m',
         '--live',
         '--enable-position-stacking',
+        '--disable-max-market-positions',
         '--refresh-pairs-cached',
         '--timerange', ':100',
         '--export', '/bar/foo'
@@ -332,7 +333,10 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
 
     assert 'position_stacking'in config
     assert log_has('Parameter --enable-position-stacking detected ...', caplog.record_tuples)
-    assert log_has('Using max_open_trades: 1 ...', caplog.record_tuples)
+
+    assert 'use_max_market_positions' in config
+    assert log_has('Parameter --disable-max-market-positions detected ...', caplog.record_tuples)
+    assert log_has('max_open_trades set to unlimited ...', caplog.record_tuples)
 
     assert 'refresh_pairs'in config
     assert log_has('Parameter -r/--refresh-pairs-cached detected ...', caplog.record_tuples)


### PR DESCRIPTION
## Summary
This PR will remove the `--realistic-simulation` flag and replace it with `--enable-position-stacking` and `--disable-max-market-positions`.

Solve the issue: #1035

## Business case

The `--realistic-simulation` flag (referenced as `--realistic` from now on) did 2 things - enable max_open_trades in backtest and disable "position stacking" - buying the same pair multiple times.
Having this combined creates a lot of confusion (see slack discussion yesterday evening) - and limits the usefullness of backtesting as it limts what different scenarios can be tested.

The default is now a `--realistic` mode - simulating how the bot should behave in production (i know we're not there yet), as the assumption is that new users will want to experiment with this first, and dive into the other options once they are comfortable with strategy development.



## quick changelog
* remove `--realistic-simulation`
* add `--enable-position-stacking`
* add `--disable-max-market-positions`


i think the new `--help` explains this best:
```
  --enable-position-stacking
                        Allow buying the same pair twice (position stacking)
  --disable-max-market-positions
                        Disable applying `max_open_trades` during backtest
                        (same as setting `max_open_trades` to a very high
                        number)

```