### PR TITLE
No telegram rate updates when orderbook is enabled

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -592,7 +592,7 @@ class FreqtradeBot(object):
             logger.debug('Using order book to get sell rate')
 
             order_book = self.exchange.get_order_book(pair, 1)
-            rate = order_book['asks'][0][0]
+            rate = order_book['bids'][0][0]
 
         else:
             rate = self.exchange.get_ticker(pair, refresh)['bid']

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -94,7 +94,7 @@ class RPC(object):
                     order = self._freqtrade.exchange.get_order(trade.open_order_id, trade.pair)
                 # calculate profit and send message to user
                 try:
-                    current_rate = self._freqtrade.exchange.get_ticker(trade.pair, False)['bid']
+                    current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
                 current_profit = trade.calc_profit_percent(current_rate)
@@ -125,7 +125,7 @@ class RPC(object):
             for trade in trades:
                 # calculate profit and send message to user
                 try:
-                    current_rate = self._freqtrade.exchange.get_ticker(trade.pair, False)['bid']
+                    current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
                 trade_perc = (100 * trade.calc_profit_percent(current_rate))
@@ -213,7 +213,7 @@ class RPC(object):
             else:
                 # Get current rate
                 try:
-                    current_rate = self._freqtrade.exchange.get_ticker(trade.pair, False)['bid']
+                    current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
                 profit_percent = trade.calc_profit_percent(rate=current_rate)
@@ -280,9 +280,9 @@ class RPC(object):
             else:
                 try:
                     if coin == 'USDT':
-                        rate = 1.0 / self._freqtrade.exchange.get_ticker('BTC/USDT', False)['bid']
+                        rate = 1.0 / self._freqtrade.get_sell_rate('BTC/USDT', False)
                     else:
-                        rate = self._freqtrade.exchange.get_ticker(coin + '/BTC', False)['bid']
+                        rate = self._freqtrade.get_sell_rate(coin + '/BTC', False)
                 except (TemporaryError, DependencyException):
                     continue
             est_btc: float = rate * balance['total']
@@ -356,7 +356,7 @@ class RPC(object):
                     return
 
             # Get current rate and execute sell
-            current_rate = self._freqtrade.exchange.get_ticker(trade.pair, False)['bid']
+            current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
             self._freqtrade.execute_sell(trade, current_rate, SellType.FORCE_SELL)
         # ---- EOF def _exec_forcesell ----
 

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2984,7 +2984,7 @@ def test_get_sell_rate(default_conf, mocker, ticker, order_book_l2) -> None:
     ft = get_patched_freqtradebot(mocker, default_conf)
     rate = ft.get_sell_rate(pair, True)
     assert isinstance(rate, float)
-    assert rate == 0.043949
+    assert rate == 0.043936
 
 
 def test_startup_messages(default_conf, mocker):

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2962,6 +2962,31 @@ def test_order_book_ask_strategy(default_conf, limit_buy_order, limit_sell_order
     assert freqtrade.handle_trade(trade) is True
 
 
+def test_get_sell_rate(default_conf, mocker, ticker, order_book_l2) -> None:
+
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        get_order_book=order_book_l2,
+        get_ticker=ticker,
+    )
+    pair = "ETH/BTC"
+
+    # Test regular mode
+    ft = get_patched_freqtradebot(mocker, default_conf)
+    rate = ft.get_sell_rate(pair, True)
+    assert isinstance(rate, float)
+    assert rate == 0.00001098
+
+    # Test orderbook mode
+    default_conf['ask_strategy']['use_order_book'] = True
+    default_conf['ask_strategy']['order_book_min'] = 1
+    default_conf['ask_strategy']['order_book_max'] = 2
+    ft = get_patched_freqtradebot(mocker, default_conf)
+    rate = ft.get_sell_rate(pair, True)
+    assert isinstance(rate, float)
+    assert rate == 0.043949
+
+
 def test_startup_messages(default_conf, mocker):
     default_conf['pairlist'] = {'method': 'VolumePairList',
                                 'config': {'number_assets': 20}


### PR DESCRIPTION
## Summary
get_ticker is not updating when orderbook is enabled since it's never called.
extacted the get_ticker logic (using [bid] ...) to a separate function which is called from RPC.

Solve the issue: #1658

## Quick changelog

- Reenable updates when orderbook asks  is on

*note*: before using this, read the outcome of #1667  - I may have discovered a bug in the orderbook ask logic.

