### PR TITLE
fix typos in full_json_example

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -39,12 +39,12 @@
         "buy": "limit",
         "sell": "limit",
         "stoploss": "market",
-        "stoploss_on_exchange": "false",
+        "stoploss_on_exchange": false,
         "stoploss_on_exchange_interval": 60
     },
     "order_time_in_force": {
         "buy": "gtc",
-        "sell": "gtc",
+        "sell": "gtc"
     },
     "pairlist": {
         "method": "VolumePairList",


### PR DESCRIPTION
## Summary
Fix typos in example_full.json - it serves an example - and should be correct.
