### PR TITLE
Catch ModuleNotFoundError when importing external code

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -31,7 +31,11 @@ class IResolver(object):
         # Generate spec based on absolute path
         spec = importlib.util.spec_from_file_location('unknown', str(module_path))
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints
+        try:
+            spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints
+        except ModuleNotFoundError as err:
+            # Catch errors in case a specific module is not installed
+            logger.info(f"Could not import {module_path} due to '{err}'")
 
         valid_objects_gen = (
             obj for name, obj in inspect.getmembers(module, inspect.isclass)


### PR DESCRIPTION
## Summary
Don't fail but skip if a strategy is present which requires modules that are not installed.

## Quick changelog
Observed:

```
2019-03-11 19:35:45,187 - freqtrade - ERROR - Fatal exception!
Traceback (most recent call last):
  File "/home/xmatt/development/freqtrade/freqtrade/main.py", line 45, in main
    freqtrade = FreqtradeBot(config)
  File "/home/xmatt/development/freqtrade/freqtrade/freqtradebot.py", line 54, in __init__
    self.strategy: IStrategy = StrategyResolver(self.config).strategy
  File "/home/xmatt/development/freqtrade/freqtrade/resolvers/strategy_resolver.py", line 40, in __init__
    extra_dir=config.get('strategy_path'))
  File "/home/xmatt/development/freqtrade/freqtrade/resolvers/strategy_resolver.py", line 150, in _load_strategy
    object_name=strategy_name, kwargs={'config': config})
  File "/home/xmatt/development/freqtrade/freqtrade/resolvers/iresolver.py", line 57, in _search_object
    object_type, Path.resolve(directory.joinpath(entry)), object_name
  File "/home/xmatt/development/freqtrade/freqtrade/resolvers/iresolver.py", line 34, in _get_valid_object
    spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/xmatt/development/xmatt/strategies/BollingerStochRSI.py", line 6, in <module>
    from pyti.stochrsi import stochrsi
ModuleNotFoundError: No module named 'pyti'

```

I did not find a way to test for this case without adding a strategy with a module that does not exist ... but if anyone has a better idea let me know.