### PR TITLE
Add libssl-dev to fix #1604

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.2-slim-stretch
 
 RUN apt-get update \
-    && apt-get -y install curl build-essential \
+    && apt-get -y install curl build-essential libssl-dev \
     && apt-get clean \
     && pip install --upgrade pip
 


### PR DESCRIPTION
## Summary
Add libssl-dev to have cryptography compile again.

Solve the issue: #1604
