### PR TITLE
remove amount_to_lots (deprecated / removed)

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -462,12 +462,3 @@ class Exchange(object):
                 f'Could not get fee info due to {e.__class__.__name__}. Message: {e}')
         except ccxt.BaseError as e:
             raise OperationalException(e)
-
-    def get_amount_lots(self, pair: str, amount: float) -> float:
-        """
-        get buyable amount rounding, ..
-        """
-        # validate that markets are loaded before trying to get fee
-        if not self._api.markets:
-            self._api.load_markets()
-        return self._api.amount_to_lots(pair, amount)

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -823,15 +823,3 @@ def test_get_fee(default_conf, mocker):
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock,
                            'get_fee', 'calculate_fee')
-
-
-def test_get_amount_lots(default_conf, mocker):
-    api_mock = MagicMock()
-    api_mock.amount_to_lots = MagicMock(return_value=1.0)
-    api_mock.markets = None
-    marketmock = MagicMock()
-    api_mock.load_markets = marketmock
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
-
-    assert exchange.get_amount_lots('LTC/BTC', 1.54) == 1
-    assert marketmock.call_count == 1


### PR DESCRIPTION
remove amount_to_lots (deprecated / removed)

was removed from ccxt in https://github.com/ccxt/ccxt/commit/527f082e59e1cd3698cb7ae95bdcaae4459ea218
in addition to that, we didn't use this anywhere anyway.
