### PR TITLE
add Password option to API login, GDAX as example requires. 

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -127,6 +127,7 @@ CONF_SCHEMA = {
                 'key': {'type': 'string'},
                 'secret': {'type': 'string'},
                 'password': {'type': 'string'},
+                'uid': {'type': 'string'},
                 'pair_whitelist': {
                     'type': 'array',
                     'items': {

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -126,6 +126,7 @@ CONF_SCHEMA = {
                 'name': {'type': 'string'},
                 'key': {'type': 'string'},
                 'secret': {'type': 'string'},
+                'password': {'type': 'string'},
                 'pair_whitelist': {
                     'type': 'array',
                     'items': {


### PR DESCRIPTION
As per CCXT docs some exchanges require Password in addition to API Key/Secret. 
Adding into config.json and allowing in constants provides this. 
Tested working on GDAX 

The _API tells us the required fields. 

<img width="742" alt="screen shot 2018-07-27 at 12 11 11 pm" src="https://user-images.githubusercontent.com/34645187/43319967-3fab5102-9196-11e8-8c8d-5fb89f41b7f5.png">



CCXT API setup docs
> API Keys Setup
> The API credentials usually include the following:
> 
> apiKey. This is your public API Key and/or Token. This part is non-secret, it is included in your request header or body and sent over HTTPS in open text to identify your request. It is often a string in Hex or Base64 encoding or an UUID identifier.
> secret. This is your private key. Keep it secret, don't tell it to anybody. It is used to sign your requests locally before sending them to exchanges. The secret key does not get sent over the internet in the request-response process and should not be published or emailed. It is used together with the nonce to generate a cryptographically strong signature. That signature is sent with your public key to authenticate your identity. Each request has a unique nonce and therefore a unique cryptographic signature.
> uid. Some exchanges (not all of them) also generate a user id or uid for short. It can be a string or numeric literal. You should set it, if that is explicitly required by your exchange. See their docs for details.
> password. Some exchanges (not all of them) also require your password/phrase for trading. You should set this string, if that is explicitly required by your exchange. See their docs for details.