### PR TITLE
update plotly dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ coinmarketcap==5.0.3
 scikit-optimize==0.5.2
 
 # Required for plotting data
-#plotly==3.0.0
+#plotly==3.1.1


### PR DESCRIPTION
## summary

updates plotly frorm 3.0.0 to 3.1.1.

This is not covered by pyupbot as it's commented in the requiremnets file.