### PR TITLE
Reset stake-currency when using config to download pairs

### DIFF
--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -31,6 +31,7 @@ if args.config:
     configuration = Configuration(args)
     config = configuration._load_config_file(args.config)
 
+    config['stake_currency'] = ''
     # Ensure we do not use Exchange credentials
     config['exchange']['key'] = ''
     config['exchange']['secret'] = ''


### PR DESCRIPTION
## Summary
Fix problem when using download-script with `--config ` in combination of `--pairlist` with different stake currency.

Stake-currency is not relevant for downloading pairs.