### PR TITLE
execute_buy, handle_trade: do not use ticker if use_order_book:true is set in config

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -577,7 +577,6 @@ class FreqtradeBot(object):
             raise ValueError(f'Attempt to handle closed trade: {trade}')
 
         logger.debug('Handling %s ...', trade)
-        sell_rate = self.exchange.get_ticker(trade.pair)['bid']
 
         (buy, sell) = (False, False)
         experimental = self.config.get('experimental', {})
@@ -597,18 +596,15 @@ class FreqtradeBot(object):
 
             for i in range(order_book_min, order_book_max + 1):
                 order_book_rate = order_book['asks'][i - 1][0]
-
-                # if orderbook has higher rate (high profit),
-                # use orderbook, otherwise just use bids rate
                 logger.info('  order book asks top %s: %0.8f', i, order_book_rate)
-                if sell_rate < order_book_rate:
-                    sell_rate = order_book_rate
+                sell_rate = order_book_rate
 
                 if self.check_sell(trade, sell_rate, buy, sell):
                     return True
 
         else:
             logger.debug('checking sell')
+            sell_rate = self.exchange.get_ticker(trade.pair)['bid']
             if self.check_sell(trade, sell_rate, buy, sell):
                 return True
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -204,7 +204,7 @@ class FreqtradeBot(object):
             self.state = State.STOPPED
         return state_changed
 
-    def get_target_bid(self, pair: str, test_ticker: Dict[str, float]) -> float:
+    def get_target_bid(self, pair: str, test_ticker: Dict[str, float] = None) -> float:
         """
         Calculates bid target between current ask price and last price
         :param test_ticker: Ticker to use for getting Ask and Last Price; left for tests

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -204,19 +204,11 @@ class FreqtradeBot(object):
             self.state = State.STOPPED
         return state_changed
 
-    def get_target_bid(self, pair: str, ticker: Dict[str, float]) -> float:
+    def get_target_bid(self, pair: str) -> float:
         """
         Calculates bid target between current ask price and last price
-        :param ticker: Ticker to use for getting Ask and Last Price
         :return: float: Price
         """
-        if ticker['ask'] < ticker['last']:
-            ticker_rate = ticker['ask']
-        else:
-            balance = self.config['bid_strategy']['ask_last_balance']
-            ticker_rate = ticker['ask'] + balance * (ticker['last'] - ticker['ask'])
-
-        used_rate = ticker_rate
         config_bid_strategy = self.config.get('bid_strategy', {})
         if 'use_order_book' in config_bid_strategy and\
                 config_bid_strategy.get('use_order_book', False):
@@ -226,15 +218,16 @@ class FreqtradeBot(object):
             logger.debug('order_book %s', order_book)
             # top 1 = index 0
             order_book_rate = order_book['bids'][order_book_top - 1][0]
-            # if ticker has lower rate, then use ticker ( usefull if down trending )
             logger.info('...top %s order book buy rate %0.8f', order_book_top, order_book_rate)
-            if ticker_rate < order_book_rate:
-                logger.info('...using ticker rate instead %0.8f', ticker_rate)
-                used_rate = ticker_rate
-            else:
-                used_rate = order_book_rate
+            used_rate = order_book_rate
         else:
             logger.info('Using Last Ask / Last Price')
+            ticker = self.exchange.get_ticker(pair)
+            if ticker['ask'] < ticker['last']:
+                ticker_rate = ticker['ask']
+            else:
+                balance = self.config['bid_strategy']['ask_last_balance']
+                ticker_rate = ticker['ask'] + balance * (ticker['last'] - ticker['ask'])
             used_rate = ticker_rate
 
         return used_rate
@@ -380,7 +373,7 @@ class FreqtradeBot(object):
             buy_limit_requested = price
         else:
             # Calculate amount
-            buy_limit_requested = self.get_target_bid(pair, self.exchange.get_ticker(pair))
+            buy_limit_requested = self.get_target_bid(pair)
 
         min_stake_amount = self._get_min_pair_stake_amount(pair_s, buy_limit_requested)
         if min_stake_amount is not None and min_stake_amount > stake_amount:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -204,9 +204,10 @@ class FreqtradeBot(object):
             self.state = State.STOPPED
         return state_changed
 
-    def get_target_bid(self, pair: str) -> float:
+    def get_target_bid(self, pair: str, test_ticker: Dict[str, float]) -> float:
         """
         Calculates bid target between current ask price and last price
+        :param test_ticker: Ticker to use for getting Ask and Last Price; left for tests
         :return: float: Price
         """
         config_bid_strategy = self.config.get('bid_strategy', {})
@@ -222,7 +223,10 @@ class FreqtradeBot(object):
             used_rate = order_book_rate
         else:
             logger.info('Using Last Ask / Last Price')
-            ticker = self.exchange.get_ticker(pair)
+            if test_ticker is not None:
+                ticker = test_ticker
+            else:
+                ticker = self.exchange.get_ticker(pair)
             if ticker['ask'] < ticker['last']:
                 ticker_rate = ticker['ask']
             else:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -204,10 +204,9 @@ class FreqtradeBot(object):
             self.state = State.STOPPED
         return state_changed
 
-    def get_target_bid(self, pair: str, test_ticker: Dict[str, float] = None) -> float:
+    def get_target_bid(self, pair: str) -> float:
         """
         Calculates bid target between current ask price and last price
-        :param test_ticker: Ticker to use for getting Ask and Last Price; left for tests
         :return: float: Price
         """
         config_bid_strategy = self.config.get('bid_strategy', {})
@@ -223,10 +222,7 @@ class FreqtradeBot(object):
             used_rate = order_book_rate
         else:
             logger.info('Using Last Ask / Last Price')
-            if test_ticker is not None:
-                ticker = test_ticker
-            else:
-                ticker = self.exchange.get_ticker(pair)
+            ticker = self.exchange.get_ticker(pair)
             if ticker['ask'] < ticker['last']:
                 ticker_rate = ticker['ask']
             else:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2858,7 +2858,9 @@ def test_order_book_bid_strategy2(mocker, default_conf, order_book_l2, markets) 
     default_conf['telegram']['enabled'] = False
 
     freqtrade = FreqtradeBot(default_conf)
-    assert freqtrade.get_target_bid('ETH/BTC', ) == 0.042
+    # ordrebook shall be used even if tickers would be lower.
+    assert freqtrade.get_target_bid('ETH/BTC', ) != 0.042
+    assert ticker_mock.call_count == 0
 
 
 def test_check_depth_of_market_buy(default_conf, mocker, order_book_l2, markets) -> None:


### PR DESCRIPTION
This PR corresponds to:
https://github.com/freqtrade/freqtrade/issues/1377#issue-386200394
by @mishaker in understanding that a ticker is mostly a statistical thing, but on the other side, create_trade/execute_buy.

It resolves problem with some exchanges (BitMex) where ticker structure returned by ccxt does not contain bid and ask values.

1. On exchanges like Bitmex, set use_order_book: true for buys. FT won't request ticker and will use data from order book only.
2. On exchanges where order book is not available, set use_order_book: false, ticker data (including ask/last balance logic) will be used.
3. On other exchanges, either approach may be used in the config.

Performance: current implementation fetches ticker every time even if order book data will be later used. With this change it's eliminated. So performance gets better.

Comparison of order book rate and ticker rate is removed (in order to split fetching order book and ticker completely in execute_buy), so some tests that touch this code may require adjustments.

