### PR TITLE
Cosmetic: fix logging

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -267,9 +267,8 @@ class FreqtradeBot(object):
         # Check if stake_amount is fulfilled
         if avaliable_amount < stake_amount:
             raise DependencyException(
-                'Available balance(%f %s) is lower than stake amount(%f %s)' % (
-                    avaliable_amount, self.config['stake_currency'],
-                    stake_amount, self.config['stake_currency'])
+                f'Available balance({avaliable_amount} {self.config['stake_currency']}) is lower than '
+                f'stake amount({stake_amount} {self.config['stake_currency']})'
             )
 
         return stake_amount
@@ -333,10 +332,7 @@ class FreqtradeBot(object):
                 if not stake_amount:
                     return False
 
-                logger.info(
-                    'Buy signal found: about create a new trade with stake_amount: %f ...',
-                    stake_amount
-                )
+                logger.info(f'Buy signal found: about create a new trade with stake_amount: {stake_amount} ...')
 
                 bidstrat_check_depth_of_market = self.config.get('bid_strategy', {}).\
                     get('check_depth_of_market', {})
@@ -388,8 +384,8 @@ class FreqtradeBot(object):
         min_stake_amount = self._get_min_pair_stake_amount(pair_s, buy_limit_requested)
         if min_stake_amount is not None and min_stake_amount > stake_amount:
             logger.warning(
-                f'Can\'t open a new trade for {pair_s}: stake amount'
-                f' is too small ({stake_amount} < {min_stake_amount})'
+                f'Can\'t open a new trade for {pair_s}: stake amount '
+                f'is too small ({stake_amount} < {min_stake_amount})'
             )
             return False
 
@@ -507,7 +503,7 @@ class FreqtradeBot(object):
                         trade.fee_open = 0
 
                 except OperationalException as exception:
-                    logger.warning("could not update trade amount: %s", exception)
+                    logger.warning("Could not update trade amount: %s", exception)
 
                 trade.update(order)
 
@@ -566,12 +562,12 @@ class FreqtradeBot(object):
                     fee_abs += exectrade['fee']['cost']
 
         if amount != order_amount:
-            logger.warning(f"amount {amount} does not match amount {trade.amount}")
+            logger.warning(f"Amount {amount} does not match amount {trade.amount}")
             raise OperationalException("Half bought? Amounts don't match")
         real_amount = amount - fee_abs
         if fee_abs != 0:
-            logger.info(f"""Applying fee on amount for {trade} \
-(from {order_amount} to {real_amount}) from Trades""")
+            logger.info(f"Applying fee on amount for {trade} "
+                        f"(from {order_amount} to {real_amount}) from Trades")
         return real_amount
 
     def handle_trade(self, trade: Trade) -> bool:
@@ -580,7 +576,7 @@ class FreqtradeBot(object):
         :return: True if trade has been sold, False otherwise
         """
         if not trade.is_open:
-            raise ValueError(f'attempt to handle closed trade: {trade}')
+            raise ValueError(f'Attempt to handle closed trade: {trade}')
 
         logger.debug('Handling %s ...', trade)
         sell_rate = self.exchange.get_ticker(trade.pair)['bid']

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -267,8 +267,8 @@ class FreqtradeBot(object):
         # Check if stake_amount is fulfilled
         if avaliable_amount < stake_amount:
             raise DependencyException(
-                f'Available balance({avaliable_amount} {self.config['stake_currency']}) is lower than '
-                f'stake amount({stake_amount} {self.config['stake_currency']})'
+                f"Available balance({avaliable_amount} {self.config['stake_currency']}) is lower than "
+                f"stake amount({stake_amount} {self.config['stake_currency']})"
             )
 
         return stake_amount

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -267,8 +267,8 @@ class FreqtradeBot(object):
         # Check if stake_amount is fulfilled
         if avaliable_amount < stake_amount:
             raise DependencyException(
-                f"Available balance({avaliable_amount} {self.config['stake_currency']}) is lower than "
-                f"stake amount({stake_amount} {self.config['stake_currency']})"
+                f"Available balance({avaliable_amount} {self.config['stake_currency']}) is "
+                f"lower than stake amount({stake_amount} {self.config['stake_currency']})"
             )
 
         return stake_amount
@@ -332,7 +332,8 @@ class FreqtradeBot(object):
                 if not stake_amount:
                     return False
 
-                logger.info(f'Buy signal found: about create a new trade with stake_amount: {stake_amount} ...')
+                logger.info(f"Buy signal found: about create a new trade with stake_amount: "
+                            f"{stake_amount} ...")
 
                 bidstrat_check_depth_of_market = self.config.get('bid_strategy', {}).\
                     get('check_depth_of_market', {})

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -691,7 +691,7 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order,
     assert trade.amount == 90.99181073703367
 
     assert log_has(
-        'Buy signal found: about create a new trade with stake_amount: 0.001000 ...',
+        'Buy signal found: about create a new trade with stake_amount: 0.001 ...',
         caplog.record_tuples
     )
 
@@ -1318,7 +1318,7 @@ def test_process_maybe_execute_sell_exception(mocker, default_conf,
         side_effect=OperationalException()
     )
     freqtrade.process_maybe_execute_sell(trade)
-    assert log_has('could not update trade amount: ', caplog.record_tuples)
+    assert log_has('Could not update trade amount: ', caplog.record_tuples)
 
     # Test raise of DependencyException exception
     mocker.patch(


### PR DESCRIPTION
Output stake_amount as it is defined in the config (it may be int) instead of float. In order to avoid unnecessary questions where and why it was converted to float and changed in the last digit while it should be integer for the exchange...

Other small cosmetic improvements to logging in freqtradebot.py
