### PR TITLE
fix a bug in the database migration script

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -83,6 +83,8 @@ def check_migrate(engine) -> None:
 
     # Check for latest column
     if not has_column(cols, 'max_rate'):
+        fee_open = get_column_def(cols, 'fee_open', 'fee')
+        fee_close = get_column_def(cols, 'fee_close', 'fee')
         open_rate_requested = get_column_def(cols, 'open_rate_requested', 'null')
         close_rate_requested = get_column_def(cols, 'close_rate_requested', 'null')
         stop_loss = get_column_def(cols, 'stop_loss', '0.0')
@@ -109,7 +111,7 @@ def check_migrate(engine) -> None:
                     else pair
                     end
                 pair,
-                is_open, fee fee_open, fee fee_close,
+                is_open, {fee_open} fee_open, {fee_close} fee_close,
                 open_rate, {open_rate_requested} open_rate_requested, close_rate,
                 {close_rate_requested} close_rate_requested, close_profit,
                 stake_amount, amount, open_date, close_date, open_order_id,

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -469,6 +469,65 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
     assert log_has("trying trades_bak2", caplog.record_tuples)
 
 
+def test_migrate_mid_state(mocker, default_conf, fee, caplog):
+    """
+    Test Database migration (starting with new pairformat)
+    """
+    amount = 103.223
+    create_table_old = """CREATE TABLE IF NOT EXISTS "trades" (
+                                id INTEGER NOT NULL,
+                                exchange VARCHAR NOT NULL,
+                                pair VARCHAR NOT NULL,
+                                is_open BOOLEAN NOT NULL,
+                                fee_open FLOAT NOT NULL,
+                                fee_close FLOAT NOT NULL,
+                                open_rate FLOAT,
+                                close_rate FLOAT,
+                                close_profit FLOAT,
+                                stake_amount FLOAT NOT NULL,
+                                amount FLOAT,
+                                open_date DATETIME NOT NULL,
+                                close_date DATETIME,
+                                open_order_id VARCHAR,
+                                PRIMARY KEY (id),
+                                CHECK (is_open IN (0, 1))
+                                );"""
+    insert_table_old = """INSERT INTO trades (exchange, pair, is_open, fee_open, fee_close,
+                          open_rate, stake_amount, amount, open_date)
+                          VALUES ('binance', 'ETC/BTC', 1, {fee}, {fee},
+                          0.00258580, {stake}, {amount},
+                          '2019-11-28 12:44:24.000000')
+                          """.format(fee=fee.return_value,
+                                     stake=default_conf.get("stake_amount"),
+                                     amount=amount
+                                     )
+    engine = create_engine('sqlite://')
+    mocker.patch('freqtrade.persistence.create_engine', lambda *args, **kwargs: engine)
+
+    # Create table using the old format
+    engine.execute(create_table_old)
+    engine.execute(insert_table_old)
+
+    # Run init to test migration
+    init(default_conf)
+
+    assert len(Trade.query.filter(Trade.id == 1).all()) == 1
+    trade = Trade.query.filter(Trade.id == 1).first()
+    assert trade.fee_open == fee.return_value
+    assert trade.fee_close == fee.return_value
+    assert trade.open_rate_requested is None
+    assert trade.close_rate_requested is None
+    assert trade.is_open == 1
+    assert trade.amount == amount
+    assert trade.stake_amount == default_conf.get("stake_amount")
+    assert trade.pair == "ETC/BTC"
+    assert trade.exchange == "binance"
+    assert trade.max_rate == 0.0
+    assert trade.stop_loss == 0.0
+    assert trade.initial_stop_loss == 0.0
+    assert log_has("trying trades_bak0", caplog.record_tuples)
+
+
 def test_adjust_stop_loss(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',


### PR DESCRIPTION
## Summary
Small bugfix to solve a bot crash at startup if a database is in a specific state

this happens if `fee_open` and `fee_close` exist but a migration is still necessary 

## Previous bug 

* remove fix in persistence.py - but leave the test there

## Seen error:
```
Traceback (most recent call last):
  File "/freqtrade/freqtrade/main.py", line 45, in main
    freqtrade = FreqtradeBot(config)
  File "/freqtrade/freqtrade/freqtradebot.py", line 55, in __init__
    self._init_modules()
  File "/freqtrade/freqtrade/freqtradebot.py", line 64, in _init_modules
    persistence.init(self.config)
  File "/freqtrade/freqtrade/persistence.py", line 56, in init
    check_migrate(engine)
  File "/freqtrade/freqtrade/persistence.py", line 119, in check_migrate
    """)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 2075, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 942, in execute
    return self._execute_text(object, multiparams, params)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1104, in _execute_text
    statement, parameters
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
    exc_info
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 248, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 509, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: fee [SQL: "insert into trades\n                (id, exchange, pair, is_open, fee_open, fee_close, open_rate,\n                open_rate_requested, close_rate, close_rate_requested, close_profit,\n                stake_amount, amount, open_date, close_date, open_order_id,\n                stop_loss, initial_stop_loss, max_rate\n                )\n            select id, lower(exchange),\n                case\n                    when instr(pair, '_') != 0 then\n                    substr(pair,    instr(pair, '_') + 1) || '/' ||\n                    substr(pair, 1, instr(pair, '_') - 1)\n                    else pair\n                    end\n                pair,\n                is_open, fee fee_open, fee fee_close,\n                open_rate, open_rate_requested open_rate_requested, close_rate,\n                close_rate_requested close_rate_requested, close_profit,\n                stake_amount, amount, open_date, close_date, open_order_id,\n                0.0 stop_loss, 0.0 initial_stop_loss,\n                0.0 max_rate\n                from trades_bak0\n             "] (Background on this error at: http://sqlalche.me/e/e3q8)
Exception ignored in: <module 'threading' from '/usr/local/lib/python3.6/threading.py'>
```