### PR TITLE
Fix hyperopt pickle

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -41,6 +41,14 @@ class Hyperopt(Backtesting):
     hyperopt.start()
     """
     def __init__(self, config: Dict[str, Any]) -> None:
+        if config.get('strategy') and config.get('strategy') != 'DefaultStrategy':
+            logger.error("Please don't use --strategy for hyperopt.")
+            logger.error(
+                "Read the documentation at "
+                "https://github.com/freqtrade/freqtrade/blob/develop/docs/hyperopt.md "
+                "to understand how to configure hyperopt.")
+            raise ValueError("--strategy configured but not supported for hyperopt")
+
         super().__init__(config)
         # set TARGET_TRADES to suit your number concurrent trades so its realistic
         # to the number of days
@@ -152,7 +160,7 @@ class Hyperopt(Backtesting):
     @staticmethod
     def generate_roi_table(params: Dict) -> Dict[int, float]:
         """
-        Generate the ROI table thqt will be used by Hyperopt
+        Generate the ROI table that will be used by Hyperopt
         """
         roi_table = {}
         roi_table[0] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -41,14 +41,6 @@ class Hyperopt(Backtesting):
     hyperopt.start()
     """
     def __init__(self, config: Dict[str, Any]) -> None:
-        if config.get('strategy') and config.get('strategy') != 'DefaultStrategy':
-            logger.error("Please don't use --strategy for hyperopt.")
-            logger.error(
-                "Read the documentation at "
-                "https://github.com/freqtrade/freqtrade/blob/develop/docs/hyperopt.md "
-                "to understand how to configure hyperopt.")
-            raise ValueError("--strategy configured but not supported for hyperopt")
-
         super().__init__(config)
         # set TARGET_TRADES to suit your number concurrent trades so its realistic
         # to the number of days
@@ -410,6 +402,13 @@ def start(args: Namespace) -> None:
     config['exchange']['key'] = ''
     config['exchange']['secret'] = ''
 
+    if config.get('strategy') and config.get('strategy') != 'DefaultStrategy':
+        logger.error("Please don't use --strategy for hyperopt.")
+        logger.error(
+            "Read the documentation at "
+            "https://github.com/freqtrade/freqtrade/blob/develop/docs/hyperopt.md "
+            "to understand how to configure hyperopt.")
+        raise ValueError("--strategy configured but not supported for hyperopt")
     # Initialize backtesting object
     hyperopt = Hyperopt(config)
     hyperopt.start()

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -3,7 +3,8 @@ import sys
 from copy import deepcopy
 
 from freqtrade.strategy.interface import IStrategy
-
+# Import Default-Strategy to have hyperopt correctly resolve
+from freqtrade.strategy.default_strategy import DefaultStrategy  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -65,6 +65,31 @@ def test_start(mocker, default_conf, caplog) -> None:
     assert start_mock.call_count == 1
 
 
+def test_start_failure(mocker, default_conf, caplog) -> None:
+    start_mock = MagicMock()
+    mocker.patch(
+        'freqtrade.configuration.Configuration._load_config_file',
+        lambda *args, **kwargs: default_conf
+    )
+    mocker.patch('freqtrade.optimize.hyperopt.Hyperopt.start', start_mock)
+    patch_exchange(mocker)
+
+    args = [
+        '--config', 'config.json',
+        '--strategy', 'TestStrategy',
+        'hyperopt',
+        '--epochs', '5'
+    ]
+    args = get_args(args)
+    StrategyResolver({'strategy': 'DefaultStrategy'})
+    with pytest.raises(ValueError):
+        start(args)
+    assert log_has(
+        "Please don't use --strategy for hyperopt.",
+        caplog.record_tuples
+    )
+
+
 def test_loss_calculation_prefer_correct_trade_count(hyperopt) -> None:
     StrategyResolver({'strategy': 'DefaultStrategy'})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests==2.19.1
 urllib3==1.22
 wrapt==1.10.11
 pandas==0.23.4
-scikit-learn==0.19.2
+scikit-learn==0.20.0
 scipy==1.1.0
 jsonschema==2.6.0
 numpy==1.15.2


### PR DESCRIPTION
## Summary
Fix hyperopt to work with new version of scikit-learn

Solve the issue shown after the update of scikit-learn to 0.20.0:  #1242
Potentially fixes #1232 - but will need further testing.

## Quick changelog

- Show error if `--strategy` is used with hyperopt. 
  methods from the strategy are not used anyway, so using a custom strategy does not provide gains here - as currently the hyperopt file needs to be modified

The problem comes from hyperopt-processes not properly finding the strategy class - and therefore pickle shows an error on load. This is caused by the fact on how we load strategies.

### error:

```
2018-09-28 12:34:38,933 - freqtrade.optimize.hyperopt - INFO - Found 2 CPU cores. Let's make them scream!
sklearn.externals.joblib.externals.loky.process_executor._RemoteTraceback: 
'''
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sklearn/externals/joblib/externals/loky/process_executor.py", line 393, in _process_worker
    call_item = call_queue.get(block=True, timeout=timeout)
  File "/opt/python/3.6.3/lib/python3.6/multiprocessing/queues.py", line 113, in get
    return _ForkingPickler.loads(res)
AttributeError: Can't get attribute 'DefaultStrategy' on <module 'freqtrade.strategy' from '/home/travis/build/freqtrade/freqtrade/freqtrade/strategy/__init__.py'>
'''
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "freqtrade/main.py", line 89, in <module>
    main(sys.argv[1:])
  File "freqtrade/main.py", line 35, in main
    args.func(args)
  File "/home/travis/build/freqtrade/freqtrade/freqtrade/optimize/hyperopt.py", line 407, in start
    hyperopt.start()
  File "/home/travis/build/freqtrade/freqtrade/freqtrade/optimize/hyperopt.py", line 368, in start
    f_val = self.run_optimizer_parallel(parallel, asked)
  File "/home/travis/build/freqtrade/freqtrade/freqtrade/optimize/hyperopt.py", line 332, in run_optimizer_parallel
    return parallel(delayed(self.generate_optimizer)(v) for v in asked)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sklearn/externals/joblib/parallel.py", line 996, in __call__
    self.retrieve()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sklearn/externals/joblib/parallel.py", line 899, in retrieve
    self._output.extend(job.get(timeout=self.timeout))
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sklearn/externals/joblib/_parallel_backends.py", line 517, in wrap_future_result
    return future.result(timeout=timeout)
  File "/opt/python/3.6.3/lib/python3.6/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/opt/python/3.6.3/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
sklearn.externals.joblib.externals.loky.process_executor.BrokenProcessPool: A task has failed to un-serialize. Please ensure that the arguments of the function are all picklable.
```