### PR TITLE
Catch all exceptions from fiat-convert api calls

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -7,7 +7,6 @@ import logging
 import time
 from typing import Dict, List
 
-from requests.exceptions import RequestException
 from coinmarketcap import Market
 
 from freqtrade.constants import SUPPORTED_FIAT
@@ -90,10 +89,10 @@ class CryptoToFiatConverter(object):
             coinlistings = self._coinmarketcap.listings()
             self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"])),
                                        coinlistings["data"]))
-        except (ValueError, RequestException) as exception:
+        except (BaseException) as exception:
             logger.error(
                 "Could not load FIAT Cryptocurrency map for the following problem: %s",
-                exception
+                type(exception).__name__
             )
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -183,6 +183,24 @@ def test_fiat_convert_without_network(mocker):
     CryptoToFiatConverter._coinmarketcap = cmc_temp
 
 
+def test_fiat_invalid_response(mocker, caplog):
+    # Because CryptoToFiatConverter is a Singleton we reset the listings
+    listmock = MagicMock(return_value="{'novalidjson':DEADBEEFf}")
+    mocker.patch.multiple(
+        'freqtrade.fiat_convert.Market',
+        listings=listmock,
+    )
+    # with pytest.raises(RequestEsxception):
+    fiat_convert = CryptoToFiatConverter()
+    fiat_convert._cryptomap = {}
+    fiat_convert._load_cryptomap()
+
+    length_cryptomap = len(fiat_convert._cryptomap)
+    assert length_cryptomap == 0
+    assert log_has('Could not load FIAT Cryptocurrency map for the following problem: TypeError',
+                   caplog.record_tuples)
+
+
 def test_convert_amount(mocker):
     patch_coinmarketcap(mocker)
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter.get_price', return_value=12345.0)


### PR DESCRIPTION
## Summary
Fiat convert should under no circumstance cause the bot to stop functioning, therefore all exceptions from the API should be cought (coinmarketcap may have a bad day and return rubbish or whatever ... but it's not vital for the bot so if it doesn't work we can ignore it.

This was in place for find_price, but not for the initialization of the library.

Solve the issue: #1052

## Quick changelog

- Catch all exceptions
