### PR TITLE
Use pandas own min and max

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -77,7 +77,7 @@ class Backtesting(object):
         :return: tuple containing min_date, max_date
         """
         timeframe = [
-            (arrow.get(min(frame.date)), arrow.get(max(frame.date)))
+            (arrow.get(frame['date'].min()), arrow.get(frame['date'].max()))
             for frame in data.values()
         ]
         return min(timeframe, key=operator.itemgetter(0))[0], \


### PR DESCRIPTION
Trivial change: you should use Pandas' own `min` and `max` instead of Python's built-in. In this case it's over 300 times faster. With 54 days of 5min ticker data, this shaved off over 10% of the total backtest time.
