### PR TITLE
Refactor/binance

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -22,12 +22,6 @@ ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList']
 DRY_RUN_WALLET = 999.9
 
-# Urls to exchange markets, insert quote and base with .format()
-_EXCHANGE_URLS = {
-    "Bittrex": '/Market/Index?MarketName={quote}-{base}',
-    "Binance": '/tradeDetail.html?symbol={base}_{quote}',
-}
-
 TICKER_INTERVAL_MINUTES = {
     '1m': 1,
     '3m': 3,

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -22,6 +22,12 @@ ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList']
 DRY_RUN_WALLET = 999.9
 
+# Urls to exchange markets, insert quote and base with .format()
+_EXCHANGE_URLS = {
+    "Bittrex": '/Market/Index?MarketName={quote}-{base}',
+    "Binance": '/tradeDetail.html?symbol={base}_{quote}',
+}
+
 TICKER_INTERVAL_MINUTES = {
     '1m': 1,
     '3m': 3,

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -24,3 +24,9 @@ class Binance(Exchange):
         limit = min(list(filter(lambda x: limit <= x, limit_range)))
 
         return super().get_order_book(pair, limit)
+
+    def validate_order_time_in_force(self, order_time_in_force: Dict) -> None:
+        """
+        Checks if order time in force configured in strategy/config are supported
+        """
+        pass

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -11,6 +11,7 @@ class Binance(Exchange):
 
     _ft_has: Dict = {
         "stoploss_on_exchange": True,
+        "order_time_in_force": ['gtc', 'fok', 'ioc'],
     }
 
     def get_order_book(self, pair: str, limit: int = 100) -> dict:
@@ -24,9 +25,3 @@ class Binance(Exchange):
         limit = min(list(filter(lambda x: limit <= x, limit_range)))
 
         return super().get_order_book(pair, limit)
-
-    def validate_order_time_in_force(self, order_time_in_force: Dict) -> None:
-        """
-        Checks if order time in force configured in strategy/config are supported
-        """
-        pass

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -272,7 +272,7 @@ class Exchange(object):
         if any(v not in self._ft_has["order_time_in_force"]
                for k, v in order_time_in_force.items()):
             raise OperationalException(
-                f'Time in force policies are not supporetd for  {self.name} yet.')
+                f'Time in force policies are not supported for {self.name} yet.')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -21,13 +21,6 @@ logger = logging.getLogger(__name__)
 API_RETRY_COUNT = 4
 
 
-# Urls to exchange markets, insert quote and base with .format()
-_EXCHANGE_URLS = {
-    ccxt.bittrex.__name__: '/Market/Index?MarketName={quote}-{base}',
-    ccxt.binance.__name__: '/tradeDetail.html?symbol={base}_{quote}',
-}
-
-
 def retrier_async(f):
     async def wrapper(*args, **kwargs):
         count = kwargs.pop('count', API_RETRY_COUNT)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -13,7 +13,7 @@ import ccxt
 import ccxt.async_support as ccxt_async
 from pandas import DataFrame
 
-from freqtrade import constants, OperationalException, DependencyException, TemporaryError
+from freqtrade import constants, DependencyException, OperationalException, TemporaryError
 from freqtrade.data.converter import parse_ticker_dataframe
 
 logger = logging.getLogger(__name__)
@@ -269,9 +269,8 @@ class Exchange(object):
         Checks if order time in force configured in strategy/config are supported
         """
         if any(v != 'gtc' for k, v in order_time_in_force.items()):
-            if self.name != 'Binance':
-                raise OperationalException(
-                    f'Time in force policies are not supporetd for  {self.name} yet.')
+            raise OperationalException(
+                f'Time in force policies are not supporetd for  {self.name} yet.')
 
     def exchange_has(self, endpoint: str) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -65,8 +65,9 @@ class Exchange(object):
     # Dict to specify which options each exchange implements
     # TODO: this should be merged with attributes from subclasses
     # To avoid having to copy/paste this to all subclasses.
-    _ft_has = {
+    _ft_has: Dict = {
         "stoploss_on_exchange": False,
+        "order_time_in_force": ["gtc"],
     }
 
     def __init__(self, config: dict) -> None:
@@ -268,7 +269,8 @@ class Exchange(object):
         """
         Checks if order time in force configured in strategy/config are supported
         """
-        if any(v != 'gtc' for k, v in order_time_in_force.items()):
+        if any(v not in self._ft_has["order_time_in_force"]
+               for k, v in order_time_in_force.items()):
             raise OperationalException(
                 f'Time in force policies are not supporetd for  {self.name} yet.')
 


### PR DESCRIPTION
## Summary
Move Binance specific stuff to subclass.

## Quick changelog
- add `validate_order_time_in_force`in Binance subclass
- change `validate_order_time_in_force` in `exchange.py`
- move `_EXCHANGE_URLS` to constants

## What's new?
Two small adjustments:
1. Remove the Binance specific condition in `validate_order_time_in_force` from `exchange.py` and skip it in Binance subclass (valid input values are checked via conf_schema).
2. Move `_EXCHANGE_URLS` to constants.

I was thinking about moving `stoploss_limit`, but as we said in other threads, I think it makes sense to leave it until we're sure it doesn't work for more exchanges.