### PR TITLE
flush session for /forcesell all

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -363,6 +363,7 @@ class RPC(object):
             # Execute sell for all open orders
             for trade in Trade.query.filter(Trade.is_open.is_(True)).all():
                 _exec_forcesell(trade)
+            Trade.session.flush()
             return
 
         # Query for trade


### PR DESCRIPTION
## Summary
`/forcesell 1` does flush the session at the end.
`/forcesell all` does not as it exits before doing the flush, causing trades to show up in status-table after /forcesell.