### PR TITLE
Allow sandbox API use on exchanges

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -124,6 +124,7 @@ CONF_SCHEMA = {
             'type': 'object',
             'properties': {
                 'name': {'type': 'string'},
+                'sandbox': {'type': 'boolean'},
                 'key': {'type': 'string'},
                 'secret': {'type': 'string'},
                 'pair_whitelist': {

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -95,6 +95,11 @@ class Exchange(object):
         except (KeyError, AttributeError):
             raise OperationalException(f'Exchange {name} is not supported')
 
+        # check if config requests sanbox, if so use ['test'] from url
+        if (exchange_config.get('sandbox')):
+            api.urls['api'] = api.urls['test'];
+            # exchange.urls['api'] = exchange.urls['test'];
+
         return api
 
     @property


### PR DESCRIPTION
CCXT provides exchanges sandbox apis as the ['test'] url.

This change introduces sandbox in config.json with supporting code in exchange init.
```
  "exchange": {
        "name": "gdax",
        "sandbox": true
```
Here are the URLs set in _api with sandbox set false
<img width="704" alt="screen shot 2018-07-27 at 8 25 30 am" src="https://user-images.githubusercontent.com/34645187/43310746-ff518ce8-9177-11e8-9c41-4cf377f50db8.png">


here  they are after
<img width="670" alt="screen shot 2018-07-27 at 8 24 40 am" src="https://user-images.githubusercontent.com/34645187/43310577-7948ea42-9177-11e8-8e7f-36bb5bcba7cc.png">

And my Log showing sand box is being used:
<img width="926" alt="screen shot 2018-07-27 at 8 26 52 am" src="https://user-images.githubusercontent.com/34645187/43310592-89512954-9177-11e8-8879-863ca4eb0eb4.png">

Here is an example of what is being hooked from CCXT:
<img width="967" alt="screen shot 2018-07-27 at 8 32 13 am" src="https://user-images.githubusercontent.com/34645187/43310629-a61d34f6-9177-11e8-8333-0ee872caa3bf.png">

A link for convenience 
https://github.com/ccxt/ccxt/blob/master/python/ccxt/gdax.py
