### PR TITLE
Drop indexes on renamed table during migration

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -100,6 +100,9 @@ def check_migrate(engine) -> None:
 
         # Schema migration necessary
         engine.execute(f"alter table trades rename to {table_back_name}")
+        # drop indexes on backup table
+        for index in inspector.get_indexes(table_back_name):
+            engine.execute(f"drop index {index['name']}")
         # let SQLAlchemy create the schema as required
         _DECL_BASE.metadata.create_all(engine)
 

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -446,6 +446,8 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
 
     # Create table using the old format
     engine.execute(create_table_old)
+    engine.execute("create index ix_trades_is_open on trades(is_open)")
+    engine.execute("create index ix_trades_pair on trades(pair)")
     engine.execute(insert_table_old)
 
     # fake previous backup


### PR DESCRIPTION
## Summary
avoid naming conflicts on recreate (indexes are not renamed, and keeping
them on backup tables does not really make sense).

Solve the issue: #1396