### PR TITLE
Docs: wrong rendering at freqtrade.io fixed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,8 +70,8 @@ Mandatory Parameters are marked as **Required**.
 | `strategy` | DefaultStrategy | Defines Strategy class to use.
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a folder).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
-| `logfile` | | Specify Logfile. Uses a rolling strategy of 10 files, with 1Mb per file.
 | `internals.sd_notify` | false | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details.
+| `logfile` | | Specify Logfile. Uses a rolling strategy of 10 files, with 1Mb per file.
 
 ### Parameters in the strategy
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,8 +19,7 @@ of course constantly aim to improve the bot but it will _always_ be a
 gamble, which should leave you with modest wins on monthly basis but
 you can't say much from few trades.
 
-#### I’d like to change the stake amount. Can I just stop the bot with
-/stop and then change the config.json and run it again?
+#### I’d like to change the stake amount. Can I just stop the bot with /stop and then change the config.json and run it again?
 
 Not quite. Trades are persisted to a database but the configuration is
 currently only read when the bot is killed and restarted. `/stop` more
@@ -31,16 +30,16 @@ like pauses. You can stop your bot, adjust settings and start it again.
 That's great. We have a nice backtesting and hyperoptimizing setup. See
 the tutorial [here|Testing-new-strategies-with-Hyperopt](bot-usage.md#hyperopt-commands).
 
-#### Is there a setting to only SELL the coins being held and not
-perform anymore BUYS?
+#### Is there a setting to only SELL the coins being held and not perform anymore BUYS?
 
 You can use the `/forcesell all` command from Telegram.
 
 ### Hyperopt module
 
 #### How many epoch do I need to get a good Hyperopt result?
+
 Per default Hyperopts without `-e` or `--epochs` parameter will only
-run 100 epochs, means 100 evals of your triggers, guards, .... Too few
+run 100 epochs, means 100 evals of your triggers, guards, ... Too few
 to find a great result (unless if you are very lucky), so you probably
 have to run it for 10.000 or more. But it will take an eternity to
 compute.
@@ -64,10 +63,10 @@ Finding a great Hyperopt results takes time.
 If you wonder why it takes a while to find great hyperopt results
 
 This answer was written during the under the release 0.15.1, when we had:
+
 - 8 triggers
 - 9 guards: let's say we evaluate even 10 values from each
-- 1 stoploss calculation: let's say we want 10 values from that too to
-be evaluated
+- 1 stoploss calculation: let's say we want 10 values from that too to be evaluated
 
 The following calculation is still very rough and not very precise
 but it will give the idea. With only these triggers and guards there is
@@ -82,10 +81,9 @@ of the search space.
 The Edge module is mostly a result of brainstorming of [@mishaker](https://github.com/mishaker) and [@creslinux](https://github.com/creslinux) freqtrade team members.
 
 You can find further info on expectancy, winrate, risk management and position size in the following sources:
-* https://www.tradeciety.com/ultimate-math-guide-for-traders/
-* http://www.vantharp.com/tharp-concepts/expectancy.asp
-* https://samuraitradingacademy.com/trading-expectancy/
-* https://www.learningmarkets.com/determining-expectancy-in-your-trading/
-* http://www.lonestocktrader.com/make-money-trading-positive-expectancy/
-* https://www.babypips.com/trading/trade-expectancy-matter
-
+- https://www.tradeciety.com/ultimate-math-guide-for-traders/
+- http://www.vantharp.com/tharp-concepts/expectancy.asp
+- https://samuraitradingacademy.com/trading-expectancy/
+- https://www.learningmarkets.com/determining-expectancy-in-your-trading/
+- http://www.lonestocktrader.com/make-money-trading-positive-expectancy/
+- https://www.babypips.com/trading/trade-expectancy-matter


### PR DESCRIPTION
in faq.md:
* Titles render wrong both in the docs dir and at freqtrade.io.
* Last list of links renders wrong at freqtrade.io.
* Small cosmetic changes.

in configuration.md:
* Order of items in the table fixed.
