### PR TITLE
Add general ccxt configuration options

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -28,7 +28,10 @@
         "name": "bittrex",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
-        "ccxt_rate_limit": true,
+        "ccxt_config": {"enableRateLimit": true},
+        "ccxt_async_config": {
+            "enableRateLimit": false
+        },
         "pair_whitelist": [
             "ETH/BTC",
             "LTC/BTC",

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -37,7 +37,11 @@
         "name": "bittrex",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
-        "ccxt_rate_limit": true,
+        "ccxt_config": {"enableRateLimit": true},
+        "ccxt_async_config": {
+            "enableRateLimit": false,
+            "aiohttp_trust_env": false
+        },
         "pair_whitelist": [
             "ETH/BTC",
             "LTC/BTC",
@@ -53,11 +57,7 @@
         "pair_blacklist": [
             "DOGE/BTC"
         ],
-        "outdated_offset": 5,
-        "ccxt_config": {},
-        "ccxt_async_config": {
-            "aiohttp_trust_env": false
-            }
+        "outdated_offset": 5
     },
     "experimental": {
         "use_sell_signal": false,

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -53,7 +53,11 @@
         "pair_blacklist": [
             "DOGE/BTC"
         ],
-        "outdated_offset": 5
+        "outdated_offset": 5,
+        "ccxt_config": {},
+        "ccxt_async_config": {
+            "aiohttp_trust_env": false
+            }
     },
     "experimental": {
         "use_sell_signal": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ The table below will list all configuration parameters.
 | `exchange.secret` | secret | No | API secret to use for the exchange. Only required when you are in production mode.
 | `exchange.pair_whitelist` | [] | No | List of currency to use by the bot. Can be overrided with `--dynamic-whitelist` param.
 | `exchange.pair_blacklist` | [] | No | List of currency the bot must avoid. Useful when using `--dynamic-whitelist` param.
-| `exchange.ccxt_rate_limit` | True | No | Have CCXT handle Exchange rate limits. Depending on the exchange, having this to false can lead to temporary bans from the exchange.
+| `exchange.ccxt_rate_limit` | True | No | DEPRECATED!! Have CCXT handle Exchange rate limits. Depending on the exchange, having this to false can lead to temporary bans from the exchange.
 | `exchange.ccxt_config` | None | No | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | No | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `experimental.use_sell_signal` | false | No | Use your sell strategy in addition of the `minimal_roi`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,8 @@ The table below will list all configuration parameters.
 | `exchange.pair_whitelist` | [] | No | List of currency to use by the bot. Can be overrided with `--dynamic-whitelist` param.
 | `exchange.pair_blacklist` | [] | No | List of currency the bot must avoid. Useful when using `--dynamic-whitelist` param.
 | `exchange.ccxt_rate_limit` | True | No | Have CCXT handle Exchange rate limits. Depending on the exchange, having this to false can lead to temporary bans from the exchange.
+| `exchange.ccxt_config` | None | No | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
+| `exchange.ccxt_async_config` | None | No | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `experimental.use_sell_signal` | false | No | Use your sell strategy in addition of the `minimal_roi`.
 | `experimental.sell_profit_only` | false | No | waits until you have made a positive profit before taking a sell decision.
 | `experimental.ignore_roi_if_buy_signal` | false | No | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`
@@ -204,7 +206,28 @@ you run it in production mode.
 }
 
 ```
+
 If you have not your Bittrex API key yet, [see our tutorial](https://github.com/freqtrade/freqtrade/blob/develop/docs/pre-requisite.md).
+
+### Using proxy with FreqTrade
+
+To use a proxy with freqtrade, add the kwarg `"aiohttp_trust_env"=true` to the `"ccxt_async_kwargs"` dict in the exchange section of the configuration.
+
+An example for this can be found in `config_full.json.example`
+
+``` json
+"ccxt_async_config": {
+    "aiohttp_trust_env": true
+}
+```
+
+Then, export your proxy settings using the variables `"HTTP_PROXY"` and `"HTTPS_PROXY"` set to the appropriate values
+
+``` bash
+export HTTP_PROXY="http://addr:port"
+export HTTPS_PROXY="http://addr:port"
+freqtrade
+```
 
 
 ### Embedding Strategies
@@ -213,7 +236,7 @@ FreqTrade provides you with with an easy way to embed the strategy into your con
 This is done by utilizing BASE64 encoding and providing this string at the strategy configuration field,
 in your chosen config file.
 
-##### Encoding a string as BASE64
+#### Encoding a string as BASE64
 
 This is a quick example, how to generate the BASE64 string in python
 

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -129,9 +129,3 @@ Day         Profit BTC      Profit USD
 ## /version
 > **Version:** `0.14.3` 
 
-### using proxy with telegram
-```
-$ export HTTP_PROXY="http://addr:port"
-$ export HTTPS_PROXY="http://addr:port"
-$ freqtrade
-```

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -271,6 +271,11 @@ class Configuration(object):
             raise OperationalException(
                 exception_msg
             )
+        # Depreciation warning
+        if 'ccxt_rate_limit' in config.get('exchange', {}):
+            logger.warning("`ccxt_rate_limit` has been deprecated in favor of "
+                           "`ccxt_config` and `ccxt_async_config` and will be removed "
+                           "in future a future version.")
 
         logger.debug('Exchange "%s" supported', exchange)
         return True

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -275,7 +275,7 @@ class Configuration(object):
         if 'ccxt_rate_limit' in config.get('exchange', {}):
             logger.warning("`ccxt_rate_limit` has been deprecated in favor of "
                            "`ccxt_config` and `ccxt_async_config` and will be removed "
-                           "in future a future version.")
+                           "in a future version.")
 
         logger.debug('Exchange "%s" supported', exchange)
         return True

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -164,7 +164,9 @@ CONF_SCHEMA = {
                     },
                     'uniqueItems': True
                 },
-                'outdated_offset': {'type': 'integer', 'minimum': 1}
+                'outdated_offset': {'type': 'integer', 'minimum': 1},
+                'ccxt_config': {'type': 'object'},
+                'ccxt_async_config': {'type': 'object'}
             },
             'required': ['name', 'key', 'secret', 'pair_whitelist']
         }

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -371,7 +371,7 @@ def test_hyperopt_with_arguments(mocker, default_conf, caplog) -> None:
     assert log_has('Parameter -s/--spaces detected: [\'all\']', caplog.record_tuples)
 
 
-def test_check_exchange(default_conf) -> None:
+def test_check_exchange(default_conf, caplog) -> None:
     configuration = Configuration(Namespace())
 
     # Test a valid exchange
@@ -391,6 +391,15 @@ def test_check_exchange(default_conf) -> None:
         match=r'.*Exchange "unknown_exchange" not supported.*'
     ):
         configuration.check_exchange(default_conf)
+
+    # Test ccxt_rate_limit depreciation
+    default_conf.get('exchange').update({'name': 'binance'})
+    default_conf['exchange']['ccxt_rate_limit'] = True
+    configuration.check_exchange(default_conf)
+    assert log_has("`ccxt_rate_limit` has been deprecated in favor of "
+                   "`ccxt_config` and `ccxt_async_config` and will be removed "
+                   "in future a future version.",
+                   caplog.record_tuples)
 
 
 def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -398,7 +398,7 @@ def test_check_exchange(default_conf, caplog) -> None:
     configuration.check_exchange(default_conf)
     assert log_has("`ccxt_rate_limit` has been deprecated in favor of "
                    "`ccxt_config` and `ccxt_async_config` and will be removed "
-                   "in future a future version.",
+                   "in a future version.",
                    caplog.record_tuples)
 
 

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -10,7 +10,14 @@ from freqtrade import arguments
 from freqtrade.arguments import TimeRange
 from freqtrade.exchange import Exchange
 from freqtrade.optimize import download_backtesting_testdata
+from freqtrade.configuration import set_loggers
 
+import logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+)
+set_loggers(0)
 
 DEFAULT_DL_PATH = 'user_data/data'
 
@@ -54,7 +61,9 @@ exchange = Exchange({'key': '',
                      'exchange': {
                          'name': args.exchange,
                          'pair_whitelist': [],
-                         'ccxt_rate_limit': False
+                         'ccxt_async_config': {
+                             "enableRateLimit": False
+                         }
                      }
                      })
 pairs_not_available = []


### PR DESCRIPTION
## Summary

Allow usage of any ccxt configuration option. see [CCXT documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation) for details on what is possible for each exchange.

Proxy support for asyncio was moved to an attribute of ccxt in https://github.com/ccxt/ccxt/issues/3867 . While not a problem, we have no easy way to set custom options in ccxt.

CCXT uses every key as attribute, and every value as it's value and initializes with these settings. This allwos overwriting of almost all ccxt options from within these 2 dictionaries, seperated between async and sync (not everything will make sense for both).


Solve the issue: #1207

## Quick changelog

- allow setting of any possible (or impossible) ccxt attribute to support as many options as possible
- deprecate `ccxt_rate_limit`, as it cannot be configured differently between async and non-async
- add proper documentation for proxy usage


