### PR TITLE
fix stoploss_on_exchange_interval type

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -113,7 +113,7 @@ CONF_SCHEMA = {
                 'sell': {'type': 'string', 'enum': ORDERTYPE_POSSIBILITIES},
                 'stoploss': {'type': 'string', 'enum': ORDERTYPE_POSSIBILITIES},
                 'stoploss_on_exchange': {'type': 'boolean'},
-                'stoploss_on_exchange_interval': {'type': 'boolean'}
+                'stoploss_on_exchange_interval': {'type': 'number'}
             },
             'required': ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']
         },


### PR DESCRIPTION
from boolean to number

BUGFIX:

Invalid configuration. See config.json.example. Reason: 60 is not of type 'boolean'
Failed validating 'type' in schema['properties']['order_types']['properties']['stoploss_on_exchange_interval']:
    {'type': 'boolean'}

On instance['order_types']['stoploss_on_exchange_interval']:
    60