### PR TITLE
Initializing CCXT with rate_limit parameter optional (default to true) [EDITED]

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -17,7 +17,7 @@
         "name": "bittrex",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
-        "ccxt_rate_limit": false,
+        "ccxt_rate_limit": true,
         "pair_whitelist": [
             "ETH/BTC",
             "LTC/BTC",

--- a/config.json.example
+++ b/config.json.example
@@ -17,6 +17,7 @@
         "name": "bittrex",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
+        "ccxt_rate_limit": false,
         "pair_whitelist": [
             "ETH/BTC",
             "LTC/BTC",

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -26,6 +26,7 @@
         "name": "bittrex",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
+        "ccxt_rate_limit": true,
         "pair_whitelist": [
             "ETH/BTC",
             "LTC/BTC",

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -91,7 +91,7 @@ class Exchange(object):
                 'secret': exchange_config.get('secret'),
                 'password': exchange_config.get('password'),
                 'uid': exchange_config.get('uid', ''),
-                'enableRateLimit': exchange_config.get('ccxt_rate_limit', False),
+                'enableRateLimit': exchange_config.get('ccxt_rate_limit', True),
             })
         except (KeyError, AttributeError):
             raise OperationalException(f'Exchange {name} is not supported')

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -91,7 +91,7 @@ class Exchange(object):
                 'secret': exchange_config.get('secret'),
                 'password': exchange_config.get('password'),
                 'uid': exchange_config.get('uid', ''),
-                'enableRateLimit': True,
+                'enableRateLimit': exchange_config.get('ccxt_rate_limit', False),
             })
         except (KeyError, AttributeError):
             raise OperationalException(f'Exchange {name} is not supported')


### PR DESCRIPTION
## Summary
The CCXT rate limit is too strict. it slows down async fetching. 

## Quick changelog

- adding a config in exchange (ccxt_rate_limit)
- using above variable in ccxt initializer instead of hardcoded "True"