### PR TITLE
Fix /balance rpc call if coin is not properly listed

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -322,7 +322,7 @@ class Exchange(object):
                 return data
             except (ccxt.NetworkError, ccxt.ExchangeError) as e:
                 raise TemporaryError(
-                    f'Could not load ticker history due to {e.__class__.__name__}. Message: {e}')
+                    f'Could not load ticker due to {e.__class__.__name__}. Message: {e}')
             except ccxt.BaseError as e:
                 raise OperationalException(e)
         else:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -13,6 +13,7 @@ import sqlalchemy as sql
 from numpy import mean, nan_to_num
 from pandas import DataFrame
 
+from freqtrade import TemporaryError
 from freqtrade.fiat_convert import CryptoToFiatConverter
 from freqtrade.misc import shorten_date
 from freqtrade.persistence import Trade
@@ -271,10 +272,13 @@ class RPC(object):
             if coin == 'BTC':
                 rate = 1.0
             else:
-                if coin == 'USDT':
-                    rate = 1.0 / self._freqtrade.exchange.get_ticker('BTC/USDT', False)['bid']
-                else:
-                    rate = self._freqtrade.exchange.get_ticker(coin + '/BTC', False)['bid']
+                try:
+                    if coin == 'USDT':
+                        rate = 1.0 / self._freqtrade.exchange.get_ticker('BTC/USDT', False)['bid']
+                    else:
+                        rate = self._freqtrade.exchange.get_ticker(coin + '/BTC', False)['bid']
+                except TemporaryError:
+                    continue
             est_btc: float = rate * balance['total']
             total = total + est_btc
             output.append({


### PR DESCRIPTION
## Summary
For `/balance`, we're using `get_ticker` to get the latest rate. This fails if a coin is not yet listed on the exchange, breaking `/balance` until the coin is listed or the balance is somehow removed from the account.
This should not happen as the balance for all other coins is still valid.

While this is an edge-case with VTHO, it could happen with other coins which are either unlisted, or have a similar introduction than VTHO.

Solve the issue: #1111 

## Quick changelog

- Add test for failed case
- Catch error and skip this coin