### PR TITLE
Cosmetic: move default amount_reserve_percent value into constants

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -13,6 +13,7 @@ DEFAULT_HYPEROPT = 'DefaultHyperOpts'
 DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'
 DEFAULT_DB_DRYRUN_URL = 'sqlite://'
 UNLIMITED_STAKE_AMOUNT = 'unlimited'
+DEFAULT_AMOUNT_RESERVE_PERCENT = 0.05
 REQUIRED_ORDERTIF = ['buy', 'sell']
 REQUIRED_ORDERTYPES = ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']
 ORDERTYPE_POSSIBILITIES = ['limit', 'market']

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -291,7 +291,8 @@ class FreqtradeBot(object):
             return None
 
         # reserve some percent defined in config (5% default) + stoploss
-        amount_reserve_percent = 1.0 - self.config.get('amount_reserve_percent', 0.05)
+        amount_reserve_percent = 1.0 - self.config.get('amount_reserve_percent',
+                                                       constants.DEFAULT_AMOUNT_RESERVE_PERCENT)
         if self.strategy.stoploss is not None:
             amount_reserve_percent += self.strategy.stoploss
         # it should not be more than 50%


### PR DESCRIPTION
Default value should not be hardcoded somewhere deep in the code.
