### PR TITLE
Fix failing tests when metadata in `analyze_ticker` is actually used

### DIFF
--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -14,7 +14,7 @@ def load_dataframe_pair(pairs, strategy):
     assert isinstance(pairs[0], str)
     dataframe = ld[pairs[0]]
 
-    dataframe = strategy.analyze_ticker(dataframe, pairs[0])
+    dataframe = strategy.analyze_ticker(dataframe, {'pair': pairs[0]})
     return dataframe
 
 


### PR DESCRIPTION
## Summary
Fix failing test if metadata is used as shown in #1119.

This only impacts tests, but was missed in the initial pr #1044 


## Quick changelog

- Adapt test to work if metadata-dict is used

