### PR TITLE
Catch syntaxerror on import

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -33,9 +33,9 @@ class IResolver(object):
         module = importlib.util.module_from_spec(spec)
         try:
             spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints
-        except ModuleNotFoundError as err:
+        except (ModuleNotFoundError, SyntaxError) as err:
             # Catch errors in case a specific module is not installed
-            logger.info(f"Could not import {module_path} due to '{err}'")
+            logger.warning(f"Could not import {module_path} due to '{err}'")
 
         valid_objects_gen = (
             obj for name, obj in inspect.getmembers(module, inspect.isclass)


### PR DESCRIPTION
## Summary
Explain in one sentence the goal of this PR

Solve the issue - raised on slack

## Quick changelog

- Catch Syntax error
- Use Warn not Info as log level - since this could lead to problems if the strategy to load causes the exception.

#### before:
``` 
root@vmanager6003:~/freqtrade# source .env/bin/activate; python ./freqtrade/main.py -s APstrat1 backtesting
2019-03-14 21:20:18,133 - freqtrade.configuration - INFO - Verbosity set to 0
2019-03-14 21:20:18,134 - freqtrade.configuration - INFO - Dry run is disabled
2019-03-14 21:20:18,134 - freqtrade.configuration - INFO - Using DB: "sqlite:///tradesv3.prodrun.sqlite"
2019-03-14 21:20:18,134 - freqtrade.configuration - INFO - Using max_open_trades: 3 ...
2019-03-14 21:20:18,134 - freqtrade.configuration - INFO - Using data folder: user_data/data/binance ...
2019-03-14 21:20:18,135 - freqtrade.optimize.backtesting - INFO - Starting freqtrade in Backtesting mode
Traceback (most recent call last):
  File "./freqtrade/main.py", line 89, in <module>
    main(sys.argv[1:])
  File "./freqtrade/main.py", line 35, in main
    args.func(args)
  File "/root/freqtrade/freqtrade/optimize/backtesting.py", line 489, in start
    backtesting = Backtesting(config)
  File "/root/freqtrade/freqtrade/optimize/backtesting.py", line 79, in __init__
    self.strategylist.append(StrategyResolver(self.config).strategy)
  File "/root/freqtrade/freqtrade/resolvers/strategy_resolver.py", line 40, in __init__
    extra_dir=config.get('strategy_path'))
  File "/root/freqtrade/freqtrade/resolvers/strategy_resolver.py", line 150, in _load_strategy
    object_name=strategy_name, kwargs={'config': config})
  File "/root/freqtrade/freqtrade/resolvers/iresolver.py", line 57, in _search_object
    object_type, Path.resolve(directory.joinpath(entry)), object_name
  File "/root/freqtrade/freqtrade/resolvers/iresolver.py", line 34, in _get_valid_object
    spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/freqtrade/user_data/strategies/APstrat2.py", line 72
    ),
    ^
SyntaxError: invalid syntax

```

### after:

```
2019-03-15 19:51:59,238 - freqtrade.resolvers.iresolver - WARNING - Could not import /home/xmatt/development/python/strategies/BinHV27.py due to 'invalid syntax (BinHV27.py, line 88)'
2019-03-15 19:51:59,242 - freqtrade.resolvers.iresolver - WARNING - Could not import /home/xmatt/development/python/strategies/BollingerStochRSI.py due to 'No module named 'pyti''

```