### PR TITLE
refactor startup_messages to rpc_manger

### DIFF
--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -4,7 +4,7 @@ This module contains class to manage RPC communications (Telegram, Slack, ...)
 import logging
 from typing import List, Dict, Any
 
-from freqtrade.rpc import RPC
+from freqtrade.rpc import RPC, RPCMessageType
 
 logger = logging.getLogger(__name__)
 
@@ -51,3 +51,35 @@ class RPCManager(object):
         for mod in self.registered_modules:
             logger.debug('Forwarding message to rpc.%s', mod.name)
             mod.send_msg(msg)
+
+    def startup_messages(self, config) -> None:
+        if config.get('dry_run', False):
+            self.send_msg({
+                'type': RPCMessageType.WARNING_NOTIFICATION,
+                'status': 'Dry run is enabled. All trades are simulated.'
+            })
+        stake_currency = config['stake_currency']
+        stake_amount = config['stake_amount']
+        minimal_roi = config['minimal_roi']
+        ticker_interval = config['ticker_interval']
+        exchange_name = config['exchange']['name']
+        strategy_name = config.get('strategy', '')
+        self.send_msg({
+            'type': RPCMessageType.CUSTOM_NOTIFICATION,
+            'status': f'*Exchange:* `{exchange_name}`\n'
+                      f'*Stake per trade:* `{stake_amount} {stake_currency}`\n'
+                      f'*Minimum ROI:* `{minimal_roi}`\n'
+                      f'*Ticker Interval:* `{ticker_interval}`\n'
+                      f'*Strategy:* `{strategy_name}`'
+        })
+        if config.get('dynamic_whitelist', False):
+            top_pairs = 'top volume ' + str(config.get('dynamic_whitelist', 20))
+            specific_pairs = ''
+        else:
+            top_pairs = 'whitelisted'
+            specific_pairs = '\n' + ', '.join(config['exchange'].get('pair_whitelist', ''))
+        self.send_msg({
+            'type': RPCMessageType.STATUS_NOTIFICATION,
+            'status': f'Searching for {top_pairs} {stake_currency} pairs to buy and sell...'
+                      f'{specific_pairs}'
+        })


### PR DESCRIPTION

## Summary
refactor startup_messages to rpc_manger
this cleans up freqtradebot slightly, as this method/class is overly crouded and long.

* also adds test.