### PR TITLE
[PoC] Option to enable compound gains

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,6 +5,7 @@
     "fiat_display_currency": "USD",
     "ticker_interval" : "5m",
     "dry_run": false,
+    "compound": false,
     "trailing_stop": false,
     "unfilledtimeout": {
         "buy": 10,

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -4,6 +4,7 @@
     "stake_amount": 0.05,
     "fiat_display_currency": "USD",
     "dry_run": false,
+    "compound": false,
     "ticker_interval": "5m",
     "trailing_stop": false,
     "trailing_stop_positive": 0.005,


### PR DESCRIPTION
## Summary
This PR proposes an option to take advantage of compound gains and changes how `max_open_trades` is used. 

Now the `stake_amount` is fixed for every trade and multiplied by `max_open_trades`. 

With `compound` option enabled the `stake_amount` becomes the total stake to use for all trades and `max_open_trades` dynamically splits the total stake according to open trades.

In this way we can use all available stake and so take advantage of compound gains.

Example:
- with `"compound": false`, `"stake_amount": 0.1`, `"max_open_trades": 2` 
```
tot profit % = 15.25
tot profit BTC = 0.03052708
```

- with `"compound": true`, `"stake_amount": 0.2`, `"max_open_trades": 2` 
```
tot profit % = 15.25
tot profit BTC = 0.03173375
```

This is only a proposal for discussion so only backtest and no tests.

## Quick changelog

- added ability to take advantage of compound gains
- changed behaviour of `max_open_trades`