### PR TITLE
Updating ‘close’ price of the last complete candle with ‘open’ price of the partial one

### DIFF
--- a/freqtrade/exchange/exchange_helpers.py
+++ b/freqtrade/exchange/exchange_helpers.py
@@ -15,6 +15,13 @@ def parse_ticker_dataframe(ticker: list) -> DataFrame:
     :return: DataFrame
     """
     cols = ['date', 'open', 'high', 'low', 'close', 'volume']
+
+    # Sometimes the newly open candle "open price" is different from
+    # the complete candle "close price". we should consider the
+    # partial candle open price as the close price for last
+    # complete candle
+    ticker[-2][4] = ticker[-1][1]
+
     frame = DataFrame(ticker, columns=cols)
 
     frame['date'] = to_datetime(frame['date'],


### PR DESCRIPTION
## Summary
Sometimes there is a gap between close price of current candle and open price of the next one. 
It is better to consider open price of the partial candle as last close price before dropping it