### PR TITLE
trailing stoploss configuration in strategy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,10 +19,10 @@ The table below will list all configuration parameters.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode.
 | `process_only_new_candles` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. Can be set either in Configuration or in the strategy.
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file.
-| `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. If set, this parameter will override `stoploss` from your strategy file.
-| `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file).
-| `trailing_stop_positve` | 0 | No | Changes stop-loss once profit has been reached.
-| `trailing_stop_positve_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive.
+| `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md).
+| `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md).
+| `trailing_stop_positve` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md).
+| `trailing_stop_positve_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md).
 | `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
 | `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -6,6 +6,9 @@ At this stage the bot contains the following stoploss support modes:
 2. trailing stop loss, defined in the configuration
 3. trailing stop loss, custom positive loss, defined in configuration
 
+!!! Note
+    All stoploss properties can be configured in eihter Strategy or configuration. Configuration values override strategy values.
+
 ## Static Stop Loss
 
 This is very simple, basically you define a stop loss of x in your strategy file or alternative in the configuration, which

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -52,6 +52,9 @@ class StrategyResolver(IResolver):
                       ]
         for attribute in attributes:
             self._override_attribute_helper(config, attribute)
+
+        # Loop this list again to have output combined
+        for attribute in attributes:
             if attribute in config:
                 logger.info("Strategy using %s: %s", attribute, config[attribute])
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -58,8 +58,6 @@ class StrategyResolver(IResolver):
             if attribute in config:
                 logger.info("Strategy using %s: %s", attribute, config[attribute])
 
-
-
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(
             {int(key): value for (key, value) in self.strategy.minimal_roi.items()}.items(),

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -52,6 +52,9 @@ class StrategyResolver(IResolver):
                       ]
         for attribute in attributes:
             self._override_attribute_helper(config, attribute)
+            if attribute in config:
+                logger.info("Strategy using %s: %s", attribute, config[attribute])
+
 
 
         # Sort and apply type conversions

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -56,6 +56,33 @@ class StrategyResolver(IResolver):
         else:
             config['stoploss'] = self.strategy.stoploss
 
+        if 'trailing_stop' in config:
+            self.strategy.trailing_stop = config['trailing_stop']
+            logger.info(
+                "Override strategy 'trailing_stop' with value in config file: %s.",
+                config['trailing_stop']
+            )
+        elif hasattr(self.strategy, "trailing_stop"):
+            config['trailing_stop'] = self.strategy.trailing_stop
+
+        if 'trailing_stop_positive' in config:
+            self.strategy.trailing_stop_positive = config['trailing_stop_positive']
+            logger.info(
+                "Override strategy 'trailing_stop_positive' with value in config file: %s.",
+                config['trailing_stop_positive']
+            )
+        elif hasattr(self.strategy, "trailing_stop_positive"):
+            config['trailing_stop_positive'] = self.strategy.trailing_stop_positive
+
+        if 'trailing_stop_positive_offset' in config:
+            self.strategy.trailing_stop_positive_offset = config['trailing_stop_positive_offset']
+            logger.info(
+                "Override strategy 'trailing_stop_positive_offset' with value in config file: %s.",
+                config['trailing_stop_positive_offset']
+            )
+        elif hasattr(self.strategy, "trailing_stop_positive_offset"):
+            config['trailing_stop_positive_offset'] = self.strategy.trailing_stop_positive_offset
+
         if 'ticker_interval' in config:
             self.strategy.ticker_interval = config['ticker_interval']
             logger.info(

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -40,15 +40,19 @@ class StrategyResolver(IResolver):
                                                        extra_dir=config.get('strategy_path'))
         # Set attributes
         # Check if we need to override configuration
-        self._override_attribute_helper(config, "minimal_roi")
-        self._override_attribute_helper(config, "ticker_interval")
-        self._override_attribute_helper(config, "stoploss")
-        self._override_attribute_helper(config, "trailing_stop")
-        self._override_attribute_helper(config, "trailing_stop_positive")
-        self._override_attribute_helper(config, "trailing_stop_positive_offset")
-        self._override_attribute_helper(config, "process_only_new_candles")
-        self._override_attribute_helper(config, "order_types")
-        self._override_attribute_helper(config, "order_time_in_force")
+        attributes = ["minimal_roi",
+                      "ticker_interval",
+                      "stoploss",
+                      "trailing_stop",
+                      "trailing_stop_positive",
+                      "trailing_stop_positive_offset",
+                      "process_only_new_candles",
+                      "order_types",
+                      "order_time_in_force"
+                      ]
+        for attribute in attributes:
+            self._override_attribute_helper(config, attribute)
+
 
         # Sort and apply type conversions
         self.strategy.minimal_roi = OrderedDict(sorted(

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -67,6 +67,11 @@ class IStrategy(ABC):
     # associated stoploss
     stoploss: float
 
+    # trailing stoploss
+    trailing_stop: bool = False
+    trailing_stop_positive: float
+    trailing_stop_positive_offset: float
+
     # associated ticker interval
     ticker_interval: str
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -150,6 +150,45 @@ def test_strategy_override_stoploss(caplog):
             ) in caplog.record_tuples
 
 
+def test_strategy_override_trailing_stop(caplog):
+    caplog.set_level(logging.INFO)
+    config = {
+        'strategy': 'DefaultStrategy',
+        'trailing_stop': True
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.trailing_stop
+    assert isinstance(resolver.strategy.trailing_stop, bool)
+    assert ('freqtrade.resolvers.strategy_resolver',
+            logging.INFO,
+            "Override strategy 'trailing_stop' with value in config file: True."
+            ) in caplog.record_tuples
+
+
+def test_strategy_override_trailing_stop_positive(caplog):
+    caplog.set_level(logging.INFO)
+    config = {
+        'strategy': 'DefaultStrategy',
+        'trailing_stop_positive': -0.1,
+        'trailing_stop_positive_offset': -0.2
+
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.trailing_stop_positive == -0.1
+    assert ('freqtrade.resolvers.strategy_resolver',
+            logging.INFO,
+            "Override strategy 'trailing_stop_positive' with value in config file: -0.1."
+            ) in caplog.record_tuples
+
+    assert resolver.strategy.trailing_stop_positive_offset == -0.2
+    assert ('freqtrade.resolvers.strategy_resolver',
+            logging.INFO,
+            "Override strategy 'trailing_stop_positive' with value in config file: -0.1."
+            ) in caplog.record_tuples
+
+
 def test_strategy_override_ticker_interval(caplog):
     caplog.set_level(logging.INFO)
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -217,8 +217,7 @@ def test_strategy_override_process_only_new_candles(caplog):
     assert resolver.strategy.process_only_new_candles
     assert ('freqtrade.resolvers.strategy_resolver',
             logging.INFO,
-            "Override process_only_new_candles 'process_only_new_candles' "
-            "with value in config file: True."
+            "Override strategy 'process_only_new_candles' with value in config file: True."
             ) in caplog.record_tuples
 
 

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -42,6 +42,11 @@ class TestStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
+    # trailing stoploss
+    trailing_stop = False
+    trailing_stop_positive = 0.01
+    trailing_stop_positive_offset = None  # Disabled / not configured
+
     # Optimal ticker interval for the strategy
     ticker_interval = '5m'
 


### PR DESCRIPTION
## Summary
Allow configuration of trailing_stop attributes in strategy

## Quick changelog

- Allow configuration of trailing_stop attributes in strategy
- output summary of strategy attributes so it's clear which value is used
- simplify code by some refactoring ...


## What's new?

```
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using minimal_roi: {'0': 1}
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using ticker_interval: 5m
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stoploss: -0.5
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop: False
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop_positive: 0.015
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop_positive_offset: 0.03
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using process_only_new_candles: False
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_types: {'buy': 'limit', 'sell': 'limit', 'stoploss': 'limit', 'stoploss_on_exchange': False}
2019-01-05 07:25:17,073 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_time_in_force: {'buy': 'gtc', 'sell': 'gtc'}

```