### PR TITLE
don't print "NAN" lines in "left_open_trades"

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -108,7 +108,8 @@ class Backtesting(object):
         return min(timeframe, key=operator.itemgetter(0))[0], \
             max(timeframe, key=operator.itemgetter(1))[1]
 
-    def _generate_text_table(self, data: Dict[str, Dict], results: DataFrame) -> str:
+    def _generate_text_table(self, data: Dict[str, Dict], results: DataFrame,
+                             skip_nan: bool = False) -> str:
         """
         Generates and returns a text table for the given backtest data and the results dataframe
         :return: pretty printed table with tabulate as str
@@ -121,6 +122,9 @@ class Backtesting(object):
                    'total profit ' + stake_currency, 'avg duration', 'profit', 'loss']
         for pair in data:
             result = results[results.pair == pair]
+            if skip_nan and result.profit_abs.isnull().all():
+                continue
+
             tabular_data.append([
                 pair,
                 len(result.index),
@@ -404,7 +408,7 @@ class Backtesting(object):
             print(self._generate_text_table_sell_reason(data, results))
 
             print(' LEFT OPEN TRADES REPORT '.center(119, '='))
-            print(self._generate_text_table(data, results.loc[results.open_at_end]))
+            print(self._generate_text_table(data, results.loc[results.open_at_end], True))
             print()
         if len(all_results) > 1:
             # Print Strategy summary table


### PR DESCRIPTION
## Summary
Backtesting is very verbose.
the "left-open-trades" table should not contain pairs which were not left open.

## Quick changelog

- Reduce number of non-meaningfull lines in output for backtesting

## What's new?

before:
```
================================================== BACKTESTING REPORT =================================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration   |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:---------------|---------:|-------:|
| LTC/ETH   |          51 |          -0.04 |          -2.26 |        -0.00225942 | 2:04:00        |       24 |     27 |
| IOTA/ETH  |          61 |           0.11 |           6.58 |         0.00659000 | 2:10:00        |       38 |     23 |
| XMR/ETH   |          72 |           0.00 |           0.02 |         0.00001544 | 2:00:00        |       39 |     33 |
| XRP/ETH   |          50 |           0.10 |           4.93 |         0.00493210 | 2:27:00        |       27 |     23 |
| NCASH/ETH |          72 |           0.05 |           3.78 |         0.00378853 | 1:41:00        |       45 |     27 |
| MTH/ETH   |         126 |           0.17 |          20.81 |         0.02083471 | 1:19:00        |       82 |     44 |
| AST/ETH   |         127 |           0.20 |          26.01 |         0.02603625 | 1:29:00        |       78 |     49 |
| TNT/ETH   |         143 |           0.33 |          47.19 |         0.04723802 | 1:21:00        |      101 |     42 |
| ETC/ETH   |          51 |          -0.04 |          -1.83 |        -0.00183391 | 2:43:00        |       29 |     22 |
| TOTAL     |         753 |           0.14 |         105.24 |         0.10534172 | 1:45:00        |      463 |    290 |
================================================== SELL REASON STATS ==================================================
| Sell Reason   |   Count |
|:--------------|--------:|
| sell_signal   |     479 |
| roi           |     251 |
| stop_loss     |      21 |
| force_sell    |       2 |
=============================================== LEFT OPEN TRADES REPORT ===============================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration   |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:---------------|---------:|-------:|
| LTC/ETH   |           1 |           0.35 |           0.35 |         0.00035121 | 5:50:00        |        1 |      0 |
| IOTA/ETH  |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| XMR/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| XRP/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| NCASH/ETH |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| MTH/ETH   |           1 |          -1.47 |          -1.47 |        -0.00147048 | 5:35:00        |        0 |      1 |
| AST/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| TNT/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| ETC/ETH   |           0 |         nan    |           0.00 |         0.00000000 | 0:00           |        0 |      0 |
| TOTAL     |           2 |          -0.56 |          -1.12 |        -0.00111927 | 5:42:00        |        1 |      1 |


```
after:
```
================================================== BACKTESTING REPORT =================================================
| pair      |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration   |   profit |   loss |
|:----------|------------:|---------------:|---------------:|-------------------:|:---------------|---------:|-------:|
| LTC/ETH   |          51 |          -0.04 |          -2.26 |        -0.00225942 | 2:04:00        |       24 |     27 |
| IOTA/ETH  |          61 |           0.11 |           6.58 |         0.00659000 | 2:10:00        |       38 |     23 |
| XMR/ETH   |          72 |           0.00 |           0.02 |         0.00001544 | 2:00:00        |       39 |     33 |
| XRP/ETH   |          50 |           0.10 |           4.93 |         0.00493210 | 2:27:00        |       27 |     23 |
| NCASH/ETH |          72 |           0.05 |           3.78 |         0.00378853 | 1:41:00        |       45 |     27 |
| MTH/ETH   |         126 |           0.17 |          20.81 |         0.02083471 | 1:19:00        |       82 |     44 |
| AST/ETH   |         127 |           0.20 |          26.01 |         0.02603625 | 1:29:00        |       78 |     49 |
| TNT/ETH   |         143 |           0.33 |          47.19 |         0.04723802 | 1:21:00        |      101 |     42 |
| ETC/ETH   |          51 |          -0.04 |          -1.83 |        -0.00183391 | 2:43:00        |       29 |     22 |
| TOTAL     |         753 |           0.14 |         105.24 |         0.10534172 | 1:45:00        |      463 |    290 |
================================================== SELL REASON STATS ==================================================
| Sell Reason   |   Count |
|:--------------|--------:|
| sell_signal   |     479 |
| roi           |     251 |
| stop_loss     |      21 |
| force_sell    |       2 |
=============================================== LEFT OPEN TRADES REPORT ===============================================
| pair    |   buy count |   avg profit % |   cum profit % |   total profit ETH | avg duration   |   profit |   loss |
|:--------|------------:|---------------:|---------------:|-------------------:|:---------------|---------:|-------:|
| LTC/ETH |           1 |           0.35 |           0.35 |         0.00035121 | 5:50:00        |        1 |      0 |
| MTH/ETH |           1 |          -1.47 |          -1.47 |        -0.00147048 | 5:35:00        |        0 |      1 |
| TOTAL   |           2 |          -0.56 |          -1.12 |        -0.00111927 | 5:42:00        |        1 |      1 |

```
