### PR TITLE
Seperate requirements to run the bot and to develop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - ./build_helpers/install_ta-lib.sh
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 - pip install --upgrade flake8 coveralls pytest-random-order pytest-asyncio mypy
-- pip install -r requirements.txt
+- pip install -r requirements-dev.txt
 - pip install -e .
 jobs:
   include:

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,0 +1,9 @@
+FROM freqtrade:latest
+
+# Install dependencies
+COPY requirements-dev.txt /freqtrade/
+RUN pip install numpy --no-cache-dir \
+  && pip install -r requirements-dev.txt --no-cache-dir
+
+# Empty the ENTRYPOINT to allow all commands
+ENTRYPOINT []

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM freqtrade:latest
+FROM freqtradeorg/freqtrade:develop
 
 # Install dependencies
 COPY requirements-dev.txt /freqtrade/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,11 +134,10 @@ cd freqtrade
 docker build -t freqtrade .
 ```
 
-If you are developing using Docker, use `Dockerfile.develop` instead, which will also set up develop dependencies:
+If you are developing using Docker, use `Dockerfile.develop` to build a dev Docker image, which will also set up develop dependencies:
 
 ```bash
-cd freqtrade
-docker build -f ./Dockerfile.develop -t freqtrade .
+docker build -f ./Dockerfile.develop -t freqtrade-dev .
 ```
 
 For security reasons, your configuration file will not be included in the image, you will need to bind mount it. It is also advised to bind mount an SQLite database file (see the "5. Run a restartable docker image" section) to keep it between  updates.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,6 +134,13 @@ cd freqtrade
 docker build -t freqtrade .
 ```
 
+If you are developing using Docker, use `Dockerfile.develop` instead, which will also set up develop dependencies:
+
+```bash
+cd freqtrade
+docker build -f ./Dockerfile.develop -t freqtrade .
+```
+
 For security reasons, your configuration file will not be included in the image, you will need to bind mount it. It is also advised to bind mount an SQLite database file (see the "5. Run a restartable docker image" section) to keep it between  updates.
 
 ### 3. Verify the Docker image

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Include all requirements to run the bot.
+-r requirements.txt
+
+flake8==3.6.0
+pytest==4.0.2
+pytest-mock==1.10.0
+pytest-asyncio==0.9.0
+pytest-cov==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,18 +13,11 @@ scipy==1.1.0
 jsonschema==2.6.0
 numpy==1.15.4
 TA-Lib==0.4.17
-pytest==4.0.2
-pytest-mock==1.10.0
-pytest-asyncio==0.9.0
-pytest-cov==2.6.0
 tabulate==0.8.2
 coinmarketcap==5.0.3
 
 # Required for hyperopt
 scikit-optimize==0.5.2
-
-# Required for plotting data
-#plotly==3.1.1
 
 # find first, C search in arrays
 py_find_1st==1.1.3

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,16 @@ function updateenv () {
     pip3 install --quiet --upgrade pip
     pip3 install --quiet -r requirements.txt --upgrade
     pip3 install --quiet -r requirements.txt
+
+    read -p "Do you want to install dependencies for dev [Y/N]? "
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        pip3 install --quiet -r requirements-dev.txt --upgrade
+        pip3 install --quiet -r requirements-dev.txt
+    else
+        echo "Dev dependencies ignored."
+    fi
+
     pip3 install --quiet -e .
     echo "pip3 install completed"
     echo


### PR DESCRIPTION
## Summary
Separate development dependencies in another requirements file and Dockerfile.

Solve the issue: #1356

## Quick changelog

- Add a requirements-dev.txt file which includes additional deps for development.
- Add a Dockerfile.develop which installs all deps for development and also enables dev commands.
- Change related documentations on how to run/dev the bot.
