### PR TITLE
Fix Documentation Boxes

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -250,17 +250,17 @@ class Awesomestrategy(IStrategy):
             self.cust_info[metadata["pair"]["crosstime"] = 1
 ```
 
-!!! Warning:
+!!! Warning
   The data is not persisted after a bot-restart (or config-reload). Also, the amount of data should be kept smallish (no DataFrames and such), otherwise the bot will start to consume a lot of memory and eventually run out of memory and crash.
 
-!!! Note:
+!!! Note
   If the data is pair-specific, make sure to use pair as one of the keys in the dictionary.
 
 ### Additional data (DataProvider)
 
 The strategy provides access to the `DataProvider`. This allows you to get additional data to use in your strategy.
 
-!!!Note:
+!!! Note
     The DataProvier is currently not available during backtesting / hyperopt, but this is planned for the future.
 
 All methods return `None` in case of failure (do not raise an exception).
@@ -288,7 +288,7 @@ if self.dp:
                                              ticker_interval='1h')
 ```
 
-!!! Warning: Warning about backtesting
+!!! Warning Warning about backtesting
     Be carefull when using dataprovider in backtesting. `historic_ohlcv()` provides the full time-range in one go,
     so please be aware of it and make sure to not "look into the future" to avoid surprises when running in dry/live mode).
 
@@ -317,7 +317,7 @@ def informative_pairs(self):
             ]
 ```
 
-!!! Warning:
+!!! Warning
     As these pairs will be refreshed as part of the regular whitelist refresh, it's best to keep this list short.
     All intervals and all pairs can be specified as long as they are available (and active) on the used exchange.
     It is however better to use resampling to longer time-intervals when possible
@@ -327,7 +327,7 @@ def informative_pairs(self):
 
 The strategy provides access to the `Wallets` object. This contains the current balances on the exchange.
 
-!!!NOTE:
+!!! Note
     Wallets is not available during backtesting / hyperopt.
 
 Please always check if `Wallets` is available to avoid failures during backtesting.

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -47,7 +47,7 @@ python3 ./freqtrade/main.py --strategy AwesomeStrategy
 **For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
 file as reference.**
 
-!!! Note: Strategies and Backtesting
+!!! Note Strategies and Backtesting
     To avoid problems and unexpected differences between Backtesting and dry/live modes, please be aware
     that during backtesting the full time-interval is passed to the `populate_*()` methods at once.
     It is therefore best to use vectorized operations (across the whole dataframe, not loops) and

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -293,8 +293,8 @@ You can overwrite position stacking in the configuration by explicitly setting `
 
 Enabling the market-position for hyperopt is currently not possible.
 
-!!! Note:
-Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
+!!! Note
+    Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
 
 ## Next Step
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -437,9 +437,9 @@ when it changes.
 The `freqtrade.service.watchdog` file contains an example of the service unit configuration file which uses systemd 
 as the watchdog.
 
-!!! Note: 
-The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a 
-Docker container.
+!!! Note 
+  The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a 
+  Docker container.
 
 ------
 

--- a/docs/sql_cheatsheet.md
+++ b/docs/sql_cheatsheet.md
@@ -65,11 +65,11 @@ SELECT * FROM trades;
 
 ## Fix trade still open after a manual sell on the exchange
 
-!!! Warning:
+!!! Warning
   Manually selling on the exchange should not be done by default, since the bot does not detect this and will try to sell anyway.
   /foresell <tradeid> should accomplish the same thing.
 
-!!! Note:
+!!! Note
   This should not be necessary after /forcesell, as forcesell orders are closed automatically by the bot on the next iteration.
 
 ```sql

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -55,8 +55,8 @@ Once all positions are sold, run `/stop` to completely stop the bot.
 
 `/reload_conf` resets "max_open_trades" to the value set in the configuration and resets this command. 
 
-!!! warning:
-The stop-buy signal is ONLY active while the bot is running, and is not persisted anyway, so restarting the bot will cause this to reset.
+!!! warning
+   The stop-buy signal is ONLY active while the bot is running, and is not persisted anyway, so restarting the bot will cause this to reset.
 
 ### /status
 


### PR DESCRIPTION
## Summary
Some of our documentation "boxes" have a syntax-error, causing them to not render:

Sample:

![2019-03-23-194115_767x77_scrot](https://user-images.githubusercontent.com/5024695/54870236-0b3c7e80-4da4-11e9-9106-d0dac5e47c56.png)
