### PR TITLE
logs: cosmetic changes

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -191,7 +191,7 @@ class FreqtradeBot(object):
                 Trade.session.flush()
 
         except TemporaryError as error:
-            logger.warning('%s, retrying in 30 seconds...', error)
+            logger.warning(f"Error: {error}, retrying in {constants.RETRY_TIMEOUT} seconds...")
             time.sleep(constants.RETRY_TIMEOUT)
         except OperationalException:
             tb = traceback.format_exc()

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -172,7 +172,7 @@ class IStrategy(ABC):
             dataframe = self.advise_sell(dataframe, metadata)
             self._last_candle_seen_per_pair[pair] = dataframe.iloc[-1]['date']
         else:
-            logger.debug("Skippinig TA Analysis for already analyzed candle")
+            logger.debug("Skipping TA Analysis for already analyzed candle")
             dataframe['buy'] = 0
             dataframe['sell'] = 0
 

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -204,7 +204,7 @@ def test_analyze_ticker_default(ticker_history, mocker, caplog) -> None:
     assert buy_mock.call_count == 1
 
     assert log_has('TA Analysis Launched', caplog.record_tuples)
-    assert not log_has('Skippinig TA Analysis for already analyzed candle',
+    assert not log_has('Skipping TA Analysis for already analyzed candle',
                        caplog.record_tuples)
     caplog.clear()
 
@@ -214,7 +214,7 @@ def test_analyze_ticker_default(ticker_history, mocker, caplog) -> None:
     assert buy_mock.call_count == 2
     assert buy_mock.call_count == 2
     assert log_has('TA Analysis Launched', caplog.record_tuples)
-    assert not log_has('Skippinig TA Analysis for already analyzed candle',
+    assert not log_has('Skipping TA Analysis for already analyzed candle',
                        caplog.record_tuples)
 
 
@@ -242,7 +242,7 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
     assert buy_mock.call_count == 1
     assert buy_mock.call_count == 1
     assert log_has('TA Analysis Launched', caplog.record_tuples)
-    assert not log_has('Skippinig TA Analysis for already analyzed candle',
+    assert not log_has('Skipping TA Analysis for already analyzed candle',
                        caplog.record_tuples)
     caplog.clear()
 
@@ -257,5 +257,5 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
     assert ret['buy'].sum() == 0
     assert ret['sell'].sum() == 0
     assert not log_has('TA Analysis Launched', caplog.record_tuples)
-    assert log_has('Skippinig TA Analysis for already analyzed candle',
+    assert log_has('Skipping TA Analysis for already analyzed candle',
                    caplog.record_tuples)


### PR DESCRIPTION
* "30 seconds" was errorneously hardcoded in the text of the log message, while actually it's RETRY_TIMEOUT which may differ
