### PR TITLE
syntax error -z after variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ function check_installed_python() {
         return
    fi
 
-   if [ -z ${PYTHON} ]; then
+   if [ ${PYTHON} -z ]; then
         echo "No usable python found. Please make sure to have python3.6 or python3.7 installed"
         exit 1
    fi


### PR DESCRIPTION
Consider splitting mac and linux  install scripts into separate files
would always pull null and so bash   wouldn't see that python3.7 or python3.6 was installed, formatted syntax correctly for proper function of -z