### PR TITLE
Add commit and message to container

### DIFF
--- a/build_helpers/publish_docker.sh
+++ b/build_helpers/publish_docker.sh
@@ -4,6 +4,9 @@
 TAG=$(echo "${TRAVIS_BRANCH}" | sed -e "s/\//_/")
 
 
+# Add commit and commit_message to docker container
+echo "${TRAVIS_COMMIT} ${TRAVIS_COMMIT_MESSAGE}" > freqtrade_commit
+
 if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
     echo "event ${TRAVIS_EVENT_TYPE}: full rebuild - skipping cache"
     docker build -t freqtrade:${TAG} .


### PR DESCRIPTION
Add commit and message to container

without this, we have no (easy) way of knowing which commit the latest / develop container is running, which makes debugging problems in containers almost impossible.

output:
```
docker run -it --entrypoint bash freqtradeorg/freqtrade:feat_improve_travis

root@40204a56b46c:/freqtrade# cat freqtrade_commit
3a086aac58f4f2fd3530910d1adc3154e9c3ea73 Add commit and message to container

```
