### PR TITLE
Feat/add whitelist rpc

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -133,7 +133,7 @@ class FreqtradeBot(object):
                       f'*Strategy:* `{strategy_name}`'
         })
         if self.config.get('dynamic_whitelist', False):
-            top_pairs = 'top ' + str(self.config.get('dynamic_whitelist', 20))
+            top_pairs = 'top volume ' + str(self.config.get('dynamic_whitelist', 20))
             specific_pairs = ''
         else:
             top_pairs = 'whitelisted'

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -443,3 +443,10 @@ class RPC(object):
             raise RPCException('trader is not running')
 
         return Trade.query.filter(Trade.is_open.is_(True)).all()
+
+    def _rpc_whitelist(self) -> Dict:
+        """ Returns the currently active whitelist"""
+        res = {'method': self._freqtrade.config.get('dynamic_whitelist', 0) or 'static',
+               'whitelist': self._freqtrade.active_pair_whitelist
+               }
+        return res

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -480,6 +480,7 @@ class Telegram(RPC):
                   "\n" \
                   "*/balance:* `Show account balance per currency`\n" \
                   "*/reload_conf:* `Reload configuration file` \n" \
+                  "*/whitelist:* `Show current whitelist` \n" \
                   "*/help:* `This help message`\n" \
                   "*/version:* `Show version`"
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -91,6 +91,7 @@ class Telegram(RPC):
             CommandHandler('daily', self._daily),
             CommandHandler('count', self._count),
             CommandHandler('reload_conf', self._reload_conf),
+            CommandHandler('whitelist', self._whitelist),
             CommandHandler('help', self._help),
             CommandHandler('version', self._version),
         ]
@@ -435,6 +436,25 @@ class Telegram(RPC):
             message = "<pre>{}</pre>".format(message)
             logger.debug(message)
             self._send_msg(message, parse_mode=ParseMode.HTML)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
+
+    @authorized_only
+    def _whitelist(self, bot: Bot, update: Update) -> None:
+        """
+        Handler for /whitelist
+        Shows the currently active whitelist
+        """
+        try:
+            whitelist = self._rpc_whitelist()
+            if whitelist['method'] == 'static':
+                message = f"Using static whitelist with `{len(whitelist['whitelist'])}` pairs \n"
+            else:
+                message = f"Dynamic whitelist with `{whitelist['method']}` pairs\n"
+            message += f"`{', '.join(whitelist['whitelist'])}`"
+
+            logger.debug(message)
+            self._send_msg(message)
         except RPCException as e:
             self._send_msg(str(e), bot=bot)
 

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -645,3 +645,28 @@ def test_rpcforcebuy_disabled(mocker, default_conf) -> None:
     pair = 'ETH/BTC'
     with pytest.raises(RPCException, match=r'Forcebuy not enabled.'):
         rpc._rpc_forcebuy(pair, None)
+
+
+def test_rpc_whitelist(mocker, default_conf) -> None:
+    patch_coinmarketcap(mocker)
+    patch_exchange(mocker)
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
+
+    freqtradebot = FreqtradeBot(default_conf)
+    rpc = RPC(freqtradebot)
+    ret = rpc._rpc_whitelist()
+    assert ret['method'] == 'static'
+    assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']
+
+
+def test_rpc_whitelist_dynamic(mocker, default_conf) -> None:
+    patch_coinmarketcap(mocker)
+    patch_exchange(mocker)
+    default_conf['dynamic_whitelist'] = 4
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
+
+    freqtradebot = FreqtradeBot(default_conf)
+    rpc = RPC(freqtradebot)
+    ret = rpc._rpc_whitelist()
+    assert ret['method'] == 4
+    assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']


### PR DESCRIPTION
## Summary
Allows telegram to report the current whitelist.
Especially usefull with dynamic whitelist (and Edge in the future) - as the currently active whitelist is not really visible anywhere in dynamic whitelist mode.

## Quick changelog

- add `/whitelist` telegram command
- clarify startup message (we use top volume pairs)

## What's new?

handler for dynamic whitelist
![2018-11-10-201832_487x169_scrot](https://user-images.githubusercontent.com/5024695/48305143-d5e67100-e525-11e8-8a35-4e0c3ac333bb.png)

handler for static whitelist:

![2018-11-10-201842_587x194_scrot](https://user-images.githubusercontent.com/5024695/48305144-d848cb00-e525-11e8-8ffb-e0fcf156ba39.png)
