### PR TITLE
Add stoploss to startup messages

### DIFF
--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -61,6 +61,8 @@ class RPCManager(object):
         stake_currency = config['stake_currency']
         stake_amount = config['stake_amount']
         minimal_roi = config['minimal_roi']
+        stoploss = config['stoploss']
+        trailing_stop = config['trailing_stop']
         ticker_interval = config['ticker_interval']
         exchange_name = config['exchange']['name']
         strategy_name = config.get('strategy', '')
@@ -69,6 +71,7 @@ class RPCManager(object):
             'status': f'*Exchange:* `{exchange_name}`\n'
                       f'*Stake per trade:* `{stake_amount} {stake_currency}`\n'
                       f'*Minimum ROI:* `{minimal_roi}`\n'
+                      f'*{"Trailing " if trailing_stop else ""}Stoploss:* `{stoploss}`\n'
                       f'*Ticker Interval:* `{ticker_interval}`\n'
                       f'*Strategy:* `{strategy_name}`'
         })


### PR DESCRIPTION
## Summary
Show more information on telegram - stoploss is an important part and should be verified before running the bot. This should simplify that by screaming it at you ...




## Quick changelog

- Shows either Stoploss - or Trailing stoploss 
*note to self: change this stoploss, it's way to high*

![2019-03-12-070559_286x137_scrot](https://user-images.githubusercontent.com/5024695/54178285-8db86a80-4495-11e9-899d-ede8a7e832bd.png)
![2019-03-12-070606_254x139_scrot](https://user-images.githubusercontent.com/5024695/54178290-8f822e00-4495-11e9-9653-59737381aac2.png)
