### PR TITLE
[PoC] Performance: use exchange.markets instead of expensive get_markets()

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -99,7 +99,7 @@ class Exchange(object):
 
         logger.info('Using Exchange "%s"', self.name)
 
-        self._load_markets()
+        self.markets = self._load_markets()
         # Check if all pairs are available
         self.validate_pairs(config['exchange']['pair_whitelist'])
         self.validate_ordertypes(config.get('order_types', {}))
@@ -188,16 +188,18 @@ class Exchange(object):
     async def _load_async_markets(self, reload=False) -> None:
         self.markets = await self._api_async.load_markets(reload=reload)
 
-    def _load_markets(self) -> None:
+    def _load_markets(self) -> Dict[str, Any]:
         """
         Initialize markets sync for first time.
         Later, reload_async_markets() is to be called periodically if you want
         to be informed of changes in the Exchange markets
         """
         try:
-            self.markets = self._api.load_markets()
+            markets = self._api.load_markets()
+            return markets
         except ccxt.BaseError as e:
             logger.warning('Unable to initialize markets. Reason: %s', e)
+        return {}
 
     def validate_pairs(self, pairs: List[str]) -> None:
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -153,6 +153,9 @@ class FreqtradeBot(object):
         """
         state_changed = False
         try:
+            # Reload markets async
+            self.exchange.reload_async_markets()
+
             # Refresh whitelist
             self.pairlists.refresh_pairlist()
             self.active_pair_whitelist = self.pairlists.whitelist
@@ -274,12 +277,7 @@ class FreqtradeBot(object):
         return stake_amount
 
     def _get_min_pair_stake_amount(self, pair: str, price: float) -> Optional[float]:
-        markets = self.exchange.get_markets()
-        markets = [m for m in markets if m['symbol'] == pair]
-        if not markets:
-            raise ValueError(f'Can\'t get market information for symbol {pair}')
-
-        market = markets[0]
+        market = self.exchange.markets[pair]
 
         if 'limits' not in market:
             return None

--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -66,13 +66,9 @@ class IPairList(ABC):
         black_listed
         """
         sanitized_whitelist = whitelist
-        markets = self._freqtrade.exchange.get_markets()
-
-        # Filter to markets in stake currency
-        markets = [m for m in markets if m['quote'] == self._config['stake_currency']]
         known_pairs = set()
 
-        for market in markets:
+        for market in self._freqtrade.exchange.markets.values():
             pair = market['symbol']
             # pair is not int the generated dynamic market, or in the blacklist ... ignore it
             if pair not in whitelist or pair in self.blacklist:


### PR DESCRIPTION
... In addition to Part1 (https://github.com/freqtrade/freqtrade/pull/1553)

In _validate_whitelist() we definitely would like to get updates the exchange makes to the markets (active/non-active). How to handle it and remove expensive and long get_markets()? Right: let's load markets on async manner.

