### PR TITLE
Wallet Sync fix after any trade is closed

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -522,6 +522,10 @@ class FreqtradeBot(object):
 
             trade.update(order)
 
+            # Updating wallets when order is closed
+            if trade.is_open == False:
+                self.wallets.update()
+
     def get_sell_rate(self, pair: str, refresh: bool) -> float:
         """
         Get sell rate - either using get-ticker bid or first bid based on orderbook

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -523,7 +523,7 @@ class FreqtradeBot(object):
             trade.update(order)
 
             # Updating wallets when order is closed
-            if trade.is_open == False:
+            if not trade.is_open:
                 self.wallets.update()
 
     def get_sell_rate(self, pair: str, refresh: bool) -> float:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1459,6 +1459,7 @@ def test_update_trade_state_sell(default_conf, trades_for_order, limit_sell_orde
     assert trade.amount == limit_sell_order['amount']
     # Wallet needs to be updated after closing a limit-sell order to reenable buying
     assert wallet_mock.call_count == 1
+    assert not trade.is_open
 
 
 def test_handle_trade(default_conf, limit_buy_order, limit_sell_order,


### PR DESCRIPTION
The wallets is not syncing after LIMIT_SELL is occured, because the order is fullfilled few instances later after sell methods are called.

This PR tries to solve this problem syncing wallets when trade is updated, that occurs when sell order is closed.

## Quick changelog

- Added command for Wallets Sync after a trade is closed in "update_trade" method in "freqtradebot" class, this will help the Wallets get updated after a trade is sold and closed, specifically LIMIT_SELL trades, then bot can work properly with new trades.

Previously without this fix, the log of bot show this scenario:
```
2019-04-19 21:53:34,307 - freqtrade.freqtradebot - INFO - Found open order for Trade(id=4, pair=EVX/BTC, amount=20.00000000, open_rate=0.00014879, open_since=an hour ago)
2019-04-19 21:53:35,177 - freqtrade.persistence - INFO - Updating trade (id=4) ...
2019-04-19 21:53:35,179 - freqtrade.persistence - INFO - Marking Trade(id=4, pair=EVX/BTC, amount=20.00000000, open_rate=0.00014879, open_since=closed) as closed as the trade is fulfilled and found no open orders for it.
2019-04-19 21:53:35,181 - freqtrade.persistence - INFO - LIMIT_SELL has been fulfilled for Trade(id=4, pair=EVX/BTC, amount=20.00000000, open_rate=0.00014879, open_since=closed).
2019-04-19 21:53:39,281 - unknown - INFO - Searching pairs: ['ETH/BTC', 'ENJ/BTC', 'BCH/BTC', 'MITH/BTC', 'PHX/BTC', 'RVN/BTC', 'XRP/BTC', 'ADA/BTC', 'LTC/BTC', 'EOS/BTC', 'WTC/BTC', 'WABI/BTC', 'GTO/BTC', 'BAT/BTC', 'FET/BTC', 'TRX/BTC', 'QKC/BTC', 'EVX/BTC', 'MCO/BTC', 'NANO/BTC', 'CELR/BTC', 'IOST/BTC', 'WAVES/BTC', 'VET/BTC', 'XLM/BTC', 'ZIL/BTC', 'NEO/BTC', 'ARN/BTC', 'FUEL/BTC', 'DGD/BTC']
2019-04-19 21:53:43,967 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again..
```
Without update after sell order is closed, and i got this error:
```
2019-04-20 00:30:16,027 - freqtrade.freqtradebot - WARNING - Unable to create trade: Available balance(0.00021334 BTC) is lower than stake amount(0.003 BTC)
```
But with this fix, the bot will update Wallets right after trade is closed:
```
2019-04-21 02:50:22,241 - freqtrade.freqtradebot - INFO - Found open order for Trade(id=8, pair=ENJ/BTC, amount=82.00000000, open_rate=0.00003653, open_since=2 hours ago)
2019-04-21 02:50:23,495 - freqtrade.persistence - INFO - Updating trade (id=8) ...
2019-04-21 02:50:23,497 - freqtrade.persistence - INFO - Marking Trade(id=8, pair=ENJ/BTC, amount=82.00000000, open_rate=0.00003653, open_since=closed) as closed as the trade is fulfilled and found no open orders for it.
2019-04-21 02:50:23,498 - freqtrade.persistence - INFO - LIMIT_SELL has been fulfilled for Trade(id=8, pair=ENJ/BTC, amount=82.00000000, open_rate=0.00003653, open_since=closed).
2019-04-21 02:50:23,994 - freqtrade.wallets - INFO - Wallets synced.
```

And no Warnings received anymore.