### PR TITLE
Only load strategy once during backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -75,8 +75,6 @@ class Backtesting(object):
 
         else:
             # only one strategy
-            strat = StrategyResolver(self.config).strategy
-
             self.strategylist.append(StrategyResolver(self.config).strategy)
         # Load one strategy
         self._set_strategy(self.strategylist[0])


### PR DESCRIPTION
## Summary
Strategy was loaded twice during backtest, filling a unneeded variable (strat).
