### PR TITLE
send notification when stoploss_on_exchange is hit

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -855,9 +855,10 @@ class FreqtradeBot(object):
         """
         Sends rpc notification when a sell occured.
         """
-        profit_trade = trade.calc_profit(rate=trade.close_rate_requested)
+        profit_rate = trade.close_rate if trade.close_rate else trade.close_rate_requested
+        profit_trade = trade.calc_profit(rate=profit_rate)
         current_rate = self.exchange.get_ticker(trade.pair)['bid']
-        profit_percent = trade.calc_profit_percent(trade.close_rate_requested)
+        profit_percent = trade.calc_profit_percent(profit_rate)
         gain = "profit" if profit_percent > 0 else "loss"
 
         msg = {

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -266,6 +266,7 @@ class Trade(_DECL_BASE):
             logger.info('%s_SELL has been fulfilled for %s.', order_type.upper(), self)
         elif order_type == 'stop_loss_limit':
             self.stoploss_order_id = None
+            self.close_rate_requested = self.stop_loss
             logger.info('STOP_LOSS_LIMIT is hit for %s.', self)
             self.close(order['average'])
         else:

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -4,7 +4,6 @@ This module contains class to manage RPC communications (Telegram, Slack, ...)
 import logging
 from typing import Any, Dict, List
 
-from freqtrade.persistence import Trade
 from freqtrade.rpc import RPC, RPCMessageType
 
 logger = logging.getLogger(__name__)
@@ -81,35 +80,3 @@ class RPCManager(object):
             'status': f'Searching for {stake_currency} pairs to buy and sell '
                       f'based on {pairlist.short_desc()}'
         })
-
-    def notify_sell(self, trade: Trade, config, current_rate: float):
-        profit_trade = trade.calc_profit(rate=trade.close_rate_requested)
-
-        profit_percent = trade.calc_profit_percent(trade.close_rate_requested)
-        gain = "profit" if profit_percent > 0 else "loss"
-
-        msg = {
-            'type': RPCMessageType.SELL_NOTIFICATION,
-            'exchange': trade.exchange.capitalize(),
-            'pair': trade.pair,
-            'gain': gain,
-            'limit': trade.close_rate_requested,
-            'amount': trade.amount,
-            'open_rate': trade.open_rate,
-            'current_rate': current_rate,
-            'profit_amount': profit_trade,
-            'profit_percent': profit_percent,
-            'sell_reason': trade.sell_reason
-        }
-
-        # For regular case, when the configuration exists
-        if 'stake_currency' in config and 'fiat_display_currency' in config:
-            stake_currency = config['stake_currency']
-            fiat_currency = config['fiat_display_currency']
-            msg.update({
-                'stake_currency': stake_currency,
-                'fiat_currency': fiat_currency,
-            })
-
-        # Send the message
-        self.send_msg(msg)

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2105,7 +2105,7 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
     assert trade.is_open is False
     print(trade.sell_reason)
     assert trade.sell_reason == SellType.STOPLOSS_ON_EXCHANGE.value
-    assert rpc_mock.call_count == 1
+    assert rpc_mock.call_count == 2
 
 
 def test_execute_sell_without_conf_sell_up(default_conf, ticker, fee,


### PR DESCRIPTION
## Summary
Notifications should be sent when stoploss_on_exchange is hit.

Solve the issue: #1653

## Quick changelog

- create notify_sell (extracted from regular sell function
- Send notification on "stoploss on exchange"

