### PR TITLE
version to 0.18.5

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,5 +1,5 @@
 """ FreqTrade bot """
-__version__ = '0.18.2-dev'
+__version__ = '0.18.5'
 
 
 class DependencyException(BaseException):


### PR DESCRIPTION
## Changelog 

8abdbc41 Update mypy from 0.700 to 0.701
7f229bbf Update ccxt from 1.18.470 to 1.18.472
d4947ba0 Update ccxt from 1.18.470 to 1.18.472
2cee7161 Gracefully handle pickle-errors when @staticmethod is used
a7383ad3 enable ratelimit in download-backtest-data too
52cc2d22 improve documentation for exchange configuration
5db10bdc Add rateLimit parameters for different exchanges
43119efa Remove ccxt_rate_limit completely (was deprecated)
b2a623ee Update plotly from 3.7.1 to 3.8.0
c40406d2 Update pytest from 4.4.0 to 4.4.1
87ff5ad1 Update sqlalchemy from 1.3.2 to 1.3.3
aa63f2be Update sqlalchemy from 1.3.2 to 1.3.3
5cb90bdf Update ccxt from 1.18.468 to 1.18.470
4f557af6 Update ccxt from 1.18.468 to 1.18.470
7efab85b Update sqlalchemy from 1.3.1 to 1.3.2
0ece1688 Update ccxt from 1.18.353 to 1.18.468
6be4c6af Update ccxt from 1.18.466 to 1.18.468
4f6df731 Update documentation for Raspberry install since we now have a rpi-requirements file
5e0e8de4 Version bump to 3.7.3 in docker file
37b1389f Fix flake8
2f79cf13 Update ccxt from 1.18.460 to 1.18.466
9f828224 Update ccxt from 1.18.458 to 1.18.460
016e8fde wrong rendering at freqtrade.io fixed; other cosmetics in docs/
d87db70e Fix missing column header
c3b9d699 Add docstring explaining the source of the script
12ca103f Update ccxt from 1.18.456 to 1.18.458
c2ca899c fixed printed message; cosmetic changes in the code in scripts/download_backtest_data.py
902ffa68 impoved argument and exception handling in scripts/get_market_pairs.py
f736646a Update ccxt from 1.18.445 to 1.18.456
e75cdd4c Rename variable, add more tests
71e671f0 Update ccxt from 1.18.442 to 1.18.445
ff6967de Add test for too large balance
5c417095 Don't send too large messages
ffdc33d9 Update ccxt from 1.18.437 to 1.18.442
ebf11263 cosmetic: rename interval, tick_interval, etc --> ticker_interval
3a81eb7d Update ccxt from 1.18.435 to 1.18.437
3ad4d937 Correct Dockerfile.pi file to use requirements-pi.txt
c35e5ca7 Add back requirements-pi.txt file and put it into .pyup.yml
e7c8e62d Remove requirements-pi.txt, change Dockerfile.pi to utilize the requirements.txt instead
d6d16b46 docstrings improved
dc1968b9 docstrings added
d294cab9 adding order id to invalidorder exception message
f1391781 rpc_counts should be in .rpc
4eb0ed9f Add Dockerfile.pi for building docker image for raspberry pi
7a598f32 Move rpc-count calculation to _rpc class
481df98f Update ccxt from 1.18.432 to 1.18.435
41ff2a92 TemporaryError removed
acb99a03 adding stoploss on exchange manual cancel note
a505826e flake8
54d068de missing test added
25d8e93a remove unnecessary comment
9712fb2d removing unnecessary comment
2b49a11b returning InvalidOrder exception for get_order
4c5432be Added command line options in backtesting to override max_open_trades and stake_amount
13e8f25c Improve docs layout
ac1964ed Remove unnecessary comment
dbb1bbf1 Fix webhook documentation
7486cb7c fix admonitions
e3cdc0a0 typos and visual fixes
6913bce6 flake8, import in script/plot_profit.py
7010c835 Improve commentign
2aa1b43f get rid of TICKER_INTERVAL_MINUTES dict, use ccxt's parse_timeframe() instead
32cbb714 Improve commenting on backtsting and backtest_multi_tst
7f4fd616 test for canceled SL on exchange added
647534a4 flake8
31fa8573 typo
a363d443 stoploss on exchange canceled handled
ebeaf64f Update mypy from 0.670 to 0.700
6afe232c Update ccxt from 1.18.430 to 1.18.432
0cdbe714 stake amount not amount
65350ad5 final flake happy
5488c66f flake8
9ee1dd99 tests fixed
0307ba78 Remove one branch - python does lazy evaluation
1a5b0969 Fix tests (both tests where testing the same thing)
3c399fbe Improve whitelist wordings
d5498c87 adding %
a3fe5f57 adding stake amount to telegram message
92dc3c89 Update sqlalchemy from 1.3.1 to 1.3.2
eb610441 Update ccxt from 1.18.425 to 1.18.430
67eeb145 flake8
a3835b12 flake8
5f38d5ee removing % sign as it is already a pct
53eaf859 filtering edge pairs for RPC
d54acca5 move tests back to original codebase to minimize changes
b0ddb33a tests cleanup: Worker --> FreqtradeBot where the Worker object is not really needed
62141d3d test cloned, separate tests for worker and freqtrade states
7b39a308 formatting and readability
a6daf0d9 formatting pct
54f11ad6 enriching TSL log
40df0dcf tests fixed
99d25642 adding InvalidOrder to exchange
389feda6 Invalid order exception added
b9b76977 Update ccxt from 1.18.420 to 1.18.425
0cfdce0d Update function name from update_open_order to update_trade_state
ab0e657d Check for empty whitelist moved to _process()
34b40500 Check whitelist fetched from config for emptiness
a3b01355 documentation added for telegram
8546db9d wording in the log message
ab579587 adding percentage to telegram status messages
061f91ba Update pytest from 4.3.1 to 4.4.0
97b31352 Update ccxt from 1.18.418 to 1.18.420
77d2479c tests adjusted
f0b2798c fix #1704
7251e5bd bot state moved back to freqtradebot from worker
7be90f71 Add test as called from execute_buy
19d3a0cb Update comment
0ddafeea Split test for open_orders from maybe_sell
b2ad402d Split tests for update-open_order
e46dac3f Test stoploss does not raise dependencyexception
5c8fbe2c Handle exception for stoploss independently of sell order
f11a1b01 Call update_open_order inline with buy
8f4cca47 Refactor update_open_order into it's own function
4fa73611 Don't set order_id to none here - it's used in "update_open_order".
c28a0374 Update pytest-mock from 1.10.2 to 1.10.3
93229fc5 Update ccxt from 1.18.415 to 1.18.418
707a5fca ifix typos in full_json_example
9b38c045 negating SL pct and adding tests
06144a1f Wording in a comment
1a61bf7b sort imports
87a296f7 No need to call patch_coinmarketcap each tim
e98c0621 We don't need to call patch_coinmarketcap each time.
40c0b4ef Autopatch coinmarketcap
44142706 Update ccxt from 1.18.412 to 1.18.415
208832e8 flake8, mypy resolved
12066411 Update docs with logfile methods
e5008fbf Add test for logfile attribute
d4ffdaff Correctly add types
bb5a310a Add --logfile argument
82b344db Update ccxt from 1.18.407 to 1.18.412
f2599ffe pct default to None
50fc6325 added SL pct to DB
a87fc5f8 Fix tests - freqtrade should not be patched in this case
2f3f5f19 sl percentage removed form rpc test
e11eb477 stoploss precentage in telegram msg removed
daeb172b Update ccxt from 1.18.406 to 1.18.407
0e5b0ebd adding SL and SL percentage to telegram msg
941921dd initial SL and SL added to RPC
0ca3a38b moved date to top and show open order only if it is not none
1678a039 removing close profit is trade is open
e5406ed3 typo in docs and comments
4d9ca71c shifting edge help message a line lower
6045f07a telegram message concatenation refactored
9b22d5ca Fix typo, add test for validate_order_tif
753b03d5 rolback on removing MD whitespaces
1e37d8cc flake8
4038cdf7 "Edge" test for rpc telegram
0687051f Update test_rpc.py
8641da13 added RPC tests in case of edge enabled/disabled
cc32566c Update ccxt from 1.18.400 to 1.18.406
955e2d28 Update test_rpc_telegram.py
4e57969e documentation added
3bdc7b9a add missed "check" in docs
b2c2b424 Removed unwanted comment
f5744cc9 fix in the tests
1f50bc79 Update ccxt from 1.18.398 to 1.18.400
c6d2c1e5 rest of telegram tests adjusted
8aee009a test _reconfigure() adjusted
5ccd6181 tests adjusted
5161e1ab Allow to pass config into worker, as it's used in the tests
e15f2ef1 add order_time_in_force in _ft_has and revert binance
8dea640e remove exchange urls
4005b8d1 remove the if condition for binance
85ac99ae move exchange urls to constants
e085fd9e Disable dataprovider from hyperopt.
f26ed1c8 Check if added pair has correct stake-currency
4cf72820 Update dataprovider docs
0ae81d41 Provide dataprovider access during backtesting
226fc3d9 Check that dataprovider is part of strategy
bd29b7d0 Test that dataprovider is loaded to strategy
c8b0c9af Worker moved to new worker.py
fe9322ec Update pytest-mock from 1.10.1 to 1.10.2
904b3008 Update ccxt from 1.18.395 to 1.18.398
66f1e0f4 help added
fd727851 using items()
a8be277c cached pairs iteration fixed + help added
1dfbf6ee darfting edge rpc messages
29b9bb96 Fix test to support adding things to pairlist
14167f82 Fix typehints
49559f1a Improve documentation and help message
042354d0 Test blacklist-adding
f0d3901b Add blacklist-pair to documentation
9d6f629f Support adding pairs to blacklist
7b99d5eb Add blacklist and whitelist commands to telegram docs
8b2174d2 Add tests for /blacklist handler
ffdca7ee Add blacklist to default_config
684727b3 Add black blacklist handler (ro)
3a8b69d6 also support dry_run
1bba9fcc Update documentation to use freqtrade, not freqtrade/main.py
f7fc9adc Run travis with freqtrade, not main.py
e60d1788 Add new options to docu
e644493e Update ccxt from 1.18.387 to 1.18.395
06f4e627 Add stake_currency to strategy, fix  documentation typo
0dc96210 Fix formatting of boxes 2
a95f30ce Fix custom boxes on documentation
83a2427a Fix mypy in scripts
184b13f2 Flake8 for scripts
9a632d9b Formatting
c404e9ff Simplify trailing_stop logic
b1fe8c53 Simplify stoploss_reached
7307084d Move stoploss-adjustment to the top
40899d08 Fix failing test (all timezones are in UTC, so we should not convert to None)
00e6749d Refactor backtest() to be a bit more concise
05466d31 Modify test to check for this condition
34ff946f Update ccxt from 1.18.386 to 1.18.387
158cb307 further refactoring of FreqtradeBot.process()
e35daf95 minor cleanup
b4488902 test_main.py adjusted (only beginning)
be6836b0 resolve python module circular dependency
60afba55 move worker stuff to main.py
89145a77 Update ccxt from 1.18.385 to 1.18.386
7fdb0990 Reformat log statement
00821036 docs for dry_run_wallet
6b89e86a Removed Timestamp cast
0eff324c Use dedicated index for every pair
cc369f41 Update coveralls from 1.6.0 to 1.7.0
6c889895 Update ccxt from 1.18.376 to 1.18.385
2b09e3ca Update plotly from 3.7.0 to 3.7.1
9a610673 Update ccxt from 1.18.372 to 1.18.376
50ea4c39 Update ccxt from 1.18.368 to 1.18.372
8d173efe reword stopbuy message
aa698a84 rename /stopbuy message
37e6b262 Update docs to include /stopbuy
9373d0c9 Add tests for /stopbuy
a467d768 Add /stopbuy command to telegram
93739960 fix flake8
c2076af4 update tests
4de4a70b update log messages
8afce7e6 Add testcase for Testcase 2
2bf7f2fe Remove duplicate backtest-result-analysi documentation
83864964 remove tests that are no longer applicable
7f9c76a6 move stake check to the same condition as the other checks
d4d37667 use pairname for stake cur comparison
d4543be8 edit comment
e38a3051 update docstring
c907e80c make sure no dups
a241e950 prune validate_pairs
39232cbc loop over whitelist only instead of all markets
a7b60f67 update trailing_stop with high in case of backtesting
05ab1c2e Fix some comments
8c7e8255 Add detailed test for trailing stop
f0e5113a Use Magicmock instead of lambda for mocking
a830bee9 Enable trailing_stop for BTContainer tests
190ecb7a Update ccxt from 1.18.367 to 1.18.368
a77d5135 Fix backteest detail numbering ...
7b99daeb Update docstring for adjust_stoploss
2d4a2fd1 Use oppen_rate instead of artificial defaults
a0e6cd93 Use bids, not asks for sell-rate detection
fc360608 Rename function to adjust_min_max
01733c94 Split up tests for adjust_stoploss and adjust_highlow
68a9b14e Min-rate should not default to 0
738ed932 call new function
7166a474 Add min_rate - always update min/max rates
e632539b Add 15min to documentation, fix link to "parameters in THE strategy"
e7f6df46 Add missing bt file
a123246a Add test for load_backtest_data
ddb9933c Remove duplicate-check from test - it's in btanalysis
9f7f089d adjust plot_dataframe to use btanalysis
e1f48c2b Add btanalysis file
d7017ce1 Document backtest-result loading
29aa1598 Add test for get_sell_rate
6bfc3730 refactor getting sell/current rate for telegram and selling
d596a877 Update docs to link to ocnfiguration piece necessary
b9b15e5f Align help message for forcebuy
a233a8cc Be explicit in the documentation
d42ebab5 Rename function and add test
44acf2f4 Catch syntaxerror on import
6db6c3b2 Update ccxt from 1.18.362 to 1.18.367
95a3b5c4 check if ticker sort key is populated
1a83eed3 Update pandas from 0.24.1 to 0.24.2
4fa16042 Update ccxt from 1.18.361 to 1.18.362
edf2cd0b configuration test fixed
b5034cf5 TSL validator removed from exchange
29305dd0 config validation moved to configuration file
3c99e3b7 test adapted to new market refactoring
ff9231ee Format attributes-table
a1841c35 reset _last_markets_refresh
aa2d747d update docs
2bf5a384 Use close_rate for notification if available
23666858 Update pytest from 4.3.0 to 4.3.1
5151a452 Update ccxt from 1.18.358 to 1.18.361
6b948cfc Don't move notify_sell to rpc_manager - it needs exchange stuff
9054165e Adjust test, since rpc_message is now called on buy and sel
11cc33a9 Refactor notify_sell to rpc_manager
e2bcaa4d Set Requested_close_rate to stoploss when stoploss_on_exchange was hit
94b2d48d Add default value for minimal_roi (1000%)
0293a618 Update documentation for minimal_roi, which is not really optional
7ffe6577 fix test
cb9849e1 add markets_refresh_interval to CONF_SCHEMA
299e6401 include markets_refresh_interval in docs
779bcdd9 remove reload for async api
0ffefe44 reorder vars
deddbda2 delete markets patch from conftest
1a92bf9e add test
87410178 remove get_markets
35c2b961 add config param
0d980134 add markets reload func
3ad0686b fix typing
df9410cd check if markets were loaded
041e9957 add reload argument
6b97af4a add comment
e234158c update tests
c30fb7f5 return markets as dict
5c840f33 slight change to exception message
b24a22b0 use self.markets instead of get_markets
47cc04c0 use self.markets instead of _api.markets
ccad8832 adjust get_markets
3a2aa54d add markets property
d423f585 replace fetch_markets
0bcf50f1 added to stoploss doc
8d5cc42e configuration doc added
a772ab32 adding the option to resolver
f55d75e7 TSL validation tests added
3e4c9c87 Update ccxt from 1.18.357 to 1.18.358
36e95bc8 unnecessary variable removed
3e40f5c5 if condition simplified
643262bc add trailing stop loss config validator
48d33b07 Add stoploss to startup messages
0eb9dd5f Don't use timeInForce for market orders
4705b7da Add time_in_force test for sell
c0f276a8 Move kraken specific tests to their own file
e666c685 Fix tests so Market orders should not send timeInForce
f9aa3c27 Catch ModuleNotFoundError when importing external code
41add9f8 code cleanup; added message to systemd for reconfiguration
513b96b6 Update ccxt from 1.18.353 to 1.18.357
8730852d Support for systemd watchdog via sd_notify
ca496c13 TSL only offset test added
04670041 added trailing_only_offset_is_reached to full config
0eaac1cd Update sqlalchemy from 1.3.0 to 1.3.1
5f726d69 Update ccxt from 1.18.352 to 1.18.353
9c1c962a if condition fixed
c122eab7 added trailing_only_offset_is_reached option
43d30180 Update plotly from 3.6.1 to 3.7.0
3b805813 Update ccxt from 1.18.347 to 1.18.352
fa4c8110 Rename cheatsheet header
25529ad9 use || for coveralls
dba30bbf Update travis for coveralls
4cd70138 Add test to make sure this ain't reintroduced
0a2cacbb Fix #1637
702153d0 exchange.sandbox parameter was missing in the docs
9c1d4183 typo in doc
2da0d479 Update ccxt from 1.18.345 to 1.18.347
6b2f4b12 Update ccxt from 1.18.342 to 1.18.345
7b901e18 update sql_cheatsheet
e67ffd2d Fix issue that backtest is broken when stoploss_on_exchange is on
8624d83b Remove deprecated --dynamic-whitelist from freqtrade.service
962cfc5e Update ccxt from 1.18.333 to 1.18.342
35250eb2 one more typo fixed (by @xmatthias)
735e78f0 Update sqlalchemy from 1.2.18 to 1.3.0
ae7c4c33 Update ccxt from 1.18.323 to 1.18.333
c032dd0f new docs/deprecated.md added to the site menu
ce46555e docs/configuration.md reviewed: formatting, wording, grammar, etc
2f98dd04 description for --dynamic-whitelist moved to new docs/deprecated.md
71f5392f typo fixed
f6ca97d1 Update hyperopt doc to validate backtest results
386abc5e minor: doc update index.md
f16913a7 Update ccxt from 1.18.322 to 1.18.323
460e0711 How to use multiple configuration files
b8eb3ecb Update hyperopts documentation to work and match the code
2208a21a Update help strings
2d0aca0d Move --customhyperopts to hyperopt section
3c5deb9a Add test for precision_remove ...
e2cbb7e7 remove remnants markets and precisionlist
df79098a update docs
13ba5ba0 Update ccxt from 1.18.313 to 1.18.322
064f6629 delete separate pairlist
e1ae0d7e remove markets changes
c36fa0c7 add ticker argumet to get_target_bid
24c58751 add precision_filter
6bcfe658 Update scikit-learn from 0.20.2 to 0.20.3
28a70eba Update ccxt from 1.18.309 to 1.18.313
0fc54450 Update jsonschema from 3.0.0 to 3.0.1
e8ea2e6f Update ccxt from 1.18.304 to 1.18.309
b792f005 exchange cleanup
4df44d8b wallets cleanup
13de66d5 Update ccxt from 1.18.297 to 1.18.304
e5498ca2 Add libssl-dev to fix #1604
38d09f9e Update numpy from 1.16.1 to 1.16.2
768f62a2 Update ccxt from 1.18.296 to 1.18.297
761861f0 comments: removed mentioning recursion, typos, etc.
4c2961f0 eliminate recursion in _detect_next_stop_or_sell_point()
ef264841 Super() should not be called with parameters
79aac473 Remove market_url from tests
5c3177cc Adapt documentation to remove market_url
6c75b8a3 Remove pair market url
bcf5b5fd Update flake8 from 3.7.6 to 3.7.7
ef18ddd8 Update ccxt from 1.18.292 to 1.18.296
0c53bd6d Complete refactor, moving query_trades to persistance as get_open_trades
185bd1e5 Update ccxt from 1.18.290 to 1.18.292
00663500 Fix small typos
f2fd5205 Fix typo
31be4d24 Add parametrized tests
5c18346c Add typehint to binance dict
e0b634ba Parametrize exchanges and test multiple exchanges
a05155cb Adapt failing test
455b1683 add _ft_has to exchangeclass
06f486a8 Add binance exchange subclass
417bf2c9 Update jsonschema from 2.6.0 to 3.0.0
3673dba1 Update ccxt from 1.18.287 to 1.18.290
9b288c69 Add test to specifically test for merged dict
5fac4f7b Edge doc file minor improvements, typos, formatting
403ed48c rename _store_dry_order
ec6794b9 fix dry_orders
634ce87b Update ccxt from 1.18.281 to 1.18.287
98bca30d reorganize imports
cc0fae8e change < to <=
9a097214 return complete dry_order in buy and sell
9c54886f minor: formatting math expression in FAQ
a1b00f90 Edge question added; minor improvements (sections for Hyperopt and Edge)
29b8b797 Update ccxt from 1.18.280 to 1.18.281
b79d9673 add tests, further consolidate orders
69bb6eba fix comments
7738ebbc Update ccxt from 1.18.270 to 1.18.280
be754244 Only resolve exchanges from correct location
e0f426d8 Allow import freqtrade.exchange.*
e987a915 Rename exchange file
b5758e67 order creation cleanup
28518337 added _now_is_time_to_refresh()
c1ef6940 removed wrong comment: tuple is not created here
2aba9c08 fixed typos in comments
eb211706 added amount_reserve_percent into config json-schema
d9129cb9 Develop version bump to 0.18.2-dev
4315c157 Move exception handling to resolver, add test
da5bef50 cleanup
4fbba981 tests adjusted for multiple --config options
87c82dea support for multiple --config in the download_backtest_data.py utility
c08a2b66 help message fixed
7bc874c7 comments adjusted
fac0e4e6 more code cleanup in _process()
199e3d22 typo in a comment
5906d378 code cleanup in _process()
e495ffec align dry_run_orders
3e2f90a3 formatting
bb31e647 add test_sell_kraken_trading_agreement
481cf02d add test and fix exchange_resolver
2f225e23 multiple --config options
eed1c234 delete unnecessary arguments
4241caef changes to base and subclass
2103ae5f change rateLimit to 1000
0572336f revert changes to history
d8feceeb fix type-hints
da4faacd flake8
39c28626 remove error message to make pytest pass
5e8a7a03 correct time_in_force param
fe792882 load generic class if no subclass exists
d3ead2cd exchange import is not needed anymore
c879591f add exchange_resolver to resolver init
c315f63e use exchange_resolver in freqbot
2fb36b11 change variable names
ca388a9a create exchange_resolver
32b02c99 kraken subclass
54d5bce4 undo kraken specific changes
b7afcf34 add VolumePrecisionPairList
3aa614b9 bump version
3953092e output error message
ef5a0b9a add Kraken specifics