### PR TITLE
Default value for minimal_roi

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,9 +118,10 @@ See the example below:
 },
 ```
 
-Most of the strategy files already include the optimal `minimal_roi`
-value. This parameter is optional. If you use it in the configuration file, it will take over the
+Most of the strategy files already include the optimal `minimal_roi` value.
+This parameter can be set in either Strategy or Configuration file. If you use it in the configuration file, it will override the
 `minimal_roi` value from the strategy file.
+If it is not set in either Strategy or Configuration, a default of 1000% `{"0": 10}` is used, and minimal roi is disabled unless your trade generates 1000% profit.
 
 ### Understand stoploss
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -46,18 +46,18 @@ class StrategyResolver(IResolver):
         # Set attributes
         # Check if we need to override configuration
         # (Attribute name,                              default, experimental)
-        attributes = [("minimal_roi",                   {"0": 10.0},    False),
-                      ("ticker_interval",               None,    False),
-                      ("stoploss",                      None,    False),
-                      ("trailing_stop",                 None,    False),
-                      ("trailing_stop_positive",        None,    False),
-                      ("trailing_stop_positive_offset", 0.0,     False),
-                      ("process_only_new_candles",      None,    False),
-                      ("order_types",                   None,    False),
-                      ("order_time_in_force",           None,    False),
-                      ("use_sell_signal",               False,   True),
-                      ("sell_profit_only",              False,   True),
-                      ("ignore_roi_if_buy_signal",      False,   True),
+        attributes = [("minimal_roi",                   {"0": 10.0}, False),
+                      ("ticker_interval",               None,        False),
+                      ("stoploss",                      None,        False),
+                      ("trailing_stop",                 None,        False),
+                      ("trailing_stop_positive",        None,        False),
+                      ("trailing_stop_positive_offset", 0.0,         False),
+                      ("process_only_new_candles",      None,        False),
+                      ("order_types",                   None,        False),
+                      ("order_time_in_force",           None,        False),
+                      ("use_sell_signal",               False,       True),
+                      ("sell_profit_only",              False,       True),
+                      ("ignore_roi_if_buy_signal",      False,       True),
                       ]
         for attribute, default, experimental in attributes:
             if experimental:

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -46,7 +46,7 @@ class StrategyResolver(IResolver):
         # Set attributes
         # Check if we need to override configuration
         # (Attribute name,                              default, experimental)
-        attributes = [("minimal_roi",                   None,    False),
+        attributes = [("minimal_roi",                   {"0": 10.0},    False),
                       ("ticker_interval",               None,    False),
                       ("stoploss",                      None,    False),
                       ("trailing_stop",                 None,    False),


### PR DESCRIPTION
## Summary
As raised in #1633, minimal_roi is not really optional, even if that's stated in the documentaiton.


Fixes #1633 
## Quick changelog

- default to 1000%  `{"0": 10}`
- Document this behaviour

