### PR TITLE
Stop loss should also be shown when trailing is active

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -278,7 +278,8 @@ class IStrategy(ABC):
         # evaluate if the stoploss was hit
         if self.stoploss is not None and trade.stop_loss >= current_rate:
             selltype = SellType.STOP_LOSS
-            if trailing_stop:
+            # Trailing stop (and rate did move)
+            if trailing_stop and trade.open_rate != trade.max_rate:
                 selltype = SellType.TRAILING_STOP_LOSS
                 logger.debug(
                     f"HIT STOP: current price at {current_rate:.6f}, "

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -278,7 +278,7 @@ class IStrategy(ABC):
         # evaluate if the stoploss was hit
         if self.stoploss is not None and trade.stop_loss >= current_rate:
             selltype = SellType.STOP_LOSS
-            # Trailing stop (and rate did move)
+            # If Trailing stop (and max-rate did move above open rate)
             if trailing_stop and trade.open_rate != trade.max_rate:
                 selltype = SellType.TRAILING_STOP_LOSS
                 logger.debug(

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2066,6 +2066,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, markets, caplog,
 
     trade = Trade.query.first()
     trade.update(limit_buy_order)
+    trade.max_rate = trade.open_rate * 1.003
     caplog.set_level(logging.DEBUG)
     # Sell as trailing-stop is reached
     assert freqtrade.handle_trade(trade) is True


### PR DESCRIPTION
## Summary
Fix an issue pointed out on slack, where stoploss does not show the correct stop-loss reason when trailing stoploss is active.


## Quick changelog

- Do only overwrite stoploss reason when necessary
- Fix test to show positive movement - otherwise it's not a trailnig stoploss.