### PR TITLE
Error fixed in the quickstart documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Freqtrade provides a Linux/macOS script to install all dependencies and help you
 
 ```bash
 git clone git@github.com:freqtrade/freqtrade.git
-git checkout develop
 cd freqtrade
+git checkout develop
 ./setup.sh --install
 ```
 


### PR DESCRIPTION
## Summary
Make the quickstart usable by anyone.

Solve the issue: The order of the commands in quickstart are incorrect

## Quick changelog
- Changed the order of the quickstart commands
