### PR TITLE
Hide low value balances from `/balance`

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -307,11 +307,14 @@ class Telegram(RPC):
             result = self._rpc_balance(self._config.get('fiat_display_currency', ''))
             output = ''
             for currency in result['currencies']:
-                output += "*{currency}:*\n" \
-                          "\t`Available: {available: .8f}`\n" \
-                          "\t`Balance: {balance: .8f}`\n" \
-                          "\t`Pending: {pending: .8f}`\n" \
-                          "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
+                if currency['est_btc'] > 0.0001:
+                    output += "*{currency}:*\n" \
+                            "\t`Available: {available: .8f}`\n" \
+                            "\t`Balance: {balance: .8f}`\n" \
+                            "\t`Pending: {pending: .8f}`\n" \
+                            "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
+                else:
+                    output += "*{currency}*: not showing <1$ amount \n".format(**currency)
 
             output += "\n*Estimated Value*:\n" \
                       "\t`BTC: {total: .8f}`\n" \

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -314,7 +314,7 @@ class Telegram(RPC):
                             "\t`Pending: {pending: .8f}`\n" \
                             "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
                 else:
-                    output += "*{currency}*: not showing <1$ amount \n".format(**currency)
+                    output += "*{currency}:* not showing <1$ amount \n".format(**currency)
 
             output += "\n*Estimated Value*:\n" \
                       "\t`BTC: {total: .8f}`\n" \

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -507,7 +507,12 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
             'total': 10.0,
             'free': 10.0,
             'used': 0.0
-        }
+        },
+        'XRP': {
+            'total': 1.0,
+            'free': 1.0,
+            'used': 0.0
+            }
     }
 
     def mock_ticker(symbol, refresh):
@@ -517,7 +522,12 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
                 'ask': 10000.00,
                 'last': 10000.00,
             }
-
+        elif symbol == 'XRP/BTC':
+            return {
+                'bid': 0.00001,
+                'ask': 0.00001,
+                'last': 0.00001,
+            }
         return {
             'bid': 0.1,
             'ask': 0.1,
@@ -548,7 +558,8 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     assert '*USDT:*' in result
     assert 'Balance:' in result
     assert 'Est. BTC:' in result
-    assert 'BTC:  14.00000000' in result
+    assert 'BTC:  12.00000000' in result
+    assert '*XRP:* not showing <1$ amount' in result
 
 
 def test_balance_handle_empty_response(default_conf, update, mocker) -> None:


### PR DESCRIPTION
## Summary
Showing very low balances (called "dust" - at least on binance) does not make sense.

Solve the issue: #1274

## What's new?
XRP is not showing in this example:

![2018-10-10-212050_234x158_scrot](https://user-images.githubusercontent.com/5024695/46762729-3b053780-ccd8-11e8-883b-1d82a838befc.png)
