### PR TITLE
bot_id with tests

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+    "bot_id": 0,
     "max_open_trades": 3,
     "stake_currency": "BTC",
     "stake_amount": 0.05,

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -1,4 +1,5 @@
 {
+    "bot_id": 0,
     "max_open_trades": 3,
     "stake_currency": "BTC",
     "stake_amount": 0.05,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The table below will list all configuration parameters.
 
 |  Command | Default | Mandatory | Description |
 |----------|---------|----------|-------------|
+| `bot_id` | 0 | No | Allows multiple bot connect to 1 database server. This value should be unique in each bot instance.
 | `max_open_trades` | 3 | Yes | Number of trades open your bot will have.
 | `stake_currency` | BTC | Yes | Crypto-currency used for trading.
 | `stake_amount` | 0.05 | Yes | Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to 'unlimited' to allow the bot to use all avaliable balance.
@@ -54,6 +55,10 @@ The table below will list all configuration parameters.
 | `internals.process_throttle_secs` | 5 | Yes | Set the process throttle. Value in second.
 
 The definition of each config parameters is in [misc.py](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/misc.py#L205).
+
+### Understand bot_id
+
+`bot_id` is a value assigned to each instance of the bot. Use only UNIQUE `bot_id` value per bot instance when connected to a single database server such as Postgre, Mysql, etc. 
 
 ### Understand stake_amount
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -43,6 +43,7 @@ SUPPORTED_FIAT = [
 CONF_SCHEMA = {
     'type': 'object',
     'properties': {
+        'bot_id': {'type': 'integer', 'minimum': 0},
         'max_open_trades': {'type': 'integer', 'minimum': 0},
         'ticker_interval': {'type': 'string', 'enum': list(TICKER_INTERVAL_MINUTES.keys())},
         'stake_currency': {'type': 'string', 'enum': ['BTC', 'XBT', 'ETH', 'USDT', 'EUR', 'USD']},

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -118,6 +118,7 @@ class FreqtradeBot(object):
                 'type': RPCMessageType.WARNING_NOTIFICATION,
                 'status': 'Dry run is enabled. All trades are simulated.'
             })
+        bot_id = self.config.get('bot_id',0)
         stake_currency = self.config['stake_currency']
         stake_amount = self.config['stake_amount']
         minimal_roi = self.config['minimal_roi']
@@ -127,7 +128,8 @@ class FreqtradeBot(object):
         strategy_name = self.config.get('strategy', '')
         self.rpc.send_msg({
             'type': RPCMessageType.CUSTOM_NOTIFICATION,
-            'status': f'*Exchange:* `{exchange_name}`\n'
+            'status': f'*Bot ID:* `{bot_id}`\n'
+                      f'*Exchange:* `{exchange_name}`\n'
                       f'*Stake per trade:* `{stake_amount} {stake_currency}`\n'
                       f'*Minimum ROI:* `{minimal_roi}`\n'
                       f'*Ticker Interval:* `{ticker_interval}`\n'

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -118,7 +118,7 @@ class FreqtradeBot(object):
                 'type': RPCMessageType.WARNING_NOTIFICATION,
                 'status': 'Dry run is enabled. All trades are simulated.'
             })
-        bot_id = self.config.get('bot_id',0)
+        bot_id = self.config.get('bot_id', 0)
         stake_currency = self.config['stake_currency']
         stake_amount = self.config['stake_amount']
         minimal_roi = self.config['minimal_roi']

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -576,3 +576,63 @@ def test_adjust_stop_loss(limit_buy_order, limit_sell_order, fee):
     assert round(trade.stop_loss, 8) == 1.26
     assert trade.max_rate == 1.4
     assert trade.initial_stop_loss == 0.95
+
+
+def test_migrate_bot_id(mocker, default_conf, fee, caplog):
+    """
+    Test Database migration (starting with new pairformat)
+    migration will put bot_id
+    """
+    amount = 103.223
+    # Always create all columns apart from the last!
+    create_table_old = """CREATE TABLE IF NOT EXISTS "trades" (
+                                id INTEGER NOT NULL,
+                                exchange VARCHAR NOT NULL,
+                                pair VARCHAR NOT NULL,
+                                is_open BOOLEAN NOT NULL,
+                                fee FLOAT NOT NULL,
+                                open_rate FLOAT,
+                                close_rate FLOAT,
+                                close_profit FLOAT,
+                                stake_amount FLOAT NOT NULL,
+                                amount FLOAT,
+                                open_date DATETIME NOT NULL,
+                                close_date DATETIME,
+                                open_order_id VARCHAR,
+                                stop_loss FLOAT,
+                                initial_stop_loss FLOAT,
+                                max_rate FLOAT,
+                                sell_reason VARCHAR,
+                                strategy VARCHAR,
+                                PRIMARY KEY (id),
+                                CHECK (is_open IN (0, 1))
+                                );"""
+    insert_table_old = """INSERT INTO trades (exchange, pair, is_open, fee,
+                          open_rate, stake_amount, amount, open_date,
+                          stop_loss, initial_stop_loss, max_rate)
+                          VALUES ('binance', 'ETC/BTC', 1, {fee},
+                          0.00258580, {stake}, {amount},
+                          '2019-11-28 12:44:24.000000',
+                          0.0, 0.0, 0.0)
+                          """.format(fee=fee.return_value,
+                                     stake=default_conf.get("stake_amount"),
+                                     amount=amount
+                                     )
+    engine = create_engine('sqlite://')
+    mocker.patch('freqtrade.persistence.create_engine', lambda *args, **kwargs: engine)
+
+    # Create table using the old format
+    engine.execute(create_table_old)
+    engine.execute(insert_table_old)
+
+    # fake previous backup
+    # engine.execute("create table trades_bak as select * from trades")
+
+    # engine.execute("create table trades_bak1 as select * from trades")
+    # Run init to test migration
+    default_conf['bot_id'] = 1
+    init(default_conf)
+
+    assert len(Trade.query.filter(Trade.id == 1).all()) == 1
+    trade = Trade.query.filter(Trade.id == 1).first()
+    assert trade.bot_id == 1


### PR DESCRIPTION
## Summary
Added `bot_id` in trade database. Useful for multiple bots with single database server (postgre, mysql, etc)

Solves:
* bot fragmentation

## Quick changelog

- rpc.py - added bot_id to query filters
- persistence.py - added bot_id to migration function, and added to query filters
- freqtradebot.py - added bot_id to query filters 
- constants.py - added bot_id check
- docs/configuration.md - updated documentation
- tests/test_persistence.py - added new tests

## What's new?
* multiple bot can now be used in a central database server, as long as `bot_id` is unique in each bot instance.
* backwards compatible: old sqlite database will be migrated with 0 bot_id value


