### PR TITLE
add /forcebuy to telgram handler

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -425,7 +425,7 @@ class FreqtradeBot(object):
             return True
         return False
 
-    def execute_buy(self, pair: str, stake_amount: float) -> bool:
+    def execute_buy(self, pair: str, stake_amount: float, price: Optional[float] = None) -> bool:
         """
         Executes a limit buy for the given pair
         :param pair: pair for which we want to create a LIMIT_BUY
@@ -436,8 +436,11 @@ class FreqtradeBot(object):
         stake_currency = self.config['stake_currency']
         fiat_currency = self.config.get('fiat_display_currency', None)
 
-        # Calculate amount
-        buy_limit = self.get_target_bid(pair, self.exchange.get_ticker(pair))
+        if price:
+            buy_limit = price
+        else:
+            # Calculate amount
+            buy_limit = self.get_target_bid(pair, self.exchange.get_ticker(pair))
 
         min_stake_amount = self._get_min_pair_stake_amount(pair_s, buy_limit)
         if min_stake_amount is not None and min_stake_amount > stake_amount:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -379,6 +379,40 @@ class RPC(object):
         _exec_forcesell(trade)
         Trade.session.flush()
 
+    def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:
+        """
+        Handler for forcebuy <asset> <price>
+        Buys a pair trade at the given or current price
+        """
+
+        if not self._freqtrade.config.get('forcebuy_enable', False):
+            raise RPCException('Forcebuy not enabled.')
+
+        if self._freqtrade.state != State.RUNNING:
+            raise RPCException('trader is not running')
+
+        # Check pair is in stake currency
+        stake_currency = self._freqtrade.config.get('stake_currency')
+        if not pair.endswith(stake_currency):
+            raise RPCException(
+                f'Wrong pair selected. Please pairs with stake {stake_currency} pairs only')
+        # check if valid pair
+
+        # check if pair already has an open pair
+        trade = Trade.query.filter(Trade.is_open.is_(True)).filter(Trade.pair.is_(pair)).first()
+        if trade:
+            raise RPCException(f'position for {pair} already open - id: {trade.id}')
+
+        # gen stake amount
+        stakeamount = self._freqtrade._get_trade_stake_amount()
+
+        # execute buy
+        if self._freqtrade.execute_buy(pair, stakeamount, price):
+            trade = Trade.query.filter(Trade.is_open.is_(True)).filter(Trade.pair.is_(pair)).first()
+            return trade
+        else:
+            return None
+
     def _rpc_performance(self) -> List[Dict]:
         """
         Handler for performance.

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -86,6 +86,7 @@ class Telegram(RPC):
             CommandHandler('start', self._start),
             CommandHandler('stop', self._stop),
             CommandHandler('forcesell', self._forcesell),
+            CommandHandler('forcebuy', self._forcebuy),
             CommandHandler('performance', self._performance),
             CommandHandler('daily', self._daily),
             CommandHandler('count', self._count),
@@ -369,6 +370,24 @@ class Telegram(RPC):
         trade_id = update.message.text.replace('/forcesell', '').strip()
         try:
             self._rpc_forcesell(trade_id)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
+
+    @authorized_only
+    def _forcebuy(self, bot: Bot, update: Update) -> None:
+        """
+        Handler for /forcebuy <asset> <price>.
+        Buys a pair trade at the given or current price
+        :param bot: telegram bot
+        :param update: message update
+        :return: None
+        """
+
+        message = update.message.text.replace('/forcebuy', '').strip().split()
+        pair = message[0]
+        price = float(message[1]) if len(message) > 1 else None
+        try:
+            self._rpc_forcebuy(pair, price)
         except RPCException as e:
             self._send_msg(str(e), bot=bot)
 

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -71,8 +71,8 @@ def test_init(default_conf, mocker, caplog) -> None:
     assert start_polling.start_polling.call_count == 1
 
     message_str = "rpc.telegram is listening for following commands: [['status'], ['profit'], " \
-                  "['balance'], ['start'], ['stop'], ['forcesell'], ['performance'], ['daily'], " \
-                  "['count'], ['reload_conf'], ['help'], ['version']]"
+                  "['balance'], ['start'], ['stop'], ['forcesell'], ['forcebuy'], " \
+                  "['performance'], ['daily'], ['count'], ['reload_conf'], ['help'], ['version']]"
 
     assert log_has(message_str, caplog.record_tuples)
 
@@ -853,6 +853,63 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
     telegram._forcesell(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'invalid argument' in msg_mock.call_args_list[0][0][0]
+
+
+def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
+    patch_coinmarketcap(mocker, value={'price_usd': 15000.0})
+    mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
+    mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        _load_markets=MagicMock(return_value={}),
+        get_markets=markets
+        )
+    fbuy_mock = MagicMock(return_value=None)
+    mocker.patch('freqtrade.rpc.RPC._rpc_forcebuy', fbuy_mock)
+
+    freqtradebot = FreqtradeBot(default_conf)
+    patch_get_signal(freqtradebot, (True, False))
+    telegram = Telegram(freqtradebot)
+
+    update.message.text = '/forcebuy ETH/BTC'
+    telegram._forcebuy(bot=MagicMock(), update=update)
+
+    assert fbuy_mock.call_count == 1
+    assert fbuy_mock.call_args_list[0][0][0] == 'ETH/BTC'
+    assert fbuy_mock.call_args_list[0][0][1] is None
+
+    # Reset and retry with specified price
+    fbuy_mock = MagicMock(return_value=None)
+    mocker.patch('freqtrade.rpc.RPC._rpc_forcebuy', fbuy_mock)
+    update.message.text = '/forcebuy ETH/BTC 0.055'
+    telegram._forcebuy(bot=MagicMock(), update=update)
+
+    assert fbuy_mock.call_count == 1
+    assert fbuy_mock.call_args_list[0][0][0] == 'ETH/BTC'
+    assert isinstance(fbuy_mock.call_args_list[0][0][1], float)
+    assert fbuy_mock.call_args_list[0][0][1] == 0.055
+
+
+def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> None:
+    patch_coinmarketcap(mocker, value={'price_usd': 15000.0})
+    mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
+    rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
+    mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        _load_markets=MagicMock(return_value={}),
+        get_markets=markets
+    )
+    freqtradebot = FreqtradeBot(default_conf)
+    patch_get_signal(freqtradebot, (True, False))
+    telegram = Telegram(freqtradebot)
+
+    update.message.text = '/forcebuy ETH/Nonepair'
+    telegram._forcebuy(bot=MagicMock(), update=update)
+
+    assert rpc_mock.call_count == 1
+    assert rpc_mock.call_args_list[0][0][0] == 'Forcebuy not enabled.'
 
 
 def test_performance_handle(default_conf, update, ticker, fee,

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -689,6 +689,54 @@ def test_balance_bigger_last_ask(mocker, default_conf) -> None:
     assert freqtrade.get_target_bid('ETH/BTC', {'ask': 5, 'last': 10}) == 5
 
 
+def test_execute_buy(mocker, default_conf, fee, markets, limit_buy_order) -> None:
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    freqtrade = FreqtradeBot(default_conf)
+    stake_amount = 2
+    bid = 0.11
+    get_bid = MagicMock(return_value=bid)
+    mocker.patch.multiple(
+        'freqtrade.freqtradebot.FreqtradeBot',
+        get_target_bid=get_bid,
+        _get_min_pair_stake_amount=MagicMock(return_value=1)
+        )
+    buy_mm = MagicMock(return_value={'id': limit_buy_order['id']})
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        get_ticker=MagicMock(return_value={
+            'bid': 0.00001172,
+            'ask': 0.00001173,
+            'last': 0.00001172
+        }),
+        buy=buy_mm,
+        get_fee=fee,
+        get_markets=markets
+    )
+    pair = 'ETH/BTC'
+    print(buy_mm.call_args_list)
+
+    assert freqtrade.execute_buy(pair, stake_amount)
+    assert get_bid.call_count == 1
+    assert buy_mm.call_count == 1
+    call_args = buy_mm.call_args_list[0][0]
+    assert call_args[0] == pair
+    assert call_args[1] == bid
+    assert call_args[2] == stake_amount / bid
+
+    # Test calling with price
+    fix_price = 0.06
+    assert freqtrade.execute_buy(pair, stake_amount, fix_price)
+    # Make sure get_target_bid wasn't called again
+    assert get_bid.call_count == 1
+
+    assert buy_mm.call_count == 2
+    call_args = buy_mm.call_args_list[1][0]
+    assert call_args[0] == pair
+    assert call_args[1] == fix_price
+    assert call_args[2] == stake_amount / fix_price
+
+
 def test_process_maybe_execute_buy(mocker, default_conf) -> None:
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 


### PR DESCRIPTION
## Summary
Add `/forcebuy` to initiate a trade manually and have freqtrade handle the selling (with ROI / stoploss / strategy sell signal...)

Solve the issue: #1221

## Quick changelog

- introduce `/forcebuy <pair> [<price>]` telegram setting
- disabled by default - needs explicit enabling for security reasons.


Adding this as don't merge for now as it's still missing documentation and is not fully tested yet.

## todo:
- [ ] Documentation