### PR TITLE
Should fallback to strategy stoploss if Edge cannot provide.

### DIFF
--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -157,7 +157,13 @@ class Edge():
         return position_size
 
     def stoploss(self, pair: str) -> float:
-        return self._cached_pairs[pair].stoploss
+        if pair in self._cached_pairs:
+            return self._cached_pairs[pair].stoploss
+        else:
+            logger.warning('tried to access stoploss of a non-existing pair, '
+                           'strategy stoploss is returned instead.')
+            return self.strategy.stoploss
+
 
     def adjust(self, pairs) -> list:
         """

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -164,7 +164,6 @@ class Edge():
                            'strategy stoploss is returned instead.')
             return self.strategy.stoploss
 
-
     def adjust(self, pairs) -> list:
         """
         Filters out and sorts "pairs" according to Edge calculated pairs

--- a/freqtrade/tests/edge/test_edge.py
+++ b/freqtrade/tests/edge/test_edge.py
@@ -152,6 +152,17 @@ def test_stoploss(mocker, default_conf):
     assert edge.stoploss('E/F') == -0.01
 
 
+def test_nonexisting_stoploss(mocker, default_conf):
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    edge = Edge(default_conf, freqtrade.exchange, freqtrade.strategy)
+    mocker.patch('freqtrade.edge.Edge._cached_pairs', mocker.PropertyMock(
+        return_value={
+            'E/F': PairInfo(-0.01, 0.66, 3.71, 0.50, 1.71, 10, 60),
+        }
+    ))
+
+    assert edge.stoploss('N/O') == -0.1
+
 def _validate_ohlc(buy_ohlc_sell_matrice):
     for index, ohlc in enumerate(buy_ohlc_sell_matrice):
         # if not high < open < low or not high < close < low

--- a/freqtrade/tests/edge/test_edge.py
+++ b/freqtrade/tests/edge/test_edge.py
@@ -163,6 +163,7 @@ def test_nonexisting_stoploss(mocker, default_conf):
 
     assert edge.stoploss('N/O') == -0.1
 
+
 def _validate_ohlc(buy_ohlc_sell_matrice):
     for index, ohlc in enumerate(buy_ohlc_sell_matrice):
         # if not high < open < low or not high < close < low


### PR DESCRIPTION
## Summary
When Edge doesn't have a stoploss for a pair it should return strategy stoploss, otherwise the bot crashes.

Solve the issue: #1370 