### PR TITLE
Dataprovider during backtesting

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -260,12 +260,9 @@ class Awesomestrategy(IStrategy):
 
 The strategy provides access to the `DataProvider`. This allows you to get additional data to use in your strategy.
 
-!!! Note
-    The DataProvier is currently not available during backtesting / hyperopt, but this is planned for the future.
-
 All methods return `None` in case of failure (do not raise an exception).
 
-Please always check if the `DataProvider` is available to avoid failures during backtesting.
+Please always the mode of operation to select the correct method to get data (samples see below).
 
 #### Possible options for DataProvider
 
@@ -291,6 +288,9 @@ if self.dp:
 !!! Warning Warning about backtesting
     Be carefull when using dataprovider in backtesting. `historic_ohlcv()` provides the full time-range in one go,
     so please be aware of it and make sure to not "look into the future" to avoid surprises when running in dry/live mode).
+
+!!! Warning Warning in hyperopt
+    This option should only be used in `populate_indicators()` - since it pulls the historic data from disk each time, which would be a huge performance penalty during hyperopt.
 
 #### Available Pairs
 

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -290,7 +290,7 @@ if self.dp:
     so please be aware of it and make sure to not "look into the future" to avoid surprises when running in dry/live mode).
 
 !!! Warning Warning in hyperopt
-    This option should only be used in `populate_indicators()` - since it pulls the historic data from disk each time, which would be a huge performance penalty during hyperopt.
+    This option cannot currently be used during hyperopt.
 
 #### Available Pairs
 

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -262,7 +262,7 @@ The strategy provides access to the `DataProvider`. This allows you to get addit
 
 All methods return `None` in case of failure (do not raise an exception).
 
-Please always the mode of operation to select the correct method to get data (samples see below).
+Please always check the mode of operation to select the correct method to get data (samples see below).
 
 #### Possible options for DataProvider
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -69,8 +69,10 @@ class Backtesting(object):
         exchange_name = self.config.get('exchange', {}).get('name', 'bittrex').title()
         self.exchange = ExchangeResolver(exchange_name, self.config).exchange
         self.fee = self.exchange.get_fee()
-        self.dataprovider = DataProvider(self.config, self.exchange)
-        IStrategy.dp = self.dataprovider
+
+        if self.config.get('runmode') != RunMode.HYPEROPT:
+            self.dataprovider = DataProvider(self.config, self.exchange)
+            IStrategy.dp = self.dataprovider
 
         if self.config.get('strategy_list', None):
             # Force one interval

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -16,6 +16,7 @@ from freqtrade.arguments import Arguments, TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import evaluate_result_multi
 from freqtrade.data.converter import parse_ticker_dataframe
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.optimize import get_timeframe
 from freqtrade.optimize.backtesting import (Backtesting, setup_configuration,
                                             start)
@@ -346,6 +347,7 @@ def test_backtesting_init(mocker, default_conf, order_types) -> None:
     assert callable(backtesting.strategy.tickerdata_to_dataframe)
     assert callable(backtesting.advise_buy)
     assert callable(backtesting.advise_sell)
+    assert isinstance(backtesting.strategy.dp, DataProvider)
     get_fee.assert_called()
     assert backtesting.fee == 0.5
     assert not backtesting.strategy.order_types["stoploss_on_exchange"]

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -13,12 +13,14 @@ import requests
 
 from freqtrade import (DependencyException, OperationalException,
                        TemporaryError, constants)
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCMessageType
 from freqtrade.state import State
-from freqtrade.strategy.interface import SellType, SellCheckTuple
-from freqtrade.tests.conftest import log_has, log_has_re, patch_exchange, patch_edge, patch_wallet
+from freqtrade.strategy.interface import SellCheckTuple, SellType
+from freqtrade.tests.conftest import (log_has, log_has_re, patch_edge,
+                                      patch_exchange, patch_wallet)
 
 
 # Functions for recurrent object patching
@@ -88,6 +90,10 @@ def test_worker_running(mocker, default_conf, caplog) -> None:
     assert state is State.RUNNING
     assert log_has('Changing state to: RUNNING', caplog.record_tuples)
     assert mock_throttle.call_count == 1
+    # Check strategy is loaded, and received a dataprovider object
+    assert freqtrade.strategy
+    assert freqtrade.strategy.dp
+    assert isinstance(freqtrade.strategy.dp, DataProvider)
 
 
 def test_worker_stopped(mocker, default_conf, caplog) -> None:


### PR DESCRIPTION
## Summary
Provide dataprovider also during backtesting.

Final fix for #1669, part of #1335

## Quick changelog

- Add dataprovider during backtest and hyperopt
- update documentation to state so
- add tests checking dataprovider is actually added to the class
