### PR TITLE
install numpy before ta-lib to fix build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /freqtrade
 
 # Install dependencies
 COPY requirements.txt /freqtrade/
-RUN pip install -r requirements.txt
+RUN pip install numpy \
+  && pip install -r requirements.txt
 
 # Install and execute
 COPY . /freqtrade/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,23 +56,29 @@ Reset parameter will hard reset your branch (only if you are on `master` or `dev
 
 Config parameter is a `config.json` configurator. This script will ask you questions to setup your bot and create your `config.json`.
 
-
 ## Manual installation - Linux/MacOS
+
 The following steps are made for Linux/MacOS environment
 
-**1. Clone the repo**
+### 1. Clone the repo
+
 ```bash
 git clone git@github.com:freqtrade/freqtrade.git
 git checkout develop
 cd freqtrade
 ```
-**2. Create the config file**  
+
+### 2. Create the config file
+
 Switch `"dry_run": true,`
+
 ```bash
 cp config.json.example config.json
 vi config.json
 ```
-**3. Build your docker image and run it**
+
+### 3. Build your docker image and run it
+
 ```bash
 docker build -t freqtrade .
 docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='freqtrade',
       license='GPLv3',
       packages=['freqtrade'],
       scripts=['bin/freqtrade'],
-      setup_requires=['pytest-runner'],
+      setup_requires=['pytest-runner', 'numpy'],
       tests_require=['pytest', 'pytest-mock', 'pytest-cov'],
       install_requires=[
           'ccxt',


### PR DESCRIPTION
## Summary
Improve install experience with Docker as pointed out in #1073


Solve the issue: #1073


## Quick changelog

- install numpy before ta-lib (requirements.txt) to fix install errors
- Small documentation formatting 