### PR TITLE
Create binance Subclass and parametrize exchange-tests

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,2 +1,3 @@
 from freqtrade.exchange.exchange import Exchange  # noqa: F401
 from freqtrade.exchange.kraken import Kraken  # noqa: F401
+from freqtrade.exchange.binance import Binance  # noqa: F401

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class Binance(Exchange):
 
-    _ft_has = {
+    _ft_has: Dict = {
         "stoploss_on_exchange": True,
     }
 

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -1,0 +1,26 @@
+""" Binance exchange subclass """
+import logging
+from typing import Dict
+
+from freqtrade.exchange import Exchange
+
+logger = logging.getLogger(__name__)
+
+
+class Binance(Exchange):
+
+    _ft_has = {
+        "stoploss_on_exchange": True,
+    }
+
+    def get_order_book(self, pair: str, limit: int = 100) -> dict:
+        """
+        get order book level 2 from exchange
+
+        20180619: binance support limits but only on specific range
+        """
+        limit_range = [5, 10, 20, 50, 100, 500, 1000]
+        # get next-higher step in the limit_range list
+        limit = min(list(filter(lambda x: limit <= x, limit_range)))
+
+        return self.super().get_order_book(pair, limit)

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -23,4 +23,4 @@ class Binance(Exchange):
         # get next-higher step in the limit_range list
         limit = min(list(filter(lambda x: limit <= x, limit_range)))
 
-        return self.super().get_order_book(pair, limit)
+        return super(Binance, self).get_order_book(pair, limit)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -374,7 +374,7 @@ class Exchange(object):
         """
         creates a stoploss limit order.
         NOTICE: it is not supported by all exchanges. only binance is tested for now.
-        TODO: implementation maybe needs to be move to the binance subclass
+        TODO: implementation maybe needs to be moved to the binance subclass
         """
         ordertype = "stop_loss_limit"
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -244,9 +244,9 @@ class Exchange(object):
 
         if (order_types.get("stoploss_on_exchange")
                 and not self._ft_has.get("stoploss_on_exchange", False)):
-                raise OperationalException(
-                    'On exchange stoploss is not supported for %s.' % self.name
-                )
+            raise OperationalException(
+                'On exchange stoploss is not supported for %s.' % self.name
+            )
 
     def validate_order_time_in_force(self, order_time_in_force: Dict) -> None:
         """
@@ -621,7 +621,6 @@ class Exchange(object):
 
         Notes:
         20180619: bittrex doesnt support limits -.-
-        20180619: binance support limits but only on specific range
         """
         try:
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -113,7 +113,7 @@ def test_exchange_resolver(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange._load_async_markets', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
-    exchange = ExchangeResolver('Binance', default_conf).exchange
+    exchange = ExchangeResolver('Bittrex', default_conf).exchange
     assert isinstance(exchange, Exchange)
     assert log_has_re(r"No .* specific subclass found. Using the generic class instead.",
                       caplog.record_tuples)


### PR DESCRIPTION
## Summary
* Add binance subclass
* Add parametrized tests to make sure subclasses don't break regular behavior

* Add simple "ft_has" dictionary (for now it needs to be copied to all subclasses which need to change something)

It's not perfect yet (i'm not certain if stoploss_on_exchange like this works for other exchanges), but i'm hesitent to move it to the binance-class since it might work for other exchanges as well.

The volume of tests significantly raises with this, since all available subclasses (+ one non-available subclass) are tested with most functions. Mostly the results would not change - but this should allow to easily verify new subclass implementations which do override complete methods.

