### PR TITLE
Remove unversioned install of most dev packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 install:
 - cd build_helpers && ./install_ta-lib.sh; cd ..
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- pip install --upgrade flake8 coveralls pytest-random-order pytest-asyncio mypy
+- pip install --upgrade pytest-random-order
 - pip install -r requirements-dev.txt
 - pip install -e .
 jobs:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ pytest==4.1.1
 pytest-mock==1.10.0
 pytest-asyncio==0.10.0
 pytest-cov==2.6.1
+coveralls==1.5.1
+mypy==0.650


### PR DESCRIPTION
## Summary
To fix the issue appeared in #1493 - we should pin the dependencies in requirements-dev.txt.
I'm keeping pytest-random-order intentionally out of this as the requirements-dev.txt is used to install on a dev-pc - and pytest-random-order makes working on new tests sometimes cumbersome, so everyone should choose for themselfs if installing it or not.

Solve the issue: #1493 

