### PR TITLE
multiple --config options

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -78,7 +78,8 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '-c', '--config',
-            help='Specify configuration file (default: %(default)s).',
+            help='Specify configuration file (default: %(default)s). '
+                 'Multiple --config options may be used.',
             dest='config',
             action='append',
             type=str,

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -6,9 +6,7 @@ import argparse
 import os
 import re
 from typing import List, NamedTuple, Optional
-
 import arrow
-
 from freqtrade import __version__, constants
 
 
@@ -55,6 +53,11 @@ class Arguments(object):
         """
         parsed_arg = self.parser.parse_args(self.args)
 
+        # Workaround issue in argparse with action='append' and default value
+        # (see https://bugs.python.org/issue16399)
+        if parsed_arg.config is None:
+            parsed_arg.config = [constants.DEFAULT_CONFIG]
+
         return parsed_arg
 
     def common_args_parser(self) -> None:
@@ -63,7 +66,7 @@ class Arguments(object):
         """
         self.parser.add_argument(
             '-v', '--verbose',
-            help='verbose mode (-vv for more, -vvv to get all messages)',
+            help='Verbose mode (-vv for more, -vvv to get all messages).',
             action='count',
             dest='loglevel',
             default=0,
@@ -75,15 +78,15 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '-c', '--config',
-            help='specify configuration file (default: %(default)s)',
+            help='Specify configuration file (default: %(default)s).',
             dest='config',
-            default='config.json',
+            action='append',
             type=str,
             metavar='PATH',
         )
         self.parser.add_argument(
             '-d', '--datadir',
-            help='path to backtest data',
+            help='Path to backtest data.',
             dest='datadir',
             default=None,
             type=str,
@@ -91,7 +94,7 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '-s', '--strategy',
-            help='specify strategy class name (default: %(default)s)',
+            help='Specify strategy class name (default: %(default)s).',
             dest='strategy',
             default='DefaultStrategy',
             type=str,
@@ -99,14 +102,14 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '--strategy-path',
-            help='specify additional strategy lookup path',
+            help='Specify additional strategy lookup path.',
             dest='strategy_path',
             type=str,
             metavar='PATH',
         )
         self.parser.add_argument(
             '--customhyperopt',
-            help='specify hyperopt class name (default: %(default)s)',
+            help='Specify hyperopt class name (default: %(default)s).',
             dest='hyperopt',
             default=constants.DEFAULT_HYPEROPT,
             type=str,
@@ -114,8 +117,8 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '--dynamic-whitelist',
-            help='dynamically generate and update whitelist'
-                 ' based on 24h BaseVolume (default: %(const)s)'
+            help='Dynamically generate and update whitelist'
+                 ' based on 24h BaseVolume (default: %(const)s).'
                  ' DEPRECATED.',
             dest='dynamic_whitelist',
             const=constants.DYNAMIC_WHITELIST,
@@ -126,7 +129,7 @@ class Arguments(object):
         self.parser.add_argument(
             '--db-url',
             help='Override trades database URL, this is useful if dry_run is enabled'
-                 ' or in custom deployments (default: %(default)s)',
+                 ' or in custom deployments (default: %(default)s).',
             dest='db_url',
             type=str,
             metavar='PATH',
@@ -139,7 +142,7 @@ class Arguments(object):
         """
         parser.add_argument(
             '--eps', '--enable-position-stacking',
-            help='Allow buying the same pair multiple times (position stacking)',
+            help='Allow buying the same pair multiple times (position stacking).',
             action='store_true',
             dest='position_stacking',
             default=False
@@ -148,20 +151,20 @@ class Arguments(object):
         parser.add_argument(
             '--dmmp', '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '
-                 '(same as setting `max_open_trades` to a very high number)',
+                 '(same as setting `max_open_trades` to a very high number).',
             action='store_false',
             dest='use_max_market_positions',
             default=True
         )
         parser.add_argument(
             '-l', '--live',
-            help='using live data',
+            help='Use live data.',
             action='store_true',
             dest='live',
         )
         parser.add_argument(
             '-r', '--refresh-pairs-cached',
-            help='refresh the pairs files in tests/testdata with the latest data from the '
+            help='Refresh the pairs files in tests/testdata with the latest data from the '
                  'exchange. Use it if you want to run your backtesting with up-to-date data.',
             action='store_true',
             dest='refresh_pairs',
@@ -178,8 +181,8 @@ class Arguments(object):
         )
         parser.add_argument(
             '--export',
-            help='export backtest results, argument are: trades\
-                  Example --export=trades',
+            help='Export backtest results, argument are: trades. '
+                 'Example --export=trades',
             type=str,
             default=None,
             dest='export',
@@ -203,14 +206,14 @@ class Arguments(object):
         """
         parser.add_argument(
             '-r', '--refresh-pairs-cached',
-            help='refresh the pairs files in tests/testdata with the latest data from the '
+            help='Refresh the pairs files in tests/testdata with the latest data from the '
                  'exchange. Use it if you want to run your edge with up-to-date data.',
             action='store_true',
             dest='refresh_pairs',
         )
         parser.add_argument(
             '--stoplosses',
-            help='defines a range of stoploss against which edge will assess the strategy '
+            help='Defines a range of stoploss against which edge will assess the strategy '
                  'the format is "min,max,step" (without any space).'
                  'example: --stoplosses=-0.01,-0.1,-0.001',
             type=str,
@@ -226,14 +229,14 @@ class Arguments(object):
         """
         parser.add_argument(
             '-i', '--ticker-interval',
-            help='specify ticker interval (1m, 5m, 30m, 1h, 1d)',
+            help='Specify ticker interval (1m, 5m, 30m, 1h, 1d).',
             dest='ticker_interval',
             type=str,
         )
 
         parser.add_argument(
             '--timerange',
-            help='specify what timerange of data to use.',
+            help='Specify what timerange of data to use.',
             default=None,
             type=str,
             dest='timerange',
@@ -246,7 +249,7 @@ class Arguments(object):
         """
         parser.add_argument(
             '--eps', '--enable-position-stacking',
-            help='Allow buying the same pair multiple times (position stacking)',
+            help='Allow buying the same pair multiple times (position stacking).',
             action='store_true',
             dest='position_stacking',
             default=False
@@ -255,14 +258,14 @@ class Arguments(object):
         parser.add_argument(
             '--dmmp', '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '
-                 '(same as setting `max_open_trades` to a very high number)',
+                 '(same as setting `max_open_trades` to a very high number).',
             action='store_false',
             dest='use_max_market_positions',
             default=True
         )
         parser.add_argument(
             '-e', '--epochs',
-            help='specify number of epochs (default: %(default)d)',
+            help='Specify number of epochs (default: %(default)d).',
             dest='epochs',
             default=constants.HYPEROPT_EPOCH,
             type=int,
@@ -271,7 +274,7 @@ class Arguments(object):
         parser.add_argument(
             '-s', '--spaces',
             help='Specify which parameters to hyperopt. Space separate list. \
-                  Default: %(default)s',
+                  Default: %(default)s.',
             choices=['all', 'buy', 'sell', 'roi', 'stoploss'],
             default='all',
             nargs='+',
@@ -288,19 +291,19 @@ class Arguments(object):
         subparsers = self.parser.add_subparsers(dest='subparser')
 
         # Add backtesting subcommand
-        backtesting_cmd = subparsers.add_parser('backtesting', help='backtesting module')
+        backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.')
         backtesting_cmd.set_defaults(func=backtesting.start)
         self.optimizer_shared_options(backtesting_cmd)
         self.backtesting_options(backtesting_cmd)
 
         # Add edge subcommand
-        edge_cmd = subparsers.add_parser('edge', help='edge module')
+        edge_cmd = subparsers.add_parser('edge', help='Edge module.')
         edge_cmd.set_defaults(func=edge_cli.start)
         self.optimizer_shared_options(edge_cmd)
         self.edge_options(edge_cmd)
 
         # Add hyperopt subcommand
-        hyperopt_cmd = subparsers.add_parser('hyperopt', help='hyperopt module')
+        hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.')
         hyperopt_cmd.set_defaults(func=hyperopt.start)
         self.optimizer_shared_options(hyperopt_cmd)
         self.hyperopt_options(hyperopt_cmd)
@@ -364,7 +367,7 @@ class Arguments(object):
         """
         self.parser.add_argument(
             '--pairs-file',
-            help='File containing a list of pairs to download',
+            help='File containing a list of pairs to download.',
             dest='pairs_file',
             default=None,
             metavar='PATH',
@@ -372,7 +375,7 @@ class Arguments(object):
 
         self.parser.add_argument(
             '--export',
-            help='Export files to given dir',
+            help='Export files to given dir.',
             dest='export',
             default=None,
             metavar='PATH',
@@ -380,7 +383,8 @@ class Arguments(object):
 
         self.parser.add_argument(
             '-c', '--config',
-            help='specify configuration file, used for additional exchange parameters',
+            help='Specify configuration file, used for additional exchange parameters. '
+                 'Multiple --config options may be used.',
             dest='config',
             default=None,
             type=str,
@@ -389,7 +393,7 @@ class Arguments(object):
 
         self.parser.add_argument(
             '--days',
-            help='Download data for number of days',
+            help='Download data for given number of days.',
             dest='days',
             type=int,
             metavar='INT',
@@ -398,7 +402,7 @@ class Arguments(object):
 
         self.parser.add_argument(
             '--exchange',
-            help='Exchange name (default: %(default)s). Only valid if no config is provided',
+            help='Exchange name (default: %(default)s). Only valid if no config is provided.',
             dest='exchange',
             type=str,
             default='bittrex'
@@ -407,7 +411,7 @@ class Arguments(object):
         self.parser.add_argument(
             '-t', '--timeframes',
             help='Specify which tickers to download. Space separated list. \
-                  Default: %(default)s',
+                  Default: %(default)s.',
             choices=['1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h',
                      '6h', '8h', '12h', '1d', '3d', '1w'],
             default=['1m', '5m'],
@@ -417,7 +421,7 @@ class Arguments(object):
 
         self.parser.add_argument(
             '--erase',
-            help='Clean all existing data for the selected exchange/pairs/timeframes',
+            help='Clean all existing data for the selected exchange/pairs/timeframes.',
             dest='erase',
             action='store_true'
         )

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -384,10 +384,10 @@ class Arguments(object):
 
         self.parser.add_argument(
             '-c', '--config',
-            help='Specify configuration file, used for additional exchange parameters. '
+            help='Specify configuration file (default: %(default)s). '
                  'Multiple --config options may be used.',
             dest='config',
-            default=None,
+            action='append',
             type=str,
             metavar='PATH',
         )

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -3,6 +3,7 @@
 """
 bot constants
 """
+DEFAULT_CONFIG = 'config.json'
 DYNAMIC_WHITELIST = 20  # pairs
 PROCESS_THROTTLE_SECS = 5  # sec
 TICKER_INTERVAL = 5  # min

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -113,3 +113,21 @@ def format_ms_time(date: int) -> str:
     : epoch-string in ms
     """
     return datetime.fromtimestamp(date/1000.0).strftime('%Y-%m-%dT%H:%M:%S')
+
+
+def deep_merge_dicts(source, destination):
+    """
+    >>> a = { 'first' : { 'rows' : { 'pass' : 'dog', 'number' : '1' } } }
+    >>> b = { 'first' : { 'rows' : { 'fail' : 'cat', 'number' : '5' } } }
+    >>> merge(b, a) == { 'first' : { 'rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
+    True
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            deep_merge_dicts(value, node)
+        else:
+            destination[key] = value
+
+    return destination

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -16,7 +16,7 @@ def test_parse_args_none() -> None:
 
 def test_parse_args_defaults() -> None:
     args = Arguments([], '').get_parsed_arg()
-    assert args.config == 'config.json'
+    assert args.config == ['config.json']
     assert args.strategy_path is None
     assert args.datadir is None
     assert args.loglevel == 0
@@ -24,10 +24,15 @@ def test_parse_args_defaults() -> None:
 
 def test_parse_args_config() -> None:
     args = Arguments(['-c', '/dev/null'], '').get_parsed_arg()
-    assert args.config == '/dev/null'
+    assert args.config == ['/dev/null']
 
     args = Arguments(['--config', '/dev/null'], '').get_parsed_arg()
-    assert args.config == '/dev/null'
+    assert args.config == ['/dev/null']
+
+    args = Arguments(['--config', '/dev/null',
+                      '--config', '/dev/zero'],
+                     '').get_parsed_arg()
+    assert args.config == ['/dev/null', '/dev/zero']
 
 
 def test_parse_args_db_url() -> None:
@@ -139,7 +144,7 @@ def test_parse_args_backtesting_custom() -> None:
         'TestStrategy'
         ]
     call_args = Arguments(args, '').get_parsed_arg()
-    assert call_args.config == 'test_conf.json'
+    assert call_args.config == ['test_conf.json']
     assert call_args.live is True
     assert call_args.loglevel == 0
     assert call_args.subparser == 'backtesting'
@@ -158,7 +163,7 @@ def test_parse_args_hyperopt_custom() -> None:
         '--spaces', 'buy'
     ]
     call_args = Arguments(args, '').get_parsed_arg()
-    assert call_args.config == 'test_conf.json'
+    assert call_args.config == ['test_conf.json']
     assert call_args.epochs == 20
     assert call_args.loglevel == 0
     assert call_args.subparser == 'hyperopt'

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -50,18 +50,20 @@ def test_load_config_file(default_conf, mocker, caplog) -> None:
     validated_conf = configuration._load_config_file('somefile')
     assert file_mock.call_count == 1
     assert validated_conf.items() >= default_conf.items()
-    assert 'internals' in validated_conf
-    assert log_has('Validating configuration ...', caplog.record_tuples)
 
 
 def test_load_config_max_open_trades_zero(default_conf, mocker, caplog) -> None:
     default_conf['max_open_trades'] = 0
-    file_mock = mocker.patch('freqtrade.configuration.open', mocker.mock_open(
+    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
         read_data=json.dumps(default_conf)
     ))
 
-    Configuration(Namespace())._load_config_file('somefile')
-    assert file_mock.call_count == 1
+    args = Arguments([], '').get_parsed_arg()
+    configuration = Configuration(args)
+    validated_conf = configuration.load_config()
+
+    assert validated_conf['max_open_trades'] == 0
+    assert 'internals' in validated_conf
     assert log_has('Validating configuration ...', caplog.record_tuples)
 
 

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -22,7 +22,7 @@ def test_parse_args_backtesting(mocker) -> None:
     main(['backtesting'])
     assert backtesting_mock.call_count == 1
     call_args = backtesting_mock.call_args[0][0]
-    assert call_args.config == 'config.json'
+    assert call_args.config == ['config.json']
     assert call_args.live is False
     assert call_args.loglevel == 0
     assert call_args.subparser == 'backtesting'
@@ -35,7 +35,7 @@ def test_main_start_hyperopt(mocker) -> None:
     main(['hyperopt'])
     assert hyperopt_mock.call_count == 1
     call_args = hyperopt_mock.call_args[0][0]
-    assert call_args.config == 'config.json'
+    assert call_args.config == ['config.json']
     assert call_args.loglevel == 0
     assert call_args.subparser == 'hyperopt'
     assert call_args.func is not None

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -39,8 +39,6 @@ if args.config:
         # Merge config options, overwriting old values
         config = deep_merge_dicts(configuration._load_config_file(path), config)
 
-###    config = configuration._load_config_file(args.config)
-
     config['stake_currency'] = ''
     # Ensure we do not use Exchange credentials
     config['exchange']['key'] = ''

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -5,12 +5,14 @@ import json
 import sys
 from pathlib import Path
 import arrow
+from typing import Any, Dict
 
-from freqtrade import arguments
+from freqtrade.arguments import Arguments
 from freqtrade.arguments import TimeRange
 from freqtrade.exchange import Exchange
 from freqtrade.data.history import download_pair_history
 from freqtrade.configuration import Configuration, set_loggers
+from freqtrade.misc import deep_merge_dicts
 
 import logging
 logging.basicConfig(
@@ -21,7 +23,7 @@ set_loggers(0)
 
 DEFAULT_DL_PATH = 'user_data/data'
 
-arguments = arguments.Arguments(sys.argv[1:], 'download utility')
+arguments = Arguments(sys.argv[1:], 'download utility')
 arguments.testdata_dl_options()
 args = arguments.parse_args()
 
@@ -29,7 +31,15 @@ timeframes = args.timeframes
 
 if args.config:
     configuration = Configuration(args)
-    config = configuration._load_config_file(args.config)
+
+    config: Dict[str, Any] = {}
+    # Now expecting a list of config filenames here, not a string
+    for path in args.config:
+        print('Using config: %s ...', path)
+        # Merge config options, overwriting old values
+        config = deep_merge_dicts(configuration._load_config_file(path), config)
+
+###    config = configuration._load_config_file(args.config)
 
     config['stake_currency'] = ''
     # Ensure we do not use Exchange credentials


### PR DESCRIPTION
* Support for multiple --config options in the FT command line
* Default config filename value moved to constants
* Cosmetic grammar changes (as always :-) ) in the options help strings

One can use it, for example, for keeping keys and exchange secrets in the separate config files in order to avoid their disclosure by mistake.

For example:

config.json:
```
{
...
    "exchange": {
        "name": "exchangename",
        "key": "",
        "secret": "",
        ...
    },
    ...
}
```
keys-exchangename.json:
```
{
    "exchange": {
        "name": "exchangename",
        "key": "mysecretkeyhere",
        "secret": "mysecretesecretehere"
    }
}
```

Then running `freqtrade --config=config.json` or simply `freqtrade` (with default config) will launch bot with empty keys while `freqtrade --config=config.json --config=keys-exchangename.json` will fetch keys from the second config file.

Options in latter config overwrite options that were previously found in the previous config files.

One can also use it to split config between exchanges, keeping common part in a single file instead of copying configs.

TODO:
* Tests should be adjusted. Definitely.
* Documenting new ability. Probably with an example similar to above.
