### PR TITLE
add more settings to strategy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,12 +17,12 @@ The table below will list all configuration parameters.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes
 | `fiat_display_currency` | USD | Yes | Fiat currency used to show your profits. More information below.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode.
-| `process_only_new_candles` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. Can be set either in Configuration or in the strategy.
-| `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file.
-| `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md).
-| `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md).
-| `trailing_stop_positive` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md).
-| `trailing_stop_positive_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md).
+| `process_only_new_candles` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. [Strategy Override](#parameters-in-strategy).
+| `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. [Strategy Override](#parameters-in-strategy).
+| `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop_positive` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop_positive_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
 | `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
 | `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
@@ -33,8 +33,8 @@ The table below will list all configuration parameters.
 | `ask_strategy.use_order_book` | false | No | Allows selling of open traded pair using the rates in Order Book Asks.
 | `ask_strategy.order_book_min` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
 | `ask_strategy.order_book_max` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
-| `order_types` | None | No | Configure order-types depending on the action (`"buy"`, `"sell"`, `"stoploss"`, `"stoploss_on_exchange"`). [More information below](#understand-order_types).
-| `order_time_in_force` | None | No | Configure time in force for buy and sell orders. [More information below](#understand-order_time_in_force).
+| `order_types` | None | No | Configure order-types depending on the action (`"buy"`, `"sell"`, `"stoploss"`, `"stoploss_on_exchange"`). [More information below](#understand-order_types). [Strategy Override](#parameters-in-strategy).
+| `order_time_in_force` | None | No | Configure time in force for buy and sell orders. [More information below](#understand-order_time_in_force). [Strategy Override](#parameters-in-strategy).
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename).
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.
 | `exchange.secret` | secret | No | API secret to use for the exchange. Only required when you are in production mode.
@@ -44,9 +44,9 @@ The table below will list all configuration parameters.
 | `exchange.ccxt_config` | None | No | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | No | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `edge` | false | No | Please refer to [edge configuration document](edge.md) for detailed explanation.
-| `experimental.use_sell_signal` | false | No | Use your sell strategy in addition of the `minimal_roi`.
-| `experimental.sell_profit_only` | false | No | waits until you have made a positive profit before taking a sell decision.
-| `experimental.ignore_roi_if_buy_signal` | false | No | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`
+| `experimental.use_sell_signal` | false | No | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-strategy).
+| `experimental.sell_profit_only` | false | No | waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-strategy).
+| `experimental.ignore_roi_if_buy_signal` | false | No | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-strategy).
 | `pairlist.method` | StaticPairList | No | Use Static whitelist. [More information below](#dynamic-pairlists).
 | `pairlist.config` | None | No | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
 | `telegram.enabled` | true | Yes | Enable or not the usage of Telegram.
@@ -64,18 +64,37 @@ The table below will list all configuration parameters.
 | `strategy_path` | null | No | Adds an additional strategy lookup path (must be a folder).
 | `internals.process_throttle_secs` | 5 | Yes | Set the process throttle. Value in second.
 
-The definition of each config parameters is in [misc.py](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/misc.py#L205).
+### Parameters in strategy
+
+The following parameters can be set in either configuration or strategy.
+Values in the configuration are always overwriting values set in the strategy.
+
+* `minimal_roi`
+* `ticker_interval`
+* `stoploss`
+* `trailing_stop`
+* `trailing_stop_positive`
+* `trailing_stop_positive_offset`
+* `process_only_new_candles`
+* `order_types`
+* `order_time_in_force`
+* `use_sell_signal` (experimental)
+* `sell_profit_only` (experimental)
+* `ignore_roi_if_buy_signal` (experimental)
 
 ### Understand stake_amount
 
 `stake_amount` is an amount of crypto-currency your bot will use for each trade.
 The minimal value is 0.0005. If there is not enough crypto-currency in
 the account an exception is generated.
-To allow the bot to trade all the avaliable `stake_currency` in your account set<br/>
+To allow the bot to trade all the avaliable `stake_currency` in your account set
+
 ```json
 "stake_amount" : "unlimited",
 ```
-In this case a trade amount is calclulated as: <br/>
+
+In this case a trade amount is calclulated as: 
+
 ```python
 currency_balanse / (max_open_trades - current_open_trades)
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,8 +21,8 @@ The table below will list all configuration parameters.
 | `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. If set, this parameter will override `minimal_roi` from your strategy file.
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md).
 | `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md).
-| `trailing_stop_positve` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md).
-| `trailing_stop_positve_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md).
+| `trailing_stop_positive` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md).
+| `trailing_stop_positive_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md).
 | `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
 | `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ Values in the configuration are always overwriting values set in the strategy.
 `stake_amount` is an amount of crypto-currency your bot will use for each trade.
 The minimal value is 0.0005. If there is not enough crypto-currency in
 the account an exception is generated.
-To allow the bot to trade all the avaliable `stake_currency` in your account set
+To allow the bot to trade all the available `stake_currency` in your account set
 
 ```json
 "stake_amount" : "unlimited",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,60 +9,62 @@ for your bot configuration.
 
 The table below will list all configuration parameters.
 
-|  Command | Default | Mandatory | Description |
-|----------|---------|-----------|-------------|
-| `max_open_trades` | 3 | Yes | Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades)
-| `stake_currency` | BTC | Yes | Crypto-currency used for trading.
-| `stake_amount` | 0.05 | Yes | Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all avaliable balance.
-| `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | No | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes
-| `fiat_display_currency` | USD | Yes | Fiat currency used to show your profits. More information below.
-| `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode.
-| `process_only_new_candles` | false | No | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. [Strategy Override](#parameters-in-strategy).
-| `minimal_roi` | See below | No | Set the threshold in percent the bot will use to sell a trade. More information below. [Strategy Override](#parameters-in-strategy).
-| `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
-| `trailing_stop` | false | No | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
-| `trailing_stop_positive` | 0 | No | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
-| `trailing_stop_positive_offset` | 0 | No | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
-| `unfilledtimeout.buy` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
-| `unfilledtimeout.sell` | 10 | Yes | How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
-| `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
-| `bid_strategy.use_order_book` | false | No | Allows buying of pair using the rates in Order Book Bids.
-| `bid_strategy.order_book_top` | 0 | No | Bot will use the top N rate in Order Book Bids. Ie. a value of 2 will allow the bot to pick the 2nd bid rate in Order Book Bids.
-| `bid_strategy. check_depth_of_market.enabled` | false | No | Does not buy if the % difference of buy orders and sell orders is met in Order Book.
-| `bid_strategy. check_depth_of_market.bids_to_ask_delta` | 0 | No | The % difference of buy orders and sell orders found in Order Book. A value lesser than 1 means sell orders is greater, while value greater than 1 means buy orders is higher.
-| `ask_strategy.use_order_book` | false | No | Allows selling of open traded pair using the rates in Order Book Asks.
-| `ask_strategy.order_book_min` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
-| `ask_strategy.order_book_max` | 0 | No | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
-| `order_types` | None | No | Configure order-types depending on the action (`"buy"`, `"sell"`, `"stoploss"`, `"stoploss_on_exchange"`). [More information below](#understand-order_types). [Strategy Override](#parameters-in-strategy).
-| `order_time_in_force` | None | No | Configure time in force for buy and sell orders. [More information below](#understand-order_time_in_force). [Strategy Override](#parameters-in-strategy).
-| `exchange.name` | bittrex | Yes | Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename).
-| `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.
-| `exchange.secret` | secret | No | API secret to use for the exchange. Only required when you are in production mode.
-| `exchange.pair_whitelist` | [] | No | List of currency to use by the bot. Can be overrided with `--dynamic-whitelist` param.
-| `exchange.pair_blacklist` | [] | No | List of currency the bot must avoid. Useful when using `--dynamic-whitelist` param.
-| `exchange.ccxt_rate_limit` | True | No | DEPRECATED!! Have CCXT handle Exchange rate limits. Depending on the exchange, having this to false can lead to temporary bans from the exchange.
-| `exchange.ccxt_config` | None | No | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
-| `exchange.ccxt_async_config` | None | No | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
-| `edge` | false | No | Please refer to [edge configuration document](edge.md) for detailed explanation.
-| `experimental.use_sell_signal` | false | No | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-strategy).
-| `experimental.sell_profit_only` | false | No | waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-strategy).
-| `experimental.ignore_roi_if_buy_signal` | false | No | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-strategy).
-| `pairlist.method` | StaticPairList | No | Use Static whitelist. [More information below](#dynamic-pairlists).
-| `pairlist.config` | None | No | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
-| `telegram.enabled` | true | Yes | Enable or not the usage of Telegram.
-| `telegram.token` | token | No | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
-| `telegram.chat_id` | chat_id | No | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.
-| `webhook.enabled` | false | No | Enable usage of Webhook notifications
-| `webhook.url` | false | No | URL for the webhook. Only required if `webhook.enabled` is `true`. See the [webhook documentation](webhook-config.md) for more details.
-| `webhook.webhookbuy` | false | No | Payload to send on buy. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
-| `webhook.webhooksell` | false | No | Payload to send on sell. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
-| `webhook.webhookstatus` | false | No | Payload to send on status calls. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
-| `db_url` | `sqlite:///tradesv3.sqlite`| No | Declares database URL to use. NOTE: This defaults to `sqlite://` if `dry_run` is `True`.
-| `initial_state` | running | No | Defines the initial application state. More information below.
-| `forcebuy_enable` | false | No | Enables the RPC Commands to force a buy. More information below.
-| `strategy` | DefaultStrategy | No | Defines Strategy class to use.
-| `strategy_path` | null | No | Adds an additional strategy lookup path (must be a folder).
-| `internals.process_throttle_secs` | 5 | Yes | Set the process throttle. Value in second.
+Mandatory Parameters are marked as **Required**.
+
+|  Command | Default | Description |
+|----------|---------|-------------|
+| `max_open_trades` | 3 | **Required.** Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades)
+| `stake_currency` | BTC | **Required.** Crypto-currency used for trading.
+| `stake_amount` | 0.05 | **Required.** Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all avaliable balance.
+| `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes. [Strategy Override](#parameters-in-strategy).
+| `fiat_display_currency` | USD | **Required.** Fiat currency used to show your profits. More information below.
+| `dry_run` | true | **Required.** Define if the bot must be in Dry-run or production mode.
+| `process_only_new_candles` | false | If set to true indicators are processed only once a new candle arrives. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. [Strategy Override](#parameters-in-strategy).
+| `minimal_roi` | See below | Set the threshold in percent the bot will use to sell a trade. More information below. [Strategy Override](#parameters-in-strategy).
+| `stoploss` | -0.10 | Value of the stoploss in percent used by the bot. More information below. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop` | false | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop_positive` | 0 | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_stop_positive_offset` | 0 | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `unfilledtimeout.buy` | 10 | **Required.** How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
+| `unfilledtimeout.sell` | 10 | **Required.** How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
+| `bid_strategy.ask_last_balance` | 0.0 | **Required.** Set the bidding price. More information [below](#understand-ask_last_balance).
+| `bid_strategy.use_order_book` | false | Allows buying of pair using the rates in Order Book Bids.
+| `bid_strategy.order_book_top` | 0 | Bot will use the top N rate in Order Book Bids. Ie. a value of 2 will allow the bot to pick the 2nd bid rate in Order Book Bids.
+| `bid_strategy. check_depth_of_market.enabled` | false | Does not buy if the % difference of buy orders and sell orders is met in Order Book.
+| `bid_strategy. check_depth_of_market.bids_to_ask_delta` | 0 | The % difference of buy orders and sell orders found in Order Book. A value lesser than 1 means sell orders is greater, while value greater than 1 means buy orders is higher.
+| `ask_strategy.use_order_book` | false | Allows selling of open traded pair using the rates in Order Book Asks.
+| `ask_strategy.order_book_min` | 0 | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
+| `ask_strategy.order_book_max` | 0 | Bot will scan from the top min to max Order Book Asks searching for a profitable rate.
+| `order_types` | None | Configure order-types depending on the action (`"buy"`, `"sell"`, `"stoploss"`, `"stoploss_on_exchange"`). [More information below](#understand-order_types). [Strategy Override](#parameters-in-strategy).
+| `order_time_in_force` | None | Configure time in force for buy and sell orders. [More information below](#understand-order_time_in_force). [Strategy Override](#parameters-in-strategy).
+| `exchange.name` | bittrex | **Required.** Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename).
+| `exchange.key` | key | API key to use for the exchange. Only required when you are in production mode.
+| `exchange.secret` | secret | API secret to use for the exchange. Only required when you are in production mode.
+| `exchange.pair_whitelist` | [] | List of currency to use by the bot. Can be overrided with `--dynamic-whitelist` param.
+| `exchange.pair_blacklist` | [] | List of currency the bot must avoid. Useful when using `--dynamic-whitelist` param.
+| `exchange.ccxt_rate_limit` | True | DEPRECATED!! Have CCXT handle Exchange rate limits. Depending on the exchange, having this to false can lead to temporary bans from the exchange.
+| `exchange.ccxt_config` | None | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
+| `exchange.ccxt_async_config` | None | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
+| `edge` | false | Please refer to [edge configuration document](edge.md) for detailed explanation.
+| `experimental.use_sell_signal` | false | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-strategy).
+| `experimental.sell_profit_only` | false | Waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-strategy).
+| `experimental.ignore_roi_if_buy_signal` | false | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-strategy).
+| `pairlist.method` | StaticPairList | Use Static whitelist. [More information below](#dynamic-pairlists).
+| `pairlist.config` | None | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
+| `telegram.enabled` | true | **Required.** Enable or not the usage of Telegram.
+| `telegram.token` | token | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
+| `telegram.chat_id` | chat_id | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.
+| `webhook.enabled` | false | Enable usage of Webhook notifications
+| `webhook.url` | false | URL for the webhook. Only required if `webhook.enabled` is `true`. See the [webhook documentation](webhook-config.md) for more details.
+| `webhook.webhookbuy` | false | Payload to send on buy. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
+| `webhook.webhooksell` | false | Payload to send on sell. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
+| `webhook.webhookstatus` | false | Payload to send on status calls. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details.
+| `db_url` | `sqlite:///tradesv3.sqlite`| Declares database URL to use. NOTE: This defaults to `sqlite://` if `dry_run` is `True`.
+| `initial_state` | running | Defines the initial application state. More information below.
+| `forcebuy_enable` | false | Enables the RPC Commands to force a buy. More information below.
+| `strategy` | DefaultStrategy | Defines Strategy class to use.
+| `strategy_path` | null | Adds an additional strategy lookup path (must be a folder).
+| `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
 
 ### Parameters in strategy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Mandatory Parameters are marked as **Required**.
 |----------|---------|-------------|
 | `max_open_trades` | 3 | **Required.** Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades)
 | `stake_currency` | BTC | **Required.** Crypto-currency used for trading.
-| `stake_amount` | 0.05 | **Required.** Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all avaliable balance.
+| `stake_amount` | 0.05 | **Required.** Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all available balance.
 | `ticker_interval` | [1m, 5m, 30m, 1h, 1d] | The ticker interval to use (1min, 5 min, 30 min, 1 hour or 1 day). Default is 5 minutes. [Strategy Override](#parameters-in-strategy).
 | `fiat_display_currency` | USD | **Required.** Fiat currency used to show your profits. More information below.
 | `dry_run` | true | **Required.** Define if the bot must be in Dry-run or production mode.

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -45,19 +45,19 @@ class StrategyResolver(IResolver):
 
         # Set attributes
         # Check if we need to override configuration
-        # (Attribute name,                           default, experimental)
-        attributes = [("minimal_roi",                   None, False),
-                      ("ticker_interval",               None, False),
-                      ("stoploss",                      None, False),
-                      ("trailing_stop",                 None, False),
-                      ("trailing_stop_positive",        None, False),
-                      ("trailing_stop_positive_offset", 0.0, False),
-                      ("process_only_new_candles",      None, False),
-                      ("order_types",                   None, False),
-                      ("order_time_in_force",           None, False),
-                      ("use_sell_signal",               False, True),
-                      ("sell_profit_only",              False, True),
-                      ("ignore_roi_if_buy_signal",      False, True),
+        # (Attribute name,                              default, experimental)
+        attributes = [("minimal_roi",                   None,    False),
+                      ("ticker_interval",               None,    False),
+                      ("stoploss",                      None,    False),
+                      ("trailing_stop",                 None,    False),
+                      ("trailing_stop_positive",        None,    False),
+                      ("trailing_stop_positive_offset", 0.0,     False),
+                      ("process_only_new_candles",      None,    False),
+                      ("order_types",                   None,    False),
+                      ("order_time_in_force",           None,    False),
+                      ("use_sell_signal",               False,   True),
+                      ("sell_profit_only",              False,   True),
+                      ("ignore_roi_if_buy_signal",      False,   True),
                       ]
         for attribute, default, experimental in attributes:
             if experimental:

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -56,8 +56,8 @@ class StrategyResolver(IResolver):
                       ("order_types",                   None, False),
                       ("order_time_in_force",           None, False),
                       ("use_sell_signal",               False, True),
-                      ("sell_profit_only",              None, True),
-                      ("ignore_roi_if_buy_signal",      None, True),
+                      ("sell_profit_only",              False, True),
+                      ("ignore_roi_if_buy_signal",      False, True),
                       ]
         for attribute, default, experimental in attributes:
             if experimental:

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -38,24 +38,38 @@ class StrategyResolver(IResolver):
         self.strategy: IStrategy = self._load_strategy(strategy_name,
                                                        config=config,
                                                        extra_dir=config.get('strategy_path'))
+
+        # make sure experimental dict is available
+        if 'experimental' not in config:
+            config['experimental'] = {}
+
         # Set attributes
         # Check if we need to override configuration
-        attributes = ["minimal_roi",
-                      "ticker_interval",
-                      "stoploss",
-                      "trailing_stop",
-                      "trailing_stop_positive",
-                      "trailing_stop_positive_offset",
-                      "process_only_new_candles",
-                      "order_types",
-                      "order_time_in_force"
+        # (Attribute name,                           default, experimental)
+        attributes = [("minimal_roi",                   None, False),
+                      ("ticker_interval",               None, False),
+                      ("stoploss",                      None, False),
+                      ("trailing_stop",                 None, False),
+                      ("trailing_stop_positive",        None, False),
+                      ("trailing_stop_positive_offset", 0.0, False),
+                      ("process_only_new_candles",      None, False),
+                      ("order_types",                   None, False),
+                      ("order_time_in_force",           None, False),
+                      ("use_sell_signal",               False, True),
+                      ("sell_profit_only",              None, True),
+                      ("ignore_roi_if_buy_signal",      None, True),
                       ]
-        for attribute in attributes:
-            self._override_attribute_helper(config, attribute)
+        for attribute, default, experimental in attributes:
+            if experimental:
+                self._override_attribute_helper(config['experimental'], attribute, default)
+            else:
+                self._override_attribute_helper(config, attribute, default)
 
         # Loop this list again to have output combined
-        for attribute in attributes:
-            if attribute in config:
+        for attribute, _, exp in attributes:
+            if exp and attribute in config['experimental']:
+                logger.info("Strategy using %s: %s", attribute, config['experimental'][attribute])
+            elif attribute in config:
                 logger.info("Strategy using %s: %s", attribute, config[attribute])
 
         # Sort and apply type conversions
@@ -66,13 +80,24 @@ class StrategyResolver(IResolver):
 
         self._strategy_sanity_validations()
 
-    def _override_attribute_helper(self, config, attribute: str):
+    def _override_attribute_helper(self, config, attribute: str, default):
+        """
+        Override attributes in the strategy.
+        Prevalence:
+        - Configuration
+        - Strategy
+        - default (if not None)
+        """
         if attribute in config:
             setattr(self.strategy, attribute, config[attribute])
             logger.info("Override strategy '%s' with value in config file: %s.",
                         attribute, config[attribute])
         elif hasattr(self.strategy, attribute):
             config[attribute] = getattr(self.strategy, attribute)
+        # Explicitly check for None here as other "falsy" values are possible
+        elif default is not None:
+            setattr(self.strategy, attribute, default)
+            config[attribute] = default
 
     def _strategy_sanity_validations(self):
         if not all(k in self.strategy.order_types for k in constants.REQUIRED_ORDERTYPES):

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -302,7 +302,7 @@ class IStrategy(ABC):
             # and if profit is positive
             stop_loss_value = force_stoploss if force_stoploss else self.stoploss
 
-            sl_offset = self.config.get('trailing_stop_positive_offset', 0.0)
+            sl_offset = self.config.get('trailing_stop_positive_offset') or 0.0
 
             if 'trailing_stop_positive' in self.config and current_profit > sl_offset:
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -294,6 +294,62 @@ def test_strategy_override_order_tif(caplog):
         StrategyResolver(config)
 
 
+def test_strategy_override_use_sell_signal(caplog):
+    caplog.set_level(logging.INFO)
+    config = {
+        'strategy': 'DefaultStrategy',
+    }
+    resolver = StrategyResolver(config)
+    assert not resolver.strategy.use_sell_signal
+    assert isinstance(resolver.strategy.use_sell_signal, bool)
+    # must be inserted to configuration
+    assert 'use_sell_signal' in config['experimental']
+    assert not config['experimental']['use_sell_signal']
+
+    config = {
+        'strategy': 'DefaultStrategy',
+        'experimental': {
+            'use_sell_signal': True,
+        },
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.use_sell_signal
+    assert isinstance(resolver.strategy.use_sell_signal, bool)
+    assert ('freqtrade.resolvers.strategy_resolver',
+            logging.INFO,
+            "Override strategy 'use_sell_signal' with value in config file: True."
+            ) in caplog.record_tuples
+
+
+def test_strategy_override_use_sell_profit_only(caplog):
+    caplog.set_level(logging.INFO)
+    config = {
+        'strategy': 'DefaultStrategy',
+    }
+    resolver = StrategyResolver(config)
+    assert not resolver.strategy.sell_profit_only
+    assert isinstance(resolver.strategy.sell_profit_only, bool)
+    # must be inserted to configuration
+    assert 'sell_profit_only' in config['experimental']
+    assert not config['experimental']['sell_profit_only']
+
+    config = {
+        'strategy': 'DefaultStrategy',
+        'experimental': {
+            'sell_profit_only': True,
+        },
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.sell_profit_only
+    assert isinstance(resolver.strategy.sell_profit_only, bool)
+    assert ('freqtrade.resolvers.strategy_resolver',
+            logging.INFO,
+            "Override strategy 'sell_profit_only' with value in config file: True."
+            ) in caplog.record_tuples
+
+
 def test_deprecate_populate_indicators(result):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     resolver = StrategyResolver({'strategy': 'TestStrategyLegacy',

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -45,7 +45,7 @@ class TestStrategy(IStrategy):
     # trailing stoploss
     trailing_stop = False
     trailing_stop_positive = 0.01
-    trailing_stop_positive_offset = None  # Disabled / not configured
+    trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
     # Optimal ticker interval for the strategy
     ticker_interval = '5m'

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -53,6 +53,11 @@ class TestStrategy(IStrategy):
     # run "populate_indicators" only for new candle
     ta_on_candle = False
 
+    # Experimental settings (configuration will overide these if set)
+    use_sell_signal = False
+    use_profit_only = False
+    ignore_roi_if_buy_signal = False
+
     # Optional order type mapping
     order_types = {
         'buy': 'limit',


### PR DESCRIPTION
## Summary
Add experimental settings to strategy - as it's almost exclusively strategy-dependant if the sell-signal makes sense or not.

* Drop mandatory column in the documentation hoping that this will make this table simpler to read. 

