### PR TITLE
Remove direct call to pytest fixture to elliminate pytest warning

### DIFF
--- a/freqtrade/tests/test_acl_pair.py
+++ b/freqtrade/tests/test_acl_pair.py
@@ -2,38 +2,39 @@
 
 from unittest.mock import MagicMock
 
-import freqtrade.tests.conftest as tt  # test tools
+from freqtrade.tests.conftest import get_patched_freqtradebot
+
+import pytest
 
 # whitelist, blacklist, filtering, all of that will
 # eventually become some rules to run on a generic ACL engine
 # perhaps try to anticipate that by using some python package
 
 
-def whitelist_conf():
-    config = tt.default_conf()
-    config['stake_currency'] = 'BTC'
-    config['exchange']['pair_whitelist'] = [
+@pytest.fixture(scope="function")
+def whitelist_conf(default_conf):
+    default_conf['stake_currency'] = 'BTC'
+    default_conf['exchange']['pair_whitelist'] = [
         'ETH/BTC',
         'TKN/BTC',
         'TRST/BTC',
         'SWT/BTC',
         'BCC/BTC'
     ]
-    config['exchange']['pair_blacklist'] = [
+    default_conf['exchange']['pair_blacklist'] = [
         'BLK/BTC'
     ]
 
-    return config
+    return default_conf
 
 
-def test_refresh_market_pair_not_in_whitelist(mocker, markets):
-    conf = whitelist_conf()
+def test_refresh_market_pair_not_in_whitelist(mocker, markets, whitelist_conf):
 
-    freqtradebot = tt.get_patched_freqtradebot(mocker, conf)
+    freqtradebot = get_patched_freqtradebot(mocker, whitelist_conf)
 
     mocker.patch('freqtrade.exchange.Exchange.get_markets', markets)
     refreshedwhitelist = freqtradebot._refresh_whitelist(
-        conf['exchange']['pair_whitelist'] + ['XXX/BTC']
+        whitelist_conf['exchange']['pair_whitelist'] + ['XXX/BTC']
     )
     # List ordered by BaseVolume
     whitelist = ['ETH/BTC', 'TKN/BTC']
@@ -41,12 +42,12 @@ def test_refresh_market_pair_not_in_whitelist(mocker, markets):
     assert whitelist == refreshedwhitelist
 
 
-def test_refresh_whitelist(mocker, markets):
-    conf = whitelist_conf()
-    freqtradebot = tt.get_patched_freqtradebot(mocker, conf)
+def test_refresh_whitelist(mocker, markets, whitelist_conf):
+    freqtradebot = get_patched_freqtradebot(mocker, whitelist_conf)
 
     mocker.patch('freqtrade.exchange.Exchange.get_markets', markets)
-    refreshedwhitelist = freqtradebot._refresh_whitelist(conf['exchange']['pair_whitelist'])
+    refreshedwhitelist = freqtradebot._refresh_whitelist(
+        whitelist_conf['exchange']['pair_whitelist'])
 
     # List ordered by BaseVolume
     whitelist = ['ETH/BTC', 'TKN/BTC']
@@ -54,9 +55,8 @@ def test_refresh_whitelist(mocker, markets):
     assert whitelist == refreshedwhitelist
 
 
-def test_refresh_whitelist_dynamic(mocker, markets, tickers):
-    conf = whitelist_conf()
-    freqtradebot = tt.get_patched_freqtradebot(mocker, conf)
+def test_refresh_whitelist_dynamic(mocker, markets, tickers, whitelist_conf):
+    freqtradebot = get_patched_freqtradebot(mocker, whitelist_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_markets=markets,
@@ -68,21 +68,20 @@ def test_refresh_whitelist_dynamic(mocker, markets, tickers):
     whitelist = ['ETH/BTC', 'TKN/BTC']
 
     refreshedwhitelist = freqtradebot._refresh_whitelist(
-        freqtradebot._gen_pair_whitelist(conf['stake_currency'])
+        freqtradebot._gen_pair_whitelist(whitelist_conf['stake_currency'])
     )
 
     assert whitelist == refreshedwhitelist
 
 
-def test_refresh_whitelist_dynamic_empty(mocker, markets_empty):
-    conf = whitelist_conf()
-    freqtradebot = tt.get_patched_freqtradebot(mocker, conf)
+def test_refresh_whitelist_dynamic_empty(mocker, markets_empty, whitelist_conf):
+    freqtradebot = get_patched_freqtradebot(mocker, whitelist_conf)
     mocker.patch('freqtrade.exchange.Exchange.get_markets', markets_empty)
 
     # argument: use the whitelist dynamically by exchange-volume
     whitelist = []
-    conf['exchange']['pair_whitelist'] = []
+    whitelist_conf['exchange']['pair_whitelist'] = []
     freqtradebot._refresh_whitelist(whitelist)
-    pairslist = conf['exchange']['pair_whitelist']
+    pairslist = whitelist_conf['exchange']['pair_whitelist']
 
     assert set(whitelist) == set(pairslist)


### PR DESCRIPTION
## Summary
change calls to `default_config()` to use a pytest fixture instead.

this removes a warning appearing in pytest 3.7.0 about not calling fixtures directly.