### PR TITLE
Fix exception when order cannot be found

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 import arrow
-import requests
+from requests.exceptions import RequestException
 
 from cachetools import TTLCache, cached
 
@@ -646,7 +646,7 @@ class FreqtradeBot(object):
                 if not trade.open_order_id:
                     continue
                 order = self.exchange.get_order(trade.open_order_id, trade.pair)
-            except requests.exceptions.RequestException:
+            except (RequestException, DependencyException):
                 logger.info(
                     'Cannot query order for %s due to %s',
                     trade,


### PR DESCRIPTION
## Summary
Properly handle exception if the order can't be found by id.


Solve the issue: #1237

## Quick changelog

- Catch reraised exception

## What's new?

ccxt raises `OrderNotFound` - which is a sub-class of `InvalidOrder`, which we reraise as `Dependencyexception`.
Therefore, freqtrade has to catch this exception to avoid crashing (see issue for details).