### PR TITLE
Add Note about order types support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,9 @@ The below is the default which is used if this is not configured in either Strat
     },
 ```
 
+**NOTE**: Not all exchanges support "market" orders.
+The following message will be shown if your exchange does not support market orders: `"Exchange <yourexchange>  does not support market orders."`
+
 ### What values for exchange.name?
 
 Freqtrade is based on [CCXT library](https://github.com/ccxt/ccxt) that supports 115 cryptocurrency


### PR DESCRIPTION
## Summary

as pointed out [here](https://github.com/freqtrade/freqtrade/commit/d72e605cb70ffda6622601df0441ce60f84bf92a#commitcomment-31404278) - we should add a note to the docs that not all exchanges support all ordertypes.
