### PR TITLE
Fix #1704

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -79,7 +79,6 @@ class FreqtradeBot(object):
             self.config.get('edge', {}).get('enabled', False) else None
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
-
         self._init_modules()
 
         # Tell the systemd that we completed initialization phase
@@ -196,9 +195,6 @@ class FreqtradeBot(object):
             # Refresh whitelist
             self.pairlists.refresh_pairlist()
             self.active_pair_whitelist = self.pairlists.whitelist
-            if not self.active_pair_whitelist:
-                logger.warning('Whitelist is empty.')
-                return False
 
             # Calculating Edge positioning
             if self.edge:
@@ -360,6 +356,10 @@ class FreqtradeBot(object):
         interval = self.strategy.ticker_interval
         whitelist = copy.deepcopy(self.active_pair_whitelist)
 
+        if not whitelist:
+            logger.warning("Whitelist is empty.")
+            return False
+
         # Remove currently opened and latest pairs from whitelist
         for trade in Trade.get_open_trades():
             if trade.pair in whitelist:
@@ -367,7 +367,7 @@ class FreqtradeBot(object):
                 logger.debug('Ignoring %s in pair whitelist', trade.pair)
 
         if not whitelist:
-            logger.info("No currency pair left in whitelist, no more trade can be created.")
+            logger.info("No currency pair in whitelist, but checking to sell open trades.")
             return False
 
         # running get_signal on historical data fetched

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -363,7 +363,8 @@ class FreqtradeBot(object):
                 logger.debug('Ignoring %s in pair whitelist', trade.pair)
 
         if not whitelist:
-            raise DependencyException('No currency pairs in whitelist')
+            logger.info("No currency pairs left in whitelist, no trades can be created.")
+            return False
 
         # running get_signal on historical data fetched
         for _pair in whitelist:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -363,7 +363,7 @@ class FreqtradeBot(object):
                 logger.debug('Ignoring %s in pair whitelist', trade.pair)
 
         if not whitelist:
-            logger.info("No currency pairs left in whitelist, no trades can be created.")
+            logger.info("No currency pair left in whitelist, no more trade can be created.")
             return False
 
         # running get_signal on historical data fetched

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -79,8 +79,6 @@ class FreqtradeBot(object):
             self.config.get('edge', {}).get('enabled', False) else None
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
-        if not self.active_pair_whitelist:
-            raise DependencyException('Whitelist is empty.')
 
         self._init_modules()
 
@@ -198,6 +196,9 @@ class FreqtradeBot(object):
             # Refresh whitelist
             self.pairlists.refresh_pairlist()
             self.active_pair_whitelist = self.pairlists.whitelist
+            if not self.active_pair_whitelist:
+                logger.warning('Whitelist is empty.')
+                return False
 
             # Calculating Edge positioning
             if self.edge:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -79,6 +79,9 @@ class FreqtradeBot(object):
             self.config.get('edge', {}).get('enabled', False) else None
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
+        if not self.active_pair_whitelist:
+            raise DependencyException('Whitelist is empty.')
+
         self._init_modules()
 
         # Tell the systemd that we completed initialization phase

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -545,8 +545,7 @@ def test_create_trade_too_small_stake_amount(default_conf, ticker, limit_buy_ord
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
-    result = freqtrade.create_trade()
-    assert result is False
+    assert not freqtrade.create_trade()
 
 
 def test_create_trade_limit_reached(default_conf, ticker, limit_buy_order,
@@ -567,7 +566,7 @@ def test_create_trade_limit_reached(default_conf, ticker, limit_buy_order,
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
-    assert freqtrade.create_trade() is False
+    assert not freqtrade.create_trade()
     assert freqtrade._get_trade_stake_amount('ETH/BTC') is None
 
 
@@ -588,9 +587,7 @@ def test_create_trade_no_pairs(default_conf, ticker, limit_buy_order, fee, marke
     patch_get_signal(freqtrade)
 
     freqtrade.create_trade()
-
-    with pytest.raises(DependencyException, match=r'.*No currency pairs in whitelist.*'):
-        freqtrade.create_trade()
+    assert not freqtrade.create_trade()
 
 
 def test_create_trade_no_pairs_after_blacklist(default_conf, ticker,
@@ -610,9 +607,7 @@ def test_create_trade_no_pairs_after_blacklist(default_conf, ticker,
     patch_get_signal(freqtrade)
 
     freqtrade.create_trade()
-
-    with pytest.raises(DependencyException, match=r'.*No currency pairs in whitelist.*'):
-        freqtrade.create_trade()
+    assert not freqtrade.create_trade()
 
 
 def test_create_trade_no_signal(default_conf, fee, mocker) -> None:


### PR DESCRIPTION
Fix for #1704.

DependencyException is not now raised in the case of empty whitelist. Probably this check should be placed somewhere else to verify original whitelist that came from config before pairs were removed from it.

The log message was changed to be less confusing.
