### PR TITLE
Dask multithreading analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ target/
 
 .pytest_cache/
 .mypy_cache/
+
+# Dask
+dask-worker-space/

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,5 +1,5 @@
 """ FreqTrade bot """
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 
 
 class DependencyException(BaseException):

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -415,6 +415,10 @@ class FreqtradeBot(object):
                             (bidstrat_check_depth_of_market.get('bids_to_ask_delta', 0) > 0):
                         if self._check_depth_of_market_buy(_pair, bidstrat_check_depth_of_market):
                             self.execute_buy(_pair, stake_amount)
+                        else:
+                            continue
+                    else:
+                        self.execute_buy(_pair, stake_amount)
 
             client.restart()  # restart workers to prevent side effects of memory leaks
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -415,8 +415,6 @@ class FreqtradeBot(object):
                             (bidstrat_check_depth_of_market.get('bids_to_ask_delta', 0) > 0):
                         if self._check_depth_of_market_buy(_pair, bidstrat_check_depth_of_market):
                             self.execute_buy(_pair, stake_amount)
-                    else:
-                        self.execute_buy(_pair, stake_amount)
 
             client.restart()  # restart workers to prevent side effects of memory leaks
 

--- a/freqtrade/multithreading.py
+++ b/freqtrade/multithreading.py
@@ -1,0 +1,18 @@
+"""
+This module contains the class to use the dask module
+"""
+
+from typing import Dict
+from dask.distributed import Client
+
+
+def init(config: Dict) -> object:
+    """
+    Initialise Dask Distributed Client
+    """
+    workers_number = config['multithreading']['workers_number']
+    client = Client(processes=False, threads_per_worker=1, n_workers=workers_number)
+
+    return client
+
+

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -127,6 +127,10 @@ def default_conf():
                 "NEO/BTC"
             ]
         },
+        "multithreading": {
+            "enabled": False,
+            "workers_number": 4
+        },
         "telegram": {
             "enabled": True,
             "token": "token",

--- a/freqtrade/tests/test_multithreading.py
+++ b/freqtrade/tests/test_multithreading.py
@@ -1,0 +1,11 @@
+from freqtrade import (multithreading)
+
+
+def test_client_init():
+    # Check if create a Dask Client
+    default_conf = {}
+    default_conf.update({
+        'multithreading': {'use_multithreading': True, 'workers_number': 4}
+    })
+    client = multithreading.init(default_conf)
+    assert (str(type(client))) == "<class 'distributed.client.Client'>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytest-mock==1.10.0
 pytest-cov==2.5.1
 tabulate==0.8.2
 coinmarketcap==5.0.3
+dask==0.19.0
 
 # Required for hyperopt
 scikit-optimize==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='freqtrade',
           'cachetools',
           'coinmarketcap',
           'scikit-optimize',
+          'dask[complete]'
       ],
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
!!!DON'T MERGE YET!!! Because of [This issue](https://github.com/dask/distributed/issues/2068)
## Summary
PR to improve freqtrade speed by taking advantage of multithreading with Dask distributed Framework

Solve issues: #746 and #1170

## Quick changelog
- Add Multithreaded Loop in create_trade function
- Create function get_history_and_signal to send to Dask Client as individual Tasks
- Add basic test for dask client initialisation

## What's new?
This PR improve drastically dask speed to get Pairs Price data and analysis to react more quickly

## How It works

**Before**
The loop is totaly synchronous and execute task each after one.
![freqtrade dask old loop](https://user-images.githubusercontent.com/7593404/44951021-e348f600-ae26-11e8-9a24-928095076a26.png)

**After**
Dask shceduler dispatch work concurently on workers depending on their availability
![freqtrade dask new loop](https://user-images.githubusercontent.com/7593404/44951022-e7751380-ae26-11e8-9af6-345507606b17.png)


## Test 
**Parameters**
**30 pairs** in whitelist
Multithreading configured with **8 workers** as below:
`
"multithreading":{
        "enabled": true,
        "workers_number": 8
    }
`
**Results**
![freqtrade speed comparison 7](https://user-images.githubusercontent.com/7593404/44957882-abcd5e80-aea5-11e8-94d1-45284751279a.png)


### To Do
- [ ] Add more tests
- [ ] Improve stability

### What's next
- Compare Performance with and discuss about possibilities with [Async PR #1101](https://github.com/freqtrade/freqtrade/pull/1101), maybe combine both aspects: Async and Multithreading with Dask
- Implement the same logic for SELL, for the moment there is a bottle neck on processing current opened trades


