### PR TITLE
Minor: impoved argument and exception handling in scripts

### DIFF
--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-
-"""This script generate json data"""
+"""
+This script generates json data
+"""
 import json
 import sys
 from pathlib import Path
@@ -35,7 +36,7 @@ if args.config:
     config: Dict[str, Any] = {}
     # Now expecting a list of config filenames here, not a string
     for path in args.config:
-        print('Using config: %s ...', path)
+        print(f"Using config: {path}...")
         # Merge config options, overwriting old values
         config = deep_merge_dicts(configuration._load_config_file(path), config)
 
@@ -44,18 +45,19 @@ if args.config:
     config['exchange']['key'] = ''
     config['exchange']['secret'] = ''
 else:
-    config = {'stake_currency': '',
-              'dry_run': True,
-              'exchange': {
-                  'name': args.exchange,
-                  'key': '',
-                  'secret': '',
-                  'pair_whitelist': [],
-                  'ccxt_async_config': {
-                      "enableRateLimit": False
-                  }
-              }
-              }
+    config = {
+        'stake_currency': '',
+        'dry_run': True,
+        'exchange': {
+            'name': args.exchange,
+            'key': '',
+            'secret': '',
+            'pair_whitelist': [],
+            'ccxt_async_config': {
+                'enableRateLimit': False
+            }
+        }
+    }
 
 
 dl_path = Path(DEFAULT_DL_PATH).joinpath(config['exchange']['name'])

--- a/scripts/get_market_pairs.py
+++ b/scripts/get_market_pairs.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(root + '/python')
@@ -49,6 +50,11 @@ def print_supported_exchanges():
 
 try:
 
+    if len(sys.argv) < 2:
+        dump("Usage: python " + sys.argv[0], green('id'))
+        print_supported_exchanges()
+        sys.exit(1)
+
     id = sys.argv[1]  # get exchange id from command line arguments
 
     # check if the exchange is supported by ccxt
@@ -87,5 +93,7 @@ try:
 
 except Exception as e:
     dump('[' + type(e).__name__ + ']', str(e))
+    dump(traceback.format_exc())
     dump("Usage: python " + sys.argv[0], green('id'))
     print_supported_exchanges()
+    sys.exit(1)


### PR DESCRIPTION
Minor impovements to the argument and exception handling in the scripts/get_market_pairs.py utility script:

* Do not raise IndexError if no exchange was specified in the command line, dump gracefully the usage string and exit with status code = 1.
* Dump traceback in case of exception.
* Exit with status code = 1 in case of exception.

P.S. Did not want to create another branch, committed here, minor changes in scripts/download_backtest_data.py:
* Fixed message (it printed out '%s').
* Cosmetic changes in the code.
