### PR TITLE
Fix backtest problem with partial data

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -337,7 +337,6 @@ class Backtesting(object):
 
         # Loop timerange and test per pair
         while tmp < end_date:
-            # print(f"time: {tmp}")
 
             for i, pair in enumerate(ticker):
                 if pair not in indexes:
@@ -358,9 +357,9 @@ class Backtesting(object):
                 if row.buy == 0 or row.sell == 1:
                     continue  # skip rows where no buy signal or that would immediately sell off
 
-                if not position_stacking:
-                    if pair in lock_pair_until and row.date <= lock_pair_until[pair]:
-                        continue
+                if (not position_stacking and pair in lock_pair_until
+                        and row.date <= lock_pair_until[pair]):
+                    continue
                 if max_open_trades > 0:
                     # Check if max_open_trades has already been reached for the given date
                     if not trade_count_lock.get(row.date, 0) < max_open_trades:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -334,10 +334,11 @@ class Backtesting(object):
         ticker: Dict = self._get_ticker_list(processed)
 
         lock_pair_until: Dict = {}
+        # Indexes per pair, so some pairs are allowed to have a missing start.
         indexes: Dict = {}
         tmp = start_date + timedelta(minutes=self.ticker_interval_mins)
 
-        # Loop timerange and test per pair
+        # Loop timerange and get candle for each pair at that point in time
         while tmp < end_date:
 
             for i, pair in enumerate(ticker):

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional
 
-from pandas import DataFrame, Timestamp
+from pandas import DataFrame
 from tabulate import tabulate
 
 from freqtrade import optimize
@@ -343,7 +343,7 @@ class Backtesting(object):
                     # Warnings for this are shown by `validate_backtest_data`
                     continue
 
-                if row.date > Timestamp(tmp.datetime):
+                if row.date > tmp.datetime:
                     continue
 
                 indexes[pair] += 1
@@ -369,7 +369,7 @@ class Backtesting(object):
                     trades.append(trade_entry)
                 else:
                     # Set lock_pair_until to end of testing period if trade could not be closed
-                    lock_pair_until[pair] = Timestamp(end_date.datetime)
+                    lock_pair_until[pair] = end_date.datetime
 
             tmp += timedelta(minutes=self.ticker_interval_mins)
         return DataFrame.from_records(trades, columns=BacktestResult._fields)

--- a/freqtrade/tests/edge/test_edge.py
+++ b/freqtrade/tests/edge/test_edge.py
@@ -122,8 +122,8 @@ def test_edge_results(edge_conf, mocker, caplog, data) -> None:
     for c, trade in enumerate(data.trades):
         res = results.iloc[c]
         assert res.exit_type == trade.sell_reason
-        assert res.open_time == _get_frame_time_from_offset(trade.open_tick)
-        assert res.close_time == _get_frame_time_from_offset(trade.close_tick)
+        assert arrow.get(res.open_time) == _get_frame_time_from_offset(trade.open_tick)
+        assert arrow.get(res.close_time) == _get_frame_time_from_offset(trade.close_tick)
 
 
 def test_adjust(mocker, edge_conf):

--- a/freqtrade/tests/optimize/__init__.py
+++ b/freqtrade/tests/optimize/__init__.py
@@ -32,7 +32,7 @@ class BTContainer(NamedTuple):
 
 def _get_frame_time_from_offset(offset):
     return ticker_start_time.shift(minutes=(offset * TICKER_INTERVAL_MINUTES[tests_ticker_interval])
-                                   ).datetime.replace(tzinfo=None)
+                                   ).datetime
 
 
 def _build_backtest_dataframe(ticker_with_signals):

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -701,9 +701,13 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair):
 
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     patch_exchange(mocker)
+
     pairs = ['ADA/BTC', 'DASH/BTC', 'ETH/BTC', 'LTC/BTC', 'NXT/BTC']
     data = history.load_data(datadir=None, ticker_interval='5m', pairs=pairs)
+    # Only use 500 lines to increase performance
     data = trim_dictlist(data, -500)
+
+    # Remove data for one pair from the beginning of the data
     data[pair] = data[pair][tres:]
     # We need to enable sell-signal - otherwise it sells on ROI!!
     default_conf['experimental'] = {"use_sell_signal": True}

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -689,7 +689,7 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair):
 
     def _trend_alternate_hold(dataframe=None, metadata=None):
         """
-        Buy every xth candle - sell every other xth -2 (hold on to pairs a bit)flake
+        Buy every xth candle - sell every other xth -2 (hold on to pairs a bit)
         """
         if metadata['pair'] in('ETH/BTC', 'LTC/BTC'):
             multi = 20


### PR DESCRIPTION
## Summary
This PR should fix the backtest with partial data, that can cause a number of open trades greater than `max_open_trades` and therefore wrong results. It's a proposal to be discussed.

Solve the issue: #1624 (all details present here).

Required for #1559.

## Quick changelog

- added a dedicated index for every pair
- skipped pairs that have a future start date