### PR TITLE
Adding an option for trailing stoploss: "trailing_only_offset_is_reached"

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -9,6 +9,7 @@
     "trailing_stop": false,
     "trailing_stop_positive": 0.005,
     "trailing_stop_positive_offset": 0.0051,
+    "trailing_only_offset_is_reached": false,
     "minimal_roi": {
         "40":  0.0,
         "30":  0.01,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ Mandatory Parameters are marked as **Required**.
 | `trailing_stop` | false | Enables trailing stop-loss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
 | `trailing_stop_positive` | 0 | Changes stop-loss once profit has been reached. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
 | `trailing_stop_positive_offset` | 0 | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
+| `trailing_only_offset_is_reached` | false | Only apply trailing stoploss when the offset is reached. [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-strategy).
 | `unfilledtimeout.buy` | 10 | **Required.** How long (in minutes) the bot will wait for an unfilled buy order to complete, after which the order will be cancelled.
 | `unfilledtimeout.sell` | 10 | **Required.** How long (in minutes) the bot will wait for an unfilled sell order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | **Required.** Set the bidding price. More information [below](#understand-ask_last_balance).
@@ -319,7 +320,7 @@ section of the configuration.
 * `VolumePairList`
   * Formerly available as `--dynamic-whitelist [<number_assets>]`. This command line
 option is deprecated and should no longer be used.
-  * It selects `number_assets` top pairs based on `sort_key`, which can be one of 
+  * It selects `number_assets` top pairs based on `sort_key`, which can be one of
 `askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
   * There is a possibility to filter low-value coins that would not allow setting a stop loss
 (set `precision_filter` parameter to `true` for this).

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -62,4 +62,4 @@ The 0.01 would translate to a 1% stop loss, once you hit 1.1% profit.
 
 You should also make sure to have this value (`trailing_stop_positive_offset`) lower than your minimal ROI, otherwise minimal ROI will apply first and sell your trade.
 
-If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached.
+If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached. Until then, the stoploss remains at the configured`stoploss`.

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -55,8 +55,11 @@ Both values can be configured in the main configuration file and requires `"trai
 ``` json
     "trailing_stop_positive":  0.01,
     "trailing_stop_positive_offset":  0.011,
+    "trailing_only_offset_is_reached": false
 ```
 
 The 0.01 would translate to a 1% stop loss, once you hit 1.1% profit.
 
 You should also make sure to have this value (`trailing_stop_positive_offset`) lower than your minimal ROI, otherwise minimal ROI will apply first and sell your trade.
+
+If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached.

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -59,7 +59,7 @@ class Configuration(object):
 
         logger.info('Validating configuration ...')
         self._validate_config_schema(config)
-        self._validate_config(config)
+        self._validate_config_consistency(config)
 
         # Set strategy if not specified in config and or if it's non default
         if self.args.strategy != constants.DEFAULT_STRATEGY or not config.get('strategy'):
@@ -310,11 +310,11 @@ class Configuration(object):
                 best_match(Draft4Validator(constants.CONF_SCHEMA).iter_errors(conf)).message
             )
 
-    def _validate_config(self, conf: Dict[str, Any]) -> None:
+    def _validate_config_consistency(self, conf: Dict[str, Any]) -> None:
         """
         Validate the configuration consistency
         :param conf: Config in JSON format
-        :return: Returns None if everything is ok, otherwise throw an exception
+        :return: Returns None if everything is ok, otherwise throw an OperationalException
         """
 
         # validating trailing stoploss
@@ -332,11 +332,11 @@ class Configuration(object):
         if tsl_only_offset:
             if tsl_positive == 0.0:
                 raise OperationalException(
-                    f'The config trailing_only_offset_is_reached need '
+                    f'The config trailing_only_offset_is_reached needs '
                     'trailing_stop_positive_offset to be more than 0 in your config.')
         if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
             raise OperationalException(
-                f'The config trailing_stop_positive_offset need '
+                f'The config trailing_stop_positive_offset needs '
                 'to be greater than trailing_stop_positive_offset in your config.')
 
     def get_config(self) -> Dict[str, Any]:

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -73,6 +73,7 @@ CONF_SCHEMA = {
         'trailing_stop': {'type': 'boolean'},
         'trailing_stop_positive': {'type': 'number', 'minimum': 0, 'maximum': 1},
         'trailing_stop_positive_offset': {'type': 'number', 'minimum': 0, 'maximum': 1},
+        'trailing_only_offset_is_reached': {'type': 'boolean'},
         'unfilledtimeout': {
             'type': 'object',
             'properties': {

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -118,7 +118,6 @@ class Exchange(object):
         self.validate_pairs(config['exchange']['pair_whitelist'])
         self.validate_ordertypes(config.get('order_types', {}))
         self.validate_order_time_in_force(config.get('order_time_in_force', {}))
-        self.validate_trailing_stoploss(config)
 
         if config.get('ticker_interval'):
             # Check if timeframe is available
@@ -284,28 +283,6 @@ class Exchange(object):
             if self.name != 'Binance':
                 raise OperationalException(
                     f'Time in force policies are not supporetd for  {self.name} yet.')
-
-    def validate_trailing_stoploss(self, config) -> None:
-        """
-        Validates the trailing stoploss configuration
-        """
-        # Skip if trailing stoploss is not activated
-        if not config.get('trailing_stop', False):
-            return
-
-        tsl_positive = float(config.get('trailing_stop_positive', 0))
-        tsl_offset = float(config.get('trailing_stop_positive_offset', 0))
-        tsl_only_offset = config.get('trailing_only_offset_is_reached', False)
-
-        if tsl_only_offset:
-            if tsl_positive == 0.0:
-                raise OperationalException(
-                    f'The config trailing_only_offset_is_reached need '
-                    'trailing_stop_positive_offset to be more than 0 in your config.')
-        if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
-            raise OperationalException(
-                f'The config trailing_stop_positive_offset need '
-                'to be greater than trailing_stop_positive_offset in your config.')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -278,10 +278,10 @@ class Exchange(object):
                 raise OperationalException(
                     f'The config trailing_only_offset_is_reached need  '
                     'trailing_stop_positive_offset to be more than 0 in your config')
-        if tsl_positive > 0 and tsl_offset > 0 and tsl_offset <= tsl_positive:
+        if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
             raise OperationalException(
                 f'The config trailing_stop_positive_offset need  '
-                    'to be greater than trailing_stop_positive_offset in your config')
+                'to be greater than trailing_stop_positive_offset in your config')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -274,12 +274,12 @@ class Exchange(object):
         if tsl_only_offset:
             if tsl_positive == 0.0:
                 raise OperationalException(
-                    f'The config trailing_only_offset_is_reached need  '
-                    'trailing_stop_positive_offset to be more than 0 in your config')
+                    f'The config trailing_only_offset_is_reached need '
+                    'trailing_stop_positive_offset to be more than 0 in your config.')
         if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
             raise OperationalException(
-                f'The config trailing_stop_positive_offset need  '
-                'to be greater than trailing_stop_positive_offset in your config')
+                f'The config trailing_stop_positive_offset need '
+                'to be greater than trailing_stop_positive_offset in your config.')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -263,10 +263,8 @@ class Exchange(object):
         """
         Validates the trailing stoploss configuration
         """
-
-        tsl = config.get('trailing_stop', False)
         # Skip if trailing stoploss is not activated
-        if not tsl:
+        if not config.get('trailing_stop', False):
             return
 
         tsl_positive = float(config.get('trailing_stop_positive', 0))

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -46,18 +46,19 @@ class StrategyResolver(IResolver):
         # Set attributes
         # Check if we need to override configuration
         # (Attribute name,                              default, experimental)
-        attributes = [("minimal_roi",                   None,    False),
-                      ("ticker_interval",               None,    False),
-                      ("stoploss",                      None,    False),
-                      ("trailing_stop",                 None,    False),
-                      ("trailing_stop_positive",        None,    False),
-                      ("trailing_stop_positive_offset", 0.0,     False),
-                      ("process_only_new_candles",      None,    False),
-                      ("order_types",                   None,    False),
-                      ("order_time_in_force",           None,    False),
-                      ("use_sell_signal",               False,   True),
-                      ("sell_profit_only",              False,   True),
-                      ("ignore_roi_if_buy_signal",      False,   True),
+        attributes = [("minimal_roi", None, False),
+                      ("ticker_interval", None, False),
+                      ("stoploss", None, False),
+                      ("trailing_stop", None, False),
+                      ("trailing_stop_positive", None, False),
+                      ("trailing_stop_positive_offset", 0.0, False),
+                      ("trailing_only_offset_is_reached", None, False),
+                      ("process_only_new_candles", None, False),
+                      ("order_types", None, False),
+                      ("order_time_in_force", None, False),
+                      ("use_sell_signal", False, True),
+                      ("sell_profit_only", False, True),
+                      ("ignore_roi_if_buy_signal", False, True),
                       ]
         for attribute, default, experimental in attributes:
             if experimental:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -331,7 +331,11 @@ class IStrategy(ABC):
                              f"with offset {sl_offset:.4g} "
                              f"since we have profit {current_profit:.4f}%")
 
-            trade.adjust_stop_loss(current_rate, stop_loss_value)
+            # if trailing_only_offset_is_reached is true,
+            # we update trailing stoploss only if offset is reached.
+            tsl_only_offset = self.config.get('trailing_only_offset_is_reached', False)
+            if tsl_only_offset and current_profit > sl_offset:
+                trade.adjust_stop_loss(current_rate, stop_loss_value)
 
         return SellCheckTuple(sell_flag=False, sell_type=SellType.NONE)
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -73,6 +73,7 @@ class IStrategy(ABC):
     trailing_stop: bool = False
     trailing_stop_positive: float
     trailing_stop_positive_offset: float
+    trailing_only_offset_is_reached = False
 
     # associated ticker interval
     ticker_interval: str

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -334,7 +334,7 @@ class IStrategy(ABC):
             # if trailing_only_offset_is_reached is true,
             # we update trailing stoploss only if offset is reached.
             tsl_only_offset = self.config.get('trailing_only_offset_is_reached', False)
-            if tsl_only_offset and current_profit > sl_offset:
+            if not (tsl_only_offset and current_profit < sl_offset):
                 trade.adjust_stop_loss(current_rate, stop_loss_value)
 
         return SellCheckTuple(sell_flag=False, sell_type=SellType.NONE)

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -432,6 +432,33 @@ def test_validate_order_types(default_conf, mocker):
         Exchange(default_conf)
 
 
+def test_validate_tsl(default_conf, mocker):
+    api_mock = MagicMock()
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
+    mocker.patch('freqtrade.exchange.Exchange.name', 'Bittrex')
+    default_conf['trailing_stop'] = True
+    default_conf['trailing_stop_positive'] = 0
+    default_conf['trailing_stop_positive_offset'] = 0
+    default_conf['trailing_only_offset_is_reached'] = False
+
+    Exchange(default_conf)
+
+    default_conf['trailing_only_offset_is_reached'] = True
+    with pytest.raises(OperationalException,
+                       match=r'The config trailing_only_offset_is_reached need '
+                       'trailing_stop_positive_offset to be more than 0 in your config.'):
+        Exchange(default_conf)
+
+    default_conf['trailing_stop_positive_offset'] = 0.01
+    default_conf['trailing_stop_positive'] = 0.015
+    with pytest.raises(OperationalException,
+                       match=r'The config trailing_stop_positive_offset need '
+                       'to be greater than trailing_stop_positive_offset in your config.'):
+        Exchange(default_conf)
+
+
 def test_validate_order_types_not_in_config(default_conf, mocker):
     api_mock = MagicMock()
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -449,33 +449,6 @@ def test_validate_order_types(default_conf, mocker):
         Exchange(default_conf)
 
 
-def test_validate_tsl(default_conf, mocker):
-    api_mock = MagicMock()
-    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
-    mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
-    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
-    mocker.patch('freqtrade.exchange.Exchange.name', 'Bittrex')
-    default_conf['trailing_stop'] = True
-    default_conf['trailing_stop_positive'] = 0
-    default_conf['trailing_stop_positive_offset'] = 0
-    default_conf['trailing_only_offset_is_reached'] = False
-
-    Exchange(default_conf)
-
-    default_conf['trailing_only_offset_is_reached'] = True
-    with pytest.raises(OperationalException,
-                       match=r'The config trailing_only_offset_is_reached need '
-                       'trailing_stop_positive_offset to be more than 0 in your config.'):
-        Exchange(default_conf)
-
-    default_conf['trailing_stop_positive_offset'] = 0.01
-    default_conf['trailing_stop_positive'] = 0.015
-    with pytest.raises(OperationalException,
-                       match=r'The config trailing_stop_positive_offset need '
-                       'to be greater than trailing_stop_positive_offset in your config.'):
-        Exchange(default_conf)
-
-
 def test_validate_order_types_not_in_config(default_conf, mocker):
     api_mock = MagicMock()
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -13,7 +13,6 @@ from freqtrade import OperationalException, constants
 from freqtrade.arguments import Arguments
 from freqtrade.configuration import Configuration, set_loggers
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
-from freqtrade.exchange import Exchange
 from freqtrade.state import RunMode
 from freqtrade.tests.conftest import log_has
 
@@ -576,28 +575,22 @@ def test__create_datadir(mocker, default_conf, caplog) -> None:
     assert log_has('Created data directory: /foo/bar', caplog.record_tuples)
 
 
-def test_validate_tsl(default_conf, mocker):
-    mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
-    mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
-    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
-    mocker.patch('freqtrade.exchange.Exchange.validate_ordertypes', MagicMock())
-    mocker.patch('freqtrade.exchange.Exchange.name', 'Bittrex')
+def test_validate_tsl(default_conf):
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0
     default_conf['trailing_stop_positive_offset'] = 0
-    default_conf['trailing_only_offset_is_reached'] = False
-
-    Exchange(default_conf)
 
     default_conf['trailing_only_offset_is_reached'] = True
     with pytest.raises(OperationalException,
                        match=r'The config trailing_only_offset_is_reached need '
                        'trailing_stop_positive_offset to be more than 0 in your config.'):
-        Exchange(default_conf)
+        configuration = Configuration(Namespace())
+        configuration._validate_config(default_conf)
 
     default_conf['trailing_stop_positive_offset'] = 0.01
     default_conf['trailing_stop_positive'] = 0.015
     with pytest.raises(OperationalException,
                        match=r'The config trailing_stop_positive_offset need '
                        'to be greater than trailing_stop_positive_offset in your config.'):
-        Exchange(default_conf)
+        configuration = Configuration(Namespace())
+        configuration._validate_config(default_conf)

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -582,15 +582,20 @@ def test_validate_tsl(default_conf):
 
     default_conf['trailing_only_offset_is_reached'] = True
     with pytest.raises(OperationalException,
-                       match=r'The config trailing_only_offset_is_reached need '
+                       match=r'The config trailing_only_offset_is_reached needs '
                        'trailing_stop_positive_offset to be more than 0 in your config.'):
         configuration = Configuration(Namespace())
-        configuration._validate_config(default_conf)
+        configuration._validate_config_consistency(default_conf)
 
     default_conf['trailing_stop_positive_offset'] = 0.01
     default_conf['trailing_stop_positive'] = 0.015
     with pytest.raises(OperationalException,
-                       match=r'The config trailing_stop_positive_offset need '
+                       match=r'The config trailing_stop_positive_offset needs '
                        'to be greater than trailing_stop_positive_offset in your config.'):
         configuration = Configuration(Namespace())
-        configuration._validate_config(default_conf)
+        configuration._validate_config_consistency(default_conf)
+
+    default_conf['trailing_stop_positive'] = 0.01
+    default_conf['trailing_stop_positive_offset'] = 0.015
+    Configuration(Namespace())
+    configuration._validate_config_consistency(default_conf)

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2504,7 +2504,7 @@ def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        get_markets=markets,
+        markets=PropertyMock(return_value=markets),
     )
 
     default_conf['trailing_stop'] = True

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2512,6 +2512,72 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
     assert trade.sell_reason == SellType.TRAILING_STOP_LOSS.value
 
 
+def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
+                                 caplog, mocker, markets) -> None:
+    buy_price = limit_buy_order['price']
+    # buy_price: 0.00001099
+
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        get_ticker=MagicMock(return_value={
+            'bid': buy_price,
+            'ask': buy_price,
+            'last': buy_price
+        }),
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
+        get_markets=markets,
+    )
+
+    default_conf['trailing_stop'] = True
+    default_conf['trailing_stop_positive'] = 0.05
+    default_conf['trailing_stop_positive_offset'] = 0.055
+    default_conf['trailing_only_offset_is_reached'] = True
+
+    freqtrade = FreqtradeBot(default_conf)
+    patch_get_signal(freqtrade)
+    freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
+    freqtrade.create_trade()
+
+    trade = Trade.query.first()
+    trade.update(limit_buy_order)
+    caplog.set_level(logging.DEBUG)
+    # stop-loss not reached
+    assert freqtrade.handle_trade(trade) is False
+    assert trade.stop_loss == 0.0000098910
+
+    # Raise ticker above buy price
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
+                 MagicMock(return_value={
+                     'bid': buy_price + 0.0000004,
+                     'ask': buy_price + 0.0000004,
+                     'last': buy_price + 0.0000004
+                 }))
+
+    # stop-loss should not be adjusted as offset is not reached yet
+    assert freqtrade.handle_trade(trade) is False
+
+    assert not log_has(f'adjusted stop loss', caplog.record_tuples)
+    assert trade.stop_loss == 0.0000098910
+
+    # price rises above the offset (rises 12% when the offset is 5.5%)
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
+                 MagicMock(return_value={
+                     'bid': buy_price + 0.0000014,
+                     'ask': buy_price + 0.0000014,
+                     'last': buy_price + 0.0000014
+                 }))
+
+    assert freqtrade.handle_trade(trade) is False
+    assert log_has(f'using positive stop loss mode: 0.05 with offset 0.055 '
+                   f'since we have profit 0.1218%',
+                   caplog.record_tuples)
+    assert log_has(f'adjusted stop loss', caplog.record_tuples)
+    assert trade.stop_loss == 0.0000117705
+
+
 def test_disable_ignore_roi_if_buy_signal(default_conf, limit_buy_order,
                                           fee, markets, mocker) -> None:
     patch_RPCManager(mocker)


### PR DESCRIPTION
## Summary
This will permit to activate trailing stoploss only if the offset is reached. So basically only the part of the trailing stoploss after offset will be used. 

## TODO 
- [X] Fixing current tests
- [X] Adding new tests for the option
- [X] Add config validation
- [X] Documentation
- [X] Test on live
