### PR TITLE
Fix missing mock in backtesting

### DIFF
--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -634,6 +634,7 @@ def test_backtest_only_sell(mocker, default_conf):
 
 def test_backtest_alternate_buy_sell(default_conf, fee, mocker):
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
+    mocker.patch('freqtrade.optimize.backtesting.file_dump_json', MagicMock())
     backtest_conf = _make_backtest_conf(mocker, conf=default_conf, pair='UNITTEST/BTC')
     backtesting = Backtesting(default_conf)
     backtesting.advise_buy = _trend_alternate  # Override


### PR DESCRIPTION
## Summary
running tests  left a file called `test_.json` behind - this is anoying... as it creates a dirty git state.
