### PR TITLE
async followup PR

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -501,51 +501,6 @@ class Exchange(object):
             raise OperationalException(f'Could not fetch ticker data. Msg: {e}')
 
     @retrier
-    def get_candle_history(self, pair: str, tick_interval: str,
-                           since_ms: Optional[int] = None) -> List[Dict]:
-        try:
-            # last item should be in the time interval [now - tick_interval, now]
-            till_time_ms = arrow.utcnow().shift(
-                            minutes=-constants.TICKER_INTERVAL_MINUTES[tick_interval]
-                        ).timestamp * 1000
-            # it looks as if some exchanges return cached data
-            # and they update it one in several minute, so 10 mins interval
-            # is necessary to skeep downloading of an empty array when all
-            # chached data was already downloaded
-            till_time_ms = min(till_time_ms, arrow.utcnow().shift(minutes=-10).timestamp * 1000)
-
-            data: List[Dict[Any, Any]] = []
-            while not since_ms or since_ms < till_time_ms:
-                data_part = self._api.fetch_ohlcv(pair, timeframe=tick_interval, since=since_ms)
-
-                # Because some exchange sort Tickers ASC and other DESC.
-                # Ex: Bittrex returns a list of tickers ASC (oldest first, newest last)
-                # when GDAX returns a list of tickers DESC (newest first, oldest last)
-                data_part = sorted(data_part, key=lambda x: x[0])
-
-                if not data_part:
-                    break
-
-                logger.debug('Downloaded data for %s time range [%s, %s]',
-                             pair,
-                             arrow.get(data_part[0][0] / 1000).format(),
-                             arrow.get(data_part[-1][0] / 1000).format())
-
-                data.extend(data_part)
-                since_ms = data[-1][0] + 1
-
-            return data
-        except ccxt.NotSupported as e:
-            raise OperationalException(
-                f'Exchange {self._api.name} does not support fetching historical candlestick data.'
-                f'Message: {e}')
-        except (ccxt.NetworkError, ccxt.ExchangeError) as e:
-            raise TemporaryError(
-                f'Could not load ticker history due to {e.__class__.__name__}. Message: {e}')
-        except ccxt.BaseError as e:
-            raise OperationalException(f'Could not fetch ticker data. Msg: {e}')
-
-    @retrier
     def cancel_order(self, order_id: str, pair: str) -> None:
         if self._conf['dry_run']:
             return

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -478,7 +478,9 @@ class Exchange(object):
             # Because some exchange sort Tickers ASC and other DESC.
             # Ex: Bittrex returns a list of tickers ASC (oldest first, newest last)
             # when GDAX returns a list of tickers DESC (newest first, oldest last)
-            data = sorted(data, key=lambda x: x[0])
+            # Only sort if necessary to save computing time
+            if data and data[0][0] > data[-1][0]:
+                data = sorted(data, key=lambda x: x[0])
 
             # keeping last candle time as last refreshed time of the pair
             if data:

--- a/freqtrade/exchange/exchange_helpers.py
+++ b/freqtrade/exchange/exchange_helpers.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def parse_ticker_dataframe(ticker: list) -> DataFrame:
     """
     Analyses the trend for the given ticker history
-    :param ticker: See exchange.get_candle_history
+    :param ticker: ticker list, as returned by exchange.async_get_candle_history
     :return: DataFrame
     """
     cols = ['date', 'open', 'high', 'low', 'close', 'volume']


### PR DESCRIPTION
## Summary
Remove non-used method (everything related to this has been moved to async)

Only sort candles when necessary

Solve the issue: #1196 

## Quick changelog

- remove `get_candle_history`
- migrated sorted tests to async
- sort only when necessary
