### PR TITLE
OHLCV should be float for TA-LIB indicators in the strategy

### DIFF
--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -29,6 +29,10 @@ def parse_ticker_dataframe(ticker: list, ticker_interval: str,
                                 utc=True,
                                 infer_datetime_format=True)
 
+    # Some exchanges return int values for volume and even for ohlc.
+    # Convert them since TA-LIB indicators used in the strategy assume floats and fail with exception...
+    frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float', 'volume': 'float'})
+
     # group by index and aggregate results to eliminate duplicate ticks
     frame = frame.groupby(by='date', as_index=False, sort=True).agg({
         'open': 'first',

--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -31,7 +31,8 @@ def parse_ticker_dataframe(ticker: list, ticker_interval: str,
 
     # Some exchanges return int values for volume and even for ohlc.
     # Convert them since TA-LIB indicators used in the strategy assume floats and fail with exception...
-    frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float', 'volume': 'float'})
+    frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float', 
+                                'volume': 'float'})
 
     # group by index and aggregate results to eliminate duplicate ticks
     frame = frame.groupby(by='date', as_index=False, sort=True).agg({

--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -30,8 +30,9 @@ def parse_ticker_dataframe(ticker: list, ticker_interval: str,
                                 infer_datetime_format=True)
 
     # Some exchanges return int values for volume and even for ohlc.
-    # Convert them since TA-LIB indicators used in the strategy assume floats and fail with exception...
-    frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float', 
+    # Convert them since TA-LIB indicators used in the strategy assume floats 
+    # and fail with exception...
+    frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float',
                                 'volume': 'float'})
 
     # group by index and aggregate results to eliminate duplicate ticks

--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -30,7 +30,7 @@ def parse_ticker_dataframe(ticker: list, ticker_interval: str,
                                 infer_datetime_format=True)
 
     # Some exchanges return int values for volume and even for ohlc.
-    # Convert them since TA-LIB indicators used in the strategy assume floats 
+    # Convert them since TA-LIB indicators used in the strategy assume floats
     # and fail with exception...
     frame = frame.astype(dtype={'open': 'float', 'high': 'float', 'low': 'float', 'close': 'float',
                                 'volume': 'float'})


### PR DESCRIPTION
Some exchanges (BitMEX) return integer values for Volume field. And sometimes even for OHLC -- same, on BitMEX, since price decrease is 0.5. TA-LIB functions assume floats and fail with exception.
Of course, this can be fixed (converted) in ccxt for particular exchange, but TA-LIB will still fail for exchanges for that such a conversion is not implemented in ccxt code. So let's make perform this conversion here in order to be sure our strategy will not crash on a new exchange.
