### PR TITLE
Show warning if part of backtest data is missing

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -113,6 +113,14 @@ def load_data(datadir: str,
     for pair in pairs:
         pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
         if pairdata:
+            if timerange.starttype == 'date' and pairdata[0][0] > timerange.startts * 1000:
+                logger.warning('Missing data at start for pair %s, data starts at %s',
+                               pair,
+                               arrow.get(pairdata[0][0] // 1000).strftime('%Y-%m-%d %H:%M:%S'))
+            if timerange.stoptype == 'date' and pairdata[-1][0] < timerange.stopts * 1000:
+                logger.warning('Missing data at end for pair %s, data ends at %s',
+                               pair,
+                               arrow.get(pairdata[-1][0] // 1000).strftime('%Y-%m-%d %H:%M:%S'))
             result[pair] = pairdata
         else:
             logger.warning(


### PR DESCRIPTION
## Summary
Shows a warning if backtesting data is selected by date - and not all data is available.

ran into this myself - data for 1 pair was not complete and caused flawed backtesting results.


## Quick changelog

-Show warning
## What's new?

shows the warning during backtest startup:
```
...
2018-10-14 14:42:03,133 - freqtrade.optimize.backtesting - INFO - Using stake_currency: ETH ...
2018-10-14 14:42:03,133 - freqtrade.optimize.backtesting - INFO - Using stake_amount: 0.1 ...
2018-10-14 14:42:03,134 - freqtrade.optimize.backtesting - INFO - Using local backtesting data (using whitelist in given config) ...
2018-10-14 14:42:05,116 - freqtrade.optimize - WARNING - Missing data at end for pair TRX/ETH, data ends at 2018-09-02 18:00:00

...
