### PR TITLE
Add note to readme for binance users

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The project is currently setup in two main branches:
 
 - `develop` - This branch has often new features, but might also cause breaking changes.
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
-- `feat/*` - This are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
+- `feat/*` - These are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
 
 
 ## A note on Binance

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ hesitate to read the source code and understand the mechanism of this bot.
 ## Exchange marketplaces supported
 
 - [X] [Bittrex](https://bittrex.com/)
-- [X] [Binance](https://www.binance.com/)
+- [X] [Binance](https://www.binance.com/) ([*Note for binance users](#a-note-on-binance))
 - [ ] [113 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
 
 ## Features
@@ -152,6 +152,13 @@ The project is currently setup in two main branches:
 
 - `develop` - This branch has often new features, but might also cause breaking changes.
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
+- `feat/*` - This are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
+
+
+## A note on Binance
+
+For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.
+Accounts having BNB accounts use this to pay for fees - if your first trade happens to be on `BNB`, further trades will consume this position and make the initial BNB order unsellable as the expected amount is not there anymore.
 
 ## Support
 


### PR DESCRIPTION
## Summary
Binance uses BNB for fees. If an account does not own Fees, but a trade is made on BNB, subsequent trades use up this BNB balance for their trading fees.
This creates a problem for the BNB position, as the amount reduces and the trade is finally not completed due to lack of balance.

Solve the issue: #1084

## Quick changelog

- add documentation to exclude BNB on binance

