### PR TITLE
Add support for different order types

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -33,6 +33,11 @@
         "order_book_min": 1,
         "order_book_max": 9
     },
+    "order_types": {
+        "buy": "limit",
+        "sell": "limit",
+        "stoploss": "market"
+    },
     "exchange": {
         "name": "bittrex",
         "key": "your_exchange_key",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ The table below will list all configuration parameters.
 | `ask_strategy.use_order_book` | false | No | Allows selling of open traded pair using the rates in Order Book Asks.
 | `ask_strategy.order_book_min` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
 | `ask_strategy.order_book_max` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
+| `order_types` | None | No | Configure order-types depending on the action (`"buy"`, `"sell"`, `"stoploss"`).
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename).
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.
 | `exchange.secret` | secret | No | API secret to use for the exchange. Only required when you are in production mode.
@@ -137,6 +138,22 @@ the static list of pairs) if we should buy.
 use the `last` price and values between those interpolate between ask and last
 price. Using `ask` price will guarantee quick success in bid, but bot will also
 end up paying more then would probably have been necessary.
+
+### Understand order_types
+
+`order_types` contains a dict mapping order-types to market-types. This allows to buy using limit orders, sell using limit-orders, and create stoploss orders using market.
+This can be set in the configuration or in the strategy. Configuration overwrites strategy configurations.
+
+If this is configured, all 3 values (`"buy"`, `"sell"` and `"stoploss"`) need to be present, otherwise the bot warn about it and will fail to start.
+The below is the default which is used if this is not configured in either Strategy or configuration.
+
+``` json
+    "order_types": {
+        "buy": "limit",
+        "sell": "limit",
+        "stoploss": "market"
+    },
+```
 
 ### What values for exchange.name?
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -12,6 +12,7 @@ DEFAULT_STRATEGY = 'DefaultStrategy'
 DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'
 DEFAULT_DB_DRYRUN_URL = 'sqlite://'
 UNLIMITED_STAKE_AMOUNT = 'unlimited'
+REQUIRED_ORDERTYPES = ['buy', 'sell', 'stoploss']
 
 
 TICKER_INTERVAL_MINUTES = {

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -13,6 +13,7 @@ DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'
 DEFAULT_DB_DRYRUN_URL = 'sqlite://'
 UNLIMITED_STAKE_AMOUNT = 'unlimited'
 REQUIRED_ORDERTYPES = ['buy', 'sell', 'stoploss']
+ORDERTYPE_POSSIBILITIES = ['limit', 'market']
 
 
 TICKER_INTERVAL_MINUTES = {
@@ -101,6 +102,15 @@ CONF_SCHEMA = {
                 'order_book_min': {'type': 'number', 'minimum': 1},
                 'order_book_max': {'type': 'number', 'minimum': 1, 'maximum': 50}
             }
+        },
+        'order_types': {
+            'type': 'object',
+            'properties': {
+                'buy': {'type': 'string', 'enum': ORDERTYPE_POSSIBILITIES},
+                'sell': {'type': 'string', 'enum': ORDERTYPE_POSSIBILITIES},
+                'stoploss': {'type': 'string', 'enum': ORDERTYPE_POSSIBILITIES}
+            },
+            'required': ['buy', 'sell', 'stoploss']
         },
         'exchange': {'$ref': '#/definitions/exchange'},
         'edge': {'$ref': '#/definitions/edge'},

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -277,7 +277,7 @@ class Exchange(object):
         try:
             # Set the precision for amount and price(rate) as accepted by the exchange
             amount = self.symbol_amount_prec(pair, amount)
-            rate = self.symbol_price_prec(pair, rate)
+            rate = self.symbol_price_prec(pair, rate) if ordertype != 'market' else None
 
             return self._api.create_order(pair, ordertype, 'buy', amount, rate)
         except ccxt.InsufficientFunds as e:
@@ -314,7 +314,7 @@ class Exchange(object):
         try:
             # Set the precision for amount and price(rate) as accepted by the exchange
             amount = self.symbol_amount_prec(pair, amount)
-            rate = self.symbol_price_prec(pair, rate)
+            rate = self.symbol_price_prec(pair, rate) if ordertype != 'market' else None
 
             return self._api.create_order(pair, ordertype, 'sell', amount, rate)
         except ccxt.InsufficientFunds as e:

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -249,14 +249,14 @@ class Exchange(object):
             price = ceil(big_price) / pow(10, symbol_prec)
         return price
 
-    def buy(self, pair: str, rate: float, amount: float, ordertype: str = 'limt') -> Dict:
+    def buy(self, pair: str, ordertype: str, amount: float, rate: float) -> Dict:
         if self._conf['dry_run']:
             order_id = f'dry_run_buy_{randint(0, 10**6)}'
             self._dry_run_open_orders[order_id] = {
                 'pair': pair,
                 'price': rate,
                 'amount': amount,
-                'type': 'limit',
+                'type': ordertype,
                 'side': 'buy',
                 'remaining': 0.0,
                 'datetime': arrow.utcnow().isoformat(),
@@ -287,14 +287,14 @@ class Exchange(object):
         except ccxt.BaseError as e:
             raise OperationalException(e)
 
-    def sell(self, pair: str, rate: float, amount: float, ordertype: str = 'limt') -> Dict:
+    def sell(self, pair: str, ordertype: str, amount: float, rate: float) -> Dict:
         if self._conf['dry_run']:
             order_id = f'dry_run_sell_{randint(0, 10**6)}'
             self._dry_run_open_orders[order_id] = {
                 'pair': pair,
                 'price': rate,
                 'amount': amount,
-                'type': 'limit',
+                'type': ordertype,
                 'side': 'sell',
                 'remaining': 0.0,
                 'datetime': arrow.utcnow().isoformat(),

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -249,7 +249,7 @@ class Exchange(object):
             price = ceil(big_price) / pow(10, symbol_prec)
         return price
 
-    def buy(self, pair: str, rate: float, amount: float) -> Dict:
+    def buy(self, pair: str, rate: float, amount: float, ordertype: str = 'limt') -> Dict:
         if self._conf['dry_run']:
             order_id = f'dry_run_buy_{randint(0, 10**6)}'
             self._dry_run_open_orders[order_id] = {
@@ -270,7 +270,7 @@ class Exchange(object):
             amount = self.symbol_amount_prec(pair, amount)
             rate = self.symbol_price_prec(pair, rate)
 
-            return self._api.create_limit_buy_order(pair, amount, rate)
+            return self._api.create_order(pair, ordertype, 'buy', amount, rate)
         except ccxt.InsufficientFunds as e:
             raise DependencyException(
                 f'Insufficient funds to create limit buy order on market {pair}.'
@@ -287,7 +287,7 @@ class Exchange(object):
         except ccxt.BaseError as e:
             raise OperationalException(e)
 
-    def sell(self, pair: str, rate: float, amount: float) -> Dict:
+    def sell(self, pair: str, rate: float, amount: float, ordertype: str = 'limt') -> Dict:
         if self._conf['dry_run']:
             order_id = f'dry_run_sell_{randint(0, 10**6)}'
             self._dry_run_open_orders[order_id] = {
@@ -307,7 +307,7 @@ class Exchange(object):
             amount = self.symbol_amount_prec(pair, amount)
             rate = self.symbol_price_prec(pair, rate)
 
-            return self._api.create_limit_sell_order(pair, amount, rate)
+            return self._api.create_order(pair, ordertype, 'sell', amount, rate)
         except ccxt.InsufficientFunds as e:
             raise DependencyException(
                 f'Insufficient funds to create limit sell order on market {pair}.'

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -102,7 +102,7 @@ class Exchange(object):
         self.markets = self._load_markets()
         # Check if all pairs are available
         self.validate_pairs(config['exchange']['pair_whitelist'])
-
+        self.validate_ordertypes(config.get('order_types', {}))
         if config.get('ticker_interval'):
             # Check if timeframe is available
             self.validate_timeframes(config['ticker_interval'])
@@ -217,6 +217,15 @@ class Exchange(object):
         if timeframe not in timeframes:
             raise OperationalException(
                 f'Invalid ticker {timeframe}, this Exchange supports {timeframes}')
+
+    def validate_ordertypes(self, order_types: Dict) -> None:
+        """
+        Checks if order-types configured in strategy/config are supported
+        """
+        if any(v == 'market' for k, v in order_types.items()):
+            if not self.exchange_has('createMarketOrder'):
+                raise OperationalException(
+                    f'Exchange {self.name} does not support market orders.')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -475,8 +475,8 @@ class FreqtradeBot(object):
 
         amount = stake_amount / buy_limit
 
-        order_id = self.exchange.buy(pair=pair, rate=buy_limit, amount=amount,
-                                     ordertype=self.strategy.order_types['buy'])['id']
+        order_id = self.exchange.buy(pair=pair, ordertype=self.strategy.order_types['buy'],
+                                     amount=amount, rate=buy_limit)['id']
 
         self.rpc.send_msg({
             'type': RPCMessageType.BUY_NOTIFICATION,
@@ -767,8 +767,9 @@ class FreqtradeBot(object):
         if sell_reason in (SellType.STOP_LOSS, SellType.TRAILING_STOP_LOSS):
             sell_type = 'stoploss'
         # Execute sell and update trade record
-        order_id = self.exchange.sell(pair=str(trade.pair), rate=limit, amount=trade.amount,
-                                      ordertype=self.strategy.order_types[sell_type])['id']
+        order_id = self.exchange.sell(pair=str(trade.pair),
+                                      ordertype=self.strategy.order_types[sell_type],
+                                      amount=trade.amount, rate=limit)['id']
         trade.open_order_id = order_id
         trade.close_rate_requested = limit
         trade.sell_reason = sell_reason.value

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -475,7 +475,8 @@ class FreqtradeBot(object):
 
         amount = stake_amount / buy_limit
 
-        order_id = self.exchange.buy(pair, buy_limit, amount)['id']
+        order_id = self.exchange.buy(pair=pair, rate=buy_limit, amount=amount,
+                                     ordertype=self.strategy.order_types['buy'])['id']
 
         self.rpc.send_msg({
             'type': RPCMessageType.BUY_NOTIFICATION,
@@ -762,8 +763,12 @@ class FreqtradeBot(object):
         :param sellreason: Reason the sell was triggered
         :return: None
         """
+        sell_type = 'sell'
+        if sell_reason in (SellType.STOP_LOSS, SellType.TRAILING_STOP_LOSS):
+            sell_type = 'stoploss'
         # Execute sell and update trade record
-        order_id = self.exchange.sell(str(trade.pair), limit, trade.amount)['id']
+        order_id = self.exchange.sell(pair=str(trade.pair), rate=limit, amount=trade.amount,
+                                      ordertype=self.strategy.order_types[sell_type])['id']
         trade.open_order_id = order_id
         trade.close_rate_requested = limit
         trade.sell_reason = sell_reason.value

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -28,6 +28,13 @@ class DefaultStrategy(IStrategy):
     # Optimal ticker interval for the strategy
     ticker_interval = '5m'
 
+    # Optional order types
+    order_types = {
+        'buy': 'limit',
+        'sell': 'limit',
+        'stoploss': 'market'
+    }
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -28,7 +28,7 @@ class DefaultStrategy(IStrategy):
     # Optimal ticker interval for the strategy
     ticker_interval = '5m'
 
-    # Optional order types
+    # Optional order type mapping
     order_types = {
         'buy': 'limit',
         'sell': 'limit',

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -32,7 +32,7 @@ class DefaultStrategy(IStrategy):
     order_types = {
         'buy': 'limit',
         'sell': 'limit',
-        'stoploss': 'market'
+        'stoploss': 'limit'
     }
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -70,6 +70,13 @@ class IStrategy(ABC):
     # associated ticker interval
     ticker_interval: str
 
+    # Optional order types
+    order_types: Dict = {
+        'buy': 'limit',
+        'sell': 'limit',
+        'stoploss': 'market'
+    }
+
     # run "populate_indicators" only for new candle
     process_only_new_candles: bool = False
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -74,7 +74,7 @@ class IStrategy(ABC):
     order_types: Dict = {
         'buy': 'limit',
         'sell': 'limit',
-        'stoploss': 'market'
+        'stoploss': 'limit'
     }
 
     # run "populate_indicators" only for new candle

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -75,6 +75,15 @@ class StrategyResolver(object):
         else:
             config['process_only_new_candles'] = self.strategy.process_only_new_candles
 
+        if 'order_types' in config:
+            self.strategy.order_types = config['order_types']
+            logger.info(
+                "Override strategy 'order_types' with value in config file: %s.",
+                config['order_types']
+            )
+        else:
+            config['order_types'] = self.strategy.order_types
+
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(
             {int(key): value for (key, value) in self.strategy.minimal_roi.items()}.items(),

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -84,6 +84,10 @@ class StrategyResolver(object):
         else:
             config['order_types'] = self.strategy.order_types
 
+        if not all(k in self.strategy.order_types for k in constants.REQUIRED_ORDERTYPES):
+            raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
+                              f"Order-types mapping is incomplete.")
+
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(
             {int(key): value for (key, value) in self.strategy.minimal_roi.items()}.items(),

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -30,6 +30,7 @@ def log_has(line, logs):
 def patch_exchange(mocker, api_mock=None) -> None:
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
+    mocker.patch('freqtrade.exchange.Exchange.validate_ordertypes', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value="Bittrex"))
     mocker.patch('freqtrade.exchange.Exchange.id', PropertyMock(return_value="bittrex"))
     if api_mock:

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -381,7 +381,7 @@ def test_buy_dry_run(default_conf, mocker):
 def test_buy_prod(default_conf, mocker):
     api_mock = MagicMock()
     order_id = 'test_prod_buy_{}'.format(randint(0, 10 ** 6))
-    api_mock.create_limit_buy_order = MagicMock(return_value={
+    api_mock.create_order = MagicMock(return_value={
         'id': order_id,
         'info': {
             'foo': 'bar'
@@ -397,22 +397,22 @@ def test_buy_prod(default_conf, mocker):
 
     # test exception handling
     with pytest.raises(DependencyException):
-        api_mock.create_limit_buy_order = MagicMock(side_effect=ccxt.InsufficientFunds)
+        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.buy(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(DependencyException):
-        api_mock.create_limit_buy_order = MagicMock(side_effect=ccxt.InvalidOrder)
+        api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.buy(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(TemporaryError):
-        api_mock.create_limit_buy_order = MagicMock(side_effect=ccxt.NetworkError)
+        api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.buy(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(OperationalException):
-        api_mock.create_limit_buy_order = MagicMock(side_effect=ccxt.BaseError)
+        api_mock.create_order = MagicMock(side_effect=ccxt.BaseError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.buy(pair='ETH/BTC', rate=200, amount=1)
 
@@ -429,7 +429,7 @@ def test_sell_dry_run(default_conf, mocker):
 def test_sell_prod(default_conf, mocker):
     api_mock = MagicMock()
     order_id = 'test_prod_sell_{}'.format(randint(0, 10 ** 6))
-    api_mock.create_limit_sell_order = MagicMock(return_value={
+    api_mock.create_order = MagicMock(return_value={
         'id': order_id,
         'info': {
             'foo': 'bar'
@@ -446,22 +446,22 @@ def test_sell_prod(default_conf, mocker):
 
     # test exception handling
     with pytest.raises(DependencyException):
-        api_mock.create_limit_sell_order = MagicMock(side_effect=ccxt.InsufficientFunds)
+        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.sell(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(DependencyException):
-        api_mock.create_limit_sell_order = MagicMock(side_effect=ccxt.InvalidOrder)
+        api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.sell(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(TemporaryError):
-        api_mock.create_limit_sell_order = MagicMock(side_effect=ccxt.NetworkError)
+        api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.sell(pair='ETH/BTC', rate=200, amount=1)
 
     with pytest.raises(OperationalException):
-        api_mock.create_limit_sell_order = MagicMock(side_effect=ccxt.BaseError)
+        api_mock.create_order = MagicMock(side_effect=ccxt.BaseError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         exchange.sell(pair='ETH/BTC', rate=200, amount=1)
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -419,18 +419,28 @@ def test_buy_prod(default_conf, mocker):
         }
     })
     default_conf['dry_run'] = False
+    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
 
     order = exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert 'id' in order
     assert 'info' in order
     assert order['id'] == order_id
+    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
     assert api_mock.create_order.call_args[0][1] == order_type
+    assert api_mock.create_order.call_args[0][2] == 'buy'
+    assert api_mock.create_order.call_args[0][3] == 1
+    assert api_mock.create_order.call_args[0][4] is None
 
     api_mock.create_order.reset_mock()
     order_type = 'limit'
     order = exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
+    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
     assert api_mock.create_order.call_args[0][1] == order_type
+    assert api_mock.create_order.call_args[0][2] == 'buy'
+    assert api_mock.create_order.call_args[0][3] == 1
+    assert api_mock.create_order.call_args[0][4] == 200
 
     # test exception handling
     with pytest.raises(DependencyException):
@@ -476,17 +486,27 @@ def test_sell_prod(default_conf, mocker):
     default_conf['dry_run'] = False
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
 
     order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert 'id' in order
     assert 'info' in order
     assert order['id'] == order_id
+    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
     assert api_mock.create_order.call_args[0][1] == order_type
+    assert api_mock.create_order.call_args[0][2] == 'sell'
+    assert api_mock.create_order.call_args[0][3] == 1
+    assert api_mock.create_order.call_args[0][4] is None
 
     api_mock.create_order.reset_mock()
     order_type = 'limit'
     order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
+    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
     assert api_mock.create_order.call_args[0][1] == order_type
+    assert api_mock.create_order.call_args[0][2] == 'sell'
+    assert api_mock.create_order.call_args[0][3] == 1
+    assert api_mock.create_order.call_args[0][4] == 200
 
     # test exception handling
     with pytest.raises(DependencyException):

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -373,7 +373,7 @@ def test_buy_dry_run(default_conf, mocker):
     default_conf['dry_run'] = True
     exchange = get_patched_exchange(mocker, default_conf)
 
-    order = exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+    order = exchange.buy(pair='ETH/BTC', ordertype='limit', amount=1, rate=200)
     assert 'id' in order
     assert 'dry_run_buy_' in order['id']
 
@@ -381,6 +381,7 @@ def test_buy_dry_run(default_conf, mocker):
 def test_buy_prod(default_conf, mocker):
     api_mock = MagicMock()
     order_id = 'test_prod_buy_{}'.format(randint(0, 10 ** 6))
+    order_type = 'market'
     api_mock.create_order = MagicMock(return_value={
         'id': order_id,
         'info': {
@@ -390,38 +391,43 @@ def test_buy_prod(default_conf, mocker):
     default_conf['dry_run'] = False
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
 
-    order = exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+    order = exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert 'id' in order
     assert 'info' in order
     assert order['id'] == order_id
+    assert api_mock.create_order.call_args[0][1] == order_type
+    order_type = 'limit'
+    api_mock.create_order.reset_mock()
+    order = exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
+    assert api_mock.create_order.call_args[0][1] == order_type
 
     # test exception handling
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+        exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+        exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(TemporaryError):
         api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+        exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(OperationalException):
         api_mock.create_order = MagicMock(side_effect=ccxt.BaseError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.buy(pair='ETH/BTC', rate=200, amount=1)
+        exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
 
 def test_sell_dry_run(default_conf, mocker):
     default_conf['dry_run'] = True
     exchange = get_patched_exchange(mocker, default_conf)
 
-    order = exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+    order = exchange.sell(pair='ETH/BTC', ordertype='limit', amount=1, rate=200)
     assert 'id' in order
     assert 'dry_run_sell_' in order['id']
 
@@ -429,6 +435,7 @@ def test_sell_dry_run(default_conf, mocker):
 def test_sell_prod(default_conf, mocker):
     api_mock = MagicMock()
     order_id = 'test_prod_sell_{}'.format(randint(0, 10 ** 6))
+    order_type = 'market'
     api_mock.create_order = MagicMock(return_value={
         'id': order_id,
         'info': {
@@ -439,31 +446,37 @@ def test_sell_prod(default_conf, mocker):
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
 
-    order = exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+    order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert 'id' in order
     assert 'info' in order
     assert order['id'] == order_id
+    assert api_mock.create_order.call_args[0][1] == order_type
+
+    order_type = 'limit'
+    api_mock.create_order.reset_mock()
+    order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
+    assert api_mock.create_order.call_args[0][1] == order_type
 
     # test exception handling
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+        exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+        exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(TemporaryError):
         api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+        exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
     with pytest.raises(OperationalException):
         api_mock.create_order = MagicMock(side_effect=ccxt.BaseError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.sell(pair='ETH/BTC', rate=200, amount=1)
+        exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
 
 
 def test_get_balance_dry_run(default_conf, mocker):

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -396,8 +396,9 @@ def test_buy_prod(default_conf, mocker):
     assert 'info' in order
     assert order['id'] == order_id
     assert api_mock.create_order.call_args[0][1] == order_type
-    order_type = 'limit'
+
     api_mock.create_order.reset_mock()
+    order_type = 'limit'
     order = exchange.buy(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert api_mock.create_order.call_args[0][1] == order_type
 
@@ -452,8 +453,8 @@ def test_sell_prod(default_conf, mocker):
     assert order['id'] == order_id
     assert api_mock.create_order.call_args[0][1] == order_type
 
-    order_type = 'limit'
     api_mock.create_order.reset_mock()
+    order_type = 'limit'
     order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
     assert api_mock.create_order.call_args[0][1] == order_type
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -182,6 +182,32 @@ def test_strategy_override_process_only_new_candles(caplog):
             ) in caplog.record_tuples
 
 
+def test_strategy_override_order_types(caplog):
+    caplog.set_level(logging.INFO)
+
+    order_types = {
+        'buy': 'market',
+        'sell': 'limit',
+        'stoploss': 'limit'
+    }
+
+    config = {
+        'strategy': 'DefaultStrategy',
+        'order_types': order_types
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.order_types
+    for method in ['buy', 'sell', 'stoploss']:
+        assert resolver.strategy.order_types[method] == order_types[method]
+
+    assert ('freqtrade.strategy.resolver',
+            logging.INFO,
+            "Override strategy 'order_types' with value in config file:"
+            " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit'}."
+            ) in caplog.record_tuples
+
+
 def test_deprecate_populate_indicators(result):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     resolver = StrategyResolver({'strategy': 'TestStrategyLegacy',

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -88,8 +88,8 @@ def test_load_strategy_invalid_directory(result, caplog):
 def test_load_not_found_strategy():
     strategy = StrategyResolver()
     with pytest.raises(ImportError,
-                       match=r'Impossible to load Strategy \'NotFoundStrategy\'.'
-                             r' This class does not exist or contains Python code errors'):
+                       match=r"Impossible to load Strategy 'NotFoundStrategy'."
+                             r" This class does not exist or contains Python code errors"):
         strategy._load_strategy(strategy_name='NotFoundStrategy', config={})
 
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -207,6 +207,16 @@ def test_strategy_override_order_types(caplog):
             " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit'}."
             ) in caplog.record_tuples
 
+    config = {
+        'strategy': 'DefaultStrategy',
+        'order_types': {'buy': 'market'}
+    }
+    # Raise error for invalid configuration
+    with pytest.raises(ImportError,
+                       match=r"Impossible to load Strategy 'DefaultStrategy'. "
+                             r"Order-types mapping is incomplete."):
+        StrategyResolver(config)
+
 
 def test_deprecate_populate_indicators(result):
     default_location = path.join(path.dirname(path.realpath(__file__)))

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -553,7 +553,7 @@ def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order,
     patch_get_signal(freqtrade)
 
     freqtrade.create_trade()
-    rate, amount = buy_mock.call_args[0][1], buy_mock.call_args[0][2]
+    rate, amount = buy_mock.call_args[1]['rate'], buy_mock.call_args[1]['amount']
     assert rate * amount >= default_conf['stake_amount']
 
 
@@ -863,10 +863,10 @@ def test_execute_buy(mocker, default_conf, fee, markets, limit_buy_order) -> Non
     assert freqtrade.execute_buy(pair, stake_amount)
     assert get_bid.call_count == 1
     assert buy_mm.call_count == 1
-    call_args = buy_mm.call_args_list[0][0]
-    assert call_args[0] == pair
-    assert call_args[1] == bid
-    assert call_args[2] == stake_amount / bid
+    call_args = buy_mm.call_args_list[0][1]
+    assert call_args['pair'] == pair
+    assert call_args['rate'] == bid
+    assert call_args['amount'] == stake_amount / bid
 
     # Test calling with price
     fix_price = 0.06
@@ -875,10 +875,10 @@ def test_execute_buy(mocker, default_conf, fee, markets, limit_buy_order) -> Non
     assert get_bid.call_count == 1
 
     assert buy_mm.call_count == 2
-    call_args = buy_mm.call_args_list[1][0]
-    assert call_args[0] == pair
-    assert call_args[1] == fix_price
-    assert call_args[2] == stake_amount / fix_price
+    call_args = buy_mm.call_args_list[1][1]
+    assert call_args['pair'] == pair
+    assert call_args['rate'] == fix_price
+    assert call_args['amount'] == stake_amount / fix_price
 
 
 def test_process_maybe_execute_buy(mocker, default_conf) -> None:

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -48,6 +48,13 @@ class TestStrategy(IStrategy):
     # run "populate_indicators" only for new candle
     ta_on_candle = False
 
+    # Optional order type mapping
+    order_types = {
+        'buy': 'limit',
+        'sell': 'limit',
+        'stoploss': 'market'
+    }
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame


### PR DESCRIPTION
## Summary
As mentioned in #1326, there is a pretty simple way to support different order types.

Solves issue: #893

## Quick changelog

- Add order mapping between buy/sell/stoploss - allowing different types for each order

## still todo

this is a very quick drawup on how i immagine this to work, and it's nowhere near production ready.

* [x] documentation
* [x] add tests to verify that parameter is passed to ccxt correctly
* [x] allow setting this in configuration
* [x] add to default sample strategy
* [x] add test to check strategy validity
* [x] fix tests