### PR TITLE
add pairs to blacklist dynamically

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -28,6 +28,8 @@ official commands. You can ask at any moment for help with `/help`.
 | `/performance` | | Show performance of each finished trade grouped by pair
 | `/balance` | | Show account balance per currency
 | `/daily <n>` | 7 | Shows profit or loss per day, over the last n days
+| `/whitelist` | | Show the current whitelist
+| `/blacklist` | | Show the current blacklist
 | `/help` | | Show help message
 | `/version` | | Show version
 
@@ -159,6 +161,21 @@ Day         Profit BTC      Profit USD
 2018-01-02  0.00033131 BTC   4,307 USD
 2018-01-01  0.00269130 BTC  34.986 USD
 ```
+
+### /whitelist
+
+Shows the current whitelist
+
+> Using whitelist `StaticPairList` with 22 pairs  
+> `IOTA/BTC, NEO/BTC, TRX/BTC, VET/BTC, ADA/BTC, ETC/BTC, NCASH/BTC, DASH/BTC, XRP/BTC, XVG/BTC, EOS/BTC, LTC/BTC, OMG/BTC, BTG/BTC, LSK/BTC, ZEC/BTC, HOT/BTC, IOTX/BTC, XMR/BTC, AST/BTC, XLM/BTC, NANO/BTC`
+
+
+### /blacklist
+
+Shows the current blacklist
+
+> Using blacklist `StaticPairList` with 2 pairs  
+>`DODGE/BTC`, `HOT/BTC`.
 
 ### /version
 

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -173,6 +173,7 @@ Shows the current whitelist
 
 Shows the current blacklist.
 If Pair is set, then this pair will be added to the pairlist.
+Also supports multiple pairs, seperated by a space.
 Use `/reload_conf` to reset the blacklist.
 
 > Using blacklist `StaticPairList` with 2 pairs  

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -29,7 +29,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/balance` | | Show account balance per currency
 | `/daily <n>` | 7 | Shows profit or loss per day, over the last n days
 | `/whitelist` | | Show the current whitelist
-| `/blacklist` | | Show the current blacklist
+| `/blacklist [pair]` | | Show the current blacklist, or adds a pair to the blacklist.
 | `/help` | | Show help message
 | `/version` | | Show version
 
@@ -169,10 +169,11 @@ Shows the current whitelist
 > Using whitelist `StaticPairList` with 22 pairs  
 > `IOTA/BTC, NEO/BTC, TRX/BTC, VET/BTC, ADA/BTC, ETC/BTC, NCASH/BTC, DASH/BTC, XRP/BTC, XVG/BTC, EOS/BTC, LTC/BTC, OMG/BTC, BTG/BTC, LSK/BTC, ZEC/BTC, HOT/BTC, IOTX/BTC, XMR/BTC, AST/BTC, XLM/BTC, NANO/BTC`
 
+### /blacklist [pair]
 
-### /blacklist
-
-Shows the current blacklist
+Shows the current blacklist.
+If Pair is set, then this pair will be added to the pairlist.
+Use `/reload_conf` to reset the blacklist.
 
 > Using blacklist `StaticPairList` with 2 pairs  
 >`DODGE/BTC`, `HOT/BTC`.

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -456,7 +456,15 @@ class RPC(object):
     def _rpc_whitelist(self) -> Dict:
         """ Returns the currently active whitelist"""
         res = {'method': self._freqtrade.pairlists.name,
-               'length': len(self._freqtrade.pairlists.whitelist),
+               'length': len(self._freqtrade.active_pair_whitelist),
                'whitelist': self._freqtrade.active_pair_whitelist
+               }
+        return res
+
+    def _rpc_blacklist(self) -> Dict:
+        """ Returns the currently active blacklist"""
+        res = {'method': self._freqtrade.pairlists.name,
+               'length': len(self._freqtrade.pairlists.blacklist),
+               'blacklist': self._freqtrade.pairlists.blacklist
                }
         return res

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -461,8 +461,11 @@ class RPC(object):
                }
         return res
 
-    def _rpc_blacklist(self) -> Dict:
+    def _rpc_blacklist(self, add: List[str]) -> Dict:
         """ Returns the currently active blacklist"""
+        if add:
+            self._freqtrade.pairlists.blacklist.extend(add)
+
         res = {'method': self._freqtrade.pairlists.name,
                'length': len(self._freqtrade.pairlists.blacklist),
                'blacklist': self._freqtrade.pairlists.blacklist

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -4,7 +4,7 @@
 This module manage Telegram communication
 """
 import logging
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 from tabulate import tabulate
 from telegram import Bot, ParseMode, ReplyKeyboardMarkup, Update
@@ -93,7 +93,7 @@ class Telegram(RPC):
             CommandHandler('reload_conf', self._reload_conf),
             CommandHandler('stopbuy', self._stopbuy),
             CommandHandler('whitelist', self._whitelist),
-            CommandHandler('blacklist', self._blacklist),
+            CommandHandler('blacklist', self._blacklist, pass_args=True),
             CommandHandler('help', self._help),
             CommandHandler('version', self._version),
         ]
@@ -472,15 +472,16 @@ class Telegram(RPC):
             self._send_msg(str(e), bot=bot)
 
     @authorized_only
-    def _blacklist(self, bot: Bot, update: Update) -> None:
+    def _blacklist(self, bot: Bot, update: Update, args: List[str]) -> None:
         """
         Handler for /blacklist
         Shows the currently active blacklist
         """
         try:
-            blacklist = self._rpc_blacklist()
 
-            message = f"Using blacklist `{blacklist['method']}` with {blacklist['length']} pairs\n"
+            blacklist = self._rpc_blacklist(args)
+
+            message = f"Blacklist contains {blacklist['length']} pairs\n"
             message += f"`{', '.join(blacklist['blacklist'])}`"
 
             logger.debug(message)

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 logger.debug('Included module rpc.telegram ...')
 
 
-def authorized_only(command_handler: Callable[[Any, Bot, Update], None]) -> Callable[..., Any]:
+def authorized_only(command_handler: Callable[..., None]) -> Callable[..., Any]:
     """
     Decorator to check if the message comes from the correct chat_id
     :param command_handler: Telegram CommandHandler

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -516,7 +516,8 @@ class Telegram(RPC):
                   "*/stopbuy:* `Stops buying, but handles open trades gracefully` \n" \
                   "*/reload_conf:* `Reload configuration file` \n" \
                   "*/whitelist:* `Show current whitelist` \n" \
-                  "*/blacklist:* `Show current blacklist` \n" \
+                  "*/blacklist [pair]:* `Show current blacklist, or adds one or more pairs " \
+                  "to the blacklist.` \n" \
                   "*/help:* `This help message`\n" \
                   "*/version:* `Show version`"
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -93,6 +93,7 @@ class Telegram(RPC):
             CommandHandler('reload_conf', self._reload_conf),
             CommandHandler('stopbuy', self._stopbuy),
             CommandHandler('whitelist', self._whitelist),
+            CommandHandler('blacklist', self._blacklist),
             CommandHandler('help', self._help),
             CommandHandler('version', self._version),
         ]
@@ -471,6 +472,23 @@ class Telegram(RPC):
             self._send_msg(str(e), bot=bot)
 
     @authorized_only
+    def _blacklist(self, bot: Bot, update: Update) -> None:
+        """
+        Handler for /blacklist
+        Shows the currently active blacklist
+        """
+        try:
+            blacklist = self._rpc_blacklist()
+
+            message = f"Using blacklist `{blacklist['method']}` with {blacklist['length']} pairs\n"
+            message += f"`{', '.join(blacklist['blacklist'])}`"
+
+            logger.debug(message)
+            self._send_msg(message)
+        except RPCException as e:
+            self._send_msg(str(e), bot=bot)
+
+    @authorized_only
     def _help(self, bot: Bot, update: Update) -> None:
         """
         Handler for /help.
@@ -497,6 +515,7 @@ class Telegram(RPC):
                   "*/stopbuy:* `Stops buying, but handles open trades gracefully` \n" \
                   "*/reload_conf:* `Reload configuration file` \n" \
                   "*/whitelist:* `Show current whitelist` \n" \
+                  "*/blacklist:* `Show current blacklist` \n" \
                   "*/help:* `This help message`\n" \
                   "*/version:* `Show version`"
 

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -171,6 +171,10 @@ def default_conf():
                 "LTC/BTC",
                 "XRP/BTC",
                 "NEO/BTC"
+            ],
+            "pair_blacklist": [
+                "DOGE/BTC",
+                "HOT/BTC",
             ]
         },
         "telegram": {

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -702,6 +702,14 @@ def test_rpc_blacklist(mocker, default_conf) -> None:
 
     freqtradebot = FreqtradeBot(default_conf)
     rpc = RPC(freqtradebot)
-    ret = rpc._rpc_blacklist()
+    ret = rpc._rpc_blacklist(None)
     assert ret['method'] == 'StaticPairList'
+    assert len(ret['blacklist']) == 2
     assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']
+    assert ret['blacklist'] == ['DOGE/BTC', 'HOT/BTC']
+
+    ret = rpc._rpc_blacklist(["ETH/BTC"])
+    assert ret['method'] == 'StaticPairList'
+    assert len(ret['blacklist']) == 3
+    assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']
+    assert ret['blacklist'] == ['DOGE/BTC', 'HOT/BTC', 'ETH/BTC']

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -693,3 +693,15 @@ def test_rpc_whitelist_dynamic(mocker, default_conf) -> None:
     assert ret['method'] == 'VolumePairList'
     assert ret['length'] == 4
     assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']
+
+
+def test_rpc_blacklist(mocker, default_conf) -> None:
+    patch_coinmarketcap(mocker)
+    patch_exchange(mocker)
+    mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
+
+    freqtradebot = FreqtradeBot(default_conf)
+    rpc = RPC(freqtradebot)
+    ret = rpc._rpc_blacklist()
+    assert ret['method'] == 'StaticPairList'
+    assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -1086,10 +1086,18 @@ def test_blacklist_static(default_conf, update, mocker) -> None:
 
     telegram = Telegram(freqtradebot)
 
-    telegram._blacklist(bot=MagicMock(), update=update)
+    telegram._blacklist(bot=MagicMock(), update=update, args=[])
     assert msg_mock.call_count == 1
-    assert ('Using blacklist `StaticPairList` with 2 pairs\n`DOGE/BTC, HOT/BTC`'
+    assert ("Blacklist contains 2 pairs\n`DOGE/BTC, HOT/BTC`"
             in msg_mock.call_args_list[0][0][0])
+
+    msg_mock.reset_mock()
+    telegram._blacklist(bot=MagicMock(), update=update, args=["ETH/BTC"])
+    assert msg_mock.call_count == 1
+    assert ("Blacklist contains 3 pairs\n`DOGE/BTC, HOT/BTC, ETH/BTC`"
+            in msg_mock.call_args_list[0][0][0])
+    assert freqtradebot.pairlists.blacklist == ["DOGE/BTC", "HOT/BTC", "ETH/BTC"]
+
 
 
 def test_help_handle(default_conf, update, mocker) -> None:

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -1099,7 +1099,6 @@ def test_blacklist_static(default_conf, update, mocker) -> None:
     assert freqtradebot.pairlists.blacklist == ["DOGE/BTC", "HOT/BTC", "ETH/BTC"]
 
 
-
 def test_help_handle(default_conf, update, mocker) -> None:
     patch_coinmarketcap(mocker)
     msg_mock = MagicMock()

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -74,7 +74,7 @@ def test_init(default_conf, mocker, caplog) -> None:
     message_str = "rpc.telegram is listening for following commands: [['status'], ['profit'], " \
                   "['balance'], ['start'], ['stop'], ['forcesell'], ['forcebuy'], " \
                   "['performance'], ['daily'], ['count'], ['reload_conf'], " \
-                  "['stopbuy'], ['whitelist'], ['help'], ['version']]"
+                  "['stopbuy'], ['whitelist'], ['blacklist'], ['help'], ['version']]"
 
     assert log_has(message_str, caplog.record_tuples)
 
@@ -1071,6 +1071,24 @@ def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     telegram._whitelist(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert ('Using whitelist `VolumePairList` with 4 pairs\n`ETH/BTC, LTC/BTC, XRP/BTC, NEO/BTC`'
+            in msg_mock.call_args_list[0][0][0])
+
+
+def test_blacklist_static(default_conf, update, mocker) -> None:
+    patch_coinmarketcap(mocker)
+    msg_mock = MagicMock()
+    mocker.patch.multiple(
+        'freqtrade.rpc.telegram.Telegram',
+        _init=MagicMock(),
+        _send_msg=msg_mock
+    )
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+
+    telegram = Telegram(freqtradebot)
+
+    telegram._blacklist(bot=MagicMock(), update=update)
+    assert msg_mock.call_count == 1
+    assert ('Using blacklist `StaticPairList` with 2 pairs\n`DOGE/BTC, HOT/BTC`'
             in msg_mock.call_args_list[0][0][0])
 
 


### PR DESCRIPTION
## Summary
add `/blacklist` and `/blacklist <pair>` calls to rpc / telegram

Solve the issue: #1625

## Quick changelog

- `/blacklist` -> outputs current blacklist
- `/blacklist PAIR` -> adds pair to current blacklist
- add documentation for /whitelist and /blacklist.