### PR TITLE
Enable analytical telegram commands when stopped

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -84,9 +84,7 @@ class RPC(object):
         """
         # Fetch open trade
         trades = Trade.query.filter(Trade.is_open.is_(True)).all()
-        if self._freqtrade.state != State.RUNNING:
-            raise RPCException('trader is not running')
-        elif not trades:
+        if not trades:
             raise RPCException('no active trade')
         else:
             results = []
@@ -118,9 +116,7 @@ class RPC(object):
 
     def _rpc_status_table(self) -> DataFrame:
         trades = Trade.query.filter(Trade.is_open.is_(True)).all()
-        if self._freqtrade.state != State.RUNNING:
-            raise RPCException('trader is not running')
-        elif not trades:
+        if not trades:
             raise RPCException('no active order')
         else:
             trades_list = []
@@ -385,8 +381,6 @@ class RPC(object):
         Handler for performance.
         Shows a performance statistic from finished trades
         """
-        if self._freqtrade.state != State.RUNNING:
-            raise RPCException('trader is not running')
 
         pair_rates = Trade.session.query(Trade.pair,
                                          sql.func.sum(Trade.close_profit).label('profit_sum'),

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -40,10 +40,6 @@ def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)
 
-    freqtradebot.state = State.STOPPED
-    with pytest.raises(RPCException, match=r'.*trader is not running*'):
-        rpc._rpc_trade_status()
-
     freqtradebot.state = State.RUNNING
     with pytest.raises(RPCException, match=r'.*no active trade*'):
         rpc._rpc_trade_status()
@@ -80,10 +76,6 @@ def test_rpc_status_table(default_conf, ticker, fee, markets, mocker) -> None:
     freqtradebot = FreqtradeBot(default_conf)
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)
-
-    freqtradebot.state = State.STOPPED
-    with pytest.raises(RPCException, match=r'.*trader is not running*'):
-        rpc._rpc_status_table()
 
     freqtradebot.state = State.RUNNING
     with pytest.raises(RPCException, match=r'.*no active order*'):

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -250,9 +250,10 @@ def test_status_handle(default_conf, update, ticker, fee, markets, mocker) -> No
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
+    # Status is also enabled when stopped
     telegram._status(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
-    assert 'trader is not running' in msg_mock.call_args_list[0][0][0]
+    assert 'no active trade' in msg_mock.call_args_list[0][0][0]
     msg_mock.reset_mock()
 
     freqtradebot.state = State.RUNNING
@@ -295,9 +296,10 @@ def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker)
     telegram = Telegram(freqtradebot)
 
     freqtradebot.state = State.STOPPED
+    # Status table is also enabled when stopped
     telegram._status_table(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
-    assert 'trader is not running' in msg_mock.call_args_list[0][0][0]
+    assert 'no active order' in msg_mock.call_args_list[0][0][0]
     msg_mock.reset_mock()
 
     freqtradebot.state = State.RUNNING
@@ -893,26 +895,6 @@ def test_performance_handle(default_conf, update, ticker, fee,
     assert msg_mock.call_count == 1
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
     assert '<code>ETH/BTC\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
-
-
-def test_performance_handle_invalid(default_conf, update, mocker) -> None:
-    patch_coinmarketcap(mocker)
-    patch_exchange(mocker)
-    msg_mock = MagicMock()
-    mocker.patch.multiple(
-        'freqtrade.rpc.telegram.Telegram',
-        _init=MagicMock(),
-        _send_msg=msg_mock
-    )
-    freqtradebot = FreqtradeBot(default_conf)
-    patch_get_signal(freqtradebot, (True, False))
-    telegram = Telegram(freqtradebot)
-
-    # Trader is not running
-    freqtradebot.state = State.STOPPED
-    telegram._performance(bot=MagicMock(), update=update)
-    assert msg_mock.call_count == 1
-    assert 'not running' in msg_mock.call_args_list[0][0][0]
 
 
 def test_count_handle(default_conf, update, ticker, fee, markets, mocker) -> None:


### PR DESCRIPTION
## Summary
Enable analytical telegram commands in `stopped` state.

Solve the issue: #326

## Quick changelog
Enables when stopped:
- `/status`
- `/status table`
- `/performance`

`/balance` does already work in stopped state.

