### PR TITLE
Script to get market pairs

### DIFF
--- a/scripts/get_market_pairs.py
+++ b/scripts/get_market_pairs.py
@@ -1,0 +1,93 @@
+import os
+import sys
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+
+def style(s, style):
+    return style + s + '\033[0m'
+
+
+def green(s):
+    return style(s, '\033[92m')
+
+
+def blue(s):
+    return style(s, '\033[94m')
+
+
+def yellow(s):
+    return style(s, '\033[93m')
+
+
+def red(s):
+    return style(s, '\033[91m')
+
+
+def pink(s):
+    return style(s, '\033[95m')
+
+
+def bold(s):
+    return style(s, '\033[1m')
+
+
+def underline(s):
+    return style(s, '\033[4m')
+
+
+def dump(*args):
+    print(' '.join([str(arg) for arg in args]))
+
+
+def print_supported_exchanges():
+    dump('Supported exchanges:', green(', '.join(ccxt.exchanges)))
+
+
+try:
+
+    id = sys.argv[1]  # get exchange id from command line arguments
+
+
+    # check if the exchange is supported by ccxt
+    exchange_found = id in ccxt.exchanges
+
+    if exchange_found:
+        dump('Instantiating', green(id), 'exchange')
+
+        # instantiate the exchange by id
+        exchange = getattr(ccxt, id)({
+            # 'proxy':'https://cors-anywhere.herokuapp.com/',
+        })
+
+        # load all markets from the exchange
+        markets = exchange.load_markets()
+
+        # output a list of all market symbols
+        dump(green(id), 'has', len(exchange.symbols), 'symbols:', exchange.symbols)
+
+        tuples = list(ccxt.Exchange.keysort(markets).items())
+
+        # debug
+        for (k, v) in tuples:
+            print(v)
+
+        # output a table of all markets
+        dump(pink('{:<15} {:<15} {:<15} {:<15}'.format('id', 'symbol', 'base', 'quote')))
+
+        for (k, v) in tuples:
+            dump('{:<15} {:<15} {:<15} {:<15}'.format(v['id'], v['symbol'], v['base'], v['quote']))
+
+    else:
+
+        dump('Exchange ' + red(id) + ' not found')
+        print_supported_exchanges()
+
+except Exception as e:
+    dump('[' + type(e).__name__ + ']', str(e))
+    dump("Usage: python " + sys.argv[0], green('id'))
+    print_supported_exchanges()
+


### PR DESCRIPTION
A python script to return

 - all exchanges supported by CCXT
 - all markets on a exchange

 Invoked as `python get_market_pairs.py` it will list exchanges
 Invoked as `python get_market_pairs binance` it will list all markets on binance

Sample output: `python get_market_pairs.py`
```
Supported exchanges: _1broker, _1btcxe, acx, allcoin, anxpro, anybi
```

Sample output: `python get_market_pairs.py binance `
```
binance has 384 symbols: ['ADA/BNB', 'ADA/BTC', 'ADA/ETH', 'ADA/USDT', 'ADX/BNB', 'ADX/BTC', 'ADX/ETH', 'AE/BNB', 'AE/BTC', 'AE/ETH', 'AGI/BNB', 'AGI/BTC', 'AGI/ETH', 'AION/BNB', 'AION/BTC', 'AION/ETH', 'AMB/BNB', 'AMB/BTC', 'AMB/ETH', 'APPC/BNB', 'APPC/BTC', 'APPC/ETH', 'ARDR/BNB', 'ARDR/BTC', 'ARDR/ETH', 'ARK/BTC', 'ARK/ETH', 'ARN/BTC', 'ARN/ETH', 'AST/BTC', 'AST/ETH', 'BAT/BNB', 'BAT/BTC', 'BAT/ETH', 'BCD/BTC', 'BCD/ETH', 'BCH/BNB', 'BCH/BTC', 'BCH/ETH', 'BCH/USDT', 'BCN/BNB', 'BCN/BTC', 'BCN/ETH', 'BCPT/BNB', 'BCPT/BTC', 'BCPT/ETH', 'BLZ/BNB', 'BLZ/BTC', 'BLZ/ETH', 'BNB/BTC', 'BNB/ETH', 'BNB/USDT', 'BNT/BTC', 'BNT/ETH', 'BQX/BTC', 'BQX/ETH', 'BRD/BNB', 'BRD/BTC', 'BRD/ETH', 'BTC/USDT', 'BTG/BTC', 'BTG/ETH', 'BTS/BNB', 'BTS/BTC', 'BTS/ETH', 'CDT/BTC', 'CDT/ETH', 'CHAT/BTC', 'CHAT/ETH', 'CLOAK/BTC', 'CLOAK/ETH', 'CMT/BNB', 'CMT/BTC', 'CMT/ETH', 'CND/BNB', 'CND/BTC', 'CND/ETH', 'CVC/BNB', 'CVC/BTC', 'CVC/ETH', 'DASH/BTC', 'DASH/ETH', 'DATA/BTC', 'DATA/ETH', 'DENT/BTC', 'DENT/ETH', 'DGD/BTC', 'DGD/ETH', 'DLT/BNB', 'DLT/BTC', 'DLT/ETH', 'DNT/BTC', 'DNT/ETH', 'DOCK/BTC', 'DOCK/ETH', 'EDO/BTC', 'EDO/ETH', 'ELF/BTC', 'ELF/ETH', 'ENG/BTC', 'ENG/ETH', 'ENJ/BNB', 'ENJ/BTC', 'ENJ/ETH', 'EOS/BNB', 'EOS/BTC', 'EOS/ETH', 'EOS/USDT', 'ETC/BNB', 'ETC/BTC', 'ETC/ETH', 'ETC/USDT', 'ETH/BTC', 'ETH/USDT', 'EVX/BTC', 'EVX/ETH', 'FUEL/BTC', 'FUEL/ETH', 'FUN/BTC', 'FUN/ETH', 'GAS/BTC', 'GNT/BNB', 'GNT/BTC', 'GNT/ETH', 'GRS/BTC', 'GRS/ETH', 'GTO/BNB', 'GTO/BTC', 'GTO/ETH', 'GVT/BTC', 'GVT/ETH', 'GXS/BTC', 'GXS/ETH', 'HOT/BTC', 'HOT/ETH', 'HSR/BTC', 'HSR/ETH', 'ICN/BTC', 'ICN/ETH', 'ICX/BNB', 'ICX/BTC', 'ICX/ETH', 'ICX/USDT', 'INS/BTC', 'INS/ETH', 'IOST/BTC', 'IOST/ETH', 'IOTA/BNB', 'IOTA/BTC', 'IOTA/ETH', 'IOTA/USDT', 'IOTX/BTC', 'IOTX/ETH', 'KEY/BTC', 'KEY/ETH', 'KMD/BTC', 'KMD/ETH', 'KNC/BTC', 'KNC/ETH', 'LEND/BTC', 'LEND/ETH', 'LINK/BTC', 'LINK/ETH', 'LOOM/BNB', 'LOOM/BTC', 'LOOM/ETH', 'LRC/BTC', 'LRC/ETH', 'LSK/BNB', 'LSK/BTC', 'LSK/ETH', 'LTC/BNB', 'LTC/BTC', 'LTC/ETH', 'LTC/USDT', 'LUN/BTC', 'LUN/ETH', 'MANA/BTC', 'MANA/ETH', 'MCO/BNB', 'MCO/BTC', 'MCO/ETH', 'MDA/BTC', 'MDA/ETH', 'MFT/BNB', 'MFT/BTC', 'MFT/ETH', 'MOD/BTC', 'MOD/ETH', 'MTH/BTC', 'MTH/ETH', 'MTL/BTC', 'MTL/ETH', 'NANO/BNB', 'NANO/BTC', 'NANO/ETH', 'NAS/BNB', 'NAS/BTC', 'NAS/ETH', 'NAV/BNB', 'NAV/BTC', 'NAV/ETH', 'NCASH/BNB', 'NCASH/BTC', 'NCASH/ETH', 'NEBL/BNB', 'NEBL/BTC', 'NEBL/ETH', 'NEO/BNB', 'NEO/BTC', 'NEO/ETH', 'NEO/USDT', 'NPXS/BTC', 'NPXS/ETH', 'NULS/BNB', 'NULS/BTC', 'NULS/ETH', 'NULS/USDT', 'NXS/BNB', 'NXS/BTC', 'NXS/ETH', 'OAX/BTC', 'OAX/ETH', 'OMG/BTC', 'OMG/ETH', 'ONT/BNB', 'ONT/BTC', 'ONT/ETH', 'ONT/USDT', 'OST/BNB', 'OST/BTC', 'OST/ETH', 'PIVX/BNB', 'PIVX/BTC', 'PIVX/ETH', 'POA/BNB', 'POA/BTC', 'POA/ETH', 'POE/BTC', 'POE/ETH', 'POLY/BNB', 'POLY/BTC', 'POWR/BNB', 'POWR/BTC', 'POWR/ETH', 'PPT/BTC', 'PPT/ETH', 'QKC/BTC', 'QKC/ETH', 'QLC/BNB', 'QLC/BTC', 'QLC/ETH', 'QSP/BNB', 'QSP/BTC', 'QSP/ETH', 'QTUM/BNB', 'QTUM/BTC', 'QTUM/ETH', 'QTUM/USDT', 'RCN/BNB', 'RCN/BTC', 'RCN/ETH', 'RDN/BNB', 'RDN/BTC', 'RDN/ETH', 'REP/BNB', 'REP/BTC', 'REP/ETH', 'REQ/BTC', 'REQ/ETH', 'RLC/BNB', 'RLC/BTC', 'RLC/ETH', 'RPX/BNB', 'RPX/BTC', 'RPX/ETH', 'SALT/BTC', 'SALT/ETH', 'SC/BNB', 'SC/BTC', 'SC/ETH', 'SKY/BNB', 'SKY/BTC', 'SKY/ETH', 'SNGLS/BTC', 'SNGLS/ETH', 'SNM/BTC', 'SNM/ETH', 'SNT/BTC', 'SNT/ETH', 'STEEM/BNB', 'STEEM/BTC', 'STEEM/ETH', 'STORJ/BTC', 'STORJ/ETH', 'STORM/BNB', 'STORM/BTC', 'STORM/ETH', 'STRAT/BTC', 'STRAT/ETH', 'SUB/BTC', 'SUB/ETH', 'SYS/BNB', 'SYS/BTC', 'SYS/ETH', 'THETA/BNB', 'THETA/BTC', 'THETA/ETH', 'TNB/BTC', 'TNB/ETH', 'TNT/BTC', 'TNT/ETH', 'TRIG/BNB', 'TRIG/BTC', 'TRIG/ETH', 'TRX/BTC', 'TRX/ETH', 'TRX/USDT', 'TUSD/BNB', 'TUSD/BTC', 'TUSD/ETH', 'TUSD/USDT', 'VEN/BNB', 'VEN/BTC', 'VEN/ETH', 'VEN/USDT', 'VET/BNB', 'VET/BTC', 'VET/ETH', 'VET/USDT', 'VIA/BNB', 'VIA/BTC', 'VIA/ETH', 'VIB/BTC', 'VIB/ETH', 'VIBE/BTC', 'VIBE/ETH', 'WABI/BNB', 'WABI/BTC', 'WABI/ETH', 'WAN/BNB', 'WAN/BTC', 'WAN/ETH', 'WAVES/BNB', 'WAVES/BTC', 'WAVES/ETH', 'WINGS/BTC', 'WINGS/ETH', 'WPR/BTC', 'WPR/ETH', 'WTC/BNB', 'WTC/BTC', 'WTC/ETH', 'XEM/BNB', 'XEM/BTC', 'XEM/ETH', 'XLM/BNB', 'XLM/BTC', 'XLM/ETH', 'XLM/USDT', 'XMR/BTC', 'XMR/ETH', 'XRP/BNB', 'XRP/BTC', 'XRP/ETH', 'XRP/USDT', 'XVG/BTC', 'XVG/ETH', 'XZC/BNB', 'XZC/BTC', 'XZC/ETH', 'YOYOW/BNB', 'YOYOW/BTC', 'YOYOW/ETH', 'ZEC/BTC', 'ZEC/ETH', 'ZEN/BNB', 'ZEN/BTC', 'ZEN/ETH', 'ZIL/BNB', 'ZIL/BTC', 'ZIL/ETH', 'ZRX/BTC', 'ZRX/ETH']
{'fee_loaded': False, 'percentage': True, 'tierBased': False, 'taker': 0.001, 'maker': 0.001, 'precision': {'base': 8, 'quote': 8, 'amount': 1, 'price': 5}, 'limits': {'amount': {'min': 0.1, 'max': 90000000.0}, 'price': {'min': 0.001, 'max': 0.09985}, 'cost': {'min': 1.0, 'max': None}}, 'id': 'ADABNB', 'symbol': 'ADA/BNB', 'base': 'ADA', 'quote': 'BNB', 'baseId': 'ADA', 'quoteId': 'BNB', 'info': {'symbol': 'ADABNB', 'status': 'TRADING', 'baseAsset': 'ADA', 'baseAssetPrecision': 8, 'quoteAsset': 'BNB', 'quotePrecision': 8, 'orderTypes': ['LIMIT', 'LIMIT_MAKER', 'MARKET', 'STOP_LOSS_LIMIT', 'TAKE_PROFIT_LIMIT'], 'icebergAllowed': True, 'filters': [{'filterType': 'PRICE_FILTER', 'minPrice': '0.00100000', 'maxPrice': '0.09985000', 'tickSize': '0.00001000'}, {'filterType': 'LOT_SIZE', 'minQty': '0.10000000', 'maxQty': '90000000.00000000', 'stepSize': '0.10000000'}, {'filterType': 'MIN_NOTIONAL', 'minNotional': '1.00000000'}, {'filterType': 'ICEBERG_PARTS', 'limit': 10}, {'filterType': 'MAX_NUM_ALGO_ORDERS', 'maxNumAlgoOrders': 5}]}, 'lot': 0.1, 'active': True}
{'fee_loaded': False, 'perce
```

```
id              symbol          base            quote          
ADABNB          ADA/BNB         ADA             BNB            
ADABTC          ADA/BTC         ADA             BTC            
ADAETH          ADA/ETH         ADA             ETH            
ADAUSDT         ADA/USDT        ADA             USDT           
ADXBNB          ADX/B
```