### PR TITLE
Replace ujson with rapidjson

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -13,7 +13,6 @@ from typing import Optional, List, Dict, Tuple, Any
 
 import arrow
 from pandas import DataFrame
-import rapidjson
 
 from freqtrade import misc, constants, OperationalException
 from freqtrade.data.converter import parse_ticker_dataframe
@@ -21,15 +20,6 @@ from freqtrade.exchange import Exchange
 from freqtrade.arguments import TimeRange
 
 logger = logging.getLogger(__name__)
-
-
-def json_load(data):
-    """
-    load data with rapidjson
-    Use this to have a consistent experience,
-    sete number_mode to "NM_NATIVE" for greatest speed
-    """
-    return rapidjson.load(data, number_mode=rapidjson.NM_NATIVE)
 
 
 def trim_tickerlist(tickerlist: List[Dict], timerange: TimeRange) -> List[Dict]:
@@ -83,11 +73,11 @@ def load_tickerdata_file(
     if gzipfile.is_file():
         logger.debug('Loading ticker data from file %s', gzipfile)
         with gzip.open(gzipfile) as tickerdata:
-            pairdata = json_load(tickerdata)
+            pairdata = misc.json_load(tickerdata)
     elif file.is_file():
         logger.debug('Loading ticker data from file %s', file)
         with open(file) as tickerdata:
-            pairdata = json_load(tickerdata)
+            pairdata = misc.json_load(tickerdata)
     else:
         return None
 
@@ -185,7 +175,7 @@ def load_cached_data_for_updating(filename: Path, tick_interval: str,
     # read the cached file
     if filename.is_file():
         with open(filename, "rt") as file:
-            data = json_load(file)
+            data = misc.json_load(file)
         # remove the last item, could be incomplete candle
         if data:
             data.pop()

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -13,7 +13,7 @@ from typing import Optional, List, Dict, Tuple, Any
 
 import arrow
 from pandas import DataFrame
-import ujson
+import rapidjson
 
 from freqtrade import misc, constants, OperationalException
 from freqtrade.data.converter import parse_ticker_dataframe
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 def json_load(data):
     """
-    load data with ujson
+    load data with rapidjson
     Use this to have a consistent experience,
-    otherwise "precise_float" needs to be passed to all load operations
+    sete number_mode to "NM_NATIVE" for greatest speed
     """
-    return ujson.load(data, precise_float=True)
+    return rapidjson.load(data, number_mode=rapidjson.NM_NATIVE)
 
 
 def trim_tickerlist(tickerlist: List[Dict], timerange: TimeRange) -> List[Dict]:

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -67,18 +67,10 @@ def load_tickerdata_file(
     path = make_testdata_path(datadir)
     pair_s = pair.replace('/', '_')
     file = path.joinpath(f'{pair_s}-{ticker_interval}.json')
-    gzipfile = file.with_suffix(file.suffix + '.gz')
 
-    # Try gzip file first, otherwise regular json file.
-    if gzipfile.is_file():
-        logger.debug('Loading ticker data from file %s', gzipfile)
-        with gzip.open(gzipfile) as tickerdata:
-            pairdata = misc.json_load(tickerdata)
-    elif file.is_file():
-        logger.debug('Loading ticker data from file %s', file)
-        with open(file) as tickerdata:
-            pairdata = misc.json_load(tickerdata)
-    else:
+    pairdata = misc.file_load_json(file)
+
+    if not pairdata:
         return None
 
     if timerange:

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -5,8 +5,6 @@ includes:
 * download data from exchange and store to disk
 """
 
-import gzip
-
 import logging
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Any

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -71,7 +71,7 @@ def file_dump_json(filename, data, is_zip=False) -> None:
     :param data: JSON Data to save
     :return:
     """
-    print(f'dumping json to "{filename}"')
+    logger.info(f'dumping json to "{filename}"')
 
     if is_zip:
         if not filename.endswith('.gz'):
@@ -81,6 +81,8 @@ def file_dump_json(filename, data, is_zip=False) -> None:
     else:
         with open(filename, 'w') as fp:
             rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
+
+    logger.debug(f'done json to "{filename}"')
 
 
 def json_load(datafile):

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -3,7 +3,6 @@ Various tool function for Freqtrade and scripts
 """
 
 import gzip
-import json
 import logging
 import re
 from datetime import datetime
@@ -11,6 +10,7 @@ from typing import Dict
 
 import numpy as np
 from pandas import DataFrame
+import rapidjson
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +77,10 @@ def file_dump_json(filename, data, is_zip=False) -> None:
         if not filename.endswith('.gz'):
             filename = filename + '.gz'
         with gzip.open(filename, 'w') as fp:
-            json.dump(data, fp, default=str)
+            rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
     else:
         with open(filename, 'w') as fp:
-            json.dump(data, fp, default=str)
+            rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
 
 
 def format_ms_time(date: int) -> str:

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -83,13 +83,31 @@ def file_dump_json(filename, data, is_zip=False) -> None:
             rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
 
 
-def json_load(data):
+def json_load(datafile):
     """
     load data with rapidjson
     Use this to have a consistent experience,
     sete number_mode to "NM_NATIVE" for greatest speed
     """
-    return rapidjson.load(data, number_mode=rapidjson.NM_NATIVE)
+    return rapidjson.load(datafile, number_mode=rapidjson.NM_NATIVE)
+
+
+def file_load_json(file):
+
+    gzipfile = file.with_suffix(file.suffix + '.gz')
+
+    # Try gzip file first, otherwise regular json file.
+    if gzipfile.is_file():
+        logger.debug('Loading ticker data from file %s', gzipfile)
+        with gzip.open(gzipfile) as tickerdata:
+            pairdata = json_load(tickerdata)
+    elif file.is_file():
+        logger.debug('Loading ticker data from file %s', file)
+        with open(file) as tickerdata:
+            pairdata = json_load(tickerdata)
+    else:
+        return None
+    return pairdata
 
 
 def format_ms_time(date: int) -> str:

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -83,6 +83,15 @@ def file_dump_json(filename, data, is_zip=False) -> None:
             rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
 
 
+def json_load(data):
+    """
+    load data with rapidjson
+    Use this to have a consistent experience,
+    sete number_mode to "NM_NATIVE" for greatest speed
+    """
+    return rapidjson.load(data, number_mode=rapidjson.NM_NATIVE)
+
+
 def format_ms_time(date: int) -> str:
     """
     convert MS date to readable format.

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -450,7 +450,7 @@ def test_trim_tickerlist() -> None:
     assert not ticker
 
 
-def test_file_dump_json() -> None:
+def test_file_dump_json_tofile() -> None:
     file = os.path.join(os.path.dirname(__file__), '..', 'testdata',
                         'test_{id}.json'.format(id=str(uuid.uuid4())))
     data = {'bar': 'foo'}

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -2,11 +2,12 @@
 
 import datetime
 from unittest.mock import MagicMock
+from pathlib import Path
 
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.misc import (common_datearray, datesarray_to_datetimearray,
-                            file_dump_json, format_ms_time, shorten_date)
-from freqtrade.data.history import load_tickerdata_file
+                            file_dump_json, file_load_json, format_ms_time, shorten_date)
+from freqtrade.data.history import load_tickerdata_file, make_testdata_path
 from freqtrade.strategy.default_strategy import DefaultStrategy
 
 
@@ -55,6 +56,19 @@ def test_file_dump_json(mocker) -> None:
     file_dump_json('somefile', [1, 2, 3], True)
     assert file_open.call_count == 1
     assert json_dump.call_count == 1
+
+
+def test_file_load_json(mocker) -> None:
+
+    # 7m .json does not exist
+    ret = file_load_json(make_testdata_path(None).joinpath('UNITTEST_BTC-7m.json'))
+    assert not ret
+    # 1m json exists (but no .gz exists)
+    ret = file_load_json(make_testdata_path(None).joinpath('UNITTEST_BTC-1m.json'))
+    assert ret
+    # 8 .json is empty and will fail if it's loaded. .json.gz is a copy of 1.json
+    ret = file_load_json(make_testdata_path(None).joinpath('UNITTEST_BTC-8m.json'))
+    assert ret
 
 
 def test_format_ms_time() -> None:

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -2,7 +2,6 @@
 
 import datetime
 from unittest.mock import MagicMock
-from pathlib import Path
 
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.misc import (common_datearray, datesarray_to_datetimearray,

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -46,12 +46,12 @@ def test_common_datearray(default_conf) -> None:
 
 def test_file_dump_json(mocker) -> None:
     file_open = mocker.patch('freqtrade.misc.open', MagicMock())
-    json_dump = mocker.patch('json.dump', MagicMock())
+    json_dump = mocker.patch('rapidjson.dump', MagicMock())
     file_dump_json('somefile', [1, 2, 3])
     assert file_open.call_count == 1
     assert json_dump.call_count == 1
     file_open = mocker.patch('freqtrade.misc.gzip.open', MagicMock())
-    json_dump = mocker.patch('json.dump', MagicMock())
+    json_dump = mocker.patch('rapidjson.dump', MagicMock())
     file_dump_json('somefile', [1, 2, 3], True)
     assert file_open.call_count == 1
     assert json_dump.call_count == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ scikit-optimize==0.5.2
 py_find_1st==1.1.3
 
 #Load ticker files 30% faster
-ujson==1.35
+python-rapidjson==0.6.3

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='freqtrade',
           'cachetools',
           'coinmarketcap',
           'scikit-optimize',
-          'ujson',
+          'python-rapidjson',
           'py_find_1st'
       ],
       include_package_data=True,


### PR DESCRIPTION
## Summary
This will replace `ujson` with `rapidjson`.

Writing files to disk does also take a long time with the regular json module (updating 5m historic data (~5m) does take multiple seconds to write to disk (longer than downloading 1 days of data).

Writing with ujson however concerns me (see below for reasons). Rapidjson does offer similar performance, while beeing maintained and supported.

### new:
* replace `ujson` with `rapidjson`
* use rapidjson for writing as well (speeds up download script / `backtesting --refresh-pairs-cached`)
* Writing with rapidjson (or ujson) does create files without whitespace, which however is fine for our usecase as it keeps files smaller.

#### Reasons:

* ujson is unmaintained (last release was 2 years ago)
* github repository abandoned
* unresponsive in their issues 
* no wheel builds (compile from source during pip install)
* has several memory leaks when writing  (see issue tracker [here](https://github.com/esnme/ultrajson/issues)

* rapidjson has similar performance [here](https://python-rapidjson.readthedocs.io/en/latest/benchmarks.html)
* rapidjson is maintained and maintainers are responsive
* rapidjson does provide [wheels](https://pypi.org/project/python-rapidjson/#files) for simple installation


# self-measurements  with our usecase to compare to ujson

Test-file was a 5.8Mb 5min ticker file, measured on a pc with ssd.

![2018-12-28-095647_726x161_scrot](https://user-images.githubusercontent.com/5024695/50511003-1f662d80-0a8c-11e9-8e35-1c2a87891c09.png)

