### PR TITLE
Output min-roi setting when overwriting from config

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -79,10 +79,12 @@ def check_migrate(engine) -> None:
     table_back_name = 'trades_bak'
     for i, table_back_name in enumerate(tabs):
         table_back_name = f'trades_bak{i}'
-        logger.info(f'trying {table_back_name}')
+        logger.debug(f'trying {table_back_name}')
 
     # Check for latest column
     if not has_column(cols, 'ticker_interval'):
+        logger.info(f'Running database migration - backup available as {table_back_name}')
+
         fee_open = get_column_def(cols, 'fee_open', 'fee')
         fee_close = get_column_def(cols, 'fee_close', 'fee')
         open_rate_requested = get_column_def(cols, 'open_rate_requested', 'null')

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -44,14 +44,15 @@ class StrategyResolver(object):
         # Check if we need to override configuration
         if 'minimal_roi' in config:
             self.strategy.minimal_roi = config['minimal_roi']
-            logger.info("Override strategy \'minimal_roi\' with value in config file.")
+            logger.info("Override strategy 'minimal_roi' with value in config file: %s.",
+                        config['minimal_roi'])
         else:
             config['minimal_roi'] = self.strategy.minimal_roi
 
         if 'stoploss' in config:
             self.strategy.stoploss = config['stoploss']
             logger.info(
-                "Override strategy \'stoploss\' with value in config file: %s.", config['stoploss']
+                "Override strategy 'stoploss' with value in config file: %s.", config['stoploss']
             )
         else:
             config['stoploss'] = self.strategy.stoploss
@@ -59,7 +60,7 @@ class StrategyResolver(object):
         if 'ticker_interval' in config:
             self.strategy.ticker_interval = config['ticker_interval']
             logger.info(
-                "Override strategy \'ticker_interval\' with value in config file: %s.",
+                "Override strategy 'ticker_interval' with value in config file: %s.",
                 config['ticker_interval']
             )
         else:

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -130,7 +130,7 @@ def test_strategy_override_minimal_roi(caplog):
     assert resolver.strategy.minimal_roi[0] == 0.5
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
-            'Override strategy \'minimal_roi\' with value in config file.'
+            "Override strategy 'minimal_roi' with value in config file: {'0': 0.5}."
             ) in caplog.record_tuples
 
 
@@ -145,7 +145,7 @@ def test_strategy_override_stoploss(caplog):
     assert resolver.strategy.stoploss == -0.5
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
-            'Override strategy \'stoploss\' with value in config file: -0.5.'
+            "Override strategy 'stoploss' with value in config file: -0.5."
             ) in caplog.record_tuples
 
 
@@ -161,7 +161,7 @@ def test_strategy_override_ticker_interval(caplog):
     assert resolver.strategy.ticker_interval == 60
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
-            'Override strategy \'ticker_interval\' with value in config file: 60.'
+            "Override strategy 'ticker_interval' with value in config file: 60."
             ) in caplog.record_tuples
 
 

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -1,5 +1,6 @@
 # pragma pylint: disable=missing-docstring, C0103
 from unittest.mock import MagicMock
+import logging
 
 import pytest
 from sqlalchemy import create_engine
@@ -403,6 +404,7 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
     """
     Test Database migration (starting with new pairformat)
     """
+    caplog.set_level(logging.DEBUG)
     amount = 103.223
     # Always create all columns apart from the last!
     create_table_old = """CREATE TABLE IF NOT EXISTS "trades" (
@@ -471,12 +473,15 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
     assert trade.ticker_interval is None
     assert log_has("trying trades_bak1", caplog.record_tuples)
     assert log_has("trying trades_bak2", caplog.record_tuples)
+    assert log_has("Running database migration - backup available as trades_bak2",
+                   caplog.record_tuples)
 
 
 def test_migrate_mid_state(mocker, default_conf, fee, caplog):
     """
     Test Database migration (starting with new pairformat)
     """
+    caplog.set_level(logging.DEBUG)
     amount = 103.223
     create_table_old = """CREATE TABLE IF NOT EXISTS "trades" (
                                 id INTEGER NOT NULL,
@@ -530,6 +535,8 @@ def test_migrate_mid_state(mocker, default_conf, fee, caplog):
     assert trade.stop_loss == 0.0
     assert trade.initial_stop_loss == 0.0
     assert log_has("trying trades_bak0", caplog.record_tuples)
+    assert log_has("Running database migration - backup available as trades_bak0",
+                   caplog.record_tuples)
 
 
 def test_adjust_stop_loss(limit_buy_order, limit_sell_order, fee):


### PR DESCRIPTION
## Summary
print min-roi settings from config if used from config-file (same as done with stoploss or ticker_interval

Also removed unnecessary escaping - if string is in double-quotes, `'` does need no escaping.

Database migration logging slightly changed to not always info-log which tables have been tried in a migration scenario.

## changed output
old:
```
Override strategy 'minimal_roi' with value in config file.
```
new:
```
Override strategy 'minimal_roi' with value in config file: {'0': 0.5}.
```