### PR TITLE
Remaining amount in check_handle_timedout should be treated as float not int.

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -694,7 +694,7 @@ class FreqtradeBot(object):
             ordertime = arrow.get(order['datetime']).datetime
 
             # Check if trade is still actually open
-            if int(order['remaining']) == 0:
+            if float(order['remaining']) == 0.0:
                 self.wallets.update()
                 continue
 


### PR DESCRIPTION
## Summary
in `check_handle_timedout` remaining amount is converted to ìnt`before comparison leading to cases as described in #1424 

I don't see any reason for it. changing it to float solves the problem.

Solve the issue: #1424 