### PR TITLE
[WIP]Funcional tests / backtest stoploss alignment

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -206,12 +206,20 @@ class Backtesting(object):
 
             buy_signal = sell_row.buy
             sell = self.strategy.should_sell(trade, sell_row.open, sell_row.date, buy_signal,
-                                             sell_row.sell)
+                                             sell_row.sell, low=sell_row.low, high=sell_row.high)
             if sell.sell_flag:
+                if sell.sell_type in (SellType.STOP_LOSS, SellType.TRAILING_STOP_LOSS):
+                    # Set close_rate to stoploss
+                    closerate = trade.stop_loss
+                elif sell.sell_type == (SellType.ROI):
+                    # set close-rate to min-roi
+                    closerate = trade.open_rate + trade.open_rate * self.strategy.minimal_roi[0]
+                else:
+                    closerate = sell_row.open
 
                 return BacktestResult(pair=pair,
-                                      profit_percent=trade.calc_profit_percent(rate=sell_row.open),
-                                      profit_abs=trade.calc_profit(rate=sell_row.open),
+                                      profit_percent=trade.calc_profit_percent(rate=closerate),
+                                      profit_abs=trade.calc_profit(rate=closerate),
                                       open_time=buy_row.date,
                                       close_time=sell_row.date,
                                       trade_duration=int((
@@ -220,7 +228,7 @@ class Backtesting(object):
                                       close_index=sell_row.Index,
                                       open_at_end=False,
                                       open_rate=buy_row.open,
-                                      close_rate=sell_row.open,
+                                      close_rate=closerate,
                                       sell_reason=sell.sell_type
                                       )
         if partial_ticker:
@@ -260,7 +268,7 @@ class Backtesting(object):
             position_stacking: do we allow position stacking? (default: False)
         :return: DataFrame
         """
-        headers = ['date', 'buy', 'open', 'close', 'sell']
+        headers = ['date', 'buy', 'open', 'close', 'sell', 'low', 'high']
         processed = args['processed']
         max_open_trades = args.get('max_open_trades', 0)
         position_stacking = args.get('position_stacking', False)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -203,7 +203,7 @@ class IStrategy(ABC):
         return buy, sell
 
     def should_sell(self, trade: Trade, rate: float, date: datetime, buy: bool,
-                    sell: bool, low: float=None, high: float=None) -> SellCheckTuple:
+                    sell: bool, low: float = None, high: float = None) -> SellCheckTuple:
         """
         This function evaluate if on the condition required to trigger a sell has been reached
         if the threshold is reached and updates the trade record.
@@ -212,8 +212,8 @@ class IStrategy(ABC):
         # Set current rate to low for backtesting sell
         current_rate = rate if not low else low
         current_profit = trade.calc_profit_percent(current_rate)
-        stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade, current_time=date,
-                                              current_profit=current_profit)
+        stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade,
+                                              current_time=date, current_profit=current_profit)
         if stoplossflag.sell_flag:
             return stoplossflag
         # Set current rate to low for backtesting sell

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -203,18 +203,22 @@ class IStrategy(ABC):
         return buy, sell
 
     def should_sell(self, trade: Trade, rate: float, date: datetime, buy: bool,
-                    sell: bool) -> SellCheckTuple:
+                    sell: bool, low: float=None, high: float=None) -> SellCheckTuple:
         """
         This function evaluate if on the condition required to trigger a sell has been reached
         if the threshold is reached and updates the trade record.
         :return: True if trade should be sold, False otherwise
         """
-        current_profit = trade.calc_profit_percent(rate)
-        stoplossflag = self.stop_loss_reached(current_rate=rate, trade=trade, current_time=date,
+        # Set current rate to low for backtesting sell
+        current_rate = rate if not low else low
+        current_profit = trade.calc_profit_percent(current_rate)
+        stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade, current_time=date,
                                               current_profit=current_profit)
         if stoplossflag.sell_flag:
             return stoplossflag
-
+        # Set current rate to low for backtesting sell
+        current_rate = rate if not high else high
+        current_profit = trade.calc_profit_percent(current_rate)
         experimental = self.config.get('experimental', {})
 
         if buy and experimental.get('ignore_roi_if_buy_signal', False):

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -17,6 +17,12 @@ ticker_start_time = arrow.get(2018, 10, 3)
 ticker_interval_in_minute = 60
 
 
+class BTrade(NamedTuple):
+    sell_r: SellType
+    open_tick: int
+    close_tick: int
+
+
 class BTContainer(NamedTuple):
     """
     NamedTuple Defining BacktestResults inputs.
@@ -24,71 +30,56 @@ class BTContainer(NamedTuple):
     data: List[float]
     stop_loss: float
     roi: float
-    trades: int
+    trades: List[BTrade]
     profit_perc: float
-    sell_r: SellType
+
+
+def _get_frame_time(offset):
+    return ticker_start_time.shift(
+        minutes=(offset * ticker_interval_in_minute)).datetime
 
 
 def _build_dataframe(ticker_with_signals):
     columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
 
     frame = DataFrame.from_records(ticker_with_signals, columns=columns)
-    frame['date'] = frame['date'].apply(lambda x: ticker_start_time.shift(
-                    minutes=(x * ticker_interval_in_minute)).datetime)
+    frame['date'] = frame['date'].apply(_get_frame_time)
     # Ensure floats are in place
     for column in ['open', 'high', 'low', 'close', 'volume']:
         frame[column] = frame[column].astype('float64')
     return frame
 
 
-data_profit = [
-    [0, 0.0009910, 0.001011, 0.00098618, 0.001000, 12345, 1, 0],
-    [1, 0.001000, 0.001010, 0.0009900, 0.0009900, 12345, 0, 0],
-    [2, 0.0009900, 0.001011, 0.00091618, 0.0009900, 12345, 0, 0],
-    [3, 0.001000, 0.001011, 0.00098618, 0.001100, 12345, 0, 1],
-    [4, 0.001000, 0.001011, 0.00098618, 0.0009900, 12345, 0, 0]]
-
-tc_profit1 = BTContainer(data=data_profit, stop_loss=-0.01, roi=1, trades=1,
-                         profit_perc=0.10557, sell_r=SellType.STOP_LOSS)  # should be stoploss - drops 8%
-tc_profit2 = BTContainer(data=data_profit, stop_loss=-0.10, roi=1,
-                         trades=1, profit_perc=0.10557, sell_r=SellType.STOP_LOSS)
-
-
-tc_loss0 = BTContainer(data=[
-    [0, 0.0009910, 0.001011, 0.00098618, 0.001000, 12345, 1, 0],
-    [1, 0.001000, 0.001010, 0.0009900, 0.001000, 12345, 0, 0],
-    [2, 0.001000, 0.001011, 0.0010618, 0.00091618, 12345, 0, 0],
-    [3, 0.001000, 0.001011, 0.00098618, 0.00091618, 12345, 0, 0],
-    [4, 0.001000, 0.001011, 0.00098618, 0.00091618, 12345, 0, 0]],
-    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sell_r=SellType.STOP_LOSS)
-
-
 # Test 1 Minus 8% Close
 # Candle Data for test 1 – close at -8% (9200)
 # Test with Stop-loss at 1%
 # TC1: Stop-Loss Triggered 1% loss
-tc1 = BTContainer(data=[
+tc0 = BTContainer(data=[
     [0, 10000.0, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9200, 9200, 12345, 0, 0],  # Exit with stoploss hit
     [3, 9950, 10000, 9960, 9955, 12345, 0, 0],
     [4, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [5, 9990, 9990, 9990, 9900, 12345, 0, 0]],
-    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)
+    stop_loss=-0.01, roi=1, profit_perc=-0.01,
+    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+)
 
 
 # Test 2 Minus 4% Low, minus 1% close
 # Candle Data for test 2
 # Test with Stop-Loss at 3%
 # TC2: Stop-Loss Triggered 3% Loss
-tc2 = BTContainer(data=[
+tc1 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9925, 9950, 12345, 0, 0],
     [3, 9950, 10000, 9600, 9925, 12345, 0, 0],  # Exit with stoploss hit
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)
+    stop_loss=-0.03, roi=1, profit_perc=-0.03,
+    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=3)]
+    )
 
 
 # Test 3 Candle drops 4%, Recovers 1%.
@@ -98,79 +89,90 @@ tc2 = BTContainer(data=[
 # Test with Stop-Loss at 2%
 # TC3: Trade-A: Stop-Loss Triggered 2% Loss
 #          Trade-B: Stop-Loss Triggered 2% Loss
-tc3 = BTContainer(data=[
+tc2 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9600, 9950, 12345, 0, 0],
-    [3, 9950, 10000, 9900, 9925, 12345, 1, 0],  # enter trade 2 (signal on last candle)
-    [4, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 1, 0],
+    [4, 9950, 10000, 9900, 9925, 12345, 0, 0],  # enter trade 2 (signal on last candle)
     [5, 9925, 9975, 8000, 8000, 12345, 0, 0],
     [6, 9900, 9950, 9950, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.04, sell_r=SellType.STOP_LOSS)
+    stop_loss=-0.02, roi=1, profit_perc=-0.04,
+    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2),
+            BTrade(sell_r=SellType.STOP_LOSS, open_tick=4, close_tick=5)]
+)
 
 # Test 4 Minus 3% / recovery +15%
 # Candle Data for test 4 – Candle drops 3% Closed 15% up
 # Test with Stop-loss at 2% ROI 6%
 # TC4: Stop-Loss Triggered 2% Loss
-tc4 = BTContainer(data=[
+tc3 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 11500, 9700, 11500, 12345, 0, 0],
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],  # Exit with stoploss hit
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)
+    stop_loss=-0.02, roi=0.06, profit_perc=-0.02,
+    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+)
 
 # Test 5 / Drops 0.5% Closes +20%
 # Candle Data for test 5
 # Set stop-loss at 1% ROI 3%
 # TC5: ROI triggers 3% Gain
-tc5 = BTContainer(data=[
+tc4 = BTContainer(data=[
     [0, 10000, 10050, 9960, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9960, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10050, 9950, 9975, 12345, 0, 0],
     [3, 9950, 12000, 9950, 12000, 12345, 0, 0],  # ROI
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)
+    stop_loss=-0.01, roi=0.03, profit_perc=0.03,
+    trades=[BTrade(sell_r=SellType.ROI, open_tick=1, close_tick=3)]
+)
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
 # Candle Data for test 6
 # Set stop-loss at 2% ROI at 5%
 # TC6: Stop-Loss triggers 2% Loss
-tc6 = BTContainer(data=[
+tc5 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10600, 9700, 10100, 12345, 0, 0],  # Exit with stoploss
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)
+    stop_loss=-0.02, roi=0.05, profit_perc=-0.02,
+    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+)
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
 # Candle Data for test 7
 # Set stop-loss at 2% ROI at 3%
 # TC7: ROI Triggers 3% Gain
-tc7 = BTContainer(data=[
+tc6 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10600, 9900, 10100, 12345, 0, 0],  # ROI
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)
+    stop_loss=-0.02, roi=0.03, profit_perc=0.03,
+    trades=[BTrade(sell_r=SellType.ROI, open_tick=1, close_tick=2)]
+    )
 
 TESTS = [
     # tc_profit1,
     # tc_profit2,
     # tc_loss0,
+    tc0,
     tc1,
     tc2,
     tc3,
     tc4,
     tc5,
     tc6,
-    tc7,
 ]
 
 
@@ -203,17 +205,22 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     )
     print(results.T)
 
-    assert len(results) == data.trades
+    assert len(results) == len(data.trades)
     assert round(results["profit_percent"].sum(), 3) == round(data.profit_perc, 3)
-    if data.sell_r == SellType.STOP_LOSS:
-        assert log_has("Stop loss hit.", caplog.record_tuples)
-    else:
-        assert not log_has("Stop loss hit.", caplog.record_tuples)
-    log_test = (f'Force_selling still open trade UNITTEST/BTC with '
-                f'{results.iloc[-1].profit_percent} perc - {results.iloc[-1].profit_abs}')
-    if data.sell_r == SellType.FORCE_SELL:
-        assert log_has(log_test,
-                       caplog.record_tuples)
-    else:
-        assert not log_has(log_test,
-                           caplog.record_tuples)
+    # if data.sell_r == SellType.STOP_LOSS:
+    #     assert log_has("Stop loss hit.", caplog.record_tuples)
+    # else:
+    #     assert not log_has("Stop loss hit.", caplog.record_tuples)
+    # log_test = (f'Force_selling still open trade UNITTEST/BTC with '
+    #             f'{results.iloc[-1].profit_percent} perc - {results.iloc[-1].profit_abs}')
+    # if data.sell_r == SellType.FORCE_SELL:
+    #     assert log_has(log_test,
+    #                    caplog.record_tuples)
+    # else:
+    #     assert not log_has(log_test,
+    #                        caplog.record_tuples)
+    for c, trade in enumerate(data.trades):
+        res = results.iloc[c]
+        assert res.sell_reason == trade.sell_r
+        assert res.open_time == _get_frame_time(trade.open_tick)
+        assert res.close_time == _get_frame_time(trade.close_tick)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -21,7 +21,8 @@ class BTContainer(NamedTuple):
     roi: float
     trades: int
     profit_perc: float
-    sl: float
+    sl: bool
+    remains: bool
 
 
 columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
@@ -39,9 +40,9 @@ data_profit = DataFrame([
 ], columns=columns)
 
 tc_profit1 = BTContainer(data=data_profit, stop_loss=-0.01, roi=1, trades=1,
-                         profit_perc=0.10557, sl=False)  # should be stoploss - drops 8%
+                         profit_perc=0.10557, sl=False, remains=False)  # should be stoploss - drops 8%
 tc_profit2 = BTContainer(data=data_profit, stop_loss=-0.10, roi=1,
-                         trades=1, profit_perc=0.10557, sl=True)
+                         trades=1, profit_perc=0.10557, sl=True, remains=False)
 
 
 tc_loss0 = BTContainer(data=DataFrame([
@@ -56,31 +57,37 @@ tc_loss0 = BTContainer(data=DataFrame([
     [getdate('2018-07-08 22:00:00').datetime, 0.001000,
      0.001011, 0.00098618, 0.00091618, 12345, 0, 0]
 ], columns=columns),
-    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sl=True)
+    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sl=True, remains=False)
 
 
 # Test 1 Minus 8% Close
 # Candle Data for test 1 – close at -8% (9200)
 # Test with Stop-loss at 1%
+# TC1: Stop-Loss Triggered 1% loss
 tc1 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9200, 9200, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9960, 9955, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9200, 9200, 12345, 0, 0]
+    [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9990, 9900, 12345, 0, 0]
 ], columns=columns),
-    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.07999, sl=True)
+    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sl=True, remains=False)  # should be
+    stop_loss=-0.01, roi=1, trades=1, profit_perc=0.071, sl=False, remains=True)  #
+
 
 # Test 2 Minus 4% Low, minus 1% close
 # Candle Data for test 2
 # Test with Stop-Loss at 3%
+# TC2: Stop-Loss Triggered 3% Loss
 tc2 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9600, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns), stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.00999, sl=False)  #
+], columns=columns),
+    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sl=True, remains=False)  #should be
+    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.00999, sl=False, remains=True)  #
 
 
 # Test 3 Candle drops 4%, Recovers 1%.
@@ -88,19 +95,23 @@ tc2 = BTContainer(data=DataFrame([
 # 	            Candle drops 20%
 # Candle Data for test 3
 # Test with Stop-Loss at 2%
+# TC3: Trade-A: Stop-Loss Triggered 2% Loss
+#          Trade-B: Stop-Loss Triggered 2% Loss
 tc3 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9600, 9950, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 1, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
-], columns=columns), stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.19999, sl=True)  #
+], columns=columns),
+    # stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.4, sl=True, remains=False)  #should be
+    stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.19999, sl=True, remains=False)  #
 
 
 # Test 4 Minus 3% / recovery +15%
 # Candle Data for test 4 – Candle drops 3% Closed 15% up
 # Test with Stop-loss at 2% ROI 6%
-
+# TC4: Stop-Loss Triggered 2% Loss
 tc4 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 11500, 9700, 11500, 12345, 0, 0],
@@ -108,49 +119,55 @@ tc4 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.141, sl=True)
+    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sl=False, remains=False)  #should be
+    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.141, sl=True, remains=False)
 
 # Test 5 / Drops 0.5% Closes +20%
 # Candle Data for test 5
 # Set stop-loss at 1% ROI 3%
+# TC5: ROI triggers 3% Gain
 tc5 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 12000, 9950, 12000, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10050, 9950, 9975, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 12000, 9950, 12000, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.177, sl=True)
+    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sl=False, remains=False)  #should be
+    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.197, sl=False, remains=False)
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
 # Candle Data for test 6
 # Set stop-loss at 2% ROI at 5%
+# TC6: Stop-Loss triggers 2% Loss
 tc6 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9700, 10100, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns), stop_loss=-0.02, roi=0.05,
-    trades=1, profit_perc=-0.025, sl=False)
+], columns=columns),
+    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sl=False, remains=False)  #should be
+    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.025, sl=False, remains=True)  #
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
 # Candle Data for test 7
 # Set stop-loss at 2% ROI at 3%
-
+# TC7: ROI Triggers 3% Gain
 tc7 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9900, 10100, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns), stop_loss=-0.02, roi=0.03,
-    trades=1, profit_perc=-0.025, sl=False)
+], columns=columns),
+    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.03, sl=False, remains=False)  #should be
+    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.025, sl=False, remains=True)  #
 
 TESTS = [
     # tc_profit1,
     # tc_profit2,
-    tc_loss0,
+    # tc_loss0,
     tc1,
     tc2,
     tc3,
@@ -195,5 +212,12 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     if data.sl:
         assert log_has("Stop loss hit.", caplog.record_tuples)
     else:
-
         assert not log_has("Stop loss hit.", caplog.record_tuples)
+    log_test = (f'Force_selling still open trade UNITTEST/BTC with '
+                f'{results.iloc[-1].profit_percent} perc - {results.iloc[-1].profit_abs}')
+    if data.remains:
+        assert log_has(log_test,
+                       caplog.record_tuples)
+    else:
+        assert not log_has(log_test,
+                           caplog.record_tuples)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -72,8 +72,8 @@ tc1 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9990, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)  # should be
-    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.003, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)  # should be
+    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.003, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 2 Minus 4% Low, minus 1% close
@@ -88,8 +88,8 @@ tc2 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)  #should be
-    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)  #should be
+    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.007, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 3 Candle drops 4%, Recovers 1%.
@@ -108,8 +108,9 @@ tc3 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 12:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
     [getdate('2018-06-10 13:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.4, sell_r=SellType.STOP_LOSS)  #should be
-    stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.04, sell_r=SellType.STOP_LOSS)  #should be
+    # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
+    # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 4 Minus 3% / recovery +15%
@@ -124,8 +125,8 @@ tc4 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
-    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
+    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
+    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
 # Test 5 / Drops 0.5% Closes +20%
 # Candle Data for test 5
@@ -139,8 +140,8 @@ tc5 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
-    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
+    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
+    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
 # Candle Data for test 6
@@ -154,8 +155,8 @@ tc6 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
-    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
+    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
 # Candle Data for test 7
@@ -169,8 +170,8 @@ tc7 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
-    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
+    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 TESTS = [
     # tc_profit1,
@@ -193,7 +194,9 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     """
     default_conf["stoploss"] = data.stop_loss
     default_conf["minimal_roi"] = {"0": data.roi}
-    mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
+    # mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
+    # TODO: don't Mock fee to for now
+    mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.0))
     patch_exchange(mocker)
 
     backtesting = Backtesting(default_conf)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -21,7 +21,7 @@ class BTrade(NamedTuple):
     """
     Minimalistic Trade result used for functional backtesting
     """
-    sell_r: SellType
+    sell_reason: SellType
     open_tick: int
     close_tick: int
 
@@ -64,7 +64,7 @@ tc0 = BTContainer(data=[
     [4, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [5, 9990, 9990, 9990, 9900, 12345, 0, 0]],
     stop_loss=-0.01, roi=1, profit_perc=-0.01,
-    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
 
@@ -79,7 +79,7 @@ tc1 = BTContainer(data=[
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.03, roi=1, profit_perc=-0.03,
-    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=3)]
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=3)]
     )
 
 
@@ -99,8 +99,8 @@ tc2 = BTContainer(data=[
     [5, 9925, 9975, 8000, 8000, 12345, 0, 0],  # exit with stoploss hit
     [6, 9900, 9950, 9950, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=1, profit_perc=-0.04,
-    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2),
-            BTrade(sell_r=SellType.STOP_LOSS, open_tick=4, close_tick=5)]
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2),
+            BTrade(sell_reason=SellType.STOP_LOSS, open_tick=4, close_tick=5)]
 )
 
 # Test 4 Minus 3% / recovery +15%
@@ -115,7 +115,7 @@ tc3 = BTContainer(data=[
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.06, profit_perc=-0.02,
-    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
 # Test 4 / Drops 0.5% Closes +20%
@@ -129,7 +129,7 @@ tc4 = BTContainer(data=[
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.01, roi=0.03, profit_perc=0.03,
-    trades=[BTrade(sell_r=SellType.ROI, open_tick=1, close_tick=3)]
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
@@ -144,7 +144,7 @@ tc5 = BTContainer(data=[
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.05, profit_perc=-0.02,
-    trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
@@ -159,7 +159,7 @@ tc6 = BTContainer(data=[
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.03, profit_perc=0.03,
-    trades=[BTrade(sell_r=SellType.ROI, open_tick=1, close_tick=2)]
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=2)]
     )
 
 TESTS = [
@@ -218,6 +218,6 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     #                        caplog.record_tuples)
     for c, trade in enumerate(data.trades):
         res = results.iloc[c]
-        assert res.sell_reason == trade.sell_r
+        assert res.sell_reason == trade.sell_reason
         assert res.open_time == _get_frame_time(trade.open_tick)
         assert res.close_time == _get_frame_time(trade.close_tick)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -1,0 +1,77 @@
+# pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103, unused-argument
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from arrow import get as getdate
+
+from freqtrade.optimize.backtesting import Backtesting
+from freqtrade.tests.conftest import patch_exchange, log_has
+
+
+columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
+data_profit = pd.DataFrame([[getdate('2018-07-08 18:00:00').datetime,
+                             0.0009910, 0.001011, 0.00098618, 0.001000, 47027.0, 1, 0],
+                            [getdate('2018-07-08 19:00:00').datetime,
+                             0.001000, 0.001010, 0.0009900, 0.0009900, 87116.0, 0, 0],
+                            [getdate('2018-07-08 20:00:00').datetime,
+                             0.0009900, 0.001011, 0.00091618, 0.0009900, 58539.0, 0, 0],
+                            [getdate('2018-07-08 21:00:00').datetime,
+                             0.001000, 0.001011, 0.00098618, 0.001100,  37498.0, 0, 1],
+                            [getdate('2018-07-08 22:00:00').datetime,
+                             0.001000, 0.001011, 0.00098618, 0.0009900,  59792.0, 0, 0]],
+                           columns=columns)
+
+data_loss = pd.DataFrame([[getdate('2018-07-08 18:00:00').datetime,
+                           0.0009910, 0.001011, 0.00098618, 0.001000, 47027.0, 1, 0],
+                          [getdate('2018-07-08 19:00:00').datetime,
+                           0.001000, 0.001010, 0.0009900, 0.001000, 87116.0, 0, 0],
+                          [getdate('2018-07-08 20:00:00').datetime,
+                           0.001000, 0.001011, 0.0010618, 0.00091618, 58539.0, 0, 0],
+                          [getdate('2018-07-08 21:00:00').datetime,
+                           0.001000, 0.001011, 0.00098618, 0.00091618,  37498.0, 0, 0],
+                          [getdate('2018-07-08 22:00:00').datetime,
+                           0.001000, 0.001011, 0.00098618, 0.00091618,  59792.0, 0, 0]],
+                         columns=columns)
+
+
+@pytest.mark.parametrize("data, stoploss, tradecount, profit_perc, sl", [
+                         (data_profit, -0.01, 1, 0.10557, False),  # should be stoploss - drops 8%
+                         # (data_profit, -0.10, 1, 0.10557, True),  # win
+                         (data_loss, -0.05, 1, -0.08839, True),  # Stoploss ...
+                         ])
+def test_backtest_results(default_conf, fee, mocker, caplog,
+                          data, stoploss, tradecount, profit_perc, sl) -> None:
+    """
+    run functional tests
+    """
+    default_conf["stoploss"] = stoploss
+    mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
+    mocker.patch('freqtrade.analyze.Analyze.populate_sell_trend', MagicMock(return_value=data))
+    mocker.patch('freqtrade.analyze.Analyze.populate_buy_trend', MagicMock(return_value=data))
+    patch_exchange(mocker)
+
+    backtesting = Backtesting(default_conf)
+    caplog.set_level(logging.DEBUG)
+
+    pair = 'UNITTEST/BTC'
+    # Dummy data as we mock the analyze functions
+    data_processed = {pair: pd.DataFrame()}
+    results = backtesting.backtest(
+        {
+            'stake_amount': default_conf['stake_amount'],
+            'processed': data_processed,
+            'max_open_trades': 10,
+            'realistic': True
+        }
+    )
+    print(results.T)
+
+    assert len(results) == tradecount
+    assert round(results["profit_percent"].sum(), 5) == profit_perc
+    if sl:
+        assert log_has("Stop loss hit.", caplog.record_tuples)
+    else:
+
+        assert not log_has("Stop loss hit.", caplog.record_tuples)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -18,6 +18,9 @@ ticker_interval_in_minute = 60
 
 
 class BTrade(NamedTuple):
+    """
+    Minimalistic Trade result used for functional backtesting
+    """
     sell_r: SellType
     open_tick: int
     close_tick: int
@@ -25,7 +28,7 @@ class BTrade(NamedTuple):
 
 class BTContainer(NamedTuple):
     """
-    NamedTuple Defining BacktestResults inputs.
+    Minimal BacktestContainer defining Backtest inputs and results.
     """
     data: List[float]
     stop_loss: float
@@ -50,14 +53,13 @@ def _build_dataframe(ticker_with_signals):
     return frame
 
 
-# Test 1 Minus 8% Close
-# Candle Data for test 1 – close at -8% (9200)
+# Test 0 Minus 8% Close
 # Test with Stop-loss at 1%
 # TC1: Stop-Loss Triggered 1% loss
 tc0 = BTContainer(data=[
     [0, 10000.0, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
-    [2, 9975, 10025, 9200, 9200, 12345, 0, 0],  # Exit with stoploss hit
+    [2, 9975, 10025, 9200, 9200, 12345, 0, 0],  # exit with stoploss hit
     [3, 9950, 10000, 9960, 9955, 12345, 0, 0],
     [4, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [5, 9990, 9990, 9990, 9900, 12345, 0, 0]],
@@ -66,15 +68,14 @@ tc0 = BTContainer(data=[
 )
 
 
-# Test 2 Minus 4% Low, minus 1% close
-# Candle Data for test 2
+# Test 1 Minus 4% Low, minus 1% close
 # Test with Stop-Loss at 3%
 # TC2: Stop-Loss Triggered 3% Loss
 tc1 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9925, 9950, 12345, 0, 0],
-    [3, 9950, 10000, 9600, 9925, 12345, 0, 0],  # Exit with stoploss hit
+    [3, 9950, 10000, 9600, 9925, 12345, 0, 0],  # exit with stoploss hit
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.03, roi=1, profit_perc=-0.03,
@@ -92,10 +93,10 @@ tc1 = BTContainer(data=[
 tc2 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
-    [2, 9975, 10025, 9600, 9950, 12345, 0, 0],
+    [2, 9975, 10025, 9600, 9950, 12345, 0, 0],  # exit with stoploss hit
     [3, 9950, 10000, 9900, 9925, 12345, 1, 0],
     [4, 9950, 10000, 9900, 9925, 12345, 0, 0],  # enter trade 2 (signal on last candle)
-    [5, 9925, 9975, 8000, 8000, 12345, 0, 0],
+    [5, 9925, 9975, 8000, 8000, 12345, 0, 0],  # exit with stoploss hit
     [6, 9900, 9950, 9950, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=1, profit_perc=-0.04,
     trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2),
@@ -103,22 +104,21 @@ tc2 = BTContainer(data=[
 )
 
 # Test 4 Minus 3% / recovery +15%
-# Candle Data for test 4 – Candle drops 3% Closed 15% up
+# Candle Data for test 3 – Candle drops 3% Closed 15% up
 # Test with Stop-loss at 2% ROI 6%
 # TC4: Stop-Loss Triggered 2% Loss
 tc3 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
     [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
-    [2, 9975, 11500, 9700, 11500, 12345, 0, 0],
+    [2, 9975, 11500, 9700, 11500, 12345, 0, 0],  # Exit with stoploss hit
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],  # Exit with stoploss hit
+    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.06, profit_perc=-0.02,
     trades=[BTrade(sell_r=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
-# Test 5 / Drops 0.5% Closes +20%
-# Candle Data for test 5
+# Test 4 / Drops 0.5% Closes +20%
 # Set stop-loss at 1% ROI 3%
 # TC5: ROI triggers 3% Gain
 tc4 = BTContainer(data=[
@@ -163,9 +163,6 @@ tc6 = BTContainer(data=[
     )
 
 TESTS = [
-    # tc_profit1,
-    # tc_profit2,
-    # tc_loss0,
     tc0,
     tc1,
     tc2,

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -69,8 +69,8 @@ tc_loss0 = BTContainer(data=[
 # TC1: Stop-Loss Triggered 1% loss
 tc1 = BTContainer(data=[
     [0, 10000.0, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [2, 9975, 10025, 9200, 9200, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
+    [2, 9975, 10025, 9200, 9200, 12345, 0, 0],  # Exit with stoploss hit
     [3, 9950, 10000, 9960, 9955, 12345, 0, 0],
     [4, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [5, 9990, 9990, 9990, 9900, 12345, 0, 0]],
@@ -83,13 +83,12 @@ tc1 = BTContainer(data=[
 # TC2: Stop-Loss Triggered 3% Loss
 tc2 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9925, 9950, 12345, 0, 0],
-    [3, 9950, 10000, 9600, 9925, 12345, 0, 0],
+    [3, 9950, 10000, 9600, 9925, 12345, 0, 0],  # Exit with stoploss hit
     [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)  #should be
-    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.007, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)
 
 
 # Test 3 Candle drops 4%, Recovers 1%.
@@ -101,16 +100,13 @@ tc2 = BTContainer(data=[
 #          Trade-B: Stop-Loss Triggered 2% Loss
 tc3 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10025, 9600, 9950, 12345, 0, 0],
-    [3, 9950, 10000, 9900, 9925, 12345, 1, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 1, 0],  # enter trade 2 (signal on last candle)
     [4, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [5, 9925, 9975, 8000, 8000, 12345, 0, 0],
     [6, 9900, 9950, 9950, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.04, sell_r=SellType.STOP_LOSS)  #should be
-    # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
-    # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
-
+    stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.04, sell_r=SellType.STOP_LOSS)
 
 # Test 4 Minus 3% / recovery +15%
 # Candle Data for test 4 – Candle drops 3% Closed 15% up
@@ -118,13 +114,12 @@ tc3 = BTContainer(data=[
 # TC4: Stop-Loss Triggered 2% Loss
 tc4 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 11500, 9700, 11500, 12345, 0, 0],
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
+    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],  # Exit with stoploss hit
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
-    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
+    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)
 
 # Test 5 / Drops 0.5% Closes +20%
 # Candle Data for test 5
@@ -132,13 +127,12 @@ tc4 = BTContainer(data=[
 # TC5: ROI triggers 3% Gain
 tc5 = BTContainer(data=[
     [0, 10000, 10050, 9960, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9960, 9975, 12345, 0, 0],
+    [1, 10000, 10050, 9960, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
     [2, 9975, 10050, 9950, 9975, 12345, 0, 0],
-    [3, 9950, 12000, 9950, 12000, 12345, 0, 0],
+    [3, 9950, 12000, 9950, 12000, 12345, 0, 0],  # ROI
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
-    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
+    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
 # Candle Data for test 6
@@ -146,13 +140,12 @@ tc5 = BTContainer(data=[
 # TC6: Stop-Loss triggers 2% Loss
 tc6 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [2, 9975, 10600, 9700, 10100, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
+    [2, 9975, 10600, 9700, 10100, 12345, 0, 0],  # Exit with stoploss
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
-    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
 # Candle Data for test 7
@@ -160,13 +153,12 @@ tc6 = BTContainer(data=[
 # TC7: ROI Triggers 3% Gain
 tc7 = BTContainer(data=[
     [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [2, 9975, 10600, 9900, 10100, 12345, 0, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],  # enter trade (signal on last candle)
+    [2, 9975, 10600, 9900, 10100, 12345, 0, 0],  # ROI
     [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
-    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
-    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
+    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)
 
 TESTS = [
     # tc_profit1,
@@ -189,7 +181,7 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     """
     default_conf["stoploss"] = data.stop_loss
     default_conf["minimal_roi"] = {"0": data.roi}
-    # mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
+    mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     # TODO: don't Mock fee to for now
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.0))
     patch_exchange(mocker)

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -9,6 +9,7 @@ from arrow import get as getdate
 
 
 from freqtrade.optimize.backtesting import Backtesting
+from freqtrade.strategy.interface import SellType
 from freqtrade.tests.conftest import patch_exchange, log_has
 
 
@@ -21,8 +22,7 @@ class BTContainer(NamedTuple):
     roi: float
     trades: int
     profit_perc: float
-    sl: bool
-    remains: bool
+    sell_r: SellType
 
 
 columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
@@ -40,9 +40,9 @@ data_profit = DataFrame([
 ], columns=columns)
 
 tc_profit1 = BTContainer(data=data_profit, stop_loss=-0.01, roi=1, trades=1,
-                         profit_perc=0.10557, sl=False, remains=False)  # should be stoploss - drops 8%
+                         profit_perc=0.10557, sell_r=SellType.STOP_LOSS)  # should be stoploss - drops 8%
 tc_profit2 = BTContainer(data=data_profit, stop_loss=-0.10, roi=1,
-                         trades=1, profit_perc=0.10557, sl=True, remains=False)
+                         trades=1, profit_perc=0.10557, sell_r=SellType.STOP_LOSS)
 
 
 tc_loss0 = BTContainer(data=DataFrame([
@@ -57,7 +57,7 @@ tc_loss0 = BTContainer(data=DataFrame([
     [getdate('2018-07-08 22:00:00').datetime, 0.001000,
      0.001011, 0.00098618, 0.00091618, 12345, 0, 0]
 ], columns=columns),
-    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sl=True, remains=False)
+    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sell_r=SellType.STOP_LOSS)
 
 
 # Test 1 Minus 8% Close
@@ -71,8 +71,8 @@ tc1 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9990, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sl=True, remains=False)  # should be
-    stop_loss=-0.01, roi=1, trades=1, profit_perc=0.071, sl=False, remains=True)  #
+    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)  # should be
+    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.003, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 2 Minus 4% Low, minus 1% close
@@ -86,8 +86,8 @@ tc2 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sl=True, remains=False)  #should be
-    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.00999, sl=False, remains=True)  #
+    # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)  #should be
+    stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 3 Candle drops 4%, Recovers 1%.
@@ -104,8 +104,8 @@ tc3 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.4, sl=True, remains=False)  #should be
-    stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.19999, sl=True, remains=False)  #
+    # stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.4, sell_r=SellType.STOP_LOSS)  #should be
+    stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 
 # Test 4 Minus 3% / recovery +15%
@@ -119,8 +119,8 @@ tc4 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sl=False, remains=False)  #should be
-    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.141, sl=True, remains=False)
+    # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
+    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
 # Test 5 / Drops 0.5% Closes +20%
 # Candle Data for test 5
@@ -133,8 +133,8 @@ tc5 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sl=False, remains=False)  #should be
-    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.197, sl=False, remains=False)
+    # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
+    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
 # Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
 # Candle Data for test 6
@@ -147,8 +147,8 @@ tc6 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sl=False, remains=False)  #should be
-    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.025, sl=False, remains=True)  #
+    # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
+    stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 # Test 7 - 6% Positive / 1% Negative / Close 1% Positve
 # Candle Data for test 7
@@ -161,8 +161,8 @@ tc7 = BTContainer(data=DataFrame([
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
     [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
 ], columns=columns),
-    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.03, sl=False, remains=False)  #should be
-    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.025, sl=False, remains=True)  #
+    # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
+    stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
 TESTS = [
     # tc_profit1,
@@ -186,12 +186,11 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     default_conf["stoploss"] = data.stop_loss
     default_conf["minimal_roi"] = {"0": data.roi}
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
-    mocker.patch.multiple('freqtrade.analyze.Analyze',
-                          populate_sell_trend=MagicMock(return_value=data.data),
-                          populate_buy_trend=MagicMock(return_value=data.data))
     patch_exchange(mocker)
 
     backtesting = Backtesting(default_conf)
+    backtesting.advise_buy = lambda a, m: data.data
+    backtesting.advise_sell = lambda a, m: data.data
     caplog.set_level(logging.DEBUG)
 
     pair = 'UNITTEST/BTC'
@@ -202,20 +201,19 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
             'stake_amount': default_conf['stake_amount'],
             'processed': data_processed,
             'max_open_trades': 10,
-            'realistic': True
         }
     )
     print(results.T)
 
     assert len(results) == data.trades
     assert round(results["profit_percent"].sum(), 3) == round(data.profit_perc, 3)
-    if data.sl:
+    if data.sell_r == SellType.STOP_LOSS:
         assert log_has("Stop loss hit.", caplog.record_tuples)
     else:
         assert not log_has("Stop loss hit.", caplog.record_tuples)
     log_test = (f'Force_selling still open trade UNITTEST/BTC with '
                 f'{results.iloc[-1].profit_percent} perc - {results.iloc[-1].profit_abs}')
-    if data.remains:
+    if data.sell_r == SellType.FORCE_SELL:
         assert log_has(log_test,
                        caplog.record_tuples)
     else:

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -65,7 +65,8 @@ tc_loss0 = BTContainer(data=DataFrame([
 # Test with Stop-loss at 1%
 # TC1: Stop-Loss Triggered 1% loss
 tc1 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9200, 9200, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9960, 9955, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
@@ -80,7 +81,8 @@ tc1 = BTContainer(data=DataFrame([
 # Test with Stop-Loss at 3%
 # TC2: Stop-Loss Triggered 3% Loss
 tc2 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9600, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
@@ -98,11 +100,13 @@ tc2 = BTContainer(data=DataFrame([
 # TC3: Trade-A: Stop-Loss Triggered 2% Loss
 #          Trade-B: Stop-Loss Triggered 2% Loss
 tc3 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9600, 9950, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 1, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
+    [getdate('2018-06-10 11:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
+    [getdate('2018-06-10 13:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
 ], columns=columns),
     # stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.4, sell_r=SellType.STOP_LOSS)  #should be
     stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
@@ -113,7 +117,8 @@ tc3 = BTContainer(data=DataFrame([
 # Test with Stop-loss at 2% ROI 6%
 # TC4: Stop-Loss Triggered 2% Loss
 tc4 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 11500, 9700, 11500, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
@@ -127,7 +132,8 @@ tc4 = BTContainer(data=DataFrame([
 # Set stop-loss at 1% ROI 3%
 # TC5: ROI triggers 3% Gain
 tc5 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 12000, 9950, 12000, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
@@ -141,7 +147,8 @@ tc5 = BTContainer(data=DataFrame([
 # Set stop-loss at 2% ROI at 5%
 # TC6: Stop-Loss triggers 2% Loss
 tc6 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9700, 10100, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
@@ -155,7 +162,8 @@ tc6 = BTContainer(data=DataFrame([
 # Set stop-loss at 2% ROI at 3%
 # TC7: ROI Triggers 3% Gain
 tc7 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
     [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9900, 10100, 12345, 0, 0],
     [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
     [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -1,55 +1,177 @@
 # pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103, unused-argument
 import logging
 from unittest.mock import MagicMock
+from typing import NamedTuple
 
-import pandas as pd
+from pandas import DataFrame
 import pytest
 from arrow import get as getdate
+
 
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.tests.conftest import patch_exchange, log_has
 
 
+class BTContainer(NamedTuple):
+    """
+    NamedTuple Defining BacktestResults inputs.
+    """
+    data: DataFrame
+    stop_loss: float
+    roi: float
+    trades: int
+    profit_perc: float
+    sl: float
+
+
 columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
-data_profit = pd.DataFrame([[getdate('2018-07-08 18:00:00').datetime,
-                             0.0009910, 0.001011, 0.00098618, 0.001000, 47027.0, 1, 0],
-                            [getdate('2018-07-08 19:00:00').datetime,
-                             0.001000, 0.001010, 0.0009900, 0.0009900, 87116.0, 0, 0],
-                            [getdate('2018-07-08 20:00:00').datetime,
-                             0.0009900, 0.001011, 0.00091618, 0.0009900, 58539.0, 0, 0],
-                            [getdate('2018-07-08 21:00:00').datetime,
-                             0.001000, 0.001011, 0.00098618, 0.001100,  37498.0, 0, 1],
-                            [getdate('2018-07-08 22:00:00').datetime,
-                             0.001000, 0.001011, 0.00098618, 0.0009900,  59792.0, 0, 0]],
-                           columns=columns)
+data_profit = DataFrame([
+    [getdate('2018-07-08 18:00:00').datetime, 0.0009910,
+     0.001011, 0.00098618, 0.001000, 12345, 1, 0],
+    [getdate('2018-07-08 19:00:00').datetime, 0.001000,
+     0.001010, 0.0009900, 0.0009900, 12345, 0, 0],
+    [getdate('2018-07-08 20:00:00').datetime, 0.0009900,
+     0.001011, 0.00091618, 0.0009900, 12345, 0, 0],
+    [getdate('2018-07-08 21:00:00').datetime, 0.001000,
+     0.001011, 0.00098618, 0.001100, 12345, 0, 1],
+    [getdate('2018-07-08 22:00:00').datetime, 0.001000,
+     0.001011, 0.00098618, 0.0009900, 12345, 0, 0]
+], columns=columns)
 
-data_loss = pd.DataFrame([[getdate('2018-07-08 18:00:00').datetime,
-                           0.0009910, 0.001011, 0.00098618, 0.001000, 47027.0, 1, 0],
-                          [getdate('2018-07-08 19:00:00').datetime,
-                           0.001000, 0.001010, 0.0009900, 0.001000, 87116.0, 0, 0],
-                          [getdate('2018-07-08 20:00:00').datetime,
-                           0.001000, 0.001011, 0.0010618, 0.00091618, 58539.0, 0, 0],
-                          [getdate('2018-07-08 21:00:00').datetime,
-                           0.001000, 0.001011, 0.00098618, 0.00091618,  37498.0, 0, 0],
-                          [getdate('2018-07-08 22:00:00').datetime,
-                           0.001000, 0.001011, 0.00098618, 0.00091618,  59792.0, 0, 0]],
-                         columns=columns)
+tc_profit1 = BTContainer(data=data_profit, stop_loss=-0.01, roi=1, trades=1,
+                         profit_perc=0.10557, sl=False)  # should be stoploss - drops 8%
+tc_profit2 = BTContainer(data=data_profit, stop_loss=-0.10, roi=1,
+                         trades=1, profit_perc=0.10557, sl=True)
 
 
-@pytest.mark.parametrize("data, stoploss, tradecount, profit_perc, sl", [
-                         (data_profit, -0.01, 1, 0.10557, False),  # should be stoploss - drops 8%
-                         # (data_profit, -0.10, 1, 0.10557, True),  # win
-                         (data_loss, -0.05, 1, -0.08839, True),  # Stoploss ...
-                         ])
-def test_backtest_results(default_conf, fee, mocker, caplog,
-                          data, stoploss, tradecount, profit_perc, sl) -> None:
+tc_loss0 = BTContainer(data=DataFrame([
+    [getdate('2018-07-08 18:00:00').datetime, 0.0009910,
+     0.001011, 0.00098618, 0.001000, 12345, 1, 0],
+    [getdate('2018-07-08 19:00:00').datetime, 0.001000,
+     0.001010, 0.0009900, 0.001000, 12345, 0, 0],
+    [getdate('2018-07-08 20:00:00').datetime, 0.001000,
+     0.001011, 0.0010618, 0.00091618, 12345, 0, 0],
+    [getdate('2018-07-08 21:00:00').datetime, 0.001000,
+     0.001011, 0.00098618, 0.00091618, 12345, 0, 0],
+    [getdate('2018-07-08 22:00:00').datetime, 0.001000,
+     0.001011, 0.00098618, 0.00091618, 12345, 0, 0]
+], columns=columns),
+    stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sl=True)
+
+
+# Test 1 Minus 8% Close
+# Candle Data for test 1 – close at -8% (9200)
+# Test with Stop-loss at 1%
+tc1 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9960, 9955, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9200, 9200, 12345, 0, 0]
+], columns=columns),
+    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.07999, sl=True)
+
+# Test 2 Minus 4% Low, minus 1% close
+# Candle Data for test 2
+# Test with Stop-Loss at 3%
+tc2 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9600, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
+], columns=columns), stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.00999, sl=False)  #
+
+
+# Test 3 Candle drops 4%, Recovers 1%.
+#               Entry Criteria Met
+# 	            Candle drops 20%
+# Candle Data for test 3
+# Test with Stop-Loss at 2%
+tc3 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9600, 9950, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 1, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
+], columns=columns), stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.19999, sl=True)  #
+
+
+# Test 4 Minus 3% / recovery +15%
+# Candle Data for test 4 – Candle drops 3% Closed 15% up
+# Test with Stop-loss at 2% ROI 6%
+
+tc4 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 11500, 9700, 11500, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
+], columns=columns),
+    stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.141, sl=True)
+
+# Test 5 / Drops 0.5% Closes +20%
+# Candle Data for test 5
+# Set stop-loss at 1% ROI 3%
+tc5 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 12000, 9950, 12000, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
+], columns=columns),
+    stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.177, sl=True)
+
+# Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
+# Candle Data for test 6
+# Set stop-loss at 2% ROI at 5%
+tc6 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9700, 10100, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
+], columns=columns), stop_loss=-0.02, roi=0.05,
+    trades=1, profit_perc=-0.025, sl=False)
+
+# Test 7 - 6% Positive / 1% Negative / Close 1% Positve
+# Candle Data for test 7
+# Set stop-loss at 2% ROI at 3%
+
+tc7 = BTContainer(data=DataFrame([
+    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9900, 10100, 12345, 0, 0],
+    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
+], columns=columns), stop_loss=-0.02, roi=0.03,
+    trades=1, profit_perc=-0.025, sl=False)
+
+TESTS = [
+    # tc_profit1,
+    # tc_profit2,
+    tc_loss0,
+    tc1,
+    tc2,
+    tc3,
+    tc4,
+    tc5,
+    tc6,
+    tc7,
+]
+
+
+@pytest.mark.parametrize("data", TESTS)
+def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     """
     run functional tests
     """
-    default_conf["stoploss"] = stoploss
+    default_conf["stoploss"] = data.stop_loss
+    default_conf["minimal_roi"] = {"0": data.roi}
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
-    mocker.patch('freqtrade.analyze.Analyze.populate_sell_trend', MagicMock(return_value=data))
-    mocker.patch('freqtrade.analyze.Analyze.populate_buy_trend', MagicMock(return_value=data))
+    mocker.patch.multiple('freqtrade.analyze.Analyze',
+                          populate_sell_trend=MagicMock(return_value=data.data),
+                          populate_buy_trend=MagicMock(return_value=data.data))
     patch_exchange(mocker)
 
     backtesting = Backtesting(default_conf)
@@ -57,7 +179,7 @@ def test_backtest_results(default_conf, fee, mocker, caplog,
 
     pair = 'UNITTEST/BTC'
     # Dummy data as we mock the analyze functions
-    data_processed = {pair: pd.DataFrame()}
+    data_processed = {pair: DataFrame()}
     results = backtesting.backtest(
         {
             'stake_amount': default_conf['stake_amount'],
@@ -68,9 +190,9 @@ def test_backtest_results(default_conf, fee, mocker, caplog,
     )
     print(results.T)
 
-    assert len(results) == tradecount
-    assert round(results["profit_percent"].sum(), 5) == profit_perc
-    if sl:
+    assert len(results) == data.trades
+    assert round(results["profit_percent"].sum(), 3) == round(data.profit_perc, 3)
+    if data.sl:
         assert log_has("Stop loss hit.", caplog.record_tuples)
     else:
 

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -1,11 +1,11 @@
 # pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103, unused-argument
 import logging
 from unittest.mock import MagicMock
-from typing import NamedTuple
+from typing import NamedTuple, List
 
 from pandas import DataFrame
 import pytest
-from arrow import get as getdate
+import arrow
 
 
 from freqtrade.optimize.backtesting import Backtesting
@@ -13,11 +13,15 @@ from freqtrade.strategy.interface import SellType
 from freqtrade.tests.conftest import patch_exchange, log_has
 
 
+ticker_start_time = arrow.get(2018, 10, 3)
+ticker_interval_in_minute = 60
+
+
 class BTContainer(NamedTuple):
     """
     NamedTuple Defining BacktestResults inputs.
     """
-    data: DataFrame
+    data: List[float]
     stop_loss: float
     roi: float
     trades: int
@@ -25,19 +29,24 @@ class BTContainer(NamedTuple):
     sell_r: SellType
 
 
-columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
-data_profit = DataFrame([
-    [getdate('2018-07-08 18:00:00').datetime, 0.0009910,
-     0.001011, 0.00098618, 0.001000, 12345, 1, 0],
-    [getdate('2018-07-08 19:00:00').datetime, 0.001000,
-     0.001010, 0.0009900, 0.0009900, 12345, 0, 0],
-    [getdate('2018-07-08 20:00:00').datetime, 0.0009900,
-     0.001011, 0.00091618, 0.0009900, 12345, 0, 0],
-    [getdate('2018-07-08 21:00:00').datetime, 0.001000,
-     0.001011, 0.00098618, 0.001100, 12345, 0, 1],
-    [getdate('2018-07-08 22:00:00').datetime, 0.001000,
-     0.001011, 0.00098618, 0.0009900, 12345, 0, 0]
-], columns=columns)
+def _build_dataframe(ticker_with_signals):
+    columns = ['date', 'open', 'high', 'low', 'close', 'volume', 'buy', 'sell']
+
+    frame = DataFrame.from_records(ticker_with_signals, columns=columns)
+    frame['date'] = frame['date'].apply(lambda x: ticker_start_time.shift(
+                    minutes=(x * ticker_interval_in_minute)).datetime)
+    # Ensure floats are in place
+    for column in ['open', 'high', 'low', 'close', 'volume']:
+        frame[column] = frame[column].astype('float64')
+    return frame
+
+
+data_profit = [
+    [0, 0.0009910, 0.001011, 0.00098618, 0.001000, 12345, 1, 0],
+    [1, 0.001000, 0.001010, 0.0009900, 0.0009900, 12345, 0, 0],
+    [2, 0.0009900, 0.001011, 0.00091618, 0.0009900, 12345, 0, 0],
+    [3, 0.001000, 0.001011, 0.00098618, 0.001100, 12345, 0, 1],
+    [4, 0.001000, 0.001011, 0.00098618, 0.0009900, 12345, 0, 0]]
 
 tc_profit1 = BTContainer(data=data_profit, stop_loss=-0.01, roi=1, trades=1,
                          profit_perc=0.10557, sell_r=SellType.STOP_LOSS)  # should be stoploss - drops 8%
@@ -45,18 +54,12 @@ tc_profit2 = BTContainer(data=data_profit, stop_loss=-0.10, roi=1,
                          trades=1, profit_perc=0.10557, sell_r=SellType.STOP_LOSS)
 
 
-tc_loss0 = BTContainer(data=DataFrame([
-    [getdate('2018-07-08 18:00:00').datetime, 0.0009910,
-     0.001011, 0.00098618, 0.001000, 12345, 1, 0],
-    [getdate('2018-07-08 19:00:00').datetime, 0.001000,
-     0.001010, 0.0009900, 0.001000, 12345, 0, 0],
-    [getdate('2018-07-08 20:00:00').datetime, 0.001000,
-     0.001011, 0.0010618, 0.00091618, 12345, 0, 0],
-    [getdate('2018-07-08 21:00:00').datetime, 0.001000,
-     0.001011, 0.00098618, 0.00091618, 12345, 0, 0],
-    [getdate('2018-07-08 22:00:00').datetime, 0.001000,
-     0.001011, 0.00098618, 0.00091618, 12345, 0, 0]
-], columns=columns),
+tc_loss0 = BTContainer(data=[
+    [0, 0.0009910, 0.001011, 0.00098618, 0.001000, 12345, 1, 0],
+    [1, 0.001000, 0.001010, 0.0009900, 0.001000, 12345, 0, 0],
+    [2, 0.001000, 0.001011, 0.0010618, 0.00091618, 12345, 0, 0],
+    [3, 0.001000, 0.001011, 0.00098618, 0.00091618, 12345, 0, 0],
+    [4, 0.001000, 0.001011, 0.00098618, 0.00091618, 12345, 0, 0]],
     stop_loss=-0.05, roi=1, trades=1, profit_perc=-0.08839, sell_r=SellType.STOP_LOSS)
 
 
@@ -64,30 +67,27 @@ tc_loss0 = BTContainer(data=DataFrame([
 # Candle Data for test 1 – close at -8% (9200)
 # Test with Stop-loss at 1%
 # TC1: Stop-Loss Triggered 1% loss
-tc1 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9200, 9200, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9960, 9955, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9955, 9975, 9955, 9990, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9990, 9990, 9990, 9900, 12345, 0, 0]
-], columns=columns),
-    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)  # should be
-    # stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.003, sell_r=SellType.FORCE_SELL)  #
+tc1 = BTContainer(data=[
+    [0, 10000.0, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 10025, 9200, 9200, 12345, 0, 0],
+    [3, 9950, 10000, 9960, 9955, 12345, 0, 0],
+    [4, 9955, 9975, 9955, 9990, 12345, 0, 0],
+    [5, 9990, 9990, 9990, 9900, 12345, 0, 0]],
+    stop_loss=-0.01, roi=1, trades=1, profit_perc=-0.01, sell_r=SellType.STOP_LOSS)
 
 
 # Test 2 Minus 4% Low, minus 1% close
 # Candle Data for test 2
 # Test with Stop-Loss at 3%
 # TC2: Stop-Loss Triggered 3% Loss
-tc2 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9925, 9950, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9600, 9925, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns),
+tc2 = BTContainer(data=[
+    [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 10025, 9925, 9950, 12345, 0, 0],
+    [3, 9950, 10000, 9600, 9925, 12345, 0, 0],
+    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
+    [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.03, sell_r=SellType.STOP_LOSS)  #should be
     # stop_loss=-0.03, roi=1, trades=1, profit_perc=-0.007, sell_r=SellType.FORCE_SELL)  #
 
@@ -99,15 +99,14 @@ tc2 = BTContainer(data=DataFrame([
 # Test with Stop-Loss at 2%
 # TC3: Trade-A: Stop-Loss Triggered 2% Loss
 #          Trade-B: Stop-Loss Triggered 2% Loss
-tc3 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10025, 9600, 9950, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 1, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9925, 9975, 8000, 8000, 12345, 0, 0],
-    [getdate('2018-06-10 13:00:00').datetime, 9900, 9950, 9950, 9900, 12345, 0, 0]
-], columns=columns),
+tc3 = BTContainer(data=[
+    [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 10025, 9600, 9950, 12345, 0, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 1, 0],
+    [4, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [5, 9925, 9975, 8000, 8000, 12345, 0, 0],
+    [6, 9900, 9950, 9950, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=1, trades=2, profit_perc=-0.04, sell_r=SellType.STOP_LOSS)  #should be
     # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
     # stop_loss=-0.02, roi=1, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
@@ -117,14 +116,13 @@ tc3 = BTContainer(data=DataFrame([
 # Candle Data for test 4 – Candle drops 3% Closed 15% up
 # Test with Stop-loss at 2% ROI 6%
 # TC4: Stop-Loss Triggered 2% Loss
-tc4 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 11500, 9700, 11500, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9875, 9900, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns),
+tc4 = BTContainer(data=[
+    [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 11500, 9700, 11500, 12345, 0, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [4, 9925, 9975, 9875, 9900, 12345, 0, 0],
+    [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
     # stop_loss=-0.02, roi=0.06, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
@@ -132,14 +130,13 @@ tc4 = BTContainer(data=DataFrame([
 # Candle Data for test 5
 # Set stop-loss at 1% ROI 3%
 # TC5: ROI triggers 3% Gain
-tc5 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9960, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 12000, 9950, 12000, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns),
+tc5 = BTContainer(data=[
+    [0, 10000, 10050, 9960, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9960, 9975, 12345, 0, 0],
+    [2, 9975, 10050, 9950, 9975, 12345, 0, 0],
+    [3, 9950, 12000, 9950, 12000, 12345, 0, 0],
+    [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.01, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
     # stop_loss=-0.01, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)
 
@@ -147,14 +144,13 @@ tc5 = BTContainer(data=DataFrame([
 # Candle Data for test 6
 # Set stop-loss at 2% ROI at 5%
 # TC6: Stop-Loss triggers 2% Loss
-tc6 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9700, 10100, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns),
+tc6 = BTContainer(data=[
+    [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 10600, 9700, 10100, 12345, 0, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.02, sell_r=SellType.STOP_LOSS)  #should be
     # stop_loss=-0.02, roi=0.05, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
@@ -162,14 +158,13 @@ tc6 = BTContainer(data=DataFrame([
 # Candle Data for test 7
 # Set stop-loss at 2% ROI at 3%
 # TC7: ROI Triggers 3% Gain
-tc7 = BTContainer(data=DataFrame([
-    [getdate('2018-06-10 07:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 1, 0],
-    [getdate('2018-06-10 08:00:00').datetime, 10000, 10050, 9950, 9975, 12345, 0, 0],
-    [getdate('2018-06-10 09:00:00').datetime, 9975, 10600, 9900, 10100, 12345, 0, 0],
-    [getdate('2018-06-10 10:00:00').datetime, 9950, 10000, 9900, 9925, 12345, 0, 0],
-    [getdate('2018-06-10 11:00:00').datetime, 9925, 9975, 9945, 9900, 12345, 0, 0],
-    [getdate('2018-06-10 12:00:00').datetime, 9900, 9950, 9850, 9900, 12345, 0, 0]
-], columns=columns),
+tc7 = BTContainer(data=[
+    [0, 10000, 10050, 9950, 9975, 12345, 1, 0],
+    [1, 10000, 10050, 9950, 9975, 12345, 0, 0],
+    [2, 9975, 10600, 9900, 10100, 12345, 0, 0],
+    [3, 9950, 10000, 9900, 9925, 12345, 0, 0],
+    [4, 9925, 9975, 9945, 9900, 12345, 0, 0],
+    [5, 9900, 9950, 9850, 9900, 12345, 0, 0]],
     stop_loss=-0.02, roi=0.03, trades=1, profit_perc=0.03, sell_r=SellType.ROI)  #should be
     # stop_loss=-0.02, roi=0.03, trades=1, profit_perc=-0.012, sell_r=SellType.FORCE_SELL)  #
 
@@ -198,10 +193,10 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     # TODO: don't Mock fee to for now
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.0))
     patch_exchange(mocker)
-
+    frame = _build_dataframe(data.data)
     backtesting = Backtesting(default_conf)
-    backtesting.advise_buy = lambda a, m: data.data
-    backtesting.advise_sell = lambda a, m: data.data
+    backtesting.advise_buy = lambda a, m: frame
+    backtesting.advise_sell = lambda a, m: frame
     caplog.set_level(logging.DEBUG)
 
     pair = 'UNITTEST/BTC'


### PR DESCRIPTION
## Summary
Fix some backtesting issues pointed out in #985.

The need for functional tests with small, concise datasets which can be understood easily has become clear after discovering these caveats.

All added tests are based on the candles and expected results provided by @creslinux [here](https://github.com/freqtrade/freqtrade/issues/985#issuecomment-403407598).

Solve the issue: #985

## Quick changelog

- Added a backtesting functional test file
- created framework to add more functional tests in the future
- fixed pointed out flaws with lows lower than than close hitting stoploss  (which was previously ignored in backtesting)
