### PR TITLE
fix and improve installation script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ function updateenv () {
     source .env/bin/activate
     echo "pip3 install in-progress. Please wait..."
     pip3 install --quiet --upgrade pip
-    pip3 install --quiet -r requirements.txt --upgrade
+    pip3 install --quiet --upgrade -r requirements.txt
     pip3 install --quiet -r requirements.txt
 
     read -p "Do you want to install dependencies for dev [Y/N]? "

--- a/setup.sh
+++ b/setup.sh
@@ -50,6 +50,11 @@ function updateenv () {
 
 # Install tab lib
 function install_talib () {
+    if [ -f /usr/local/lib/libta_lib.a ]; then
+        echo "ta-lib already installed, skipping"
+        return
+    fi
+
     cd build_helpers
     tar zxvf ta-lib-0.4.0-src.tar.gz
     cd ta-lib

--- a/setup.sh
+++ b/setup.sh
@@ -30,9 +30,9 @@ function updateenv() {
     echo "-------------------------"
     source .env/bin/activate
     echo "pip3 install in-progress. Please wait..."
-    pip3 install --quiet --upgrade pip
+    # Install numpy first to have py_find_1st install clean
+    pip3 install --quiet --upgrade pip numpy
     pip3 install --quiet --upgrade -r requirements.txt
-    pip3 install --quiet -r requirements.txt
 
     read -p "Do you want to install dependencies for dev [Y/N]? "
     if [[ $REPLY =~ ^[Yy]$ ]]

--- a/setup.sh
+++ b/setup.sh
@@ -31,14 +31,13 @@ function updateenv() {
     source .env/bin/activate
     echo "pip3 install in-progress. Please wait..."
     # Install numpy first to have py_find_1st install clean
-    pip3 install --quiet --upgrade pip numpy
-    pip3 install --quiet --upgrade -r requirements.txt
+    pip3 install --upgrade pip numpy
+    pip3 install --upgrade -r requirements.txt
 
     read -p "Do you want to install dependencies for dev [Y/N]? "
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-        pip3 install --quiet -r requirements-dev.txt --upgrade
-        pip3 install --quiet -r requirements-dev.txt
+        pip3 install --upgrade -r requirements-dev.txt
     else
         echo "Dev dependencies ignored."
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ function check_installed_python() {
 
 }
 
-function updateenv () {
+function updateenv() {
     echo "-------------------------"
     echo "Update your virtual env"
     echo "-------------------------"
@@ -49,7 +49,7 @@ function updateenv () {
 }
 
 # Install tab lib
-function install_talib () {
+function install_talib() {
     if [ -f /usr/local/lib/libta_lib.a ]; then
         echo "ta-lib already installed, skipping"
         return
@@ -67,7 +67,7 @@ function install_talib () {
 }
 
 # Install bot MacOS
-function install_macos () {
+function install_macos() {
     if [ ! -x "$(command -v brew)" ]
     then
         echo "-------------------------"
@@ -81,7 +81,7 @@ function install_macos () {
 }
 
 # Install bot Debian_ubuntu
-function install_debian () {
+function install_debian() {
     sudo add-apt-repository ppa:jonathonf/python-3.6
     sudo apt-get update
     sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
@@ -89,13 +89,13 @@ function install_debian () {
 }
 
 # Upgrade the bot
-function update () {
+function update() {
     git pull
     updateenv
 }
 
 # Reset Develop or Master branch
-function reset () {
+function reset() {
     echo "----------------------------"
     echo "Reset branch and virtual env"
     echo "----------------------------"
@@ -139,7 +139,7 @@ function test_and_fix_python_on_mac() {
     fi
 }
 
-function config_generator () {
+function config_generator() {
 
     echo "Starting to generate config.json"
     echo
@@ -185,7 +185,7 @@ function config_generator () {
 
 }
 
-function config () {
+function config() {
 
     echo "-------------------------"
     echo "Config file generator"
@@ -211,7 +211,7 @@ function config () {
     echo
 }
 
-function install () {
+function install() {
     echo "-------------------------"
     echo "Install mandatory dependencies"
     echo "-------------------------"
@@ -239,7 +239,7 @@ function install () {
     echo "You can now use the bot by executing 'source .env/bin/activate; python freqtrade/main.py'."
 }
 
-function plot () {
+function plot() {
 echo "
 -----------------------------------------
 Install dependencies for Plotting scripts
@@ -248,7 +248,7 @@ Install dependencies for Plotting scripts
 pip install plotly --upgrade
 }
 
-function help () {
+function help() {
     echo "usage:"
     echo "	-i,--install    Install freqtrade from scratch"
     echo "	-u,--update     Command git pull to update."

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,11 @@ function check_installed_python() {
         return
    fi
 
+   if [ -z ${PYTHON} ]; then
+        echo "No usable python found. Please make sure to have python3.6 or python3.7 installed"
+        exit 1
+   fi
+
 }
 
 function updateenv () {


### PR DESCRIPTION
## Summary
Fixes install script

Solve the issue: #1451

## Quick changelog

- show message if neither python3.6 nor 3.7 is found
- don't use `--quiet` on pip install - it's more verbose but shows errors.
- add numpy before `pip install -r requirements.txt` to fix `py_find_1st` installation problems.
- skip installation of ta-lib if ta-lib is already installed.
