### PR TITLE
fix running freqtrade on python3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.6-slim-stretch
+FROM python:3.7.0-slim-stretch
 
 # Install TA-lib
 RUN apt-get update && apt-get -y install curl build-essential && apt-get clean

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -12,8 +12,18 @@ def import_strategy(strategy: IStrategy, config: dict) -> IStrategy:
     Imports given Strategy instance to global scope
     of freqtrade.strategy and returns an instance of it
     """
+
     # Copy all attributes from base class and class
-    attr = deepcopy({**strategy.__class__.__dict__, **strategy.__dict__})
+
+    comb = {**strategy.__class__.__dict__, **strategy.__dict__}
+
+    # Delete '_abc_impl' from dict as deepcopy fails on 3.7 with
+    # `TypeError: can't pickle _abc_data objects``
+    # This will only apply to python 3.7
+    if '_abc_impl' in comb:
+        del comb['_abc_impl']
+
+    attr = deepcopy(comb)
     # Adjust module name
     attr['__module__'] = 'freqtrade.strategy'
 

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from copy import deepcopy
 
 from freqtrade.strategy.interface import IStrategy
@@ -20,7 +21,7 @@ def import_strategy(strategy: IStrategy, config: dict) -> IStrategy:
     # Delete '_abc_impl' from dict as deepcopy fails on 3.7 with
     # `TypeError: can't pickle _abc_data objects``
     # This will only apply to python 3.7
-    if '_abc_impl' in comb:
+    if sys.version_info.major == 3 and sys.version_info.minor == 7 and '_abc_impl' in comb:
         del comb['_abc_impl']
 
     attr = deepcopy(comb)

--- a/setup.sh
+++ b/setup.sh
@@ -211,7 +211,7 @@ function install () {
     echo "-------------------------"
     echo "Run the bot"
     echo "-------------------------"
-    echo "You can now use the bot by executing 'source .env/bin/activate; ${PYTHON} freqtrade/main.py'."
+    echo "You can now use the bot by executing 'source .env/bin/activate; python freqtrade/main.py'."
 }
 
 function plot () {

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
 #encoding=utf8
 
+# Check which python version is installed
+function check_installed_python() {
+    which python3.7
+    if [ $? -eq 0 ]; then
+        echo "using Python 3.7"
+        PYTHON=python3.7
+        return
+    fi
+
+    which python3.6
+    if [ $? -eq 0 ]; then
+        echo "using Python 3.6"
+        PYTHON=python3.6
+        return
+   fi
+
+}
+
 function updateenv () {
     echo "-------------------------"
     echo "Update your virtual env"
     echo "-------------------------"
     source .env/bin/activate
     echo "pip3 install in-progress. Please wait..."
-    pip3.6 install --quiet --upgrade pip
+    pip3 install --quiet --upgrade pip
     pip3 install --quiet -r requirements.txt --upgrade
     pip3 install --quiet -r requirements.txt
     pip3 install --quiet -e .
@@ -79,7 +97,7 @@ function reset () {
     fi
 
     echo
-    python3.6 -m venv .env
+    ${PYTHON} -m venv .env
     updateenv
 }
 
@@ -183,7 +201,7 @@ function install () {
         install_debian
     else
         echo "This script does not support your OS."
-        echo "If you have Python3.6, pip, virtualenv, ta-lib you can continue."
+        echo "If you have Python3.6 or Python3.7, pip, virtualenv, ta-lib you can continue."
         echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
         sleep 10
     fi
@@ -193,7 +211,7 @@ function install () {
     echo "-------------------------"
     echo "Run the bot"
     echo "-------------------------"
-    echo "You can now use the bot by executing 'source .env/bin/activate; python3.6 freqtrade/main.py'."
+    echo "You can now use the bot by executing 'source .env/bin/activate; ${PYTHON} freqtrade/main.py'."
 }
 
 function plot () {
@@ -213,6 +231,9 @@ function help () {
     echo "	-c,--config     Easy config generator (Will override your existing file)."
     echo "	-p,--plot       Install dependencies for Plotting scripts."
 }
+
+# Verify if 3.6 or 3.7 is installed
+check_installed_python
 
 case $* in
 --install|-i)


### PR DESCRIPTION
## Summary
This will fix the issue of the bot crashing on strategy-loading with python 3.7.

Solve the issue: #1064 

## Quick changelog

- hack-fix the "cannot pickle _abc_data" error
- update setup.sh to support systems without python 3.6

unfortunately, travis cannot run against 3.7 yet (https://github.com/travis-ci/travis-ci/issues/9815)

i'll try in a different pr to support this.
