### PR TITLE
Remove unused and duplicate datastructure

### DIFF
--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -2,12 +2,12 @@
 """ Wallet """
 import logging
 from typing import Dict, Any, NamedTuple
-from collections import namedtuple
 from freqtrade.exchange import Exchange
 
 logger = logging.getLogger(__name__)
 
 
+# wallet data structure
 class Wallet(NamedTuple):
     exchange: str
     currency: str
@@ -17,12 +17,6 @@ class Wallet(NamedTuple):
 
 
 class Wallets(object):
-
-    # wallet data structure
-    wallet = namedtuple(
-        'wallet',
-        ['exchange', 'currency', 'free', 'used', 'total']
-    )
 
     def __init__(self, exchange: Exchange) -> None:
         self.exchange = exchange


### PR DESCRIPTION
## Summary
Wallet named tuple is defined twice - which is not needed and does not make sense.