### PR TITLE
Allow multi strategy backtest without data reload

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -252,8 +252,16 @@ freqtrade backtesting --timerange 20180401-20180410 --ticker-interval 5m --strat
 ```
 
 This will save the results to `user_data/backtest_data/backtest-result-<strategy>.json`, injecting the strategy-name into the target filename.
-It will also output all results one after the other, so make sure to scroll up.
+There will be an additional table comparing win/losses of the different strategies (identical to the "Total" row in the first table).
+Detailed output for all strategies one after the other will be available, so make sure to scroll up.
 
+```
+=================================================== Strategy Summary ====================================================
+| Strategy   |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration    |   profit |   loss |
+|:-----------|------------:|---------------:|---------------:|-------------------:|:----------------|---------:|-------:|
+| Strategy1  |          19 |          -0.76 |         -14.39 |        -0.01440287 | 15:48:00        |       15 |      4 |
+| Strategy2  |           6 |          -2.73 |         -16.40 |        -0.01641299 | 1 day, 14:12:00 |        3 |      3 |
+```
 
 ## Next step
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -151,7 +151,7 @@ cp freqtrade/tests/testdata/pairs.json user_data/data/binance
 Then run:
 
 ```bash
-python scripts/download_backtest_data --exchange binance
+python scripts/download_backtest_data.py --exchange binance
 ```
 
 This will download ticker data for all the currency pairs you defined in `pairs.json`.
@@ -237,6 +237,23 @@ On the other hand, if you set a too high `minimal_roi` like `"0":  0.55`
 (55%), there is a lot of chance that the bot will never reach this 
 profit. Hence, keep in mind that your performance is a mix of your 
 strategies, your configuration, and the crypto-currency you have set up.
+
+## Backtesting multiple strategies
+
+To backtest multiple strategies, a list of Strategies can be provided.
+
+This is limited to 1 ticker-interval per run, however, data is only loaded once from disk so if you have multiple 
+strategies you'd like to compare, this should give a nice runtime boost.
+
+All listed Strategies need to be in the same folder.
+
+``` bash
+freqtrade backtesting --timerange 20180401-20180410 --ticker-interval 5m --strategy-list Strategy001 Strategy002 --export trades 
+```
+
+This will save the results to `user_data/backtest_data/backtest-result-<strategy>.json`, injecting the strategy-name into the target filename.
+It will also output all results one after the other, so make sure to scroll up.
+
 
 ## Next step
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -1,13 +1,15 @@
 # Bot usage
-This page explains the difference parameters of the bot and how to run 
-it.
+
+This page explains the difference parameters of the bot and how to run it.
 
 ## Table of Contents
+
 - [Bot commands](#bot-commands)
 - [Backtesting commands](#backtesting-commands)
 - [Hyperopt commands](#hyperopt-commands)
 
 ## Bot commands
+
 ```
 usage: freqtrade [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
                  [--strategy-path PATH] [--dynamic-whitelist [INT]]
@@ -41,6 +43,7 @@ optional arguments:
 ```
 
 ### How to use a different config file?
+
 The bot allows you to select which config file you want to use. Per 
 default, the bot will load the file `./config.json`
 
@@ -49,6 +52,7 @@ python3 ./freqtrade/main.py -c path/far/far/away/config.json
 ```
 
 ### How to use --strategy?
+
 This parameter will allow you to load your custom strategy class.
 Per default without `--strategy` or `-s` the bot will load the
 `DefaultStrategy` included with the bot (`freqtrade/strategy/default_strategy.py`).
@@ -60,6 +64,7 @@ To load a strategy, simply pass the class name (e.g.: `CustomStrategy`) in this 
 **Example:**  
 In `user_data/strategies` you have a file `my_awesome_strategy.py` which has
 a strategy class called `AwesomeStrategy` to load it:
+
 ```bash
 python3 ./freqtrade/main.py --strategy AwesomeStrategy
 ```
@@ -70,6 +75,7 @@ message the reason (File not found, or errors in your code).
 Learn more about strategy file in [optimize your bot](https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-optimization.md).
 
 ### How to use --strategy-path?
+
 This parameter allows you to add an additional strategy lookup path, which gets
 checked before the default locations (The passed path must be a folder!):
 ```bash
@@ -77,21 +83,25 @@ python3 ./freqtrade/main.py --strategy AwesomeStrategy --strategy-path /some/fol
 ```
 
 #### How to install a strategy?
+
 This is very simple. Copy paste your strategy file into the folder 
 `user_data/strategies` or use `--strategy-path`. And voila, the bot is ready to use it.
 
 ### How to use --dynamic-whitelist?
+
 Per default `--dynamic-whitelist` will retrieve the 20 currencies based 
 on BaseVolume. This value can be changed when you run the script.
 
 **By Default**  
 Get the 20 currencies based on BaseVolume.  
+
 ```bash
 python3 ./freqtrade/main.py --dynamic-whitelist
 ```
 
 **Customize the number of currencies to retrieve**  
 Get the 30 currencies based on BaseVolume.  
+
 ```bash
 python3 ./freqtrade/main.py --dynamic-whitelist 30
 ```
@@ -102,6 +112,7 @@ negative value (e.g -2), `--dynamic-whitelist` will use the default
 value (20).
 
 ### How to use --db-url?
+
 When you run the bot in Dry-run mode, per default no transactions are 
 stored in a database. If you want to store your bot actions in a DB 
 using `--db-url`. This can also be used to specify a custom database
@@ -111,14 +122,14 @@ in production mode. Example command:
 python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 ```
 
-
 ## Backtesting commands
 
 Backtesting also uses the config specified via `-c/--config`.
 
 ```
-usage: main.py backtesting [-h] [-i TICKER_INTERVAL] [--eps] [--dmmp]
+usage: freqtrade backtesting [-h] [-i TICKER_INTERVAL] [--eps] [--dmmp]
                              [--timerange TIMERANGE] [-l] [-r]
+                             [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
                              [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
@@ -139,6 +150,13 @@ optional arguments:
                         refresh the pairs files in tests/testdata with the
                         latest data from the exchange. Use it if you want to
                         run your backtesting with up-to-date data.
+  --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
+                        Provide a commaseparated list of strategies to
+                        backtest Please note that ticker-interval needs to be
+                        set either in config or via command line. When using
+                        this together with --export trades, the strategy-name
+                        is injected into the filename (so backtest-data.json
+                        becomes backtest-data-DefaultStrategy.json
   --export EXPORT       export backtest results, argument are: trades Example
                         --export=trades
   --export-filename PATH
@@ -151,6 +169,7 @@ optional arguments:
 ```
 
 ### How to use --refresh-pairs-cached parameter?
+
 The first time your run Backtesting, it will take the pairs you have 
 set in your config file and download data from Bittrex. 
 
@@ -161,7 +180,6 @@ to come back to the previous version.**
 
 To test your strategy with latest data, we recommend continuing using 
 the parameter `-l` or `--live`.
-
 
 ## Hyperopt commands
 
@@ -194,10 +212,11 @@ optional arguments:
 ```
 
 ## A parameter missing in the configuration?
+
 All parameters for `main.py`, `backtesting`, `hyperopt` are referenced
 in [misc.py](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/misc.py#L84)
 
 ## Next step
-The optimal strategy of the bot will change with time depending of the
-market trends. The next step is to 
+
+The optimal strategy of the bot will change with time depending of the market trends. The next step is to 
 [optimize your bot](https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-optimization.md).

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -146,7 +146,9 @@ class Arguments(object):
             '--strategy-list',
             help='Provide a commaseparated list of strategies to backtest '
                  'Please note that ticker-interval needs to be set either in config '
-                 'or via command line',
+                 'or via command line. When using this together with --export trades, '
+                 'the strategy-name is injected into the filename '
+                 '(so backtest-data.json becomes backtest-data-DefaultStrategy.json',
             nargs='+',
             dest='strategy_list',
         )

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -143,6 +143,14 @@ class Arguments(object):
             dest='refresh_pairs',
         )
         parser.add_argument(
+            '--strategy-list',
+            help='Provide a commaseparated list of strategies to backtest '
+                 'Please note that ticker-interval needs to be set either in config '
+                 'or via command line',
+            nargs='+',
+            dest='strategy_list',
+        )
+        parser.add_argument(
             '--export',
             help='export backtest results, argument are: trades\
                   Example --export=trades',

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -189,7 +189,7 @@ class Configuration(object):
 
         if 'strategy_list' in self.args and self.args.strategy_list:
             config.update({'strategy_list': self.args.strategy_list})
-            logger.info('using strategy list of %s Strategies', len(self.args.strategy_list))
+            logger.info('Using strategy list of %s Strategies', len(self.args.strategy_list))
 
         if 'ticker_interval' in self.args and self.args.ticker_interval:
             config.update({'ticker_interval': self.args.ticker_interval})

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -187,6 +187,14 @@ class Configuration(object):
             config.update({'refresh_pairs': True})
             logger.info('Parameter -r/--refresh-pairs-cached detected ...')
 
+        if 'strategy_list' in self.args and self.args.strategy_list:
+            config.update({'strategy_list': self.args.strategy_list})
+            logger.info('using strategy list of %s Strategies', len(self.args.strategy_list))
+
+        if 'ticker_interval' in self.args and self.args.ticker_interval:
+            config.update({'ticker_interval': self.args.ticker_interval})
+            logger.info('Overriding ticker interval with Command line argument')
+
         # If --export is used we add it to the configuration
         if 'export' in self.args and self.args.export:
             config.update({'export': self.args.export})

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -66,8 +66,8 @@ class Backtesting(object):
         self.strategylist: List[IStrategy] = []
         if self.config.get('strategy_list', None):
             # Force one interval
-            self.ticker_interval = self.config.get('ticker_interval')
-            for strat in self.config.get('strategy_list'):
+            self.ticker_interval = str(self.config.get('ticker_interval'))
+            for strat in list(self.config['strategy_list']):
                 stratconf = deepcopy(self.config)
                 stratconf['strategy'] = strat
                 self.strategylist.append(StrategyResolver(stratconf).strategy)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -91,8 +91,8 @@ class Backtesting(object):
         self.strategy = strategy
         self.ticker_interval = self.config.get('ticker_interval')
         self.tickerdata_to_dataframe = strategy.tickerdata_to_dataframe
-        self.populate_buy_trend = strategy.populate_buy_trend
-        self.populate_sell_trend = strategy.populate_sell_trend
+        self.advise_buy = strategy.advise_buy
+        self.advise_sell = strategy.advise_sell
 
     @staticmethod
     def get_timeframe(data: Dict[str, DataFrame]) -> Tuple[arrow.Arrow, arrow.Arrow]:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -388,7 +388,7 @@ class Backtesting(object):
 
             logger.info(
                 '\n' +
-                ' SELL READON STATS '.center(119, '=') +
+                ' SELL REASON STATS '.center(119, '=') +
                 '\n%s \n',
                 self._generate_text_table_sell_reason(data, results)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -396,46 +396,21 @@ class Backtesting(object):
                 self._store_backtest_result(self.config['exportfilename'], results,
                                             strategy if len(self.strategylist) > 1 else None)
 
-            logger.info("\nResult for strategy %s", strategy)
-            logger.info(
-                '\n' +
-                ' BACKTESTING REPORT '.center(119, '=') +
-                '\n%s',
-                self._generate_text_table(
-                    data,
-                    results
-                )
-            )
-            # logger.info(
-            #     results[['sell_reason']].groupby('sell_reason').count()
-            # )
+            print(f"Result for strategy {strategy}")
+            print(' BACKTESTING REPORT '.center(119, '='))
+            print(self._generate_text_table(data, results))
 
-            logger.info(
-                '\n' +
-                ' SELL REASON STATS '.center(119, '=') +
-                '\n%s \n',
-                self._generate_text_table_sell_reason(data, results)
+            print(' SELL REASON STATS '.center(119, '='))
+            print(self._generate_text_table_sell_reason(data, results))
 
-            )
-
-            logger.info(
-                '\n' +
-                ' LEFT OPEN TRADES REPORT '.center(119, '=') +
-                '\n%s',
-                self._generate_text_table(
-                    data,
-                    results.loc[results.open_at_end]
-                )
-            )
-
+            print(' LEFT OPEN TRADES REPORT '.center(119, '='))
+            print(self._generate_text_table(data, results.loc[results.open_at_end]))
+            print()
         if len(all_results) > 1:
             # Print Strategy summary table
-            logger.info(
-                '\n' +
-                ' Strategy Summary '.center(119, '=') +
-                '\n%s\n\nFor more details, please look at the detail tables above',
-                self._generate_text_table_strategy(all_results)
-            )
+            print(' Strategy Summary '.center(119, '='))
+            print(self._generate_text_table_strategy(all_results))
+            print('\nFor more details, please look at the detail tables above')
 
 
 def setup_configuration(args: Namespace) -> Dict[str, Any]:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -432,7 +432,7 @@ class Backtesting(object):
             # Print Strategy summary table
             logger.info(
                 '\n' +
-                ' Strategy Summary'.center(119, '=') +
+                ' Strategy Summary '.center(119, '=') +
                 '\n%s\n\nFor more details, please look at the detail tables above',
                 self._generate_text_table_strategy(all_results)
             )

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -775,8 +775,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
 
 
 def test_backtest_start_multi_strat(default_conf, mocker, caplog):
-    conf = deepcopy(default_conf)
-    conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
+    default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
     mocker.patch('freqtrade.exchange.Exchange.get_ticker_history',
                  new=lambda s, n, i: _load_pair_as_ticks(n, i))
     patch_exchange(mocker)
@@ -788,7 +787,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     mocker.patch('freqtrade.optimize.backtesting.Backtesting._generate_text_table_strategy',
                  gen_strattable_mock)
     mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(conf)
+        read_data=json.dumps(default_conf)
     ))
 
     args = [

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -654,6 +654,18 @@ def test_backtest_record(default_conf, fee, mocker):
     records = records[0]
     # Ensure records are of correct type
     assert len(records) == 4
+
+    # reset test to test with strategy name
+    names = []
+    records = []
+    backtesting._store_backtest_result("backtest-result.json", results, "DefStrat")
+    assert len(results) == 4
+    # Assert file_dump_json was only called once
+    assert names == ['backtest-result-DefStrat.json']
+    records = records[0]
+    # Ensure records are of correct type
+    assert len(records) == 4
+
     # ('UNITTEST/BTC', 0.00331158, '1510684320', '1510691700', 0, 117)
     # Below follows just a typecheck of the schema/type of trade-records
     oix = None

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -132,7 +132,11 @@ def test_parse_args_backtesting_custom() -> None:
         'backtesting',
         '--live',
         '--ticker-interval', '1m',
-        '--refresh-pairs-cached']
+        '--refresh-pairs-cached',
+        '--strategy-list',
+        'DefaultStrategy',
+        'TestStrategy'
+        ]
     call_args = Arguments(args, '').get_parsed_arg()
     assert call_args.config == 'test_conf.json'
     assert call_args.live is True
@@ -141,6 +145,8 @@ def test_parse_args_backtesting_custom() -> None:
     assert call_args.func is not None
     assert call_args.ticker_interval == '1m'
     assert call_args.refresh_pairs is True
+    assert type(call_args.strategy_list) is list
+    assert len(call_args.strategy_list) == 2
 
 
 def test_parse_args_hyperopt_custom() -> None:


### PR DESCRIPTION
## Summary
This PR will allow backtesting multiple strategies at once efficiently, as startup/spindown time of backtest makes most of the time (loading data, ...).

## Quick changelog

- introduce new command line option `--strategy-list`

## Changes

* [x] Add command line option
* [x] Prove it works
* [x] documentation
* [x] export trades with strategy name inside
* [x] improve readability of backtest report (happy to hear ideas)
* [x] use print for output (allows using `freqtrade backtesting --strategy-list > filename` to gather results / look at them in an editor)



## New output

the backtesting output is printed once per strategy (with the strategy-name)
The strategy-comparison table is only printed if more than 1 strategy is selected.

the full output of 2 strategies backtested would look as follows:

```
2018-07-29 13:07:53,724 - freqtrade.optimize.backtesting - INFO - 
Result for strategy BinHV27
2018-07-29 13:07:53,750 - freqtrade.optimize.backtesting - INFO - 
================================================== BACKTESTING REPORT =================================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration     |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:-----------------|---------:|-------:|
| LTC/ETH   |           1 |          -5.04 |          -5.04 |        -0.00504817 | 2 days, 7:05:00  |        0 |      1 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| XMR/ETH   |           4 |          -0.10 |          -0.42 |        -0.00041939 | 6:01:00          |        3 |      1 |
| XRP/ETH   |           3 |           0.29 |           0.86 |         0.00086551 | 5:22:00          |        3 |      0 |
| NCASH/ETH |           2 |          -2.13 |          -4.26 |        -0.00426041 | 15:48:00         |        1 |      1 |
| MTH/ETH   |           1 |         -14.99 |         -14.99 |        -0.01500944 | 5 days, 11:10:00 |        0 |      1 |
| AST/ETH   |           5 |           1.31 |           6.57 |         0.00657878 | 4:04:00          |        5 |      0 |
| TNT/ETH   |           2 |           1.25 |           2.50 |         0.00249883 | 3:15:00          |        2 |      0 |
| ETC/ETH   |           1 |           0.39 |           0.39 |         0.00039142 | 15:15:00         |        1 |      0 |
| TOTAL     |          19 |          -0.76 |         -14.39 |        -0.01440287 | 15:48:00         |       15 |      4 |
2018-07-29 13:07:53,751 - freqtrade.optimize.backtesting - INFO - 
================================================== SELL REASON STATS ==================================================
| Sell Reason   |   Count |
|:--------------|--------:|
| sell_signal   |      15 |
| force_sell    |       4 | 

2018-07-29 13:07:53,778 - freqtrade.optimize.backtesting - INFO - 
=============================================== LEFT OPEN TRADES REPORT ===============================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration     |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:-----------------|---------:|-------:|
| LTC/ETH   |           1 |          -5.04 |          -5.04 |        -0.00504817 | 2 days, 7:05:00  |        0 |      1 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| XMR/ETH   |           1 |          -0.67 |          -0.67 |        -0.00066669 | 7:45:00          |        0 |      1 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| NCASH/ETH |           1 |          -5.01 |          -5.01 |        -0.00501031 | 1 day, 6:45:00   |        0 |      1 |
| MTH/ETH   |           1 |         -14.99 |         -14.99 |        -0.01500944 | 5 days, 11:10:00 |        0 |      1 |
| AST/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| TNT/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| TOTAL     |           4 |          -6.43 |         -25.71 |        -0.02573461 | 2 days, 8:11:00  |        0 |      4 |
2018-07-29 13:07:53,779 - freqtrade.optimize.backtesting - INFO - Dumping backtest results to user_data/backtest_data/backtest-result-BinHV45.json
dumping json to "user_data/backtest_data/backtest-result-BinHV45.json"
2018-07-29 13:07:53,780 - freqtrade.optimize.backtesting - INFO - 
Result for strategy BinHV45
2018-07-29 13:07:53,806 - freqtrade.optimize.backtesting - INFO - 
================================================== BACKTESTING REPORT =================================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration     |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:-----------------|---------:|-------:|
| LTC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| XMR/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| NCASH/ETH |           1 |           1.31 |           1.31 |         0.00130853 | 1:40:00          |        1 |      0 |
| MTH/ETH   |           1 |         -10.33 |         -10.33 |        -0.01034067 | 2 days, 11:55:00 |        0 |      1 |
| AST/ETH   |           1 |           2.19 |           2.19 |         0.00218995 | 5:25:00          |        1 |      0 |
| TNT/ETH   |           3 |          -3.19 |          -9.56 |        -0.00957080 | 2 days, 6:05:00  |        1 |      2 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00             |        0 |      0 |
| TOTAL     |           6 |          -2.73 |         -16.40 |        -0.01641299 | 1 day, 14:12:00  |        3 |      3 |
2018-07-29 13:07:53,807 - freqtrade.optimize.backtesting - INFO - 
================================================== SELL REASON STATS ==================================================
| Sell Reason   |   Count |
|:--------------|--------:|
| roi           |       3 |
| stop_loss     |       2 |
| force_sell    |       1 | 

2018-07-29 13:07:53,833 - freqtrade.optimize.backtesting - INFO - 
=============================================== LEFT OPEN TRADES REPORT ===============================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration   |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:---------------|---------:|-------:|
| LTC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| XMR/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| NCASH/ETH |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| MTH/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| AST/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| TNT/ETH   |           1 |          -0.79 |          -0.79 |        -0.00079319 | 16:30:00       |        0 |      1 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| TOTAL     |           1 |          -0.79 |          -0.79 |        -0.00079319 | 16:30:00       |        0 |      1 |
2018-07-29 13:07:53,838 - freqtrade.optimize.backtesting - INFO - 
=================================================== Strategy Summary===================================================
| Strategy   |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration    |   profit |   loss |
|:-----------|------------:|---------------:|---------------:|-------------------:|:----------------|---------:|-------:|
| BinHV27    |          19 |          -0.76 |         -14.39 |        -0.01440287 | 15:48:00        |       15 |      4 |
| BinHV45    |           6 |          -2.73 |         -16.40 |        -0.01641299 | 1 day, 14:12:00 |        3 |      3 |

```