### PR TITLE
rpc Count should be in rpc.py

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -454,7 +454,7 @@ class RPC(object):
             for pair, rate, count in pair_rates
         ]
 
-    def _rpc_count(self) -> List[Trade]:
+    def _rpc_count(self) -> Dict[str, float]:
         """ Returns the number of trades running """
         if self._freqtrade.state != State.RUNNING:
             raise RPCException('trader is not running')
@@ -462,8 +462,8 @@ class RPC(object):
         trades = Trade.get_open_trades()
         return {
             'current': len(trades),
-            'max': self._config['max_open_trades'],
-            'total stake': sum((trade.open_rate * trade.amount) for trade in trades)
+            'max': float(self._freqtrade.config['max_open_trades']),
+            'total_stake': sum((trade.open_rate * trade.amount) for trade in trades)
         }
 
     def _rpc_whitelist(self) -> Dict:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -459,7 +459,12 @@ class RPC(object):
         if self._freqtrade.state != State.RUNNING:
             raise RPCException('trader is not running')
 
-        return Trade.get_open_trades()
+        trades = Trade.get_open_trades()
+        return {
+            'current': len(trades),
+            'max': self._config['max_open_trades'],
+            'total stake': sum((trade.open_rate * trade.amount) for trade in trades)
+        }
 
     def _rpc_whitelist(self) -> Dict:
         """ Returns the currently active whitelist"""

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -456,12 +456,10 @@ class Telegram(RPC):
         :return: None
         """
         try:
-            trades = self._rpc_count()
-            message = tabulate({
-                'current': [len(trades)],
-                'max': [self._config['max_open_trades']],
-                'total stake': [sum((trade.open_rate * trade.amount) for trade in trades)]
-            }, headers=['current', 'max', 'total stake'], tablefmt='simple')
+            counts = self._rpc_count()
+            message = tabulate({k: [v] for k, v in counts.items()},
+                               headers=['current', 'max', 'total stake'],
+                               tablefmt='simple')
             message = "<pre>{}</pre>".format(message)
             logger.debug(message)
             self._send_msg(message, parse_mode=ParseMode.HTML)

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -581,15 +581,13 @@ def test_rpc_count(mocker, default_conf, ticker, fee, markets) -> None:
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)
 
-    trades = rpc._rpc_count()
-    nb_trades = len(trades)
-    assert nb_trades == 0
+    counts = rpc._rpc_count()
+    assert counts["current"] == 0
 
     # Create some test data
     freqtradebot.create_trade()
-    trades = rpc._rpc_count()
-    nb_trades = len(trades)
-    assert nb_trades == 1
+    counts = rpc._rpc_count()
+    assert counts["current"] == 1
 
 
 def test_rpcforcebuy(mocker, default_conf, ticker, fee, markets, limit_buy_order) -> None:


### PR DESCRIPTION
## Summary
rpc_count should not return open trades, but a summary of counts.

## Quick changelog

- Move calculation to `rpc.py`
