### PR TITLE
Specify JsonValidatorversion explicitly

### DIFF
--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -275,7 +275,7 @@ class Configuration(object):
         :return: Returns the config if valid, otherwise throw an exception
         """
         try:
-            validate(conf, constants.CONF_SCHEMA)
+            validate(conf, constants.CONF_SCHEMA, Draft4Validator)
             return conf
         except ValidationError as exception:
             logger.critical(

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -6,7 +6,7 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from jsonschema import validate, ValidationError
+from jsonschema import validate, ValidationError, Draft4Validator
 
 from freqtrade import constants
 from freqtrade import OperationalException
@@ -486,4 +486,4 @@ def test_load_config_warn_forcebuy(default_conf, mocker, caplog) -> None:
 
 
 def test_validate_default_conf(default_conf) -> None:
-    validate(default_conf, constants.CONF_SCHEMA)
+    validate(default_conf, constants.CONF_SCHEMA, Draft4Validator)


### PR DESCRIPTION
without doing that, it exclusiveMaximum raises an exception
as jsonschema defaults to the latest version (Draft6)
which changes behaviour of this property.

fixes #1233

Once jsonschema is updated to stable version 3.0.0 we can switch the validatior to Draf6, however version 2.6.0 does not support that yet.

*for the future*: Note that this change will require a slight change in how `exclusiveMaximum` is used, so we should stick to draft4 until most of the users upgraded.