### PR TITLE
parametrize outdated_offset to simplify sandbox usage

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -41,7 +41,8 @@
         ],
         "pair_blacklist": [
             "DOGE/BTC"
-        ]
+        ],
+        "outdated_offset": 5
     },
     "experimental": {
         "use_sell_signal": false,

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -1,4 +1,5 @@
 # Sandbox API testing
+
 Where an exchange provides a sandbox for risk-free integration, or end-to-end, testing CCXT provides access to these.
 
 This document is a *light overview of configuring Freqtrade and GDAX sandbox.
@@ -11,8 +12,11 @@ https://public.sandbox.gdax.com
 https://api-public.sandbox.gdax.com
 
 ---
+
 # Configure a Sandbox account on Gdax
+
 Aim of this document section
+
 - An sanbox account
 - create 2FA (needed to create an API)
 - Add test 50BTC to account 
@@ -30,122 +34,108 @@ After registration and Email confimation you wil be redirected into your sanbox 
 > https://public.sandbox.pro.coinbase.com/
 
 ## Enable 2Fa (a prerequisite to creating sandbox API Keys)
+
 From within sand box site select your profile, top right.
 >Or as a direct link: https://public.sandbox.pro.coinbase.com/profile
 
-From the menu panel to the left of the screen select 
+From the menu panel to the left of the screen select
+
 > Security: "*View or Update*"
 
-In the new site select "enable authenticator" as typical google Authenticator. 
-- open Google Authenticator on your phone
-- scan barcode 
-- enter your generated 2fa 
+In the new site select "enable authenticator" as typical google Authenticator.
 
-## Enable API Access 
+- open Google Authenticator on your phone
+- scan barcode
+- enter your generated 2fa
+
+## Enable API Access
+
 From within sandbox select profile>api>create api-keys
 >or as a direct link: https://public.sandbox.pro.coinbase.com/profile/api
 
-Click on "create one" and ensure  **view** and **trade**  are "checked" and sumbit your 2Fa
+Click on "create one" and ensure  **view** and **trade**  are "checked" and sumbit your 2FA
+
 - **Copy and paste the Passphase** into a notepade this will be needed later
 - **Copy and paste the API Secret** popup into a notepad this will needed later
 - **Copy and paste the API Key** into a notepad this will needed later
 
 ## Add 50 BTC test funds
-To add funds, use the web interface deposit and withdraw buttons.
 
+To add funds, use the web interface deposit and withdraw buttons.
 
 To begin select 'Wallets' from the top menu.
 > Or as a direct link: https://public.sandbox.pro.coinbase.com/wallets
 
 - Deposits (bottom left of screen)
-- - Deposit Funds Bitcoin 
-- - - Coinbase BTC Wallet 
-- - - - Max (50 BTC) 
+- - Deposit Funds Bitcoin
+- - - Coinbase BTC Wallet
+- - - - Max (50 BTC)
 - - - - - Deposit
 
 *This process may be repeated for other currencies, ETH as example*
+
 ---
+
 # Configure Freqtrade to use Gax Sandbox 
 
 The aim of this document section
- - Enable sandbox URLs in Freqtrade
- - Configure API 
- - - secret
- - - key
- - - passphrase
+
+- Enable sandbox URLs in Freqtrade
+- Configure API
+- - secret
+- - key
+- - passphrase
  
 ## Sandbox URLs
-Freqtrade makes use of CCXT which in turn provides a list of URLs to Freqtrade. 
-These include `['test']` and `['api']`. 
+
+Freqtrade makes use of CCXT which in turn provides a list of URLs to Freqtrade.
+These include `['test']` and `['api']`.
+
 - `[Test]` if available will point to an Exchanges sandbox. 
 - `[Api]` normally used, and resolves to live API target on the exchange 
 
 To make use of sandbox / test add "sandbox": true, to your config.json
-```
+
+```json
   "exchange": {
         "name": "gdax",
         "sandbox": true,
         "key": "5wowfxemogxeowo;heiohgmd",
         "secret": "/ZMH1P62rCVmwefewrgcewX8nh4gob+lywxfwfxwwfxwfNsH1ySgvWCUR/w==",
         "password": "1bkjfkhfhfu6sr",
+        "outdated_offset": 5
         "pair_whitelist": [
             "BTC/USD"
 ```
+
 Also insert your 
+
 - api-key  (noted earlier)
 - api-secret (noted earlier)
 - password (the passphrase - noted earlier)
 
 ---
-## You should now be ready to test your sandbox!
+
+## You should now be ready to test your sandbox
+
 Ensure Freqtrade logs show the sandbox URL, and trades made are shown in sandbox.
-** Typically the  BTC/USD has the most activity in sandbox to test against. 
+** Typically the  BTC/USD has the most activity in sandbox to test against.
 
 ## GDAX - Old Candles problem
-It is my experience that GDAX sandbox candles may be 20+- minutes out of date. This can cause trades to fail as one of Freqtrades safety checks 
 
-To disable this check, edit: 
->strategy/interface.py
-Look for the following section:
-```
-      # Check if dataframe is out of date
-        signal_date = arrow.get(latest['date'])
-        interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + 5))):
-            logger.warning(
-                'Outdated history for pair %s. Last tick is %s minutes old',
-                pair,
-                (arrow.utcnow() - signal_date).seconds // 60
-            )
-            return False, False
-```
+It is my experience that GDAX sandbox candles may be 20+- minutes out of date. This can cause trades to fail as one of Freqtrades safety checks.
 
-You could Hash out the entire check as follows:
-```
-       # # Check if dataframe is out of date
-        # signal_date = arrow.get(latest['date'])
-        # interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        # if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + 5))):
-        #     logger.warning(
-        #         'Outdated history for pair %s. Last tick is %s minutes old',
-        #         pair,
-        #         (arrow.utcnow() - signal_date).seconds // 60
-        #     )
-        #     return False, False
- ```
- 
- Or inrease the timeout to offer a level of protection/alignment of this test to freqtrade in live.
- 
- As example, to allow an additional 30 minutes. "(interval_minutes * 2 + 5 + 30)"
- ```
-      # Check if dataframe is out of date
-        signal_date = arrow.get(latest['date'])
-        interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + 5 + 30))):
-            logger.warning(
-                'Outdated history for pair %s. Last tick is %s minutes old',
-                pair,
-                (arrow.utcnow() - signal_date).seconds // 60
-            )
-            return False, False
+To disable this check, add / change the `"outdated_offset"` parameter in the exchange section of your configuration to adjust for this delay.
+Example based on the above configuration:
+
+```json
+  "exchange": {
+        "name": "gdax",
+        "sandbox": true,
+        "key": "5wowfxemogxeowo;heiohgmd",
+        "secret": "/ZMH1P62rCVmwefewrgcewX8nh4gob+lywxfwfxwwfxwfNsH1ySgvWCUR/w==",
+        "password": "1bkjfkhfhfu6sr",
+        "outdated_offset": 30
+        "pair_whitelist": [
+            "BTC/USD"
 ```

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -145,7 +145,8 @@ CONF_SCHEMA = {
                         'pattern': '^[0-9A-Z]+/[0-9A-Z]+$'
                     },
                     'uniqueItems': True
-                }
+                },
+                'outdated_offset': {'type': 'integer', 'minimum': 1}
             },
             'required': ['name', 'key', 'secret', 'pair_whitelist']
         }

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -155,7 +155,8 @@ class IStrategy(ABC):
         # Check if dataframe is out of date
         signal_date = arrow.get(latest['date'])
         interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + 5))):
+        offset = self.config.get('outdated_offset', 5)
+        if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + offset))):
             logger.warning(
                 'Outdated history for pair %s. Last tick is %s minutes old',
                 pair,

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -155,7 +155,7 @@ class IStrategy(ABC):
         # Check if dataframe is out of date
         signal_date = arrow.get(latest['date'])
         interval_minutes = constants.TICKER_INTERVAL_MINUTES[interval]
-        offset = self.config.get('outdated_offset', 5)
+        offset = self.config.get('exchange', {}).get('outdated_offset', 5)
         if signal_date < (arrow.utcnow().shift(minutes=-(interval_minutes * 2 + offset))):
             logger.warning(
                 'Outdated history for pair %s. Last tick is %s minutes old',


### PR DESCRIPTION
## Summary
Add a parameter to dynamically change `outdated_ticker` offset.
This is needed for gdax sanbox support - but also for others. 
As shown in the sandbox configuration document changes, it'll greatly simplify usage as no change to the base-code is necessary.

to simplify usage of sandbox usage introduced in  #1078


## Quick changelog

- introduce new config parameter
