### PR TITLE
Add offset to "get_trades_for_order"

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ to understand the requirements before sending your pull-requests.
 
 ### Uptodate clock
 
-The clock must be uptodate, ideally syncronized to a NTP server rather frequently. Drifting time can lead to losses.
+The clock must be accurate, syncronized to a NTP server very frequently to avoid problems with communication to the exchanges.
 
 ### Min hardware required
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ to understand the requirements before sending your pull-requests.
 
 ## Requirements
 
+### Uptodate clock
+
+The clock must be uptodate, ideally syncronized to a NTP server rather frequently. Drifting time can lead to losses.
+
 ### Min hardware required
 
 To run this bot we recommend you a cloud instance with a minimum of:

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -591,7 +591,8 @@ class Exchange(object):
         if not self.exchange_has('fetchMyTrades'):
             return []
         try:
-            my_trades = self._api.fetch_my_trades(pair, since.timestamp())
+            # Allow 5s offset to catch slight time offsets (discovered in #1185)
+            my_trades = self._api.fetch_my_trades(pair, since.timestamp() - 5)
             matched_trades = [trade for trade in my_trades if trade['order'] == order_id]
 
             return matched_trades


### PR DESCRIPTION
## Summary
Add 5s offset to cover very slight time-differences (1s should in theory be enough - but better be safe in this case as it doesn't do any harm to get 5s more trades).

Solve the issue: #1185, #1086

## Quick changelog

- add offset to get trade if the exchange-time is slightly behind (or ours is ahead).