### PR TITLE
Fix typeerror when fetching candles

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -588,7 +588,7 @@ class Exchange(object):
                     data = sorted(data, key=lambda x: x[0])
             except IndexError:
                 logger.exception("Error loading %s. Result was %s.", pair, data)
-                return pair, None
+                return pair, []
             logger.debug("done fetching %s ...", pair)
             return pair, data
 


### PR DESCRIPTION
## Summary
Prevent crash when unexpected results are returned from an exchange

Solve the issue: #1491

## Quick changelog

- don't unzip directly - also exceptions can be returned from the async method
- check and log exceptions
