### PR TITLE
use --no-cache-dir for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /freqtrade
 WORKDIR /freqtrade
 
 # Install dependencies
-COPY requirements.txt /freqtrade/ 
+COPY requirements.txt /freqtrade/
 RUN pip install numpy --no-cache-dir \
   && pip install -r requirements.txt --no-cache-dir
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN mkdir /freqtrade
 WORKDIR /freqtrade
 
 # Install dependencies
-COPY requirements.txt /freqtrade/
-RUN pip install numpy \
-  && pip install -r requirements.txt
+COPY requirements.txt /freqtrade/ 
+RUN pip install numpy --no-cache-dir \
+  && pip install -r requirements.txt --no-cache-dir
 
 # Install and execute
 COPY . /freqtrade/
-RUN pip install -e .
+RUN pip install -e . --no-cache-dir
 ENTRYPOINT ["freqtrade"]


### PR DESCRIPTION
use --no-cache can save about 90M
``` bash
➜  freqtrade git:(develop) ✗ docker images freq
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
freq                latest              b15db8341067        7 minutes ago       800MB
➜  freqtrade git:(develop) ✗ docker images freq_nocache
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
freq_nocache        latest              e5731f28ac54        20 seconds ago      709MB
```
