### PR TITLE
Documentation cleanup

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -78,7 +78,7 @@ prevent unintended disclosure of sensitive private data when you publish example
 of your configuration in the project issues or in the Internet.
 
 See more details on this technique with examples in the documentation page on
-[configuration](https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-configuration.md).
+[configuration](bot-configuration.md).
 
 ### How to use **--strategy**?
 
@@ -101,7 +101,8 @@ python3 ./freqtrade/main.py --strategy AwesomeStrategy
 If the bot does not find your strategy file, it will display in an error
 message the reason (File not found, or errors in your code).
 
-Learn more about strategy file in [optimize your bot](https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-optimization.md).
+Learn more about strategy file in
+[optimize your bot](bot-optimization.md).
 
 ### How to use **--strategy-path**?
 
@@ -119,29 +120,13 @@ This is very simple. Copy paste your strategy file into the folder
 ### How to use **--dynamic-whitelist**?
 
 !!! danger "DEPRECATED"
-    Dynamic-whitelist is deprecated. Please move your configurations to the configuration as outlined [here](/configuration/#dynamic-pairlists)
+    This command line option is deprecated. Please move your configurations using it
+to the configurations that utilize the `StaticPairList` or `VolumePairList` methods set
+in the configuration file
+as outlined [here](configuration/#dynamic-pairlists)
 
-Per default `--dynamic-whitelist` will retrieve the 20 currencies based
-on BaseVolume. This value can be changed when you run the script.
-
-**By Default**
-Get the 20 currencies based on BaseVolume.
-
-```bash
-python3 ./freqtrade/main.py --dynamic-whitelist
-```
-
-**Customize the number of currencies to retrieve**
-Get the 30 currencies based on BaseVolume.
-
-```bash
-python3 ./freqtrade/main.py --dynamic-whitelist 30
-```
-
-**Exception**
-`--dynamic-whitelist` must be greater than 0. If you enter 0 or a
-negative value (e.g -2), `--dynamic-whitelist` will use the default
-value (20).
+Description of this deprecated feature was moved to [here](deprecated.md).
+Please no longer use it.
 
 ### How to use **--db-url**?
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,10 +67,10 @@ Mandatory Parameters are marked as **Required**.
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a folder).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
 
-### Parameters in strategy
+### Parameters in the strategy
 
-The following parameters can be set in either configuration or strategy.
-Values in the configuration are always overwriting values set in the strategy.
+The following parameters can be set in either configuration file or strategy.
+Values set in the configuration file always overwrite values set in the strategy.
 
 * `minimal_roi`
 * `ticker_interval`
@@ -87,7 +87,7 @@ Values in the configuration are always overwriting values set in the strategy.
 
 ### Understand stake_amount
 
-`stake_amount` is an amount of crypto-currency your bot will use for each trade.
+The `stake_amount` configuration parameter is an amount of crypto-currency your bot will use for each trade.
 The minimal value is 0.0005. If there is not enough crypto-currency in
 the account an exception is generated.
 To allow the bot to trade all the available `stake_currency` in your account set
@@ -104,7 +104,7 @@ currency_balanse / (max_open_trades - current_open_trades)
 
 ### Understand minimal_roi
 
-`minimal_roi` is a JSON object where the key is a duration
+The `minimal_roi` configuration parameter is a JSON object where the key is a duration
 in minutes and the value is the minimum ROI in percent.
 See the example below:
 
@@ -118,17 +118,17 @@ See the example below:
 ```
 
 Most of the strategy files already include the optimal `minimal_roi`
-value. This parameter is optional. If you use it, it will take over the
+value. This parameter is optional. If you use it in the configuration file, it will take over the
 `minimal_roi` value from the strategy file.
 
 ### Understand stoploss
 
-`stoploss` is loss in percentage that should trigger a sale.
-For example value `-0.10` will cause immediate sell if the
+The `stoploss` configuration parameter is loss in percentage that should trigger a sale.
+For example, value `-0.10` will cause immediate sell if the
 profit dips below -10% for a given trade. This parameter is optional.
 
 Most of the strategy files already include the optimal `stoploss`
-value. This parameter is optional. If you use it, it will take over the
+value. This parameter is optional. If you use it in the configuration file, it will take over the
 `stoploss` value from the strategy file.
 
 ### Understand trailing stoploss
@@ -137,40 +137,51 @@ Go to the [trailing stoploss Documentation](stoploss.md) for details on trailing
 
 ### Understand initial_state
 
-`initial_state` is an optional field that defines the initial application state.
+The `initial_state` configuration parameter is an optional field that defines the initial application state.
 Possible values are `running` or `stopped`. (default=`running`)
 If the value is `stopped` the bot has to be started with `/start` first.
 
 ### Understand forcebuy_enable
 
-`forcebuy_enable` enables the usage of forcebuy commands via Telegram.
+The `forcebuy_enable` configuration parameter enables the usage of forcebuy commands via Telegram.
 This is disabled for security reasons by default, and will show a warning message on startup if enabled.
-You send `/forcebuy ETH/BTC` to the bot, who buys the pair and holds it until a regular sell-signal appears (ROI, stoploss, /forcesell).
+For example, you can send `/forcebuy ETH/BTC` Telegram command when this feature if enabled to the bot,
+who then buys the pair and holds it until a regular sell-signal (ROI, stoploss, /forcesell) appears.
 
-Can be dangerous with some strategies, so use with care
+This can be dangerous with some strategies, so use with care.
+
 See [the telegram documentation](telegram-usage.md) for details on usage.
 
 ### Understand process_throttle_secs
 
-`process_throttle_secs` is an optional field that defines in seconds how long the bot should wait
+The `process_throttle_secs` configuration parameter is an optional field that defines in seconds how long the bot should wait
 before asking the strategy if we should buy or a sell an asset. After each wait period, the strategy is asked again for
 every opened trade wether or not we should sell, and for all the remaining pairs (either the dynamic list of pairs or
 the static list of pairs) if we should buy.
 
 ### Understand ask_last_balance
 
-`ask_last_balance` sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
+The `ask_last_balance` configuration parameter sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
 use the `last` price and values between those interpolate between ask and last
 price. Using `ask` price will guarantee quick success in bid, but bot will also
 end up paying more then would probably have been necessary.
 
 ### Understand order_types
 
-`order_types` contains a dict mapping order-types to market-types as well as stoploss on or off exchange type and stoploss on exchange update interval in seconds. This allows to buy using limit orders, sell using limit-orders, and create stoploss orders using market. It also allows to set the stoploss "on exchange" which means stoploss order would be placed immediately once the buy order is fulfilled. In case stoploss on exchange and `trailing_stop` are both set, then the bot will use `stoploss_on_exchange_interval` to check it periodically and update it if necessary (e.x. in case of trailing stoploss).
-This can be set in the configuration or in the strategy. Configuration overwrites strategy configurations.
+The `order_types` configuration parameter contains a dict mapping order-types to
+market-types as well as stoploss on or off exchange type and stoploss on exchange
+update interval in seconds. This allows to buy using limit orders, sell using
+limit-orders, and create stoploss orders using market. It also allows to set the
+stoploss "on exchange" which means stoploss order would be placed immediately once
+the buy order is fulfilled. In case stoploss on exchange and `trailing_stop` are
+both set, then the bot will use `stoploss_on_exchange_interval` to check it periodically
+and update it if necessary (e.x. in case of trailing stoploss).
+This can be set in the configuration file or in the strategy.
+Values set in the configuration file  overwrites values set in the strategy.
 
-If this is configured, all 4 values (`"buy"`, `"sell"`, `"stoploss"` and `"stoploss_on_exchange"`) need to be present, otherwise the bot warn about it and will fail to start.
-The below is the default which is used if this is not configured in either Strategy or configuration.
+If this is configured, all 4 values (`buy`, `sell`, `stoploss` and
+`stoploss_on_exchange`) need to be present, otherwise the bot will warn about it and fail to start.
+The below is the default which is used if this is not configured in either strategy or configuration file.
 
 ```python
 "order_types": {
@@ -184,22 +195,39 @@ The below is the default which is used if this is not configured in either Strat
 
 !!! Note
     Not all exchanges support "market" orders.
-    The following message will be shown if your exchange does not support market orders: `"Exchange <yourexchange>  does not support market orders."`
+    The following message will be shown if your exchange does not support market orders:
+    `"Exchange <yourexchange>  does not support market orders."`
 
 !!! Note
-    stoploss on exchange interval is not mandatory. Do not change it's value if you are unsure of what you are doing. For more information about how stoploss works please read [the stoploss documentation](stoploss.md).
+    Stoploss on exchange interval is not mandatory. Do not change its value if you are
+    unsure of what you are doing. For more information about how stoploss works please
+    read [the stoploss documentation](stoploss.md).
 
 ### Understand order_time_in_force
-`order_time_in_force` defines the policy by which the order is executed on the exchange. Three commonly used time in force are:<br/>
+The `order_time_in_force` configuration parameter defines the policy by which the order
+is executed on the exchange. Three commonly used time in force are:
+
 **GTC (Goog Till Canceled):**
-This is most of the time the default time in force. It means the order will remain on exchange till it is canceled by user. It can be fully or partially fulfilled. If partially fulfilled, the remaining will stay on the exchange till cancelled.<br/>
+
+This is most of the time the default time in force. It means the order will remain
+on exchange till it is canceled by user. It can be fully or partially fulfilled.
+If partially fulfilled, the remaining will stay on the exchange till cancelled.
+
 **FOK (Full Or Kill):**
-It means if the order is not executed immediately AND fully then it is canceled by the exchange.<br/>
+
+It means if the order is not executed immediately AND fully then it is canceled by the exchange.
+
 **IOC (Immediate Or Canceled):**
-It is the same as FOK (above) except it can be partially fulfilled. The remaining part is automatically cancelled by the exchange.
-<br/>
-`order_time_in_force` contains a dict buy and sell time in force policy. This can be set in the configuration or in the strategy. Configuration overwrites strategy configurations.<br/>
-possible values are: `gtc` (default), `fok` or `ioc`.<br/>
+
+It is the same as FOK (above) except it can be partially fulfilled. The remaining part
+is automatically cancelled by the exchange.
+
+The `order_time_in_force` parameter contains a dict with buy and sell time in force policy values.
+This can be set in the configuration file or in the strategy.
+Values set in the configuration file overwrites values set in the strategy.
+
+The possible values are: `gtc` (default), `fok` or `ioc`.
+
 ``` python
 "order_time_in_force": {
     "buy": "gtc",
@@ -208,7 +236,8 @@ possible values are: `gtc` (default), `fok` or `ioc`.<br/>
 ```
 
 !!! Warning
-    This is an ongoing work. For now it is supported only for binance and only for buy orders. Please don't change the default value unless you know what you are doing.
+    This is an ongoing work. For now it is supported only for binance and only for buy orders.
+    Please don't change the default value unless you know what you are doing.
 
 ### What values for exchange.name?
 
@@ -224,35 +253,41 @@ The bot was tested with the following exchanges:
 
 Feel free to test other exchanges and submit your PR to improve the bot.
 
-### What values for fiat_display_currency?
+### What values can be used for fiat_display_currency?
 
-`fiat_display_currency` set the base currency to use for the conversion from coin to fiat in Telegram.
-The valid values are:<br/>
+The `fiat_display_currency` configuration parameter sets the base currency to use for the
+conversion from coin to fiat in the bot Telegram reports.
+
+The valid values are:
+
 ```json
 "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD"
 ```
-In addition to FIAT currencies, a range of cryto currencies are supported.
+
+In addition to fiat currencies, a range of cryto currencies are supported.
+
 The valid values are:
+
 ```json
 "BTC", "ETH", "XRP", "LTC", "BCH", "USDT"
 ```
 
-## Switch to dry-run mode
+## Switch to Dry-run mode
 
-We recommend starting the bot in dry-run mode to see how your bot will
-behave and how is the performance of your strategy. In Dry-run mode the
+We recommend starting the bot in the Dry-run mode to see how your bot will
+behave and what is the performance of your strategy. In the Dry-run mode the
 bot does not engage your money. It only runs a live simulation without
-creating trades.
+creating trades on the exchange.
 
-1. Edit your `config.json`  file
-2. Switch dry-run to true and specify db_url for a persistent db
+1. Edit your `config.json` configuration file.
+2. Switch `dry-run` to `true` and specify `db_url` for a persistence database.
 
 ```json
 "dry_run": true,
 "db_url": "sqlite:///tradesv3.dryrun.sqlite",
 ```
 
-3. Remove your Exchange API key (change them by fake api credentials)
+3. Remove your Exchange API key and secrete (change them by empty values or fake credentials):
 
 ```json
 "exchange": {
@@ -263,24 +298,32 @@ creating trades.
 }
 ```
 
-Once you will be happy with your bot performance, you can switch it to
-production mode.
+Once you will be happy with your bot performance running in the Dry-run mode,
+you can switch it to production mode.
 
 ### Dynamic Pairlists
 
 Dynamic pairlists select pairs for you based on the logic configured.
-The bot runs against all pairs (with that stake) on the exchange, and a number of assets (`number_assets`) is selected based on the selected criteria.
+The bot runs against all pairs (with that stake) on the exchange, and a number of assets
+(`number_assets`) is selected based on the selected criteria.
 
-By default, a Static Pairlist is used (configured as `"pair_whitelist"` under the `"exchange"` section of this configuration).
+By default, the `StaticPairList` method is used.
+The Pairlist method is configured as `pair_whitelist` parameter under the `exchange`
+section of the configuration.
 
 **Available Pairlist methods:**
 
-* `"StaticPairList"`
-  * uses configuration from `exchange.pair_whitelist` and `exchange.pair_blacklist`
-* `"VolumePairList"`
-  * Formerly available as `--dynamic-whitelist [<number_assets>]`
-  * Selects `number_assets` top pairs based on `sort_key`, which can be one of `askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
-  * Possibility to filter low-value coins that would not allow setting a stop loss
+* `StaticPairList`
+  * It uses configuration from `exchange.pair_whitelist` and `exchange.pair_blacklist`.
+* `VolumePairList`
+  * Formerly available as `--dynamic-whitelist [<number_assets>]`. This command line
+option is deprecated and should no longer be used.
+  * It selects `number_assets` top pairs based on `sort_key`, which can be one of 
+`askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
+  * There is a possibility to filter low-value coins that would not allow setting a stop loss
+(set `precision_filter` parameter to `true` for this).
+
+Example:
 
 ```json
 "pairlist": {
@@ -295,7 +338,7 @@ By default, a Static Pairlist is used (configured as `"pair_whitelist"` under th
 
 ## Switch to production mode
 
-In production mode, the bot will engage your money. Be careful a wrong
+In production mode, the bot will engage your money. Be careful, since a wrong
 strategy can lose all your money. Be aware of what you are doing when
 you run it in production mode.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,7 +207,7 @@ The below is the default which is used if this is not configured in either strat
 The `order_time_in_force` configuration parameter defines the policy by which the order
 is executed on the exchange. Three commonly used time in force are:
 
-**GTC (Goog Till Canceled):**
+**GTC (Good Till Canceled):**
 
 This is most of the time the default time in force. It means the order will remain
 on exchange till it is canceled by user. It can be fully or partially fulfilled.

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,0 +1,31 @@
+# Deprecated features
+
+This page contains description of the command line arguments, configuration parameters
+and the bot features that were declared as DEPRECATED by the bot development team
+and are no longer supported. Please avoid their usage in your configuration.
+
+### The **--dynamic-whitelist** command line option
+
+Per default `--dynamic-whitelist` will retrieve the 20 currencies based
+on BaseVolume. This value can be changed when you run the script.
+
+**By Default**
+Get the 20 currencies based on BaseVolume.
+
+```bash
+python3 ./freqtrade/main.py --dynamic-whitelist
+```
+
+**Customize the number of currencies to retrieve**
+Get the 30 currencies based on BaseVolume.
+
+```bash
+python3 ./freqtrade/main.py --dynamic-whitelist 30
+```
+
+**Exception**
+`--dynamic-whitelist` must be greater than 0. If you enter 0 or a
+negative value (e.g -2), `--dynamic-whitelist` will use the default
+value (20).
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ nav:
     - Plotting: plotting.md
     - FAQ: faq.md
     - SQL Cheatsheet: sql_cheatsheet.md
-    - Sanbox testing: sandbox-testing.md
+    - Sandbox testing: sandbox-testing.md
     - Contributors guide: developer.md
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - Hyperopt: hyperopt.md
     - Edge positioning: edge.md
     - Plotting: plotting.md
+    - Deprecated features: deprecated.md
     - FAQ: faq.md
     - SQL Cheatsheet: sql_cheatsheet.md
     - Sandbox testing: sandbox-testing.md


### PR DESCRIPTION
* typo in the main site menu fixed
* description of the deprecated --dynamic-pairlist moved out of bot-usage.md to new deprecated.md in order to make bot-usage.md clear of description of deprecations.
* various improvements to configuration.md (review it carefully; I started with changing the section on PirList method but finally... what you see...)
