### PR TITLE
[WIP] Passing "context" to the strategy advise_buy and sell. it contains useful data such as current ticker and current trades.

### DIFF
--- a/freqtrade/context.py
+++ b/freqtrade/context.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict
+from collections import namedtuple
+
+
+class Context(object):
+
+    # context data structure
+    context = namedtuple(
+        'context',
+        ['trades', 'ticker']
+    )


### PR DESCRIPTION
## Intro 
One of the current FT problem is that the strategy has a limited visibility. It is limited to TA signals and pair name (via metadata). It doesn't know how many trades are currently open, what is the spot price, and many more. 
## Solution
Context class contains a structured data of useful information about current state of the bot. its aim Is to give as comprehensive data as possible to the strategy. 
For now I can think of the last ticker and trade numbers. but many things can be added in future. 
## How will it be baked in?
By initializing context class in freqtradebot.py at passing it to advise_buy and advise_sell.