### PR TITLE
Patch exchange to not cause network delays during tests

### DIFF
--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -997,6 +997,7 @@ def test_check_handle_timedout_buy_exception(default_conf, ticker, limit_buy_ord
                                              fee, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock()
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         validate_pairs=MagicMock(),


### PR DESCRIPTION
## Summary
Exchange / network calls should be properly patch to avoid random test-failures.

