### PR TITLE
Add link to edge documentation in bot-usage

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -240,6 +240,8 @@ optional arguments:
                         --stoplosses=-0.01,-0.1,-0.001
 ```
 
+To understand edge and how to read the results, please read the [edge documentation](edge.md).
+
 ## A parameter missing in the configuration?
 
 All parameters for `main.py`, `backtesting`, `hyperopt` are referenced


### PR DESCRIPTION
having the commands to run is nice ... but to understand the results, one needs to read the edge documentation ...

this (partially, at least) fixes #1380.