### PR TITLE
Support for systemd watchdog

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -38,7 +38,7 @@ optional arguments:
   --db-url PATH         Override trades database URL, this is useful if
                         dry_run is enabled or in custom deployments (default:
                         None).
-
+  --sd-notify           Notify systemd service manager.
 ```
 
 ### How to use a different configuration file?

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ Mandatory Parameters are marked as **Required**.
 | `strategy` | DefaultStrategy | Defines Strategy class to use.
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a folder).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
+| `internals.sd_notify` | false | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details.
 
 ### Parameters in the strategy
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -428,6 +428,19 @@ For this to be persistent (run when user is logged out) you'll need to enable `l
 sudo loginctl enable-linger "$USER"
 ```
 
+If you run the bot as a service, you can use systemd service manager as a software watchdog monitoring freqtrade bot 
+state and restarting it in the case of failures. If the `internals.sd_notify` parameter is set to true in the 
+configuration or the `--sd-notify` command line option is used, the bot will send keep-alive ping messages to systemd 
+using the sd_notify (systemd notifications) protocol and will also tell systemd its current state (Running or Stopped) 
+when it changes. 
+
+The `freqtrade.service.watchdog` file contains an example of the service unit configuration file which uses systemd 
+as the watchdog.
+
+!!! Note: 
+The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a 
+Docker container.
+
 ------
 
 ## Windows

--- a/freqtrade.service.watchdog
+++ b/freqtrade.service.watchdog
@@ -1,0 +1,30 @@
+[Unit]
+Description=Freqtrade Daemon
+After=network.target
+
+[Service]
+# Set WorkingDirectory and ExecStart to your file paths accordingly
+# NOTE: %h will be resolved to /home/<username>
+WorkingDirectory=%h/freqtrade
+ExecStart=/usr/bin/freqtrade --sd-notify
+
+Restart=always
+#Restart=on-failure
+
+# Note that we use Type=notify here
+Type=notify
+
+# Currently required if Type=notify
+NotifyAccess=all
+
+StartLimitInterval=1min
+StartLimitBurst=5
+
+TimeoutStartSec=1min
+
+# Use here (process_throttle_secs * 2) or longer time interval
+WatchdogSec=20
+
+[Install]
+WantedBy=default.target
+

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -127,6 +127,12 @@ class Arguments(object):
             type=str,
             metavar='PATH',
         )
+        self.parser.add_argument(
+            '--sd-notify',
+            help='Notify systemd service manager.',
+            action='store_true',
+            dest='sd_notify',
+        )
 
     @staticmethod
     def backtesting_options(parser: argparse.ArgumentParser) -> None:
@@ -140,7 +146,6 @@ class Arguments(object):
             dest='position_stacking',
             default=False
         )
-
         parser.add_argument(
             '--dmmp', '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -122,6 +122,10 @@ class Configuration(object):
         set_loggers(config['verbosity'])
         logger.info('Verbosity set to %s', config['verbosity'])
 
+        # Support for sd_notify
+        if self.args.sd_notify:
+            config['internals'].update({'sd_notify': True})
+
         # Add dynamic_whitelist if found
         if 'dynamic_whitelist' in self.args and self.args.dynamic_whitelist:
             # Update to volumePairList (the previous default)

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -171,7 +171,8 @@ CONF_SCHEMA = {
             'type': 'object',
             'properties': {
                 'process_throttle_secs': {'type': 'number'},
-                'interval': {'type': 'integer'}
+                'interval': {'type': 'integer'},
+                'sd_notify': {'type': 'boolean'},
             }
         }
     },

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -84,7 +84,7 @@ class FreqtradeBot(object):
         # Tell the systemd that we completed initialization phase
         if self._sd_notify:
             logger.debug("sd_notify: READY=1")
-            self._sd_notify.notify('READY=1')
+            self._sd_notify.notify("READY=1")
 
     def _init_modules(self) -> None:
         """
@@ -110,13 +110,20 @@ class FreqtradeBot(object):
         """
         logger.info('Cleaning up modules ...')
 
-        # Tell systemd that we are stopping now
-        if self._sd_notify:
-            logger.debug("sd_notify: STOPPING=1")
-            self._sd_notify.notify('STOPPING=1')
-
         self.rpc.cleanup()
         persistence.cleanup()
+
+    def stopping(self) -> None:
+        # Tell systemd that we are exiting now
+        if self._sd_notify:
+            logger.debug("sd_notify: STOPPING=1")
+            self._sd_notify.notify("STOPPING=1")
+
+    def reconfigure(self) -> None:
+        # Tell systemd that we initiated reconfiguring
+        if self._sd_notify:
+            logger.debug("sd_notify: RELOADING=1")
+            self._sd_notify.notify("RELOADING=1")
 
     def worker(self, old_state: State = None) -> State:
         """
@@ -144,7 +151,7 @@ class FreqtradeBot(object):
             # Ping systemd watchdog before sleeping in the stopped state
             if self._sd_notify:
                 logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: STOPPED.")
-                self._sd_notify.notify('WATCHDOG=1\nSTATUS=State: STOPPED.')
+                self._sd_notify.notify("WATCHDOG=1\nSTATUS=State: STOPPED.")
 
             time.sleep(throttle_secs)
 
@@ -152,7 +159,7 @@ class FreqtradeBot(object):
             # Ping systemd watchdog before throttling
             if self._sd_notify:
                 logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: RUNNING.")
-                self._sd_notify.notify('WATCHDOG=1\nSTATUS=State: RUNNING.')
+                self._sd_notify.notify("WATCHDOG=1\nSTATUS=State: RUNNING.")
 
             self._throttle(func=self._process, min_secs=throttle_secs)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import arrow
 from requests.exceptions import RequestException
+import sdnotify
 
 from freqtrade import (DependencyException, OperationalException,
                        TemporaryError, __version__, constants, persistence)
@@ -51,6 +52,10 @@ class FreqtradeBot(object):
 
         # Init objects
         self.config = config
+
+        self._sd_notify = sdnotify.SystemdNotifier() if \
+            self.config.get('internals', {}).get('sd_notify', False) else None
+
         self.strategy: IStrategy = StrategyResolver(self.config).strategy
 
         self.rpc: RPCManager = RPCManager(self)
@@ -76,6 +81,11 @@ class FreqtradeBot(object):
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
         self._init_modules()
 
+        # Tell the systemd that we completed initialization phase
+        if self._sd_notify:
+            logger.debug("sd_notify: READY=1")
+            self._sd_notify.notify('READY=1')
+
     def _init_modules(self) -> None:
         """
         Initializes all modules and updates the config
@@ -99,6 +109,12 @@ class FreqtradeBot(object):
         :return: None
         """
         logger.info('Cleaning up modules ...')
+
+        # Tell systemd that we are stopping now
+        if self._sd_notify:
+            logger.debug("sd_notify: STOPPING=1")
+            self._sd_notify.notify('STOPPING=1')
+
         self.rpc.cleanup()
         persistence.cleanup()
 
@@ -119,16 +135,27 @@ class FreqtradeBot(object):
             if state == State.RUNNING:
                 self.rpc.startup_messages(self.config, self.pairlists)
 
-        if state == State.STOPPED:
-            time.sleep(1)
-        elif state == State.RUNNING:
-            min_secs = self.config.get('internals', {}).get(
-                'process_throttle_secs',
-                constants.PROCESS_THROTTLE_SECS
-            )
+        throttle_secs = self.config.get('internals', {}).get(
+            'process_throttle_secs',
+            constants.PROCESS_THROTTLE_SECS
+        )
 
-            self._throttle(func=self._process,
-                           min_secs=min_secs)
+        if state == State.STOPPED:
+            # Ping systemd watchdog before sleeping in the stopped state
+            if self._sd_notify:
+                logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: STOPPED.")
+                self._sd_notify.notify('WATCHDOG=1\nSTATUS=State: STOPPED.')
+
+            time.sleep(throttle_secs)
+
+        elif state == State.RUNNING:
+            # Ping systemd watchdog before throttling
+            if self._sd_notify:
+                logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: RUNNING.")
+                self._sd_notify.notify('WATCHDOG=1\nSTATUS=State: RUNNING.')
+
+            self._throttle(func=self._process, min_secs=throttle_secs)
+
         return state
 
     def _throttle(self, func: Callable[..., Any], min_secs: float, *args, **kwargs) -> Any:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -60,6 +60,7 @@ def main(sysargv: List[str]) -> None:
         logger.exception('Fatal exception!')
     finally:
         if freqtrade:
+            freqtrade.stopping()
             freqtrade.rpc.send_msg({
                 'type': RPCMessageType.STATUS_NOTIFICATION,
                 'status': 'process died'
@@ -72,6 +73,8 @@ def reconfigure(freqtrade: FreqtradeBot, args: Namespace) -> FreqtradeBot:
     """
     Cleans up current instance, reloads the configuration and returns the new instance
     """
+    freqtrade.reconfigure()
+
     # Clean up current modules
     freqtrade.cleanup()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,8 @@ scikit-optimize==0.5.2
 # find first, C search in arrays
 py_find_1st==1.1.3
 
-#Load ticker files 30% faster
+# Load ticker files 30% faster
 python-rapidjson==0.7.0
+
+# Notify systemd
+sdnotify==0.3.2


### PR DESCRIPTION
This PR contains simple and effective watchdog capability using systemd manager as watchdog for the bot when the bot is run as a systemd service. Implemented via sd_notify protocol.

Works brilliant to me. Respawns the bot if it's killed, does not leave any zombies, even if freqtrade is run as a service with additional shell script wrapper and changes the PID of the process thus...

* New `internals.sd_notify` config parameter and the `--sd-notify` command line option are added. Any of those can be used to enable systemd notifications. Descriptions included in the docs.
* I did not get if the reloading of the configuration is currently implemented in the bot. Appropriate sd_notify message can be added additionaly for reloading of the configuration in a proper place.
* Current bot's state (Running or Stopped, throttling in sleep cycles) can be seen in the `systemctl status` output in the service Status string.
* A sample service unit configuration file `freqtrade.service.watchdog` included.
* Detailed (more or less) description added in `docs/installation.md`.
* I have no idea of how to test it with pytest since it's mostly an external service, systemd.
* Please test if it probably breaks compatibility for Windows. I mean normal running of the bot on Windows without this functionality enabled, since sd_notify does not have meaning for Windows. (I do not have devel. environment on Windows, cannot check it by myself...)

The implementation is light and simple and does not add any heavy threading logic or monitoring processes to the bot...

P.S. I changed the throttle interval for the bot running in empty sleeps (i.e. the Stopped bot state) from 1 sec to same trottle_proc_secs as for the Running state in order to simplify the throttlng logic there...
