### PR TITLE
Add information about dataframe

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -216,11 +216,39 @@ This is the set of candles the bot should download and use for the analysis.
 Common values are `"1m"`, `"5m"`, `"15m"`, `"1h"`, however all values supported by your exchange should work.
 
 Please note that the same buy/sell signals may work with one interval, but not the other.
+This setting is accessible within the strategy by using `self.ticker_interval`.
 
 ### Metadata dict
 
 The metadata-dict (available for `populate_buy_trend`, `populate_sell_trend`, `populate_indicators`) contains additional information.
 Currently this is `pair`, which can be accessed using `metadata['pair']` - and will return a pair in the format `XRP/BTC`.
+
+The Metadata-dict should not be modified and does not persist information across multiple calls.
+Instead, have a look at the section [Storing information](#Storing-information)
+
+### Storing information
+
+Storing information can be accomplished by crating a new dictionary within the strategy class.
+
+The name of the variable can be choosen at will, but should be prefixed with `cust_` to avoid naming collisions with predefined strategy variables.
+
+```python
+class Awesomestrategy(IStrategy):
+    # Create custom dictionary
+    cust_info = {}
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        # Check if the entry already exists
+        if "crosstime" in self.cust_info[metadata["pair"]:
+            self.cust_info[metadata["pair"]["crosstime"] += 1
+        else:
+            self.cust_info[metadata["pair"]["crosstime"] = 1
+```
+
+!!! Warning:
+  The data is not persisted after a bot-restart (or config-reload). Also, the amount of data should be kept smallish (no DataFrames and such), otherwise the bot will start to consume a lot of memory and eventually run out of memory and crash.
+
+!!! Note:
+  If the data is pair-specific, make sure to use pair as one of the keys in the dictionary.
 
 ### Where is the default strategy?
 


### PR DESCRIPTION
## Summary
Persisting data in a strategy can be accomplished easily within the strategy itself.
The data will not be persisted across bot restarts, however, the strategy is only instantiated once per bot so storing data in a local dict will work perfectly fine, and is an easy way for users to keep simple information (counters, ...).

Solve the issue: #1192

