### PR TITLE
Download data config

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -379,6 +379,15 @@ class Arguments(object):
         )
 
         self.parser.add_argument(
+            '-c', '--config',
+            help='specify configuration file, used for additional exchange parameters',
+            dest='config',
+            default=None,
+            type=str,
+            metavar='PATH',
+        )
+
+        self.parser.add_argument(
             '--days',
             help='Download data for number of days',
             dest='days',
@@ -389,7 +398,7 @@ class Arguments(object):
 
         self.parser.add_argument(
             '--exchange',
-            help='Exchange name (default: %(default)s)',
+            help='Exchange name (default: %(default)s). Only valid if no config is provided',
             dest='exchange',
             type=str,
             default='bittrex'

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -54,12 +54,12 @@ print(f'About to download pairs: {PAIRS} to {dl_path}')
 
 
 # Init exchange
-exchange = Exchange({'key': '',
-                     'secret': '',
-                     'stake_currency': '',
+exchange = Exchange({'stake_currency': '',
                      'dry_run': True,
                      'exchange': {
                          'name': args.exchange,
+                         'key': '',
+                         'secret': '',
                          'pair_whitelist': [],
                          'ccxt_async_config': {
                              "enableRateLimit": False


### PR DESCRIPTION
## Summary
allow providing --config to the download script.

This allows flexible configuration of the additional exchange properties (like `ccxt_async_config` - which by default does not work with kraken as it get's you blocked after 3-5 requests.

This way, a configuration working for regular bot operations does also work to download pairs.

Configuration values override `--exchange` - which is also mentioned in the help.