### PR TITLE
Update documentation for --customhyperopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,39 +68,38 @@ For any other type of installation please refer to [Installation doc](https://ww
 ### Bot commands
 
 ```
-usage: main.py [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
-               [--strategy-path PATH] [--customhyperopt NAME]
-               [--dynamic-whitelist [INT]] [--db-url PATH]
-               {backtesting,edge,hyperopt} ...
+usage: freqtrade [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
+                 [--strategy-path PATH] [--dynamic-whitelist [INT]]
+                 [--db-url PATH]
+                 {backtesting,edge,hyperopt} ...
 
 Free, open source crypto trading bot
 
 positional arguments:
   {backtesting,edge,hyperopt}
-    backtesting         backtesting module
-    edge                edge module
-    hyperopt            hyperopt module
+    backtesting         Backtesting module.
+    edge                Edge module.
+    hyperopt            Hyperopt module.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -v, --verbose         verbose mode (-vv for more, -vvv to get all messages)
-  --version             show program\'s version number and exit
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --version             show program's version number and exit
   -c PATH, --config PATH
-                        specify configuration file (default: config.json)
+                        Specify configuration file (default: None). Multiple
+                        --config options may be used.
   -d PATH, --datadir PATH
-                        path to backtest data
+                        Path to backtest data.
   -s NAME, --strategy NAME
-                        specify strategy class name (default: DefaultStrategy)
-  --strategy-path PATH  specify additional strategy lookup path
-  --customhyperopt NAME
-                        specify hyperopt class name (default:
-                        DefaultHyperOpts)
+                        Specify strategy class name (default:
+                        DefaultStrategy).
+  --strategy-path PATH  Specify additional strategy lookup path.
   --dynamic-whitelist [INT]
-                        dynamically generate and update whitelist based on 24h
-                        BaseVolume (default: 20) DEPRECATED.
+                        Dynamically generate and update whitelist based on 24h
+                        BaseVolume (default: 20). DEPRECATED.
   --db-url PATH         Override trades database URL, this is useful if
                         dry_run is enabled or in custom deployments (default:
-                        None)
+                        None).
 ```
 
 ### Telegram RPC commands

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -6,39 +6,39 @@ This page explains the different parameters of the bot and how to run it.
 ## Bot commands
 
 ```
-usage: main.py [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
-               [--strategy-path PATH] [--customhyperopt NAME]
-               [--dynamic-whitelist [INT]] [--db-url PATH]
-               {backtesting,edge,hyperopt} ...
+usage: freqtrade [-h] [-v] [--version] [-c PATH] [-d PATH] [-s NAME]
+                 [--strategy-path PATH] [--dynamic-whitelist [INT]]
+                 [--db-url PATH]
+                 {backtesting,edge,hyperopt} ...
 
 Free, open source crypto trading bot
 
 positional arguments:
   {backtesting,edge,hyperopt}
-    backtesting         backtesting module
-    edge                edge module
-    hyperopt            hyperopt module
+    backtesting         Backtesting module.
+    edge                Edge module.
+    hyperopt            Hyperopt module.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -v, --verbose         verbose mode (-vv for more, -vvv to get all messages)
-  --version             show program\'s version number and exit
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --version             show program's version number and exit
   -c PATH, --config PATH
-                        specify configuration file (default: config.json)
+                        Specify configuration file (default: None). Multiple
+                        --config options may be used.
   -d PATH, --datadir PATH
-                        path to backtest data
+                        Path to backtest data.
   -s NAME, --strategy NAME
-                        specify strategy class name (default: DefaultStrategy)
-  --strategy-path PATH  specify additional strategy lookup path
-  --customhyperopt NAME
-                        specify hyperopt class name (default:
-                        DefaultHyperOpts)
+                        Specify strategy class name (default:
+                        DefaultStrategy).
+  --strategy-path PATH  Specify additional strategy lookup path.
   --dynamic-whitelist [INT]
-                        dynamically generate and update whitelist based on 24h
-                        BaseVolume (default: 20) DEPRECATED.
+                        Dynamically generate and update whitelist based on 24h
+                        BaseVolume (default: 20). DEPRECATED.
   --db-url PATH         Override trades database URL, this is useful if
                         dry_run is enabled or in custom deployments (default:
-                        None)
+                        None).
+
 ```
 
 ### How to use a different config file?
@@ -129,27 +129,27 @@ python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.s
 Backtesting also uses the config specified via `-c/--config`.
 
 ```
-usage: main.py backtesting [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                           [--eps] [--dmmp] [-l] [-r]
-                           [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
-                           [--export EXPORT] [--export-filename PATH]
+usage: freqtrade backtesting [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
+                             [--eps] [--dmmp] [-l] [-r]
+                             [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
+                             [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        specify ticker interval (1m, 5m, 30m, 1h, 1d)
+                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
-                        specify what timerange of data to use.
+                        Specify what timerange of data to use.
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
-                        stacking)
+                        stacking).
   --dmmp, --disable-max-market-positions
                         Disable applying `max_open_trades` during backtest
                         (same as setting `max_open_trades` to a very high
-                        number)
-  -l, --live            using live data
+                        number).
+  -l, --live            Use live data.
   -r, --refresh-pairs-cached
-                        refresh the pairs files in tests/testdata with the
+                        Refresh the pairs files in tests/testdata with the
                         latest data from the exchange. Use it if you want to
                         run your backtesting with up-to-date data.
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
@@ -159,7 +159,7 @@ optional arguments:
                         this together with --export trades, the strategy-name
                         is injected into the filename (so backtest-data.json
                         becomes backtest-data-DefaultStrategy.json
-  --export EXPORT       export backtest results, argument are: trades Example
+  --export EXPORT       Export backtest results, argument are: trades. Example
                         --export=trades
   --export-filename PATH
                         Save backtest results to this filename requires
@@ -189,29 +189,30 @@ To optimize your strategy, you can use hyperopt parameter hyperoptimization
 to find optimal parameter values for your stategy.
 
 ```
-usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--eps] [--dmmp]
-                          [--timerange TIMERANGE] [-e INT]
-                          [-s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]]
+usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
+                          [--customhyperopt NAME] [--eps] [--dmmp] [-e INT]
+                          [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        specify ticker interval (1m, 5m, 30m, 1h, 1d)
+                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
+  --timerange TIMERANGE
+                        Specify what timerange of data to use.
+  --customhyperopt NAME
+                        Specify hyperopt class name (default:
+                        DefaultHyperOpts).
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
-                        stacking)
+                        stacking).
   --dmmp, --disable-max-market-positions
                         Disable applying `max_open_trades` during backtest
                         (same as setting `max_open_trades` to a very high
-                        number)
-  --timerange TIMERANGE
-                        specify what timerange of data to use.
-  --hyperopt PATH       specify hyperopt file (default:
-                        freqtrade/optimize/default_hyperopt.py)
-  -e INT, --epochs INT  specify number of epochs (default: 100)
-  -s {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...], --spaces {all,buy,roi,stoploss} [{all,buy,roi,stoploss} ...]
+                        number).
+  -e INT, --epochs INT  Specify number of epochs (default: 100).
+  -s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...], --spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]
                         Specify which parameters to hyperopt. Space separate
-                        list. Default: all
+                        list. Default: all.
 
 ```
 
@@ -220,22 +221,22 @@ optional arguments:
 To know your trade expectacny and winrate against historical data, you can use Edge.
 
 ```
-usage: main.py edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE] [-r]
-                    [--stoplosses STOPLOSS_RANGE]
+usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE] [-r]
+                      [--stoplosses STOPLOSS_RANGE]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        specify ticker interval (1m, 5m, 30m, 1h, 1d)
+                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
-                        specify what timerange of data to use.
+                        Specify what timerange of data to use.
   -r, --refresh-pairs-cached
-                        refresh the pairs files in tests/testdata with the
+                        Refresh the pairs files in tests/testdata with the
                         latest data from the exchange. Use it if you want to
                         run your edge with up-to-date data.
   --stoplosses STOPLOSS_RANGE
-                        defines a range of stoploss against which edge will
-                        assess the strategythe format is "min,max,step"
+                        Defines a range of stoploss against which edge will
+                        assess the strategy the format is "min,max,step"
                         (without any space).example:
                         --stoplosses=-0.01,-0.1,-0.001
 ```

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -285,8 +285,13 @@ This would translate to the following ROI table:
 ### Validate backtest result
 
 Once the optimized strategy has been implemented into your strategy, you should backtest this strategy to make sure everything is working as expected.
-To archive the same results (number of trades, ...) than during hyperopt, please use the command line flag `--disable-max-market-positions`.
-This setting is the default for hyperopt for speed reasons. You can overwrite this in the configuration by setting `"position_stacking"=false` or by changing the relevant line in your hyperopt file [here](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/optimize/hyperopt.py#L283).
+To archive the same results (number of trades, ...) than during hyperopt, please use the command line flags `--disable-max-market-positions` and `--enable-position-stacking` for backtesting.
+
+This configuration is the default in hyperopt for performance reasons.
+
+You can overwrite position stacking in the configuration by explicitly setting `"position_stacking"=false` or by changing the relevant line in your hyperopt file [here](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/optimize/hyperopt.py#L191).
+
+Enabling the market-position for hyperopt is currently not possible.
 
 !!! Note:
 Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -152,7 +152,7 @@ Because hyperopt tries a lot of combinations to find the best parameters it will
 We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 
 ```bash
-python3 ./freqtrade/main.py --hyperopt <hyperoptname> -c config.json hyperopt -e 5000 --spaces all
+python3 ./freqtrade/main.py -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
 Use  `<hyperoptname>` as the name of the custom hyperopt used.

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -109,14 +109,6 @@ class Arguments(object):
             metavar='PATH',
         )
         self.parser.add_argument(
-            '--customhyperopt',
-            help='Specify hyperopt class name (default: %(default)s).',
-            dest='hyperopt',
-            default=constants.DEFAULT_HYPEROPT,
-            type=str,
-            metavar='NAME',
-        )
-        self.parser.add_argument(
             '--dynamic-whitelist',
             help='Dynamically generate and update whitelist'
                  ' based on 24h BaseVolume (default: %(const)s).'
@@ -248,6 +240,14 @@ class Arguments(object):
         """
         Parses given arguments for Hyperopt scripts.
         """
+        parser.add_argument(
+            '--customhyperopt',
+            help='Specify hyperopt class name (default: %(default)s).',
+            dest='hyperopt',
+            default=constants.DEFAULT_HYPEROPT,
+            type=str,
+            metavar='NAME',
+        )
         parser.add_argument(
             '--eps', '--enable-position-stacking',
             help='Allow buying the same pair multiple times (position stacking).',

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -67,9 +67,6 @@ class Configuration(object):
         if self.args.strategy_path:
             config.update({'strategy_path': self.args.strategy_path})
 
-        # Add the hyperopt file to use
-        config.update({'hyperopt': self.args.hyperopt})
-
         # Load Common configuration
         config = self._load_common_config(config)
 
@@ -276,6 +273,11 @@ class Configuration(object):
         Extract information for sys.argv and load Hyperopt configuration
         :return: configuration as dictionary
         """
+
+        if "hyperopt" in self.args:
+            # Add the hyperopt file to use
+            config.update({'hyperopt': self.args.hyperopt})
+
         # If --epochs is used we add it to the configuration
         if 'epochs' in self.args and self.args.epochs:
             config.update({'epochs': self.args.epochs})


### PR DESCRIPTION
## Summary
As pointed out on Slack, the documentation for hyperopt is wrong.

The parameter was never called `--hyperopt` but `--customhyperopt`.

## Quick changelog

- fix documentation to call hyperopt with custom file
- move parameter from before "hyperopt" to after "hyperopt" - since it's a parameter only used by hyperopt.
