### PR TITLE
[PoC] Performance: use exchange.markets instead of expensive get_markets() (Part 1)

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -274,12 +274,7 @@ class FreqtradeBot(object):
         return stake_amount
 
     def _get_min_pair_stake_amount(self, pair: str, price: float) -> Optional[float]:
-        markets = self.exchange.get_markets()
-        markets = [m for m in markets if m['symbol'] == pair]
-        if not markets:
-            raise ValueError(f'Can\'t get market information for symbol {pair}')
-
-        market = markets[0]
+        market = self.exchange.markets[pair]
 
         if 'limits' not in market:
             return None


### PR DESCRIPTION
Every time throttle runs _process(), quite expensive get_markets() function (in particular fetch_markets() from ccxt) is called twice. It's expensive since it loads long blob of data which is not trivial for parsing by ccxt.

* First occurrence -- from _get_trade_stake_amount() just in order to take "static" limits for a pait
* Second one -- from _validate_whitelist() to iterate through exchange markets.

All those data are static (well, actually theoretically may be changed by exchange when it make changes into its markets) and already loaded by load_markets() in the exchange object. No need at all to fetch it at every throttle iteration.

This PR removes only 1st appearence of get_markets(), in _get_trade_stake_amount().
Second part is not ready yet.
