### PR TITLE
Update documentation with correct way of calling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,15 @@ jobs:
       script:
       - pytest --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
       # Allow failure for coveralls
-      - coveralls || true  
+      - coveralls || true
       name: pytest
     - script:
       - cp config.json.example config.json
-      - python freqtrade/main.py --datadir freqtrade/tests/testdata backtesting
+      - python freqtrade --datadir freqtrade/tests/testdata backtesting
       name: backtest
     - script:
       - cp config.json.example config.json
-      - python freqtrade/main.py --datadir freqtrade/tests/testdata hyperopt -e 5
+      - python freqtrade --datadir freqtrade/tests/testdata hyperopt -e 5
       name: hyperopt
     - script: flake8 freqtrade
       name: flake8

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -24,37 +24,37 @@ The backtesting is very easy with freqtrade.
 #### With 5 min tickers (Per default)
 
 ```bash
-python3 ./freqtrade/main.py backtesting
+python3 freqtrade backtesting
 ```
 
 #### With 1 min tickers
 
 ```bash
-python3 ./freqtrade/main.py backtesting --ticker-interval 1m
+python3 freqtrade backtesting --ticker-interval 1m
 ```
 
 #### Update cached pairs with the latest data
 
 ```bash
-python3 ./freqtrade/main.py backtesting --refresh-pairs-cached
+python3 freqtrade backtesting --refresh-pairs-cached
 ```
 
 #### With live data (do not alter your testdata files)
 
 ```bash
-python3 ./freqtrade/main.py backtesting --live
+python3 freqtrade backtesting --live
 ```
 
 #### Using a different on-disk ticker-data source
 
 ```bash
-python3 ./freqtrade/main.py backtesting --datadir freqtrade/tests/testdata-20180101
+python3 freqtrade backtesting --datadir freqtrade/tests/testdata-20180101
 ```
 
 #### With a (custom) strategy file
 
 ```bash
-python3 ./freqtrade/main.py -s TestStrategy backtesting
+python3 freqtrade -s TestStrategy backtesting
 ```
 
 Where `-s TestStrategy` refers to the class name within the strategy file `test_strategy.py` found in the `freqtrade/user_data/strategies` directory
@@ -62,7 +62,7 @@ Where `-s TestStrategy` refers to the class name within the strategy file `test_
 #### Exporting trades to file
 
 ```bash
-python3 ./freqtrade/main.py backtesting --export trades
+python3 freqtrade backtesting --export trades
 ```
 
 The exported trades can be used for [further analysis](#further-backtest-result-analysis), or can be used by the plotting script `plot_dataframe.py` in the scripts folder.
@@ -70,7 +70,7 @@ The exported trades can be used for [further analysis](#further-backtest-result-
 #### Exporting trades to file specifying a custom filename
 
 ```bash
-python3 ./freqtrade/main.py backtesting --export trades --export-filename=backtest_teststrategy.json
+python3 freqtrade backtesting --export trades --export-filename=backtest_teststrategy.json
 ```
 
 #### Running backtest with smaller testset
@@ -81,7 +81,7 @@ you want to use. The last N ticks/timeframes will be used.
 Example:
 
 ```bash
-python3 ./freqtrade/main.py backtesting --timerange=-200
+python3 freqtrade backtesting --timerange=-200
 ```
 
 #### Advanced use of timerange

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -14,7 +14,7 @@ Let assume you have a class called `AwesomeStrategy` in the file `awesome-strate
 2. Start the bot with the param `--strategy AwesomeStrategy` (the parameter is the class name)
 
 ```bash
-python3 ./freqtrade/main.py --strategy AwesomeStrategy
+python3 freqtrade --strategy AwesomeStrategy
 ```
 
 ## Change your strategy
@@ -41,7 +41,7 @@ The bot also include a sample strategy called `TestStrategy` you can update: `us
 You can test it with the parameter: `--strategy TestStrategy`
 
 ```bash
-python3 ./freqtrade/main.py --strategy AwesomeStrategy
+python3 freqtrade --strategy AwesomeStrategy
 ```
 
 **For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
@@ -355,7 +355,7 @@ The default buy strategy is located in the file
 If you want to use a strategy from a different folder you can pass `--strategy-path`
 
 ```bash
-python3 ./freqtrade/main.py --strategy AwesomeStrategy --strategy-path /some/folder
+python3 freqtrade --strategy AwesomeStrategy --strategy-path /some/folder
 ```
 
 ### Further strategy ideas

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -47,7 +47,7 @@ The bot allows you to select which configuration file you want to use. Per
 default, the bot will load the file `./config.json`
 
 ```bash
-python3 ./freqtrade/main.py -c path/far/far/away/config.json
+python3 freqtrade -c path/far/far/away/config.json
 ```
 
 ### How to use multiple configuration files?
@@ -63,13 +63,13 @@ empty key and secrete values while running in the Dry Mode (which does not actua
 require them):
 
 ```bash
-python3 ./freqtrade/main.py -c ./config.json
+python3 freqtrade -c ./config.json
 ```
 
 and specify both configuration files when running in the normal Live Trade Mode:
 
 ```bash
-python3 ./freqtrade/main.py -c ./config.json -c path/to/secrets/keys.config.json
+python3 freqtrade -c ./config.json -c path/to/secrets/keys.config.json
 ```
 
 This could help you hide your private Exchange key and Exchange secrete on you local machine
@@ -95,7 +95,7 @@ In `user_data/strategies` you have a file `my_awesome_strategy.py` which has
 a strategy class called `AwesomeStrategy` to load it:
 
 ```bash
-python3 ./freqtrade/main.py --strategy AwesomeStrategy
+python3 freqtrade --strategy AwesomeStrategy
 ```
 
 If the bot does not find your strategy file, it will display in an error
@@ -109,7 +109,7 @@ Learn more about strategy file in
 This parameter allows you to add an additional strategy lookup path, which gets
 checked before the default locations (The passed path must be a folder!):
 ```bash
-python3 ./freqtrade/main.py --strategy AwesomeStrategy --strategy-path /some/folder
+python3 freqtrade --strategy AwesomeStrategy --strategy-path /some/folder
 ```
 
 #### How to install a strategy?
@@ -136,7 +136,7 @@ using `--db-url`. This can also be used to specify a custom database
 in production mode. Example command:
 
 ```bash
-python3 ./freqtrade/main.py -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
+python3 freqtrade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 ```
 
 ## Backtesting commands

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -13,14 +13,14 @@ on BaseVolume. This value can be changed when you run the script.
 Get the 20 currencies based on BaseVolume.
 
 ```bash
-python3 ./freqtrade/main.py --dynamic-whitelist
+python3 freqtrade --dynamic-whitelist
 ```
 
 **Customize the number of currencies to retrieve**
 Get the 30 currencies based on BaseVolume.
 
 ```bash
-python3 ./freqtrade/main.py --dynamic-whitelist 30
+python3 freqtrade --dynamic-whitelist 30
 ```
 
 **Exception**

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -146,16 +146,19 @@ Percentage of allowed risk per trade.
 (defaults to 0.01 so 1%)
 
 #### stoploss_range_min
+
 Minimum stoploss.
 
 (defaults to -0.01)
 
 #### stoploss_range_max
+
 Maximum stoploss.
 
 (defaults to -0.10)
 
 #### stoploss_range_step
+
 As an example if this is set to -0.01 then Edge will test the strategy for \[-0.01, -0,02, -0,03 ..., -0.09, -0.10\] ranges.
 Note than having a smaller step means having a bigger range which could lead to slow calculation.
 
@@ -164,6 +167,7 @@ If you set this parameter to -0.001, you then slow down the Edge calculation by 
 (defaults to -0.01)
 
 #### minimum_winrate
+
 It filters out pairs which don't have at least minimum_winrate.
 
 This comes handy if you want to be conservative and don't comprise win rate in favour of risk reward ratio.
@@ -171,6 +175,7 @@ This comes handy if you want to be conservative and don't comprise win rate in f
 (defaults to 0.60)
 
 #### minimum_expectancy
+
 It filters out pairs which have the expectancy lower than this number.
 
 Having an expectancy of 0.20 means if you put 10$ on a trade you expect a 12$ return.
@@ -178,6 +183,7 @@ Having an expectancy of 0.20 means if you put 10$ on a trade you expect a 12$ re
 (defaults to 0.20)
 
 #### min_trade_number
+
 When calculating *W*, *R* and *E* (expectancy) against historical data, you always want to have a minimum number of trades. The more this number is the more Edge is reliable.
 
 Having a win rate of 100% on a single trade doesn't mean anything at all. But having a win rate of 70% over past 100 trades means clearly something.
@@ -185,6 +191,7 @@ Having a win rate of 100% on a single trade doesn't mean anything at all. But ha
 (defaults to 10, it is highly recommended not to decrease this number)
 
 #### max_trade_duration_minute
+
 Edge will filter out trades with long duration. If a trade is profitable after 1 month, it is hard to evaluate the strategy based on it. But if most of trades are profitable and they have maximum duration of 30 minutes, then it is clearly a good sign.
 
 **NOTICE:** While configuring this value, you should take into consideration your ticker interval. As an example filtering out trades having duration less than one day for a strategy which has 4h interval does not make sense. Default value is set assuming your strategy interval is relatively small (1m or 5m, etc.).
@@ -192,15 +199,17 @@ Edge will filter out trades with long duration. If a trade is profitable after 1
 (defaults to 1 day, i.e. to 60 * 24 = 1440 minutes)
 
 #### remove_pumps
+
 Edge will remove sudden pumps in a given market while going through historical data. However, given that pumps happen very often in crypto markets, we recommend you keep this off.
 
 (defaults to false)
 
-
 ## Running Edge independently
+
 You can run Edge independently in order to see in details the result. Here is an example:
+
 ```bash
-python3 ./freqtrade/main.py edge
+python3 freqtrade edge
 ```
 
 An example of its output:
@@ -224,18 +233,21 @@ An example of its output:
 | NEBL/BTC  |      -0.03 |       0.63 |                1.29 |                   0.58 |         0.44 |                       19 |                       59 |
 
 ### Update cached pairs with the latest data
+
 ```bash
-python3 ./freqtrade/main.py edge --refresh-pairs-cached
+python3 freqtrade edge --refresh-pairs-cached
 ```
 
 ### Precising stoploss range
+
 ```bash
-python3 ./freqtrade/main.py edge --stoplosses=-0.01,-0.1,-0.001 #min,max,step
+python3 freqtrade edge --stoplosses=-0.01,-0.1,-0.001 #min,max,step
 ```
 
 ### Advanced use of timerange
+
 ```bash
-python3 ./freqtrade/main.py edge --timerange=20181110-20181113
+python3 freqtrade edge --timerange=20181110-20181113
 ```
 
 Doing `--timerange=-200` will get the last 200 timeframes from your inputdata. You can also specify specific dates, or a range span indexed by start and stop.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,22 +46,24 @@ have to run it for 10.000 or more. But it will take an eternity to
 compute.
 
 We recommend you to run it at least 10.000 epochs:
+
 ```bash
-python3 ./freqtrade/main.py hyperopt -e 10000
+python3 freqtrade hyperopt -e 10000
 ```
 
 or if you want intermediate result to see
+
 ```bash
-for i in {1..100}; do python3 ./freqtrade/main.py hyperopt -e 100; done
+for i in {1..100}; do python3 freqtrade hyperopt -e 100; done
 ```
 
 #### Why it is so long to run hyperopt?
+
 Finding a great Hyperopt results takes time.
 
 If you wonder why it takes a while to find great hyperopt results
 
-This answer was written during the under the release 0.15.1, when we had
-:
+This answer was written during the under the release 0.15.1, when we had:
 - 8 triggers
 - 9 guards: let's say we evaluate even 10 values from each
 - 1 stoploss calculation: let's say we want 10 values from that too to

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -152,7 +152,7 @@ Because hyperopt tries a lot of combinations to find the best parameters it will
 We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 
 ```bash
-python3 ./freqtrade/main.py -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
+python3 freqtrade -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
 Use  `<hyperoptname>` as the name of the custom hyperopt used.
@@ -178,7 +178,7 @@ you want to use. The last N ticks/timeframes will be used.
 Example:
 
 ```bash
-python3 ./freqtrade/main.py hyperopt --timerange -200
+python3 freqtrade hyperopt --timerange -200
 ```
 
 ### Running Hyperopt with Smaller Search Space

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -407,7 +407,7 @@ pip3 install -e .
 If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
 
 ```bash
-python3.6 ./freqtrade/main.py -c config.json
+python3.6 freqtrade -c config.json
 ```
 
 *Note*: If you run the bot on a server, you should consider using [Docker](#automatic-installation---docker) a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.

--- a/setup.sh
+++ b/setup.sh
@@ -235,7 +235,7 @@ function install() {
     echo "-------------------------"
     echo "Run the bot !"
     echo "-------------------------"
-    echo "You can now use the bot by executing 'source .env/bin/activate; python freqtrade/main.py'."
+    echo "You can now use the bot by executing 'source .env/bin/activate; python freqtrade'."
 }
 
 function plot() {


### PR DESCRIPTION
## Summary
The documentation should reflect the correct way to run freqtrade.
As we've seen in #1521, using `python3 freqtrade/main.py ...` can result in odd behaviours.
Since freqtrade needs to be installed, we can call it by using `python freqtrade`.

This implements this on both the documentation and travis, so we know this way is and keeps working.

Solve the issue: #1521 
