### PR TITLE
Fix mac install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ to understand the requirements before sending your pull-requests.
 
 ## Requirements
 
+### Uptodate clock
+
+The clock must be uptodate, ideally syncronized to a NTP server rather frequently. Drifting time can lead to losses.
+
 ### Min hardware required
 
 To run this bot we recommend you a cloud instance with a minimum of:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -267,7 +267,7 @@ Official webpage: https://mrjbq7.github.io/ta-lib/install.html
 wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
 tar xvzf ta-lib-0.4.0-src.tar.gz
 cd ta-lib
-sed -i "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h
+sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h
 ./configure --prefix=/usr
 make
 make install

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -591,7 +591,8 @@ class Exchange(object):
         if not self.exchange_has('fetchMyTrades'):
             return []
         try:
-            my_trades = self._api.fetch_my_trades(pair, since.timestamp())
+            # Allow 5s offset to catch slight time offsets (discovered in #1185)
+            my_trades = self._api.fetch_my_trades(pair, since.timestamp() - 5)
             matched_trades = [trade for trade in my_trades if trade['order'] == order_id]
 
             return matched_trades

--- a/install_ta-lib.sh
+++ b/install_ta-lib.sh
@@ -1,6 +1,6 @@
 if [ ! -f "ta-lib/CHANGELOG.TXT" ]; then
   tar zxvf ta-lib-0.4.0-src.tar.gz
-  cd ta-lib && sed -i "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h && ./configure && make && sudo make install && cd ..
+  cd ta-lib && sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h && ./configure && make && sudo make install && cd ..
 else
   echo "TA-lib already installed, skipping download and build."
   cd ta-lib && sudo make install && cd ..


### PR DESCRIPTION
## Summary
Fix the installation of ta-lib for mac-users (`sed -i "pattern"` is invalid in bsd-versions.

Adding .bak after the -i generates a backup file of the previous version - which works on both macos and linux. 

## Quick changelog
 - documentation and install-script fix
