### PR TITLE
Add stake_currency to strategy, fix  documentation typo

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -278,7 +278,7 @@ Please always check if the `DataProvider` is available to avoid failures during 
 
 ``` python
 if self.dp:
-    if self.dp.runmode == 'live':
+    if self.dp.runmode in ('live', 'dry_run'):
         if (f'{self.stake_currency}/BTC', self.ticker_interval) in self.dp.available_pairs:
             data_eth = self.dp.ohlcv(pair='{self.stake_currency}/BTC',
                                      ticker_interval=self.ticker_interval)

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -278,13 +278,13 @@ Please always check if the `DataProvider` is available to avoid failures during 
 
 ``` python
 if self.dp:
-    if dp.runmode == 'live':
-        if ('ETH/BTC', ticker_interval) in self.dp.available_pairs:
-            data_eth = self.dp.ohlcv(pair='ETH/BTC',
-                                     ticker_interval=ticker_interval)
+    if self.dp.runmode == 'live':
+        if (f'{self.stake_currency}/BTC', self.ticker_interval) in self.dp.available_pairs:
+            data_eth = self.dp.ohlcv(pair='{self.stake_currency}/BTC',
+                                     ticker_interval=self.ticker_interval)
     else:
         # Get historic ohlcv data (cached on disk).
-        history_eth = self.dp.historic_ohlcv(pair='ETH/BTC',
+        history_eth = self.dp.historic_ohlcv(pair='{self.stake_currency}/BTC',
                                              ticker_interval='1h')
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,8 +14,8 @@ Mandatory Parameters are marked as **Required**.
 |  Command | Default | Description |
 |----------|---------|-------------|
 | `max_open_trades` | 3 | **Required.** Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades)
-| `stake_currency` | BTC | **Required.** Crypto-currency used for trading.
-| `stake_amount` | 0.05 | **Required.** Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all available balance.
+| `stake_currency` | BTC | **Required.** Crypto-currency used for trading. [Strategy Override](#parameters-in-the-strategy).
+| `stake_amount` | 0.05 | **Required.** Amount of crypto-currency your bot will use for each trade. Per default, the bot will use (0.05 BTC x 3) = 0.15 BTC in total will be always engaged. Set it to `"unlimited"` to allow the bot to use all available balance. [Strategy Override](#parameters-in-the-strategy).
 | `amount_reserve_percent` | 0.05 | Reserve some amount in min pair stake amount. Default is 5%. The bot will reserve `amount_reserve_percent` + stop-loss value when calculating min pair stake amount in order to avoid possible trade refusals.
 | `ticker_interval` | [1m, 5m, 15m, 30m, 1h, 1d, ...] | The ticker interval to use (1min, 5 min, 15 min, 30 min, 1 hour or 1 day). Default is 5 minutes. [Strategy Override](#parameters-in-the-strategy).
 | `fiat_display_currency` | USD | **Required.** Fiat currency used to show your profits. More information below.
@@ -77,8 +77,10 @@ Mandatory Parameters are marked as **Required**.
 The following parameters can be set in either configuration file or strategy.
 Values set in the configuration file always overwrite values set in the strategy.
 
-* `minimal_roi`
+* `stake_currency`
+* `stake_amount`
 * `ticker_interval`
+* `minimal_roi`
 * `stoploss`
 * `trailing_stop`
 * `trailing_stop_positive`

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -56,6 +56,8 @@ class StrategyResolver(IResolver):
                       ("process_only_new_candles",        None,        False),
                       ("order_types",                     None,        False),
                       ("order_time_in_force",             None,        False),
+                      ("stake_currency",                  None,        False),
+                      ("stake_amount",                    None,        False),
                       ("use_sell_signal",                 False,       True),
                       ("sell_profit_only",                False,       True),
                       ("ignore_roi_if_buy_signal",        False,       True),

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -194,11 +194,13 @@ def test_strategy_override_ticker_interval(caplog):
 
     config = {
         'strategy': 'DefaultStrategy',
-        'ticker_interval': 60
+        'ticker_interval': 60,
+        'stake_currency': 'ETH'
     }
     resolver = StrategyResolver(config)
 
     assert resolver.strategy.ticker_interval == 60
+    assert resolver.strategy.stake_currency == 'ETH'
     assert ('freqtrade.resolvers.strategy_resolver',
             logging.INFO,
             "Override strategy 'ticker_interval' with value in config file: 60."


### PR DESCRIPTION
## Summary
This allows users to use `self.stake_currency` within the strategy.
It's more convenient than `self.config["stake_currency"]`.

Also fixes a typo / error in the documentation for dataprovider.