### PR TITLE
ta_on_candle (not loop, with optional flag in config.json) Resubmitting - because GIT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The project is currently setup in two main branches:
 
 - `develop` - This branch has often new features, but might also cause breaking changes.
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
-- `feat/*` - This are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
+- `feat/*` - These are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
 
 
 ## A note on Binance

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ hesitate to read the source code and understand the mechanism of this bot.
 ## Exchange marketplaces supported
 
 - [X] [Bittrex](https://bittrex.com/)
-- [X] [Binance](https://www.binance.com/)
+- [X] [Binance](https://www.binance.com/) ([*Note for binance users](#a-note-on-binance))
 - [ ] [113 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
 
 ## Features
@@ -152,6 +152,13 @@ The project is currently setup in two main branches:
 
 - `develop` - This branch has often new features, but might also cause breaking changes.
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
+- `feat/*` - This are feature branches, which are beeing worked on heavily. Please don't use these unless you want to test a specific feature.
+
+
+## A note on Binance
+
+For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.
+Accounts having BNB accounts use this to pay for fees - if your first trade happens to be on `BNB`, further trades will consume this position and make the initial BNB order unsellable as the expected amount is not there anymore.
 
 ## Support
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ The table below will list all configuration parameters.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes
 | `fiat_display_currency` | USD | Yes | Fiat currency used to show your profits. More information below. 
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
+| `ta_on_candle` | false | No | if set to true indicators are processed each new candle. If false each bot loop, this will mean the same candle is processed many times creating system load and buy/sell signals.
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file. 
 | `trailing_stoploss` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ The table below will list all configuration parameters.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes
 | `fiat_display_currency` | USD | Yes | Fiat currency used to show your profits. More information below. 
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
-| `ta_on_candle` | false | No | if set to true indicators are processed each new candle. If false each bot loop, this will mean the same candle is processed many times creating system load and buy/sell signals.
+| `ta_on_candle` | false | No | if set to true indicators are processed each new candle. If false each bot loop, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. 
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file. 
 | `trailing_stoploss` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ The table below will list all configuration parameters.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes
 | `fiat_display_currency` | USD | Yes | Fiat currency used to show your profits. More information below. 
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode.
-| `ta_on_candle` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. Can be set either in Configuration or in the strategy. 
+| `process_only_new_candles` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. Can be set either in Configuration or in the strategy. 
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file. 
 | `trailing_stoploss` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file).

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -53,7 +53,7 @@ CONF_SCHEMA = {
         },
         'fiat_display_currency': {'type': 'string', 'enum': SUPPORTED_FIAT},
         'dry_run': {'type': 'boolean'},
-        'ta_on_candle': {'type': 'boolean'},
+        'process_only_new_candles': {'type': 'boolean'},
         'minimal_roi': {
             'type': 'object',
             'patternProperties': {

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -53,6 +53,7 @@ CONF_SCHEMA = {
         },
         'fiat_display_currency': {'type': 'string', 'enum': SUPPORTED_FIAT},
         'dry_run': {'type': 'boolean'},
+        'ta_on_candle': {'type': 'boolean'},
         'minimal_roi': {
             'type': 'object',
             'patternProperties': {

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -25,7 +25,7 @@ class CandleAnalyzed:
     This allows analyze_ticker to test if analysed the candle row in dataframe prior.
     To not keep testing the same candle data, which is wasteful in CPU and time
     '''
-    def __init__(self, last_seen = {}):
+    def __init__(self, last_seen={}):
         self.last_seen = last_seen
 
     def get_last_seen(self, pair):
@@ -136,9 +136,9 @@ class IStrategy(ABC):
         dataframe = parse_ticker_dataframe(ticker_history)
 
         pair = metadata['pair']
-        last_candle_seen = self.candleSeen.get_last_seen(pair)
+        last_seen = self.candleSeen.get_last_seen(pair)
 
-        if  last_candle_seen != dataframe.iloc[-1]['date'] or self.config.get('ta_on_candle') is False:
+        if last_seen != dataframe.iloc[-1]['date'] or self.config.get('ta_on_candle') is False:
             # Defs that only make change on new candle data.
             logging.info("TA Analysis Launched")
             dataframe = self.advise_indicators(dataframe, metadata)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -119,11 +119,12 @@ class IStrategy(ABC):
         add several TA indicators and buy signal to it
         :return DataFrame with ticker data and indicator data
         """
-        # Test if seen this pair and last candle before.
+
         dataframe = parse_ticker_dataframe(ticker_history)
 
         pair = str(metadata.get('pair'))
 
+        # Test if seen this pair and last candle before.
         # always run if process_only_new_candles is set to true
         if (not self.process_only_new_candles or
                 self._last_candle_seen_per_pair.get(pair, None) != dataframe.iloc[-1]['date']):

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -34,8 +34,6 @@ class CandleAnalyzed:
     def set_last_seen(self, pair, candle_date):
         self.last_seen[pair] = candle_date
 
-    candle_row = property(get_last_seen, set_last_seen)
-
 
 class SignalType(Enum):
     """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -71,7 +71,7 @@ class IStrategy(ABC):
     ticker_interval: str
 
     # run "populate_indicators" only for new candle
-    ta_on_candle: bool = False
+    process_only_new_candles: bool = False
 
     # Dict to determine if analysis is necessary
     _last_candle_seen_per_pair: Dict[str, datetime] = {}
@@ -124,8 +124,8 @@ class IStrategy(ABC):
 
         pair = str(metadata.get('pair'))
 
-        # always run if ta_on_candle is set to true
-        if (not self.ta_on_candle or
+        # always run if process_only_new_candles is set to true
+        if (not self.process_only_new_candles or
                 self._last_candle_seen_per_pair.get(pair, None) != dataframe.iloc[-1]['date']):
             # Defs that only make change on new candle data.
             logging.debug("TA Analysis Launched")

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -135,7 +135,7 @@ class IStrategy(ABC):
         # Test if seen this pair and last candle before.
         dataframe = parse_ticker_dataframe(ticker_history)
 
-        pair = metadata['pair']
+        pair = metadata.get('pair')
         last_seen = self.candleSeen.get_last_seen(pair)
 
         if last_seen != dataframe.iloc[-1]['date'] or self.config.get('ta_on_candle') is False:

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -65,14 +65,14 @@ class StrategyResolver(object):
         else:
             config['ticker_interval'] = self.strategy.ticker_interval
 
-        if 'ta_on_candle' in config:
-            self.strategy.ta_on_candle = config['ta_on_candle']
+        if 'process_only_new_candles' in config:
+            self.strategy.process_only_new_candles = config['process_only_new_candles']
             logger.info(
-                "Override ta_on_candle 'ta_on_candle' with value in config file: %s.",
-                config['ta_on_candle']
+                "Override process_only_new_candles 'process_only_new_candles' "
+                "with value in config file: %s.", config['process_only_new_candles']
             )
         else:
-            config['ta_on_candle'] = self.strategy.ta_on_candle
+            config['process_only_new_candles'] = self.strategy.process_only_new_candles
 
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -776,7 +776,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
 
 def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
-    mocker.patch('freqtrade.exchange.Exchange.get_ticker_history',
+    mocker.patch('freqtrade.exchange.Exchange.get_candle_history',
                  new=lambda s, n, i: _load_pair_as_ticks(n, i))
     patch_exchange(mocker)
     backtestmock = MagicMock()

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -131,7 +131,7 @@ def test_analyze_ticker_default(ticker_history, mocker, caplog) -> None:
     caplog.clear()
 
     strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
-    # No analysis happens as ta_on_candle is true
+    # No analysis happens as process_only_new_candles is true
     assert ind_mock.call_count == 2
     assert buy_mock.call_count == 2
     assert buy_mock.call_count == 2
@@ -153,7 +153,7 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
 
     )
     strategy = DefaultStrategy({})
-    strategy.ta_on_candle = True
+    strategy.process_only_new_candles = True
 
     ret = strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
     assert ind_mock.call_count == 1
@@ -165,7 +165,7 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
     caplog.clear()
 
     ret = strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
-    # No analysis happens as ta_on_candle is true
+    # No analysis happens as process_only_new_candles is true
     assert ind_mock.call_count == 1
     assert buy_mock.call_count == 1
     assert buy_mock.call_count == 1

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -165,19 +165,20 @@ def test_strategy_override_ticker_interval(caplog):
             ) in caplog.record_tuples
 
 
-def test_strategy_override_ta_on_candle(caplog):
+def test_strategy_override_process_only_new_candles(caplog):
     caplog.set_level(logging.INFO)
 
     config = {
         'strategy': 'DefaultStrategy',
-        'ta_on_candle': True
+        'process_only_new_candles': True
     }
     resolver = StrategyResolver(config)
 
-    assert resolver.strategy.ta_on_candle
+    assert resolver.strategy.process_only_new_candles
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
-            "Override ta_on_candle 'ta_on_candle' with value in config file: True."
+            "Override process_only_new_candles 'process_only_new_candles' "
+            "with value in config file: True."
             ) in caplog.record_tuples
 
 


### PR DESCRIPTION
This is the last cut that was in #1117 before i closed that PR

This PR allows a user to set the flag `ta_on_candle` in their config.json

This will change the behaviour of the the bot to only process indicators
when there is a new candle to be processed for that pair.

the problem being addressed is in a 5 minute candle the same dataframe with no new 
candle data will be processed by TA indicators looking at only candle data 100 times. 
In a 4 hour timeframe this is many thousands of if times. 

the bot then has to deal with expensive CPU load slowing the system and ignoring thouands of false buy/sell signals. 

The new behavour is optional, the default is no change in current behaviour. 

The test is against a dict of  {'pair': candle last processed date} not matching current last candle row OR `ta_on_candle` no being true

Either test will execute existing behaviour, to process TA regardless. 