### PR TITLE
Add missing mock

### DIFF
--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1726,7 +1726,7 @@ def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, markets, m
     assert freqtrade.handle_trade(trade) is True
 
 
-def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) -> None:
+def test_trailing_stop_loss(default_conf, limit_buy_order, fee, markets, caplog, mocker) -> None:
     """
     Test sell_profit_only feature when enabled and we have a loss
     """
@@ -1742,6 +1742,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) 
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
+        get_markets=markets,
     )
 
     conf = deepcopy(default_conf)
@@ -1763,7 +1764,8 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) 
         f'initial stop loss was at 0.000010, trade opened at 0.000011', caplog.record_tuples)
 
 
-def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, caplog, mocker) -> None:
+def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, markets,
+                                     caplog, mocker) -> None:
     """
     Test sell_profit_only feature when enabled and we have a loss
     """
@@ -1780,6 +1782,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, caplog,
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
+        get_markets=markets,
     )
 
     conf = deepcopy(default_conf)


### PR DESCRIPTION
## Summary
Found another instance of a mock not being in place, causing my tests to fail on the plane.


## Quick changelog

- Fix mocking for get_markets where it was missing