### PR TITLE
Data Provider

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -302,7 +302,7 @@ if self.dp:
 
 #### Get data for non-tradeable pairs
 
-Data for additional pairs (reference pairs) can be beneficial for some strategies.
+Data for additional, informative pairs (reference pairs) can be beneficial for some strategies.
 Ohlcv data for these pairs will be downloaded as part of the regular whitelist refresh process and is available via `DataProvider` just as other pairs (see above).
 These parts will **not** be traded unless they are also specified in the pair whitelist, or have been selected by Dynamic Whitelisting.
 
@@ -311,7 +311,7 @@ The pairs need to be specified as tuples in the format `("pair", "interval")`, w
 Sample:
 
 ``` python
-def additional_pairs(self):
+def informative_pairs(self):
     return [("ETH/USDT", "5m"),
             ("BTC/TUSD", "15m"),
             ]

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -232,7 +232,8 @@ Currently this is `pair`, which can be accessed using `metadata['pair']` - and w
 
 The strategy provides access to the `DataProvider`. This allows you to get additional data to use in your strategy.
 
-**NOTE**: The DataProvier is currently not available during backtesting / hyperopt.
+!!!Note:
+    The DataProvier is currently not available during backtesting / hyperopt, but this is planned for the future.
 
 All methods return `None` in case of failure (do not raise an exception).
 
@@ -259,6 +260,10 @@ if self.dp:
                                              ticker_interval='1h')
 ```
 
+!!! Warning: Warning about backtesting
+    Be carefull when using dataprovider in backtesting. `historic_ohlcv()` provides the full time-range in one go,
+    so please be aware of it and make sure to not "look into the future" to avoid surprises when running in dry/live mode).
+
 #### Available Pairs
 
 ``` python
@@ -267,11 +272,35 @@ if self.dp:
         print(f"available {pair}, {ticker}")
 ```
 
+#### Get data for non-tradeable pairs
+
+Data for additional pairs (reference pairs) can be beneficial for some strategies.
+Ohlcv data for these pairs will be downloaded as part of the regular whitelist refresh process and is available via `DataProvider` just as other pairs (see above).
+These parts will **not** be traded unless they are also specified in the pair whitelist, or have been selected by Dynamic Whitelisting.
+
+The pairs need to be specified as tuples in the format `("pair", "interval")`, with pair as the first and time interval as the second argument.
+
+Sample:
+
+``` python
+def additional_pairs(self):
+    return [("ETH/USDT", "5m"),
+            ("BTC/TUSD", "15m"),
+            ]
+```
+
+!!! Warning:
+    As these pairs will be refreshed as part of the regular whitelist refresh, it's best to keep this list short.
+    All intervals and all pairs can be specified as long as they are available (and active) on the used exchange.
+    It is however better to use resampling to longer time-intervals when possible
+    to avoid hammering the exchange with too many requests and risk beeing blocked.
+
 ### Additional data - Wallets
 
 The strategy provides access to the `Wallets` object. This contains the current balances on the exchange.
 
-**NOTE**: Wallets is not available during backtesting / hyperopt.
+!!!NOTE:
+    Wallets is not available during backtesting / hyperopt.
 
 Please always check if `Wallets` is available to avoid failures during backtesting.
 

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -247,7 +247,7 @@ All methods return `None` in case of failure (do not raise an exception).
 #### Possible options for DataProvider
 
 - `available_pairs` - Property containing cached pairs
-- `ohlcv(pair, ticker_interval)` - Currently cached ticker data for all pairs in the whitelist
+- `ohlcv(pair, ticker_interval)` - Currently cached ticker data for all pairs in the whitelist, returns DataFrame or empty DataFrame
 - `historic_ohlcv(pair, ticker_interval)` - Data stored on disk
 - `runmode` - Property containing the current runmode.
 

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -228,12 +228,23 @@ The strategy provides access to the `DataProvider`. This allows you to get addit
 
 **NOTE**: The DataProvier is currently not available during backtesting / hyperopt.
 
+All methods return `None` in case of failure (do not raise an exception).
+
 Please always check if the `DataProvider` is available to avoid failures during backtesting.
+
+#### Possible options for DataProvider
+
+- `available_pairs` - Property with tuples listing cached pairs with their intervals. (pair, interval)
+- `ohlcv(pair, ticker_interval)` - Currently cached ticker data for all pairs in the whitelist, returns DataFrame or empty DataFrame
+- `historic_ohlcv(pair, ticker_interval)` - Data stored on disk
+- `runmode` - Property containing the current runmode.
+
+#### ohlcv / historic_ohlcv
 
 ``` python
 if self.dp:
     if dp.runmode == 'live':
-        if 'ETH/BTC' in self.dp.available_pairs:
+        if ('ETH/BTC', ticker_interval) in self.dp.available_pairs:
             data_eth = self.dp.ohlcv(pair='ETH/BTC',
                                      ticker_interval=ticker_interval)
     else:
@@ -242,14 +253,13 @@ if self.dp:
                                              ticker_interval='1h')
 ```
 
-All methods return `None` in case of failure (do not raise an exception).
+#### Available Pairs
 
-#### Possible options for DataProvider
-
-- `available_pairs` - Property containing cached pairs
-- `ohlcv(pair, ticker_interval)` - Currently cached ticker data for all pairs in the whitelist, returns DataFrame or empty DataFrame
-- `historic_ohlcv(pair, ticker_interval)` - Data stored on disk
-- `runmode` - Property containing the current runmode.
+``` python
+if self.dp:
+    for pair, ticker in self.dp.available_pairs:
+        print(f"available {pair}, {ticker}")
+```
 
 ### Additional data - Wallets
 

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -47,6 +47,12 @@ python3 ./freqtrade/main.py --strategy AwesomeStrategy
 **For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
 file as reference.**
 
+!!! Note: Strategies and Backtesting
+    To avoid problems and unexpected differences between Backtesting and dry/live modes, please be aware
+    that during backtesting the full time-interval is passed to the `populate_*()` methods at once.
+    It is therefore best to use vectorized operations (across the whole dataframe, not loops) and
+    avoid index referencing (`df.iloc[-1]`), but instead use `df.shift()` to get to the previous candle.
+
 ### Customize Indicators
 
 Buy and sell strategies need indicators. You can add more indicators by extending the list contained in the method `populate_indicators()` from your strategy file.

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -222,6 +222,57 @@ Please note that the same buy/sell signals may work with one interval, but not t
 The metadata-dict (available for `populate_buy_trend`, `populate_sell_trend`, `populate_indicators`) contains additional information.
 Currently this is `pair`, which can be accessed using `metadata['pair']` - and will return a pair in the format `XRP/BTC`.
 
+### Additional data (DataProvider)
+
+The strategy provides access to the `DataProvider`. This allows you to get additional data to use in your strategy.
+
+**NOTE**: The DataProvier is currently not available during backtesting / hyperopt.
+
+Please always check if the `DataProvider` is available to avoid failures during backtesting.
+
+``` python
+if self.dp:
+    if dp.runmode == 'live':
+        if 'ETH/BTC' in self.dp.available_pairs:
+            data_eth = self.dp.ohlcv(pair='ETH/BTC',
+                                ticker_interval=ticker_interval)
+    else:
+        # Get historic ohlcv data (cached on disk).
+        history_eth = self.dp.historic_ohlcv(pair='ETH/BTC',
+                            ticker_interval='1h')
+```
+
+All methods return `None` in case of failure (do not raise an exception).
+
+#### Possible options for DataProvider
+
+- `available_pairs` - Property containing cached pairs
+- `ohlcv(pair, ticker_interval)` - Currently cached ticker data for all pairs in the whitelist
+- `historic_ohlcv(pair, ticker_interval)` - Data stored on disk
+- `runmode` - Property containing the current runmode.
+
+### Additional data - Wallets
+
+The strategy provides access to the `Wallets` object. This contains the current balances on the exchange.
+
+**NOTE**: Wallets is not available during backtesting / hyperopt.
+
+Please always check if `Wallets` is available to avoid failures during backtesting.
+
+``` python
+if self.wallets:
+    free_eth = self.wallets.get_free('ETH')
+    used_eth = self.wallets.get_used('ETH')
+    total_eth = self.wallets.get_total('ETH')
+```
+
+#### Possible options for Wallets
+
+- `get_free(asset)` - currently available balance to trade
+- `get_used(asset)` - currently tied up balance (open orders)
+- `get_total(asset)` - total available balance - sum of the 2 above
+
+
 ### Where is the default strategy?
 
 The default buy strategy is located in the file

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -235,11 +235,11 @@ if self.dp:
     if dp.runmode == 'live':
         if 'ETH/BTC' in self.dp.available_pairs:
             data_eth = self.dp.ohlcv(pair='ETH/BTC',
-                                ticker_interval=ticker_interval)
+                                     ticker_interval=ticker_interval)
     else:
         # Get historic ohlcv data (cached on disk).
         history_eth = self.dp.historic_ohlcv(pair='ETH/BTC',
-                            ticker_interval='1h')
+                                             ticker_interval='1h')
 ```
 
 All methods return `None` in case of failure (do not raise an exception).

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -27,7 +27,7 @@ class DataProvider(object):
         """
         Refresh data, called with each cycle
         """
-        self._exchange.refresh_tickers(pairlist, self._config['ticker_interval'])
+        self._exchange.refresh_latest_ohlcv(pairlist, self._config['ticker_interval'])
 
     @property
     def available_pairs(self) -> List[str]:

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -42,7 +42,7 @@ class DataProvider(object):
         return load_pair_history(pair=pair,
                                  ticker_interval=ticker_interval,
                                  refresh_pairs=False,
-                                 datadir=Path(self.config['datadir']) if self.config.get(
+                                 datadir=Path(self._config['datadir']) if self._config.get(
                                      'datadir') else None
                                  )
 
@@ -69,4 +69,4 @@ class DataProvider(object):
         can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
         """
         # TODO: this needs to be set somewhere ...
-        return self._config.get['runmode']
+        return str(self._config.get('runmode'))

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -37,7 +37,7 @@ class DataProvider(object):
         """
         return list(self._exchange._klines.keys())
 
-    def ohlcv(self, pair: str, copy: bool = True) -> List[str]:
+    def ohlcv(self, pair: str, copy: bool = True) -> DataFrame:
         """
         get ohlcv data for the given pair as DataFrame
         Please check `available_pairs` to verify which pairs are currently cached.
@@ -49,7 +49,7 @@ class DataProvider(object):
         if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE):
             return self._exchange.klines(pair, copy)
         else:
-            return None
+            return DataFrame()
 
     def historic_ohlcv(self, pair: str, ticker_interval: str) -> DataFrame:
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -62,16 +62,14 @@ class DataProvider(object):
         """
         Return last ticker data
         """
+        # TODO: Implement me
         pass
 
     def orderbook(self, pair: str, max: int):
         """
         return latest orderbook data
         """
-        pass
-
-    def balance(self, pair):
-        # TODO: maybe use wallet directly??
+        # TODO: Implement me
         pass
 
     @property

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -30,7 +30,7 @@ class DataProvider(object):
         self._exchange.refresh_latest_ohlcv(pairlist)
 
     @property
-    def available_pairs(self) -> List[str]:
+    def available_pairs(self) -> List[Tuple[str, str]]:
         """
         Return a list of tuples containing pair, tick_interval for which data is currently cached.
         Should be whitelist + open trades.

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -63,7 +63,7 @@ class DataProvider(object):
 
     def historic_ohlcv(self, pair: str, ticker_interval: str) -> DataFrame:
         """
-        get historic ohlcv data stored for backtesting
+        get stored historic ohlcv data
         :param pair: pair to get the data for
         :param tick_interval: ticker_interval to get pair for
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -46,7 +46,6 @@ class DataProvider(object):
         :param copy: copy dataframe before returning.
                      Use false only for RO operations (where the dataframe is not modified)
         """
-        # TODO: Should not be stored in exchange but in this class
         if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE):
             if tick_interval:
                 pairtick = (pair, tick_interval)

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -72,4 +72,4 @@ class DataProvider(object):
         Get runmode of the bot
         can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
         """
-        return self._config.get('runmode')
+        return RunMode(self._config.get('runmode', RunMode.OTHER))

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -29,6 +29,14 @@ class DataProvider(object):
         """
         self._exchange.refresh_tickers(pairlist, self._config['ticker_interval'])
 
+    @property
+    def available_pairs(self) -> List[str]:
+        """
+        Return a list of pairs for which data is currently cached.
+        Should be whitelist + open trades.
+        """
+        return list(self._exchange._klines.keys())
+
     def ohlcv(self, pair: str, copy: bool = True) -> List[str]:
         """
         get ohlcv data for the given pair as DataFrame

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -32,7 +32,7 @@ class DataProvider(object):
     @property
     def available_pairs(self) -> List[str]:
         """
-        Return a list of pairs for which data is currently cached.
+        Return a list of tuples containing pair, tick_interval for which data is currently cached.
         Should be whitelist + open trades.
         """
         return list(self._exchange._klines.keys())

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -23,11 +23,16 @@ class DataProvider(object):
         self._config = config
         self._exchange = exchange
 
-    def refresh(self, pairlist: List[Tuple[str, str]]) -> None:
+    def refresh(self,
+                pairlist: List[Tuple[str, str]],
+                helping_pairs: List[Tuple[str, str]] = None) -> None:
         """
         Refresh data, called with each cycle
         """
-        self._exchange.refresh_latest_ohlcv(pairlist)
+        if helping_pairs:
+            self._exchange.refresh_latest_ohlcv(pairlist + helping_pairs)
+        else:
+            self._exchange.refresh_latest_ohlcv(pairlist)
 
     @property
     def available_pairs(self) -> List[Tuple[str, str]]:

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -5,11 +5,13 @@ including Klines, tickers, historic data
 Common Interface for bot and strategy to access data.
 """
 import logging
+from pathlib import Path
 from typing import List, Dict
 
 from pandas import DataFrame
 
 from freqtrade.exchange import Exchange
+from freqtrade.data.history import load_pair_history
 
 logger = logging.getLogger(__name__)
 
@@ -31,14 +33,18 @@ class DataProvider(object):
         get ohlcv data for the given pair as DataFrame
         """
         # TODO: Should not be stored in exchange but in this class
-        # TODO: should return dataframe, not list
         return self._exchange.klines(pair)
 
-    def historic_ohlcv(self, pair: str) -> DataFrame:
+    def historic_ohlcv(self, pair: str, ticker_interval: str) -> DataFrame:
         """
         get historic ohlcv data stored for backtesting
         """
-        pass
+        return load_pair_history(pair=pair,
+                                 ticker_interval=ticker_interval,
+                                 refresh_pairs=False,
+                                 datadir=Path(self.config['datadir']) if self.config.get(
+                                     'datadir') else None
+                                 )
 
     def ticker(self, pair: str):
         """
@@ -62,4 +68,5 @@ class DataProvider(object):
         Get runmode of the bot
         can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
         """
+        # TODO: this needs to be set somewhere ...
         return self._config.get['runmode']

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -40,6 +40,7 @@ class DataProvider(object):
     def ohlcv(self, pair: str, copy: bool = True) -> List[str]:
         """
         get ohlcv data for the given pair as DataFrame
+        Please check `available_pairs` to verify which pairs are currently cached.
         :param pair: pair to get the data for
         :param copy: copy dataframe before returning.
                      Use false only for RO operations (where the dataframe is not modified)

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -6,12 +6,13 @@ Common Interface for bot and strategy to access data.
 """
 import logging
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 
 from pandas import DataFrame
 
-from freqtrade.exchange import Exchange
 from freqtrade.data.history import load_pair_history
+from freqtrade.exchange import Exchange
+from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
 
@@ -66,10 +67,9 @@ class DataProvider(object):
         pass
 
     @property
-    def runmode(self) -> str:
+    def runmode(self) -> RunMode:
         """
         Get runmode of the bot
         can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
         """
-        # TODO: this needs to be set somewhere ...
-        return str(self._config.get('runmode'))
+        return self._config.get('runmode')

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -32,7 +32,7 @@ class DataProvider(object):
         """
         # TODO: Should not be stored in exchange but in this class
         # TODO: should return dataframe, not list
-        return self._exchange.klines.get(pair)
+        return self._exchange.klines(pair)
 
     def historic_ohlcv(self, pair: str) -> DataFrame:
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -28,12 +28,15 @@ class DataProvider(object):
         """
         self._exchange.refresh_tickers(pairlist, self._config['ticker_interval'])
 
-    def ohlcv(self, pair: str) -> List[str]:
+    def ohlcv(self, pair: str, copy: bool = True) -> List[str]:
         """
         get ohlcv data for the given pair as DataFrame
+        :param pair: pair to get the data for
+        :param copy: copy dataframe before returning.
+                     Use false only for RO operations (where the dataframe is not modified)
         """
         # TODO: Should not be stored in exchange but in this class
-        return self._exchange.klines(pair)
+        return self._exchange.klines(pair, copy)
 
     def historic_ohlcv(self, pair: str, ticker_interval: str) -> DataFrame:
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -46,7 +46,10 @@ class DataProvider(object):
                      Use false only for RO operations (where the dataframe is not modified)
         """
         # TODO: Should not be stored in exchange but in this class
-        return self._exchange.klines(pair, copy)
+        if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE):
+            return self._exchange.klines(pair, copy)
+        else:
+            return None
 
     def historic_ohlcv(self, pair: str, ticker_interval: str) -> DataFrame:
         """
@@ -77,6 +80,6 @@ class DataProvider(object):
     def runmode(self) -> RunMode:
         """
         Get runmode of the bot
-        can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
+        can be "live", "dry-run", "backtest", "edgecli", "hyperopt" or "other".
         """
         return RunMode(self._config.get('runmode', RunMode.OTHER))

--- a/freqtrade/dataprovider.py
+++ b/freqtrade/dataprovider.py
@@ -31,6 +31,7 @@ class DataProvider(object):
         get ohlcv data for the given pair as DataFrame
         """
         # TODO: Should not be stored in exchange but in this class
+        # TODO: should return dataframe, not list
         return self._exchange.klines.get(pair)
 
     def historic_ohlcv(self, pair: str) -> DataFrame:
@@ -54,3 +55,11 @@ class DataProvider(object):
     def balance(self, pair):
         # TODO: maybe use wallet directly??
         pass
+
+    @property
+    def runmode(self) -> str:
+        """
+        Get runmode of the bot
+        can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
+        """
+        return self._config.get['runmode']

--- a/freqtrade/dataprovider.py
+++ b/freqtrade/dataprovider.py
@@ -1,0 +1,45 @@
+"""
+Dataprovider
+Responsible to provide data to the bot
+including Klines, tickers, historic data
+Common Interface for bot and strategy to access data.
+"""
+import logging
+
+from freqtrade.exchange import Exchange
+
+logger = logging.getLogger(__name__)
+
+
+class DataProvider(object):
+
+    def __init__(self, exchange: Exchange) -> None:
+        pass
+
+    def refresh() -> None:
+        """
+        Refresh data, called with each cycle
+        """
+        pass
+
+    def kline(pair: str):
+        """
+        get ohlcv data for the given pair
+        """
+        pass
+
+    def historic_kline(pair: str):
+        """
+        get historic ohlcv data stored for backtesting
+        """
+        pass
+
+    def ticker(pair: str):
+        pass
+
+    def orderbook(pair: str, max: int):
+        pass
+
+    def balance(pair):
+        # TODO: maybe use wallet directly??
+        pass

--- a/freqtrade/dataprovider.py
+++ b/freqtrade/dataprovider.py
@@ -5,6 +5,7 @@ including Klines, tickers, historic data
 Common Interface for bot and strategy to access data.
 """
 import logging
+from typing import List, Dict
 
 from pandas import DataFrame
 
@@ -19,13 +20,13 @@ class DataProvider(object):
         self._config = config
         self._exchange = exchange
 
-    def refresh() -> None:
+    def refresh(self, pairlist: List[str]) -> None:
         """
         Refresh data, called with each cycle
         """
-        pass
+        self._exchange.refresh_tickers(pairlist, self._config['ticker_interval'])
 
-    def ohlcv(self, pair: str) -> DataFrame:
+    def ohlcv(self, pair: str) -> List[str]:
         """
         get ohlcv data for the given pair as DataFrame
         """

--- a/freqtrade/dataprovider.py
+++ b/freqtrade/dataprovider.py
@@ -6,6 +6,8 @@ Common Interface for bot and strategy to access data.
 """
 import logging
 
+from pandas import DataFrame
+
 from freqtrade.exchange import Exchange
 
 logger = logging.getLogger(__name__)
@@ -13,8 +15,9 @@ logger = logging.getLogger(__name__)
 
 class DataProvider(object):
 
-    def __init__(self, exchange: Exchange) -> None:
-        pass
+    def __init__(self, config: dict, exchange: Exchange) -> None:
+        self._config = config
+        self._exchange = exchange
 
     def refresh() -> None:
         """
@@ -22,24 +25,31 @@ class DataProvider(object):
         """
         pass
 
-    def kline(pair: str):
+    def ohlcv(self, pair: str) -> DataFrame:
         """
-        get ohlcv data for the given pair
+        get ohlcv data for the given pair as DataFrame
         """
-        pass
+        # TODO: Should not be stored in exchange but in this class
+        return self._exchange.klines.get(pair)
 
-    def historic_kline(pair: str):
+    def historic_ohlcv(self, pair: str) -> DataFrame:
         """
         get historic ohlcv data stored for backtesting
         """
         pass
 
-    def ticker(pair: str):
+    def ticker(self, pair: str):
+        """
+        Return last ticker data
+        """
         pass
 
-    def orderbook(pair: str, max: int):
+    def orderbook(self, pair: str, max: int):
+        """
+        return latest orderbook data
+        """
         pass
 
-    def balance(pair):
+    def balance(self, pair):
         # TODO: maybe use wallet directly??
         pass

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -162,7 +162,7 @@ class Exchange(object):
         if pair in self._klines:
             return self._klines[pair].copy() if copy else self._klines[pair]
         else:
-            return None
+            return DataFrame()
 
     def set_sandbox(self, api, exchange_config: dict, name: str):
         if exchange_config.get('sandbox'):

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -594,7 +594,7 @@ class Exchange(object):
                     data = sorted(data, key=lambda x: x[0])
             except IndexError:
                 logger.exception("Error loading %s. Result was %s.", pair, data)
-                return pair, []
+                return pair, tick_interval, []
             logger.debug("done fetching %s ...", pair)
             return pair, tick_interval, data
 

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -545,8 +545,9 @@ class Exchange(object):
             # Calculating ticker interval in second
             interval_in_sec = constants.TICKER_INTERVAL_MINUTES[ticker_interval] * 60
 
-            if not (self._pairs_last_refresh_time.get((pair, ticker_interval), 0) + interval_in_sec >=
-                    arrow.utcnow().timestamp and (pair, ticker_interval) in self._klines):
+            if not ((self._pairs_last_refresh_time.get((pair, ticker_interval), 0)
+                    + interval_in_sec) >= arrow.utcnow().timestamp
+                    and (pair, ticker_interval) in self._klines):
                 input_coroutines.append(self._async_get_candle_history(pair, ticker_interval))
             else:
                 logger.debug("Using cached ohlcv data for %s, %s ...", pair, ticker_interval)

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -525,7 +525,7 @@ class Exchange(object):
         for p, ticker in tickers:
             if p == pair:
                 data.extend(ticker)
-        # Sort data again after extending the result - above calls return in "async order" order
+        # Sort data again after extending the result - above calls return in "async order"
         data = sorted(data, key=lambda x: x[0])
         logger.info("downloaded %s with length %s.", pair, len(data))
         return data
@@ -535,7 +535,7 @@ class Exchange(object):
         """
         Refresh in-memory ohlcv asyncronously and set `_klines`  with the result
         """
-        logger.debug("Refreshing klines for %d pairs", len(pair_list))
+        logger.debug("Refreshing ohlcv data for %d pairs", len(pair_list))
 
         # Calculating ticker interval in second
         interval_in_sec = constants.TICKER_INTERVAL_MINUTES[ticker_interval] * 60
@@ -547,7 +547,7 @@ class Exchange(object):
                     arrow.utcnow().timestamp and pair in self._klines):
                 input_coroutines.append(self._async_get_candle_history(pair, ticker_interval))
             else:
-                logger.debug("Using cached klines data for %s ...", pair)
+                logger.debug("Using cached ohlcv data for %s ...", pair)
 
         tickers = asyncio.get_event_loop().run_until_complete(
             asyncio.gather(*input_coroutines, return_exceptions=True))

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -595,7 +595,7 @@ class Exchange(object):
             except IndexError:
                 logger.exception("Error loading %s. Result was %s.", pair, data)
                 return pair, tick_interval, []
-            logger.debug("done fetching %s ...", pair)
+            logger.debug("done fetching %s, %s ...", pair, tick_interval)
             return pair, tick_interval, data
 
         except ccxt.NotSupported as e:

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -541,7 +541,7 @@ class Exchange(object):
         input_coroutines = []
 
         # Gather corotines to run
-        for pair, ticker_interval in pair_list:
+        for pair, ticker_interval in set(pair_list):
             # Calculating ticker interval in second
             interval_in_sec = constants.TICKER_INTERVAL_MINUTES[ticker_interval] * 60
 

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -518,6 +518,7 @@ class Exchange(object):
         input_coroutines = [self._async_get_candle_history(
             pair, tick_interval, since) for since in
             range(since_ms, arrow.utcnow().timestamp * 1000, one_call)]
+
         tickers = await asyncio.gather(*input_coroutines, return_exceptions=True)
 
         # Combine tickers

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -80,7 +80,7 @@ class Exchange(object):
         self._cached_ticker: Dict[str, Any] = {}
 
         # Holds last candle refreshed time of each pair
-        self._pairs_last_refresh_time: Dict[str, int] = {}
+        self._pairs_last_refresh_time: Dict[Tuple[str, str], int] = {}
 
         # Holds candles
         self._klines: Dict[Tuple[str, str], DataFrame] = {}
@@ -545,7 +545,7 @@ class Exchange(object):
             # Calculating ticker interval in second
             interval_in_sec = constants.TICKER_INTERVAL_MINUTES[ticker_interval] * 60
 
-            if not (self._pairs_last_refresh_time.get(pair, 0) + interval_in_sec >=
+            if not (self._pairs_last_refresh_time.get((pair, ticker_interval), 0) + interval_in_sec >=
                     arrow.utcnow().timestamp and (pair, ticker_interval) in self._klines):
                 input_coroutines.append(self._async_get_candle_history(pair, ticker_interval))
             else:
@@ -564,7 +564,7 @@ class Exchange(object):
             ticks = res[2]
             # keeping last candle time as last refreshed time of the pair
             if ticks:
-                self._pairs_last_refresh_time[pair] = ticks[-1][0] // 1000
+                self._pairs_last_refresh_time[(pair, tick_interval)] = ticks[-1][0] // 1000
             # keeping parsed dataframe in cache
             self._klines[(pair, tick_interval)] = parse_ticker_dataframe(
                 ticks, tick_interval, fill_missing=True)

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -579,7 +579,7 @@ class Exchange(object):
         """
         try:
             # fetch ohlcv asynchronously
-            logger.debug("fetching %s since %s ...", pair, since_ms)
+            logger.debug("fetching %s, %s since %s ...", pair, tick_interval, since_ms)
 
             data = await self._api_async.fetch_ohlcv(pair, timeframe=tick_interval,
                                                      since=since_ms)

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -530,9 +530,10 @@ class Exchange(object):
         logger.info("downloaded %s with length %s.", pair, len(data))
         return data
 
-    def refresh_tickers(self, pair_list: List[str], ticker_interval: str) -> List[Tuple[str, List]]:
+    def refresh_latest_ohlcv(self, pair_list: List[str],
+                             ticker_interval: str) -> List[Tuple[str, List]]:
         """
-        Refresh ohlcv asyncronously and set `_klines`  with the result
+        Refresh in-memory ohlcv asyncronously and set `_klines`  with the result
         """
         logger.debug("Refreshing klines for %d pairs", len(pair_list))
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -171,10 +171,10 @@ class FreqtradeBot(object):
                                                if trade.pair not in self.active_pair_whitelist])
 
             # Create pair-whitelist tuple with (pair, ticker_interval)
-            pair_whitelist = [(pair, self.config['ticker_interval'])
-                              for pair in self.active_pair_whitelist]
+            pair_whitelist_tuple = [(pair, self.config['ticker_interval'])
+                                    for pair in self.active_pair_whitelist]
             # Refreshing candles
-            self.dataprovider.refresh(pair_whitelist)
+            self.dataprovider.refresh(pair_whitelist_tuple)
 
             # First process current opened trades
             for trade in trades:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -175,7 +175,7 @@ class FreqtradeBot(object):
                                     for pair in self.active_pair_whitelist]
             # Refreshing candles
             self.dataprovider.refresh(pair_whitelist_tuple,
-                                      self.strategy.additional_pairs())
+                                      self.strategy.informative_pairs())
 
             # First process current opened trades
             for trade in trades:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -37,9 +37,9 @@ class FreqtradeBot(object):
 
     def __init__(self, config: Dict[str, Any])-> None:
         """
-        Init all variables and object the bot need to work
-        :param config: configuration dict, you can use the Configuration.get_config()
-        method to get the config dict.
+        Init all variables and objects the bot needs to work
+        :param config: configuration dict, you can use Configuration.get_config()
+        to get the config dict.
         """
 
         logger.info(
@@ -55,7 +55,6 @@ class FreqtradeBot(object):
         self.strategy: IStrategy = StrategyResolver(self.config).strategy
 
         self.rpc: RPCManager = RPCManager(self)
-        self.persistence = None
         self.exchange = Exchange(self.config)
         self.wallets = Wallets(self.exchange)
         self.dataprovider = DataProvider(self.config, self.exchange)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -158,9 +158,9 @@ class FreqtradeBot(object):
             self.active_pair_whitelist = self.pairlists.whitelist
 
             # Calculating Edge positiong
-            # Should be called before refresh_tickers
+            # Should be called before refresh_latest_ohlcv
             # Otherwise it will override cached klines in exchange
-            # with delta value (klines only from last refresh_pairs)
+            # with delta value (klines only from last refresh_latest_ohlcv)
             if self.edge:
                 self.edge.calculate()
                 self.active_pair_whitelist = self.edge.adjust(self.active_pair_whitelist)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -174,7 +174,8 @@ class FreqtradeBot(object):
             pair_whitelist_tuple = [(pair, self.config['ticker_interval'])
                                     for pair in self.active_pair_whitelist]
             # Refreshing candles
-            self.dataprovider.refresh(pair_whitelist_tuple)
+            self.dataprovider.refresh(pair_whitelist_tuple,
+                                      self.strategy.additional_pairs())
 
             # First process current opened trades
             for trade in trades:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -58,8 +58,13 @@ class FreqtradeBot(object):
         self.persistence = None
         self.exchange = Exchange(self.config)
         self.wallets = Wallets(self.exchange)
-
         self.dataprovider = DataProvider(self.config, self.exchange)
+
+        # Attach Dataprovider to Strategy baseclass
+        IStrategy.dp = self.dataprovider
+        # Attach Wallets to Strategy baseclass
+        IStrategy.wallets = self.wallets
+
         pairlistname = self.config.get('pairlist', {}).get('method', 'StaticPairList')
         self.pairlists = PairListResolver(pairlistname, self, self.config).pairlist
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -158,9 +158,6 @@ class FreqtradeBot(object):
             self.active_pair_whitelist = self.pairlists.whitelist
 
             # Calculating Edge positiong
-            # Should be called before refresh_latest_ohlcv
-            # Otherwise it will override cached klines in exchange
-            # with delta value (klines only from last refresh_latest_ohlcv)
             if self.edge:
                 self.edge.calculate()
                 self.active_pair_whitelist = self.edge.adjust(self.active_pair_whitelist)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -15,8 +15,8 @@ from requests.exceptions import RequestException
 from freqtrade import (DependencyException, OperationalException,
                        TemporaryError, __version__, constants, persistence)
 from freqtrade.data.converter import order_book_to_dataframe
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
-from freqtrade.dataprovider import DataProvider
 from freqtrade.exchange import Exchange
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCManager, RPCMessageType

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -39,7 +39,7 @@ def main(sysargv: List[str]) -> None:
     return_code = 1
     try:
         # Load and validate configuration
-        config = Configuration(args).get_config()
+        config = Configuration(args, None).get_config()
 
         # Init the bot
         freqtrade = FreqtradeBot(config)
@@ -76,7 +76,7 @@ def reconfigure(freqtrade: FreqtradeBot, args: Namespace) -> FreqtradeBot:
     freqtrade.cleanup()
 
     # Create new instance
-    freqtrade = FreqtradeBot(Configuration(args).get_config())
+    freqtrade = FreqtradeBot(Configuration(args, None).get_config())
     freqtrade.rpc.send_msg({
         'type': RPCMessageType.STATUS_NOTIFICATION,
         'status': 'config reloaded'

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -368,7 +368,7 @@ class Backtesting(object):
 
         if self.config.get('live'):
             logger.info('Downloading data for all pairs in whitelist ...')
-            self.exchange.refresh_tickers(pairs, self.ticker_interval)
+            self.exchange.refresh_latest_ohlcv(pairs, self.ticker_interval)
             data = self.exchange._klines
         else:
             logger.info('Using local backtesting data (using whitelist in given config) ...')

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -368,8 +368,9 @@ class Backtesting(object):
 
         if self.config.get('live'):
             logger.info('Downloading data for all pairs in whitelist ...')
-            self.exchange.refresh_latest_ohlcv(pairs, self.ticker_interval)
-            data = self.exchange._klines
+            self.exchange.refresh_latest_ohlcv([(pair, self.ticker_interval) for pair in pairs])
+            data = {key[0]: value for key, value in self.exchange._klines.items()}
+
         else:
             logger.info('Using local backtesting data (using whitelist in given config) ...')
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -22,6 +22,7 @@ from freqtrade.data import history
 from freqtrade.misc import file_dump_json
 from freqtrade.persistence import Trade
 from freqtrade.resolvers import StrategyResolver
+from freqtrade.state import RunMode
 from freqtrade.strategy.interface import SellType, IStrategy
 
 logger = logging.getLogger(__name__)
@@ -452,7 +453,7 @@ def setup_configuration(args: Namespace) -> Dict[str, Any]:
     :param args: Cli args from Arguments()
     :return: Configuration
     """
-    configuration = Configuration(args)
+    configuration = Configuration(args, RunMode.BACKTEST)
     config = configuration.get_config()
 
     # Ensure we do not use Exchange credentials

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -9,10 +9,11 @@ from typing import Dict, Any
 from tabulate import tabulate
 from freqtrade.edge import Edge
 
-from freqtrade.configuration import Configuration
 from freqtrade.arguments import Arguments
+from freqtrade.configuration import Configuration
 from freqtrade.exchange import Exchange
 from freqtrade.resolvers import StrategyResolver
+from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ def setup_configuration(args: Namespace) -> Dict[str, Any]:
     :param args: Cli args from Arguments()
     :return: Configuration
     """
-    configuration = Configuration(args)
+    configuration = Configuration(args, RunMode.EDGECLI)
     config = configuration.get_config()
 
     # Ensure we do not use Exchange credentials

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -25,6 +25,7 @@ from freqtrade.configuration import Configuration
 from freqtrade.data.history import load_data
 from freqtrade.optimize import get_timeframe
 from freqtrade.optimize.backtesting import Backtesting
+from freqtrade.state import RunMode
 from freqtrade.resolvers import HyperOptResolver
 
 logger = logging.getLogger(__name__)
@@ -306,7 +307,7 @@ def start(args: Namespace) -> None:
 
     # Initialize configuration
     # Monkey patch the configuration with hyperopt_conf.py
-    configuration = Configuration(args)
+    configuration = Configuration(args, RunMode.HYPEROPT)
     logger.info('Starting freqtrade in Hyperopt mode')
     config = configuration.load_config()
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -3,11 +3,11 @@
 """
 This module load custom strategies
 """
-import inspect
 import logging
 import tempfile
 from base64 import urlsafe_b64decode
 from collections import OrderedDict
+from inspect import getfullargspec
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -126,11 +126,9 @@ class StrategyResolver(IResolver):
                 if strategy:
                     logger.info('Using resolved strategy %s from \'%s\'', strategy_name, _path)
                     strategy._populate_fun_len = len(
-                        inspect.getfullargspec(strategy.populate_indicators).args)
-                    strategy._buy_fun_len = len(
-                        inspect.getfullargspec(strategy.populate_buy_trend).args)
-                    strategy._sell_fun_len = len(
-                        inspect.getfullargspec(strategy.populate_sell_trend).args)
+                        getfullargspec(strategy.populate_indicators).args)
+                    strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)
+                    strategy._sell_fun_len = len(getfullargspec(strategy.populate_sell_trend).args)
 
                     return import_strategy(strategy, config=config)
             except FileNotFoundError:

--- a/freqtrade/state.py
+++ b/freqtrade/state.py
@@ -3,13 +3,13 @@
 """
 Bot state constant
 """
-import enum
+from enum import Enum
 
 
-class State(enum.Enum):
+class State(Enum):
     """
     Bot application states
     """
-    RUNNING = 0
-    STOPPED = 1
-    RELOAD_CONF = 2
+    RUNNING = 1
+    STOPPED = 2
+    RELOAD_CONF = 3

--- a/freqtrade/state.py
+++ b/freqtrade/state.py
@@ -13,3 +13,16 @@ class State(Enum):
     RUNNING = 1
     STOPPED = 2
     RELOAD_CONF = 3
+
+
+class RunMode(Enum):
+    """
+    Bot running mode (backtest, hyperopt, ...)
+    can be "live", "dry-run", "backtest", "edgecli", "hyperopt".
+    """
+    LIVE = "live"
+    DRY_RUN = "dry_run"
+    BACKTEST = "backtest"
+    EDGECLI = "edgecli"
+    HYPEROPT = "hyperopt"
+    OTHER = "other"  # Used for plotting scripts and test

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -42,6 +42,19 @@ class DefaultStrategy(IStrategy):
         'sell': 'gtc',
     }
 
+    def additional_pairs(self):
+        """
+        Define additional pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -42,9 +42,9 @@ class DefaultStrategy(IStrategy):
         'sell': 'gtc',
     }
 
-    def additional_pairs(self):
+    def informative_pairs(self):
         """
-        Define additional pair/interval combinations to be cached from the exchange.
+        Define additional, informative pair/interval combinations to be cached from the exchange.
         These pair/interval combinations are non-tradeable, unless they are part
         of the whitelist as well.
         For more information, please consult the documentation

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -133,6 +133,19 @@ class IStrategy(ABC):
         :return: DataFrame with sell column
         """
 
+    def additional_pairs(self) -> List[Tuple[str, str]]:
+        """
+        Define additional pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def get_strategy_name(self) -> str:
         """
         Returns strategy class name

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -95,9 +95,6 @@ class IStrategy(ABC):
     # run "populate_indicators" only for new candle
     process_only_new_candles: bool = False
 
-    # Dict to determine if analysis is necessary
-    _last_candle_seen_per_pair: Dict[str, datetime] = {}
-
     # Class level variables (intentional) containing
     # the dataprovider (dp) (access to other candles, historic data, ...)
     # and wallets - access to the current balance.
@@ -106,7 +103,8 @@ class IStrategy(ABC):
 
     def __init__(self, config: dict) -> None:
         self.config = config
-        self._last_candle_seen_per_pair = {}
+        # Dict to determine if analysis is necessary
+        self._last_candle_seen_per_pair: Dict[str, datetime] = {}
 
     @abstractmethod
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -133,9 +133,9 @@ class IStrategy(ABC):
         :return: DataFrame with sell column
         """
 
-    def additional_pairs(self) -> List[Tuple[str, str]]:
+    def informative_pairs(self) -> List[Tuple[str, str]]:
         """
-        Define additional pair/interval combinations to be cached from the exchange.
+        Define additional, informative pair/interval combinations to be cached from the exchange.
         These pair/interval combinations are non-tradeable, unless they are part
         of the whitelist as well.
         For more information, please consult the documentation

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -13,7 +13,9 @@ import arrow
 from pandas import DataFrame
 
 from freqtrade import constants
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.persistence import Trade
+from freqtrade.wallets import Wallets
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +97,12 @@ class IStrategy(ABC):
 
     # Dict to determine if analysis is necessary
     _last_candle_seen_per_pair: Dict[str, datetime] = {}
+
+    # Class level variables (intentional) containing
+    # the dataprovider (dp) (access to other candles, historic data, ...)
+    # and wallets - access to the current balance.
+    dp: DataProvider
+    wallets: Wallets
 
     def __init__(self, config: dict) -> None:
         self.config = config

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -60,4 +60,4 @@ def test_available_pairs(mocker, default_conf, ticker_history):
     dp = DataProvider(default_conf, exchange)
 
     assert len(dp.available_pairs) == 2
-    assert dp.available_pairs == ['XRP/BTC', 'UNITTEST/BTC']
+    assert dp.available_pairs == [('XRP/BTC', tick_interval), ('UNITTEST/BTC', tick_interval)]

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -8,74 +8,73 @@ from freqtrade.tests.conftest import get_patched_exchange
 
 
 def test_ohlcv(mocker, default_conf, ticker_history):
-    default_conf['runmode'] = RunMode.DRY_RUN
-    tick_interval = default_conf['ticker_interval']
+    default_conf["runmode"] = RunMode.DRY_RUN
+    tick_interval = default_conf["ticker_interval"]
     exchange = get_patched_exchange(mocker, default_conf)
-    exchange._klines[('XRP/BTC', tick_interval)] = ticker_history
-    exchange._klines[('UNITTEST/BTC', tick_interval)] = ticker_history
+    exchange._klines[("XRP/BTC", tick_interval)] = ticker_history
+    exchange._klines[("UNITTEST/BTC", tick_interval)] = ticker_history
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.DRY_RUN
-    assert ticker_history.equals(dp.ohlcv('UNITTEST/BTC', tick_interval))
-    assert isinstance(dp.ohlcv('UNITTEST/BTC', tick_interval), DataFrame)
-    assert dp.ohlcv('UNITTEST/BTC', tick_interval) is not ticker_history
-    assert dp.ohlcv('UNITTEST/BTC', tick_interval, copy=False) is ticker_history
-    assert not dp.ohlcv('UNITTEST/BTC', tick_interval).empty
-    assert dp.ohlcv('NONESENSE/AAA', tick_interval).empty
+    assert ticker_history.equals(dp.ohlcv("UNITTEST/BTC", tick_interval))
+    assert isinstance(dp.ohlcv("UNITTEST/BTC", tick_interval), DataFrame)
+    assert dp.ohlcv("UNITTEST/BTC", tick_interval) is not ticker_history
+    assert dp.ohlcv("UNITTEST/BTC", tick_interval, copy=False) is ticker_history
+    assert not dp.ohlcv("UNITTEST/BTC", tick_interval).empty
+    assert dp.ohlcv("NONESENSE/AAA", tick_interval).empty
 
     # Test with and without parameter
-    assert dp.ohlcv('UNITTEST/BTC', tick_interval).equals(dp.ohlcv('UNITTEST/BTC'))
+    assert dp.ohlcv("UNITTEST/BTC", tick_interval).equals(dp.ohlcv("UNITTEST/BTC"))
 
-    default_conf['runmode'] = RunMode.LIVE
+    default_conf["runmode"] = RunMode.LIVE
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.LIVE
-    assert isinstance(dp.ohlcv('UNITTEST/BTC', tick_interval), DataFrame)
+    assert isinstance(dp.ohlcv("UNITTEST/BTC", tick_interval), DataFrame)
 
-    default_conf['runmode'] = RunMode.BACKTEST
+    default_conf["runmode"] = RunMode.BACKTEST
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.BACKTEST
-    assert dp.ohlcv('UNITTEST/BTC', tick_interval).empty
+    assert dp.ohlcv("UNITTEST/BTC", tick_interval).empty
 
 
 def test_historic_ohlcv(mocker, default_conf, ticker_history):
 
     historymock = MagicMock(return_value=ticker_history)
-    mocker.patch('freqtrade.data.dataprovider.load_pair_history', historymock)
+    mocker.patch("freqtrade.data.dataprovider.load_pair_history", historymock)
 
     # exchange = get_patched_exchange(mocker, default_conf)
     dp = DataProvider(default_conf, None)
-    data = dp.historic_ohlcv('UNITTEST/BTC', "5m")
+    data = dp.historic_ohlcv("UNITTEST/BTC", "5m")
     assert isinstance(data, DataFrame)
     assert historymock.call_count == 1
-    assert historymock.call_args_list[0][1]['datadir'] is None
-    assert historymock.call_args_list[0][1]['refresh_pairs'] is False
-    assert historymock.call_args_list[0][1]['ticker_interval'] == '5m'
+    assert historymock.call_args_list[0][1]["datadir"] is None
+    assert historymock.call_args_list[0][1]["refresh_pairs"] is False
+    assert historymock.call_args_list[0][1]["ticker_interval"] == "5m"
 
 
 def test_available_pairs(mocker, default_conf, ticker_history):
     exchange = get_patched_exchange(mocker, default_conf)
 
-    tick_interval = default_conf['ticker_interval']
-    exchange._klines[('XRP/BTC', tick_interval)] = ticker_history
-    exchange._klines[('UNITTEST/BTC', tick_interval)] = ticker_history
+    tick_interval = default_conf["ticker_interval"]
+    exchange._klines[("XRP/BTC", tick_interval)] = ticker_history
+    exchange._klines[("UNITTEST/BTC", tick_interval)] = ticker_history
     dp = DataProvider(default_conf, exchange)
 
     assert len(dp.available_pairs) == 2
-    assert dp.available_pairs == [('XRP/BTC', tick_interval), ('UNITTEST/BTC', tick_interval)]
+    assert dp.available_pairs == [
+        ("XRP/BTC", tick_interval),
+        ("UNITTEST/BTC", tick_interval),
+    ]
 
 
 def test_refresh(mocker, default_conf, ticker_history):
     refresh_mock = MagicMock()
-    mocker.patch('freqtrade.exchange.Exchange.refresh_latest_ohlcv', refresh_mock)
+    mocker.patch("freqtrade.exchange.Exchange.refresh_latest_ohlcv", refresh_mock)
 
-    exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    tick_interval = default_conf['ticker_interval']
-    pairs = [('XRP/BTC', tick_interval),
-             ('UNITTEST/BTC', tick_interval),
-             ]
+    exchange = get_patched_exchange(mocker, default_conf, id="binance")
+    tick_interval = default_conf["ticker_interval"]
+    pairs = [("XRP/BTC", tick_interval), ("UNITTEST/BTC", tick_interval)]
 
-    pairs_non_trad = [('ETH/USDT', tick_interval),
-                      ('BTC/TUSD', "1h"),
-                      ]
+    pairs_non_trad = [("ETH/USDT", tick_interval), ("BTC/TUSD", "1h")]
 
     dp = DataProvider(default_conf, exchange)
     dp.refresh(pairs)

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -18,7 +18,8 @@ def test_ohlcv(mocker, default_conf, ticker_history):
     assert isinstance(dp.ohlcv('UNITTEST/BTC'), DataFrame)
     assert dp.ohlcv('UNITTEST/BTC') is not ticker_history
     assert dp.ohlcv('UNITTEST/BTC', copy=False) is ticker_history
-    assert dp.ohlcv('NONESENSE/AAA') is None
+    assert not dp.ohlcv('UNITTEST/BTC').empty
+    assert dp.ohlcv('NONESENSE/AAA').empty
 
     default_conf['runmode'] = RunMode.LIVE
     dp = DataProvider(default_conf, exchange)
@@ -28,7 +29,7 @@ def test_ohlcv(mocker, default_conf, ticker_history):
     default_conf['runmode'] = RunMode.BACKTEST
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.BACKTEST
-    assert dp.ohlcv('UNITTEST/BTC') is None
+    assert dp.ohlcv('UNITTEST/BTC').empty
 
 
 def test_historic_ohlcv(mocker, default_conf, ticker_history):

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -10,12 +10,12 @@ def test_ohlcv(mocker, default_conf, ticker_history):
 
     exchange = get_patched_exchange(mocker, default_conf)
     exchange._klines['XRP/BTC'] = ticker_history
-    exchange._klines['UNITEST/BTC'] = ticker_history
+    exchange._klines['UNITTEST/BTC'] = ticker_history
     dp = DataProvider(default_conf, exchange)
-    assert ticker_history.equals(dp.ohlcv('UNITEST/BTC'))
-    assert isinstance(dp.ohlcv('UNITEST/BTC'), DataFrame)
-    assert dp.ohlcv('UNITEST/BTC') is not ticker_history
-    assert dp.ohlcv('UNITEST/BTC', copy=False) is ticker_history
+    assert ticker_history.equals(dp.ohlcv('UNITTEST/BTC'))
+    assert isinstance(dp.ohlcv('UNITTEST/BTC'), DataFrame)
+    assert dp.ohlcv('UNITTEST/BTC') is not ticker_history
+    assert dp.ohlcv('UNITTEST/BTC', copy=False) is ticker_history
     assert dp.ohlcv('NONESENSE/AAA') is None
 
 
@@ -32,3 +32,13 @@ def test_historic_ohlcv(mocker, default_conf, ticker_history):
     assert historymock.call_args_list[0][1]['datadir'] is None
     assert historymock.call_args_list[0][1]['refresh_pairs'] is False
     assert historymock.call_args_list[0][1]['ticker_interval'] == '5m'
+
+
+def test_available_pairs(mocker, default_conf, ticker_history):
+    exchange = get_patched_exchange(mocker, default_conf)
+    exchange._klines['XRP/BTC'] = ticker_history
+    exchange._klines['UNITTEST/BTC'] = ticker_history
+    dp = DataProvider(default_conf, exchange)
+
+    assert len(dp.available_pairs) == 2
+    assert dp.available_pairs == ['XRP/BTC', 'UNITTEST/BTC']

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -9,27 +9,31 @@ from freqtrade.tests.conftest import get_patched_exchange
 
 def test_ohlcv(mocker, default_conf, ticker_history):
     default_conf['runmode'] = RunMode.DRY_RUN
+    tick_interval = default_conf['ticker_interval']
     exchange = get_patched_exchange(mocker, default_conf)
-    exchange._klines['XRP/BTC'] = ticker_history
-    exchange._klines['UNITTEST/BTC'] = ticker_history
+    exchange._klines[('XRP/BTC', tick_interval)] = ticker_history
+    exchange._klines[('UNITTEST/BTC', tick_interval)] = ticker_history
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.DRY_RUN
-    assert ticker_history.equals(dp.ohlcv('UNITTEST/BTC'))
-    assert isinstance(dp.ohlcv('UNITTEST/BTC'), DataFrame)
-    assert dp.ohlcv('UNITTEST/BTC') is not ticker_history
-    assert dp.ohlcv('UNITTEST/BTC', copy=False) is ticker_history
-    assert not dp.ohlcv('UNITTEST/BTC').empty
-    assert dp.ohlcv('NONESENSE/AAA').empty
+    assert ticker_history.equals(dp.ohlcv('UNITTEST/BTC', tick_interval))
+    assert isinstance(dp.ohlcv('UNITTEST/BTC', tick_interval), DataFrame)
+    assert dp.ohlcv('UNITTEST/BTC', tick_interval) is not ticker_history
+    assert dp.ohlcv('UNITTEST/BTC', tick_interval, copy=False) is ticker_history
+    assert not dp.ohlcv('UNITTEST/BTC', tick_interval).empty
+    assert dp.ohlcv('NONESENSE/AAA', tick_interval).empty
+
+    # Test with and without parameter
+    assert dp.ohlcv('UNITTEST/BTC', tick_interval).equals(dp.ohlcv('UNITTEST/BTC'))
 
     default_conf['runmode'] = RunMode.LIVE
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.LIVE
-    assert isinstance(dp.ohlcv('UNITTEST/BTC'), DataFrame)
+    assert isinstance(dp.ohlcv('UNITTEST/BTC', tick_interval), DataFrame)
 
     default_conf['runmode'] = RunMode.BACKTEST
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.BACKTEST
-    assert dp.ohlcv('UNITTEST/BTC').empty
+    assert dp.ohlcv('UNITTEST/BTC', tick_interval).empty
 
 
 def test_historic_ohlcv(mocker, default_conf, ticker_history):
@@ -49,8 +53,10 @@ def test_historic_ohlcv(mocker, default_conf, ticker_history):
 
 def test_available_pairs(mocker, default_conf, ticker_history):
     exchange = get_patched_exchange(mocker, default_conf)
-    exchange._klines['XRP/BTC'] = ticker_history
-    exchange._klines['UNITTEST/BTC'] = ticker_history
+
+    tick_interval = default_conf['ticker_interval']
+    exchange._klines[('XRP/BTC', tick_interval)] = ticker_history
+    exchange._klines[('UNITTEST/BTC', tick_interval)] = ticker_history
     dp = DataProvider(default_conf, exchange)
 
     assert len(dp.available_pairs) == 2

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -1,10 +1,9 @@
-from unittest.mock import Mock, MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 from pandas import DataFrame
 
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.exchange import Exchange
-from freqtrade.tests.conftest import get_patched_exchange, log_has
+from freqtrade.tests.conftest import get_patched_exchange
 
 
 def test_ohlcv(mocker, default_conf, ticker_history):
@@ -31,6 +30,5 @@ def test_historic_ohlcv(mocker, default_conf, ticker_history):
     assert isinstance(data, DataFrame)
     assert historymock.call_count == 1
     assert historymock.call_args_list[0][1]['datadir'] is None
-    assert historymock.call_args_list[0][1]['refresh_pairs'] == False
+    assert historymock.call_args_list[0][1]['refresh_pairs'] is False
     assert historymock.call_args_list[0][1]['ticker_interval'] == '5m'
-

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, MagicMock, PropertyMock
+
+from pandas import DataFrame
+
+from freqtrade.data.dataprovider import DataProvider
+from freqtrade.exchange import Exchange
+from freqtrade.tests.conftest import get_patched_exchange, log_has
+
+
+def test_ohlcv(mocker, default_conf, ticker_history):
+
+    exchange = get_patched_exchange(mocker, default_conf)
+    exchange._klines['XRP/BTC'] = ticker_history
+    exchange._klines['UNITEST/BTC'] = ticker_history
+    dp = DataProvider(default_conf, exchange)
+    assert ticker_history.equals(dp.ohlcv('UNITEST/BTC'))
+    assert isinstance(dp.ohlcv('UNITEST/BTC'), DataFrame)
+    assert dp.ohlcv('UNITEST/BTC') is not ticker_history
+    assert dp.ohlcv('UNITEST/BTC', copy=False) is ticker_history
+    assert dp.ohlcv('NONESENSE/AAA') is None
+
+
+def test_historic_ohlcv(mocker, default_conf, ticker_history):
+
+    historymock = MagicMock(return_value=ticker_history)
+    mocker.patch('freqtrade.data.dataprovider.load_pair_history', historymock)
+
+    # exchange = get_patched_exchange(mocker, default_conf)
+    dp = DataProvider(default_conf, None)
+    data = dp.historic_ohlcv('UNITTEST/BTC', "5m")
+    assert isinstance(data, DataFrame)
+    assert historymock.call_count == 1
+    assert historymock.call_args_list[0][1]['datadir'] is None
+    assert historymock.call_args_list[0][1]['refresh_pairs'] == False
+    assert historymock.call_args_list[0][1]['ticker_interval'] == '5m'
+

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -802,10 +802,10 @@ def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
     exchange = get_patched_exchange(mocker, default_conf)
     exchange._api_async.fetch_ohlcv = get_mock_coro(tick)
 
-    pairs = ['IOTA/ETH', 'XRP/ETH']
+    pairs = [('IOTA/ETH', '5m'), ('XRP/ETH', '5m')]
     # empty dicts
     assert not exchange._klines
-    exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
+    exchange.refresh_latest_ohlcv([('IOTA/ETH', '5m'), ('XRP/ETH', '5m')])
 
     assert log_has(f'Refreshing ohlcv data for {len(pairs)} pairs', caplog.record_tuples)
     assert exchange._klines
@@ -822,10 +822,11 @@ def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
         assert exchange.klines(pair, copy=False) is exchange.klines(pair, copy=False)
 
     # test caching
-    exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
+    exchange.refresh_latest_ohlcv([('IOTA/ETH', '5m'), ('XRP/ETH', '5m')])
 
     assert exchange._api_async.fetch_ohlcv.call_count == 2
-    assert log_has(f"Using cached ohlcv data for {pairs[0]} ...", caplog.record_tuples)
+    assert log_has(f"Using cached ohlcv data for {pairs[0][0]}, {pairs[0][1]} ...",
+                   caplog.record_tuples)
 
 
 @pytest.mark.asyncio

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -807,7 +807,7 @@ def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
     assert not exchange._klines
     exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
 
-    assert log_has(f'Refreshing klines for {len(pairs)} pairs', caplog.record_tuples)
+    assert log_has(f'Refreshing ohlcv data for {len(pairs)} pairs', caplog.record_tuples)
     assert exchange._klines
     assert exchange._api_async.fetch_ohlcv.call_count == 2
     for pair in pairs:
@@ -825,7 +825,7 @@ def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
     exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
 
     assert exchange._api_async.fetch_ohlcv.call_count == 2
-    assert log_has(f"Using cached klines data for {pairs[0]} ...", caplog.record_tuples)
+    assert log_has(f"Using cached ohlcv data for {pairs[0]} ...", caplog.record_tuples)
 
 
 @pytest.mark.asyncio
@@ -854,7 +854,7 @@ async def test__async_get_candle_history(default_conf, mocker, caplog):
     assert res[0] == pair
     assert res[1] == tick
     assert exchange._api_async.fetch_ohlcv.call_count == 1
-    assert not log_has(f"Using cached klines data for {pair} ...", caplog.record_tuples)
+    assert not log_has(f"Using cached ohlcv data for {pair} ...", caplog.record_tuples)
 
     # exchange = Exchange(default_conf)
     await async_ccxt_exception(mocker, default_conf, MagicMock(),

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -765,7 +765,7 @@ def test_get_history(default_conf, mocker, caplog):
     pair = 'ETH/BTC'
 
     async def mock_candle_hist(pair, tick_interval, since_ms):
-        return pair, tick
+        return pair, tick_interval, tick
 
     exchange._async_get_candle_history = Mock(wraps=mock_candle_hist)
     # one_call calculation * 1.8 should do 2 calls
@@ -850,9 +850,10 @@ async def test__async_get_candle_history(default_conf, mocker, caplog):
     pair = 'ETH/BTC'
     res = await exchange._async_get_candle_history(pair, "5m")
     assert type(res) is tuple
-    assert len(res) == 2
+    assert len(res) == 3
     assert res[0] == pair
-    assert res[1] == tick
+    assert res[1] == "5m"
+    assert res[2] == tick
     assert exchange._api_async.fetch_ohlcv.call_count == 1
     assert not log_has(f"Using cached ohlcv data for {pair} ...", caplog.record_tuples)
 
@@ -883,9 +884,10 @@ async def test__async_get_candle_history_empty(default_conf, mocker, caplog):
     pair = 'ETH/BTC'
     res = await exchange._async_get_candle_history(pair, "5m")
     assert type(res) is tuple
-    assert len(res) == 2
+    assert len(res) == 3
     assert res[0] == pair
-    assert res[1] == tick
+    assert res[1] == "5m"
+    assert res[2] == tick
     assert exchange._api_async.fetch_ohlcv.call_count == 1
 
 
@@ -1010,7 +1012,7 @@ async def test___async_get_candle_history_sort(default_conf, mocker):
     # Test the ticker history sort
     res = await exchange._async_get_candle_history('ETH/BTC', default_conf['ticker_interval'])
     assert res[0] == 'ETH/BTC'
-    ticks = res[1]
+    ticks = res[2]
 
     assert sort_mock.call_count == 1
     assert ticks[0][0] == 1527830400000
@@ -1047,7 +1049,8 @@ async def test___async_get_candle_history_sort(default_conf, mocker):
     # Test the ticker history sort
     res = await exchange._async_get_candle_history('ETH/BTC', default_conf['ticker_interval'])
     assert res[0] == 'ETH/BTC'
-    ticks = res[1]
+    assert res[1] == default_conf['ticker_interval']
+    ticks = res[2]
     # Sorted not called again - data is already in order
     assert sort_mock.call_count == 0
     assert ticks[0][0] == 1527827700000

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -912,8 +912,9 @@ def test_refresh_latest_ohlcv_inv_result(default_conf, mocker, caplog):
 
     assert type(res) is list
     assert len(res) == 2
-    assert type(res[0]) is tuple
-    assert type(res[1]) is TypeError
+    # Test that each is in list at least once as order is not guaranteed
+    assert type(res[0]) is tuple or type(res[1]) is tuple
+    assert type(res[0]) is TypeError or type(res[1]) is TypeError
     assert log_has("Error loading ETH/BTC. Result was [[]].", caplog.record_tuples)
     assert log_has("Async code raised an exception: TypeError", caplog.record_tuples)
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -778,7 +778,7 @@ def test_get_history(default_conf, mocker, caplog):
     assert len(ret) == 2
 
 
-def test_refresh_tickers(mocker, default_conf, caplog) -> None:
+def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
     tick = [
         [
             (arrow.utcnow().timestamp - 1) * 1000,  # unix timestamp ms
@@ -805,7 +805,7 @@ def test_refresh_tickers(mocker, default_conf, caplog) -> None:
     pairs = ['IOTA/ETH', 'XRP/ETH']
     # empty dicts
     assert not exchange._klines
-    exchange.refresh_tickers(['IOTA/ETH', 'XRP/ETH'], '5m')
+    exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
 
     assert log_has(f'Refreshing klines for {len(pairs)} pairs', caplog.record_tuples)
     assert exchange._klines
@@ -822,7 +822,7 @@ def test_refresh_tickers(mocker, default_conf, caplog) -> None:
         assert exchange.klines(pair, copy=False) is exchange.klines(pair, copy=False)
 
     # test caching
-    exchange.refresh_tickers(['IOTA/ETH', 'XRP/ETH'], '5m')
+    exchange.refresh_latest_ohlcv(['IOTA/ETH', 'XRP/ETH'], '5m')
 
     assert exchange._api_async.fetch_ohlcv.call_count == 2
     assert log_has(f"Using cached klines data for {pairs[0]} ...", caplog.record_tuples)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -18,6 +18,7 @@ from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.optimize import get_timeframe
 from freqtrade.optimize.backtesting import (Backtesting, setup_configuration,
                                             start)
+from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
 from freqtrade.tests.conftest import log_has, patch_exchange
@@ -200,6 +201,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
     assert 'timerange' not in config
     assert 'export' not in config
+    assert 'runmode' in config
+    assert config['runmode'] == RunMode.BACKTEST
 
 
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
@@ -230,6 +233,8 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
     assert 'exchange' in config
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
+    assert config['runmode'] == RunMode.BACKTEST
+
     assert log_has(
         'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -448,7 +448,7 @@ def test_backtesting_start(default_conf, mocker, caplog) -> None:
 
     mocker.patch('freqtrade.data.history.load_data', mocked_load_data)
     mocker.patch('freqtrade.optimize.get_timeframe', get_timeframe)
-    mocker.patch('freqtrade.exchange.Exchange.refresh_tickers', MagicMock())
+    mocker.patch('freqtrade.exchange.Exchange.refresh_latest_ohlcv', MagicMock())
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.optimize.backtesting.Backtesting',
@@ -483,7 +483,7 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
 
     mocker.patch('freqtrade.data.history.load_data', MagicMock(return_value={}))
     mocker.patch('freqtrade.optimize.get_timeframe', get_timeframe)
-    mocker.patch('freqtrade.exchange.Exchange.refresh_tickers', MagicMock())
+    mocker.patch('freqtrade.exchange.Exchange.refresh_latest_ohlcv', MagicMock())
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.optimize.backtesting.Backtesting',

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -7,6 +7,7 @@ from typing import List
 from freqtrade.edge import PairInfo
 from freqtrade.arguments import Arguments
 from freqtrade.optimize.edge_cli import (EdgeCli, setup_configuration, start)
+from freqtrade.state import RunMode
 from freqtrade.tests.conftest import log_has, patch_exchange
 
 
@@ -26,6 +27,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     ]
 
     config = setup_configuration(get_args(args))
+    assert config['runmode'] == RunMode.EDGECLI
+
     assert 'max_open_trades' in config
     assert 'stake_currency' in config
     assert 'stake_amount' in config
@@ -70,6 +73,7 @@ def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> N
     assert 'exchange' in config
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
+    assert config['runmode'] == RunMode.EDGECLI
     assert log_has(
         'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -43,7 +43,7 @@ def patch_get_signal(freqtrade: FreqtradeBot, value=(True, False)) -> None:
     :return: None
     """
     freqtrade.strategy.get_signal = lambda e, s, t: value
-    freqtrade.exchange.refresh_tickers = lambda p, i: None
+    freqtrade.exchange.refresh_latest_ohlcv = lambda p, i: None
 
 
 def patch_RPCManager(mocker) -> MagicMock:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -807,6 +807,37 @@ def test_process_trade_no_whitelist_pair(
     assert result is True
 
 
+def test_process_informative_pairs_added(default_conf, ticker, markets, mocker) -> None:
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+
+    def _refresh_whitelist(list):
+        return ['ETH/BTC', 'LTC/BTC', 'XRP/BTC', 'NEO/BTC']
+
+    refresh_mock = MagicMock()
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        get_ticker=ticker,
+        get_markets=markets,
+        buy=MagicMock(side_effect=TemporaryError),
+        refresh_latest_ohlcv=refresh_mock,
+    )
+    inf_pairs = MagicMock(return_value=[("BTC/ETH", '1m'), ("ETH/USDT", "1h")])
+    mocker.patch('time.sleep', return_value=None)
+
+    freqtrade = FreqtradeBot(default_conf)
+    freqtrade.pairlists._validate_whitelist = _refresh_whitelist
+    freqtrade.strategy.informative_pairs = inf_pairs
+    # patch_get_signal(freqtrade)
+
+    freqtrade._process()
+    assert inf_pairs.call_count == 1
+    assert refresh_mock.call_count == 1
+    assert ("BTC/ETH", "1m") in refresh_mock.call_args[0][0]
+    assert ("ETH/USDT", "1h") in refresh_mock.call_args[0][0]
+    assert ("ETH/BTC", default_conf["ticker_interval"]) in refresh_mock.call_args[0][0]
+
+
 def test_balance_fully_ask_side(mocker, default_conf) -> None:
     default_conf['bid_strategy']['ask_last_balance'] = 0.0
     freqtrade = get_patched_freqtradebot(mocker, default_conf)

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -43,7 +43,7 @@ def patch_get_signal(freqtrade: FreqtradeBot, value=(True, False)) -> None:
     :return: None
     """
     freqtrade.strategy.get_signal = lambda e, s, t: value
-    freqtrade.exchange.refresh_latest_ohlcv = lambda p, i: None
+    freqtrade.exchange.refresh_latest_ohlcv = lambda p: None
 
 
 def patch_RPCManager(mocker) -> MagicMock:

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -138,8 +138,8 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
     tickers = {}
     if args.live:
         logger.info('Downloading pair.')
-        exchange.refresh_latest_ohlcv([pair], tick_interval)
-        tickers[pair] = exchange.klines(pair)
+        exchange.refresh_latest_ohlcv([(pair, tick_interval)])
+        tickers[pair] = exchange.klines((pair, tick_interval))
     else:
         tickers = history.load_data(
             datadir=Path(_CONF.get("datadir")),

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -138,7 +138,7 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
     tickers = {}
     if args.live:
         logger.info('Downloading pair.')
-        exchange.refresh_tickers([pair], tick_interval)
+        exchange.refresh_latest_ohlcv([pair], tick_interval)
         tickers[pair] = exchange.klines(pair)
     else:
         tickers = history.load_data(

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -29,6 +29,7 @@ from freqtrade.configuration import Configuration
 from freqtrade import constants
 from freqtrade.data import history
 from freqtrade.resolvers import StrategyResolver
+from freqtrade.state import RunMode
 import freqtrade.misc as misc
 
 
@@ -82,7 +83,7 @@ def plot_profit(args: Namespace) -> None:
     # to match the tickerdata against the profits-results
     timerange = Arguments.parse_timerange(args.timerange)
 
-    config = Configuration(args).get_config()
+    config = Configuration(args, RunMode.OTHER).get_config()
 
     # Init strategy
     try:

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -67,6 +67,19 @@ class TestStrategy(IStrategy):
         'sell': 'gtc'
     }
 
+    def additional_pairs(self):
+        """
+        Define additional pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -67,9 +67,9 @@ class TestStrategy(IStrategy):
         'sell': 'gtc'
     }
 
-    def additional_pairs(self):
+    def informative_pairs(self):
         """
-        Define additional pair/interval combinations to be cached from the exchange.
+        Define additional, informative pair/interval combinations to be cached from the exchange.
         These pair/interval combinations are non-tradeable, unless they are part
         of the whitelist as well.
         For more information, please consult the documentation


### PR DESCRIPTION
## Summary
This is the dataprovider, which provides strategy (and the bot overall) with data from the exchange.

Solves part of the issue #1335 

## Quick changelog

- [x] Provide strategy with access to data from other pairs
- [x] provide strategy with access to current wallet situation
- [x] specify non-tradeable pairs in strategy (for reference purposes) - maybe resolves #325 as additional pairs can be used for a correlation matrix (TBC)
- [x] Allow non-tradeable pairs to be downloaded at another time interval (can also be the same pairs at a different frequency)
- [x] runmode available throughout the bot (also through `DataProvider`)
- [x] Document what's new

## Still to do (but outside of the scope of this PR)

- [ ] provide orderbook data (if enabled) through dataprovider
- [ ] provide ticker-data through dataprovider
- [ ] have dataprovider available during backtesting