### PR TITLE
--print-all command line option for hyperopt

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -283,7 +283,6 @@ class Arguments(object):
             dest='position_stacking',
             default=False
         )
-
         parser.add_argument(
             '--dmmp', '--disable-max-market-positions',
             help='Disable applying `max_open_trades` during backtest '
@@ -308,6 +307,13 @@ class Arguments(object):
             default='all',
             nargs='+',
             dest='spaces',
+        )
+        parser.add_argument(
+            '--print-all',
+            help='Print all results, not only the best ones.',
+            action='store_true',
+            dest='print_all',
+            default=False
         )
 
     def _build_subcommands(self) -> None:

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -320,6 +320,10 @@ class Configuration(object):
             config.update({'spaces': self.args.spaces})
             logger.info('Parameter -s/--spaces detected: %s', config.get('spaces'))
 
+        if 'print_all' in self.args and self.args.print_all:
+            config.update({'print_all': self.args.print_all})
+            logger.info('Parameter --print-all detected: %s', config.get('print_all'))
+
         return config
 
     def _validate_config_schema(self, conf: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -115,7 +115,7 @@ class Hyperopt(Backtesting):
         """
         Log results if it is better than any previous evaluation
         """
-        if results['loss'] < self.current_best_loss:
+        if self.config.get('print_all', False) or results['loss'] < self.current_best_loss:
             current = results['current_tries']
             total = results['total_tries']
             res = results['result']


### PR DESCRIPTION
This option allows to see all results found by hyperopt, not only the best ones.
May be usefull for developers and for better understanding the hyperopt results and optimization path.
