### PR TITLE
Move coveralls to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ jobs:
     - stage: tests
       script:
       - pytest --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
-      - coveralls
       name: pytest
     - script:
       - cp config.json.example config.json
@@ -48,6 +47,8 @@ jobs:
         - build_helpers/publish_docker.sh
       name: "Build and test and push docker image"
 
+after_success:
+  - coveralls
 
 notifications:
   slack:


### PR DESCRIPTION
## Summary
Move coveralls to "after_success" since an external service should not break our builds
based on the idea from the coveralls issue: 
https://github.com/lemurheavy/coveralls-public/issues/1264#issuecomment-465257524


We should also investigate if switching to codecov (https://codecov.io/) is worth the effort, since this is not the first time coveralls has a multi-day problem.