### PR TITLE
Fix twice refresh ticker call

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -194,9 +194,6 @@ class FreqtradeBot(object):
                 self.edge.calculate()
                 self.active_pair_whitelist = self.edge.adjust(self.active_pair_whitelist)
 
-            # Refreshing candles
-            self.exchange.refresh_tickers(self.active_pair_whitelist, self.strategy.ticker_interval)
-
             # Query trades from persistence layer
             trades = Trade.query.filter(Trade.is_open.is_(True)).all()
 


### PR DESCRIPTION
For some reason there were two lines of 
`self.exchange.refresh_tickers(self.active_pair_whitelist, self.strategy.ticker_interval)`
Removed one of them.