### PR TITLE
Fix broken dry-mode sells 

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -298,7 +298,7 @@ class Exchange(object):
             'amount': amount,
             "cost": amount * rate,
             'type': ordertype,
-            'side': 'buy',
+            'side': side,
             'remaining': amount,
             'datetime': arrow.utcnow().isoformat(),
             'status': "open",

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -470,6 +470,9 @@ def test_dry_run_order(default_conf, mocker, side, exchange_name):
         pair='ETH/BTC', ordertype='limit', side=side, amount=1, rate=200)
     assert 'id' in order
     assert f'dry_run_{side}_' in order["id"]
+    assert order["side"] == side
+    assert order["type"] == "limit"
+    assert order["pair"] == "ETH/BTC"
 
 
 @pytest.mark.parametrize("side", [


### PR DESCRIPTION
## Summary
Fixes a bug where bots in dry-run mode are unable to buy/sell, because the order-side is always buy (hardcoded).

Solve the issue: #1637

