### PR TITLE
Remove deprecated --dynamic-whitelist from freqtrade.service

### DIFF
--- a/freqtrade.service
+++ b/freqtrade.service
@@ -6,7 +6,7 @@ After=network.target
 # Set WorkingDirectory and ExecStart to your file paths accordingly
 # NOTE: %h will be resolved to /home/<username>
 WorkingDirectory=%h/freqtrade
-ExecStart=/usr/bin/freqtrade --dynamic-whitelist 40
+ExecStart=/usr/bin/freqtrade
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Deprecated --dynamic-whitelist is still used in the freqtrade service configuration file.
