### PR TITLE
Improve documentation formatting

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -1,13 +1,13 @@
 # Telegram usage
 
-This page explains how to command your bot with Telegram.
-
 ## Prerequisite
+
 To control your bot with Telegram, you need first to
 [set up a Telegram bot](installation.md)
 and add your Telegram API keys into your config file.
 
 ## Telegram commands
+
 Per default, the Telegram bot shows predefined commands. Some commands
 are only available by sending them to the bot. The table below list the
 official commands. You can ask at any moment for help with `/help`.

--- a/docs/webhook-config.md
+++ b/docs/webhook-config.md
@@ -1,7 +1,5 @@
 # Webhook usage
 
-This page explains how to configure your bot to talk to webhooks.
-
 ## Configuration
 
 Enable webhooks by adding a webhook-section to your configuration file, and setting `webhook.enabled` to `true`.

--- a/docs/webhook-config.md
+++ b/docs/webhook-config.md
@@ -39,32 +39,30 @@ Different payloads can be configured for different events. Not all fields are ne
 The fields in `webhook.webhookbuy` are filled when the bot executes a buy. Parameters are filled using string.format.
 Possible parameters are:
 
-* exchange
-* pair
-* limit
-* stake_amount
-* stake_amount_fiat
-* stake_currency
-* fiat_currency
+* `exchange`
+* `pair`
+* `limit`
+* `stake_amount`
+* `stake_currency`
+* `fiat_currency`
 
 ### Webhooksell
 
 The fields in `webhook.webhooksell` are filled when the bot sells a trade. Parameters are filled using string.format.
 Possible parameters are:
 
-* exchange
-* pair
-* gain
-* limit
-* amount
-* open_rate
-* current_rate
-* profit_amount
-* profit_percent
-* profit_fiat
-* stake_currency
-* fiat_currency
-* sell_reason
+* `exchange`
+* `pair`
+* `gain`
+* `limit`
+* `amount`
+* `open_rate`
+* `current_rate`
+* `profit_amount`
+* `profit_percent`
+* `stake_currency`
+* `fiat_currency`
+* `sell_reason`
 
 ### Webhookstatus
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,11 +3,12 @@ nav:
     - About: index.md
     - Installation: installation.md
     - Configuration: configuration.md
-    - Start the bot: bot-usage.md
-    - Stoploss: stoploss.md
     - Custom Strategy: bot-optimization.md
-    - Telegram: telegram-usage.md
-    - Web Hook: webhook-config.md
+    - Stoploss: stoploss.md
+    - Start the bot: bot-usage.md
+    - Control the bot:
+        - Telegram: telegram-usage.md
+        - Web Hook: webhook-config.md
     - Backtesting: backtesting.md
     - Hyperopt: hyperopt.md
     - Edge positioning: edge.md


### PR DESCRIPTION
## Summary
Improve and fix documentation regarding webhooks.

I also added a subsection for "control the bot". 
I would like this section to be non-collapsible, but didn't find a way to prevent this - i assume it's part of the theme, but maybe it can be disabled? 

@mishaker , would you mind giving me a hand on this?

![2019-04-05-070207_217x568_scrot](https://user-images.githubusercontent.com/5024695/55604567-bf5ce280-5770-11e9-9ca3-8c9db25659d1.png)

built documentation for this is here:
https://www.freqtrade.io/en/doc-simplify/


*note*: the readthedocs build for this should be disabled once this is merged.