### PR TITLE
Ignoring max_open_trades if it is -1 in config.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ The table below will list all configuration parameters.
 
 |  Command | Default | Mandatory | Description |
 |----------|---------|----------|-------------|
-| `max_open_trades` | 3 | Yes | Number of trades open your bot will have.
+| `max_open_trades` | 3 | Yes | Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades)
 | `stake_currency` | BTC | Yes | Crypto-currency used for trading.
 | `stake_amount` | 0.05 | Yes | Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to 'unlimited' to allow the bot to use all avaliable balance.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -33,6 +33,7 @@ class Configuration(object):
     Class to read and init the bot configuration
     Reuse this class for the bot, backtesting, hyperopt and every script that required configuration
     """
+
     def __init__(self, args: Namespace) -> None:
         self.args = args
         self.config: Optional[Dict[str, Any]] = None
@@ -129,6 +130,10 @@ class Configuration(object):
 
         if config.get('forcebuy_enable', False):
             logger.warning('`forcebuy` RPC message enabled.')
+
+        # Setting max_open_trades to infinite if -1
+        if config.get('max_open_trades') == -1:
+            config['max_open_trades'] = float('inf')
 
         logger.info(f'Using DB: "{config["db_url"]}"')
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -43,7 +43,7 @@ SUPPORTED_FIAT = [
 CONF_SCHEMA = {
     'type': 'object',
     'properties': {
-        'max_open_trades': {'type': 'integer', 'minimum': 0},
+        'max_open_trades': {'type': 'integer', 'minimum': -1},
         'ticker_interval': {'type': 'string', 'enum': list(TICKER_INTERVAL_MINUTES.keys())},
         'stake_currency': {'type': 'string', 'enum': ['BTC', 'XBT', 'ETH', 'USDT', 'EUR', 'USD']},
         'stake_amount': {

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -64,6 +64,22 @@ def test_load_config_max_open_trades_zero(default_conf, mocker, caplog) -> None:
     assert log_has('Validating configuration ...', caplog.record_tuples)
 
 
+def test_load_config_max_open_trades_minus_one(default_conf, mocker, caplog) -> None:
+    default_conf['max_open_trades'] = -1
+    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
+        read_data=json.dumps(default_conf)
+    ))
+
+    args = Arguments([], '').get_parsed_arg()
+    configuration = Configuration(args)
+    validated_conf = configuration.load_config()
+    print(validated_conf)
+
+    assert validated_conf['max_open_trades'] > 999999999
+    assert validated_conf['max_open_trades'] == float('inf')
+    assert log_has('Validating configuration ...', caplog.record_tuples)
+
+
 def test_load_config_file_exception(mocker) -> None:
     mocker.patch(
         'freqtrade.configuration.open',


### PR DESCRIPTION
max_open_trades should be ignored if it is -1. 
That means potentially unlimited open positions.
This will come handy for Edge further refactoring regarding position sizing.