### PR TITLE
backtesting: try to load data with ujson if it exists

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -4,7 +4,8 @@ import gzip
 try:
     import ujson as json
 except ImportError:
-    import json
+    # see mypy/issues/1153
+    import json  # type: ignore
 import inspect
 import logging
 import os


### PR DESCRIPTION
there is #1023 and there is alot of discussion related to `ujson` and windows support. This PR takes another approach to #1023 so that it should be possible to use `ujson` if it exists in the system. Otherwise we use the default `json` module.