### PR TITLE
 Fix custom db_url ignored if provided by conf.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,7 @@ creating trades.
 
 ```json
 "dry_run": true,
-"db_url": "sqlite///tradesv3.dryrun.sqlite",
+"db_url": "sqlite:///tradesv3.dryrun.sqlite",
 ```
 
 3. Remove your Exchange API key (change them by fake api credentials)

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -124,9 +124,6 @@ class Configuration(object):
         if self.args.db_url and self.args.db_url != constants.DEFAULT_DB_PROD_URL:
             config.update({'db_url': self.args.db_url})
             logger.info('Parameter --db-url detected ...')
-        else:
-            # Set default here
-            config.update({'db_url': constants.DEFAULT_DB_PROD_URL})
 
         if config.get('dry_run', False):
             logger.info('Dry run is enabled')

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -59,7 +59,7 @@ class Edge():
 
         # checking max_open_trades. it should be -1 as with Edge
         # the number of trades is determined by position size
-        if self.config['max_open_trades'] != -1:
+        if self.config['max_open_trades'] != float('inf'):
             logger.critical('max_open_trades should be -1 in config !')
 
         if self.config['stake_amount'] != constants.UNLIMITED_STAKE_AMOUNT:


### PR DESCRIPTION
## Summary
Providing `db_url` from config.json is ignored. I also added a test, I don't know if is the right way to test it (it's my first python test) so I'm welcome for suggestions.

Moreover I fixed an error log when Edge is enabled and `max_open_trades=-1`

## Quick changelog

- removed default setting for db_url 
- fix if condition according to https://github.com/freqtrade/freqtrade/blob/b731973c7af3b705f91477fcc467255f1d1cefdb/freqtrade/configuration.py#L146

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 