### PR TITLE
prevent convert LF->CRLF line ending on window

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,12 +115,12 @@ Once you have Docker installed, simply create the config file (e.g. `config.json
 
 **1.1. Clone the git repository**
 
-Linux
+Linux/Mac/Windows with WSL
 ```bash
 git clone https://github.com/freqtrade/freqtrade.git
 ```
 
-Windows (docker or WSL)
+Windows with docker
 ```bash
 git clone --config core.autocrlf=input https://github.com/freqtrade/freqtrade.git
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,8 +115,14 @@ Once you have Docker installed, simply create the config file (e.g. `config.json
 
 **1.1. Clone the git repository**
 
+Linux
 ```bash
 git clone https://github.com/freqtrade/freqtrade.git
+```
+
+Windows (docker or WSL)
+```bash
+git clone --config core.autocrlf=input https://github.com/freqtrade/freqtrade.git
 ```
 
 **1.2. (Optional) Checkout the develop branch**


### PR DESCRIPTION
During docker built on windows if in  global git config  core.autocrlf = true then when have this message :

Step 6/12 : RUN cd /tmp && /tmp/install_ta-lib.sh && rm -r /tmp/*ta-lib*
 ---> Running in c0a626821132
/tmp/install_ta-lib.sh: 4: /tmp/install_ta-lib.sh: Syntax error: "&&" unexpected

this behave is because file is in the wrong line ending format

Has script files run on linux they need to use LF lines ending so we need to ensure they are not converted to CRLF lines ending if global git config is at  core.autocrlf = true.

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Fix built of docker image if git global config is core.autocrlf = true on windows

## Quick changelog
- change documentation install page

## What's new?
Update documentation. 
