### PR TITLE
Fix/fee not adjusted

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -500,6 +500,10 @@ class FreqtradeBot(object):
             ticker_interval=constants.TICKER_INTERVAL_MINUTES[self.config['ticker_interval']]
         )
 
+        # Update fees if order is closed already.
+        if order_status == 'closed':
+            self.update_open_order(trade, order)
+
         Trade.session.add(trade)
         Trade.session.flush()
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -472,7 +472,6 @@ class FreqtradeBot(object):
             stake_amount = order['cost']
             amount = order['amount']
             buy_limit_filled_price = order['price']
-            order_id = None
 
         self.rpc.send_msg({
             'type': RPCMessageType.BUY_NOTIFICATION,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -500,7 +500,7 @@ class FreqtradeBot(object):
             ticker_interval=constants.TICKER_INTERVAL_MINUTES[self.config['ticker_interval']]
         )
 
-        # Update fees if order is closed already.
+        # Update fees if order is closed
         if order_status == 'closed':
             self.update_open_order(trade, order)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -502,7 +502,7 @@ class FreqtradeBot(object):
 
         # Update fees if order is closed
         if order_status == 'closed':
-            self.update_open_order(trade, order)
+            self.update_trade_state(trade, order)
 
         Trade.session.add(trade)
         Trade.session.flush()
@@ -534,7 +534,7 @@ class FreqtradeBot(object):
         :return: True if executed
         """
         try:
-            self.update_open_order(trade)
+            self.update_trade_state(trade)
 
             if self.strategy.order_types.get('stoploss_on_exchange') and trade.is_open:
                 result = self.handle_stoploss_on_exchange(trade)
@@ -599,7 +599,7 @@ class FreqtradeBot(object):
                         f"(from {order_amount} to {real_amount}) from Trades")
         return real_amount
 
-    def update_open_order(self, trade, action_order: dict = None):
+    def update_trade_state(self, trade, action_order: dict = None):
         """
         Checks trades with open orders and updates the amount if necessary
         """

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1031,6 +1031,13 @@ def test_handle_stoploss_on_exchange(mocker, default_conf, fee, caplog,
     assert trade.stoploss_order_id is None
     assert trade.is_open is False
 
+    mocker.patch(
+        'freqtrade.exchange.Exchange.stoploss_limit',
+        side_effect=DependencyException()
+    )
+    freqtrade.handle_stoploss_on_exchange(trade)
+    assert log_has('Unable to create stoploss order: ', caplog.record_tuples)
+
 
 def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
                                               markets, limit_buy_order, limit_sell_order) -> None:


### PR DESCRIPTION
## Summary
Update handling of fee-recalculation after buy.

A bug introduced with FOK orders sets open_order_id to None for every immediately filled buy-order. 

https://github.com/freqtrade/freqtrade/blob/13ac1e1957431cdf58ebf1b3439da6adcc4e457e/freqtrade/freqtradebot.py#L475

This causes the calculation of BNB fees (also called Binance fix) to not apply.
Because of this, the amount in the database does not match the amount on exchange, causing stoploss-orders (or sell-orders in general) to fail.

Solve the issue: #1371

## Quick changelog

- extract open_order updates to it's own method
- catch exceptions for stoploss on exchange within that function, to not interrupt regular sell operations
- call update_open_orders from within execute_buy if the order-status is immediately closed.

## TODO:
- [x] Add test for execute_buy case - passing in the order-dict immediately from there.

I will label this as don't merge for now as i want to run some more tests with this, but i think it fixes the issue.
