### PR TITLE
hyperopt: --refresh-pairs-cached added

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -146,9 +146,11 @@ Backtesting also uses the config specified via `-c/--config`.
 
 ```
 usage: freqtrade backtesting [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                             [--eps] [--dmmp] [-l] [-r]
-                             [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
-                             [--export EXPORT] [--export-filename PATH]
+                           [--max_open_trades MAX_OPEN_TRADES]
+                           [--stake_amount STAKE_AMOUNT] [-r] [--eps] [--dmmp]
+                           [-l]
+                           [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
+                           [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -156,6 +158,14 @@ optional arguments:
                         Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
+  --max_open_trades MAX_OPEN_TRADES
+                        Specify max_open_trades to use.
+  --stake_amount STAKE_AMOUNT
+                        Specify stake_amount.
+  -r, --refresh-pairs-cached
+                        Refresh the pairs files in tests/testdata with the
+                        latest data from the exchange. Use it if you want to
+                        run your optimization commands with up-to-date data.
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
                         stacking).
@@ -164,10 +174,6 @@ optional arguments:
                         (same as setting `max_open_trades` to a very high
                         number).
   -l, --live            Use live data.
-  -r, --refresh-pairs-cached
-                        Refresh the pairs files in tests/testdata with the
-                        latest data from the exchange. Use it if you want to
-                        run your backtesting with up-to-date data.
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
                         Provide a commaseparated list of strategies to
                         backtest Please note that ticker-interval needs to be
@@ -206,8 +212,11 @@ to find optimal parameter values for your stategy.
 
 ```
 usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                          [--customhyperopt NAME] [--eps] [--dmmp] [-e INT]
-                          [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
+                        [--max_open_trades MAX_OPEN_TRADES]
+                        [--stake_amount STAKE_AMOUNT] [-r]
+                        [--customhyperopt NAME] [--eps] [--dmmp] [-e INT]
+                        [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
+                        [--print-all]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -215,6 +224,14 @@ optional arguments:
                         Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
+  --max_open_trades MAX_OPEN_TRADES
+                        Specify max_open_trades to use.
+  --stake_amount STAKE_AMOUNT
+                        Specify stake_amount.
+  -r, --refresh-pairs-cached
+                        Refresh the pairs files in tests/testdata with the
+                        latest data from the exchange. Use it if you want to
+                        run your optimization commands with up-to-date data.
   --customhyperopt NAME
                         Specify hyperopt class name (default:
                         DefaultHyperOpts).
@@ -229,7 +246,7 @@ optional arguments:
   -s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...], --spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]
                         Specify which parameters to hyperopt. Space separate
                         list. Default: all.
-
+  --print-all           Print all results, not only the best ones.
 ```
 
 ## Edge commands
@@ -237,8 +254,10 @@ optional arguments:
 To know your trade expectacny and winrate against historical data, you can use Edge.
 
 ```
-usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE] [-r]
-                      [--stoplosses STOPLOSS_RANGE]
+usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
+                    [--max_open_trades MAX_OPEN_TRADES]
+                    [--stake_amount STAKE_AMOUNT] [-r]
+                    [--stoplosses STOPLOSS_RANGE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -246,10 +265,14 @@ optional arguments:
                         Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
+  --max_open_trades MAX_OPEN_TRADES
+                        Specify max_open_trades to use.
+  --stake_amount STAKE_AMOUNT
+                        Specify stake_amount.
   -r, --refresh-pairs-cached
                         Refresh the pairs files in tests/testdata with the
                         latest data from the exchange. Use it if you want to
-                        run your edge with up-to-date data.
+                        run your optimization commands with up-to-date data.
   --stoplosses STOPLOSS_RANGE
                         Defines a range of stoploss against which edge will
                         assess the strategy the format is "min,max,step"

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -142,9 +142,52 @@ class Arguments(object):
         )
 
     @staticmethod
+    def optimizer_shared_options(parser: argparse.ArgumentParser) -> None:
+        """
+        Parses given common arguments for Backtesting, Edge and Hyperopt modules.
+        :param parser:
+        :return:
+        """
+        parser.add_argument(
+            '-i', '--ticker-interval',
+            help='Specify ticker interval (1m, 5m, 30m, 1h, 1d).',
+            dest='ticker_interval',
+            type=str,
+        )
+        parser.add_argument(
+            '--timerange',
+            help='Specify what timerange of data to use.',
+            default=None,
+            type=str,
+            dest='timerange',
+        )
+        parser.add_argument(
+            '--max_open_trades',
+            help='Specify max_open_trades to use.',
+            default=None,
+            type=int,
+            dest='max_open_trades',
+        )
+        parser.add_argument(
+            '--stake_amount',
+            help='Specify stake_amount.',
+            default=None,
+            type=float,
+            dest='stake_amount',
+        )
+        parser.add_argument(
+            '-r', '--refresh-pairs-cached',
+            help='Refresh the pairs files in tests/testdata with the latest data from the '
+                 'exchange. Use it if you want to run your optimization commands with '
+                 'up-to-date data.',
+            action='store_true',
+            dest='refresh_pairs',
+        )
+
+    @staticmethod
     def backtesting_options(parser: argparse.ArgumentParser) -> None:
         """
-        Parses given arguments for Backtesting scripts.
+        Parses given arguments for Backtesting module.
         """
         parser.add_argument(
             '--eps', '--enable-position-stacking',
@@ -166,13 +209,6 @@ class Arguments(object):
             help='Use live data.',
             action='store_true',
             dest='live',
-        )
-        parser.add_argument(
-            '-r', '--refresh-pairs-cached',
-            help='Refresh the pairs files in tests/testdata with the latest data from the '
-                 'exchange. Use it if you want to run your backtesting with up-to-date data.',
-            action='store_true',
-            dest='refresh_pairs',
         )
         parser.add_argument(
             '--strategy-list',
@@ -207,15 +243,8 @@ class Arguments(object):
     @staticmethod
     def edge_options(parser: argparse.ArgumentParser) -> None:
         """
-        Parses given arguments for Backtesting scripts.
+        Parses given arguments for Edge module.
         """
-        parser.add_argument(
-            '-r', '--refresh-pairs-cached',
-            help='Refresh the pairs files in tests/testdata with the latest data from the '
-                 'exchange. Use it if you want to run your edge with up-to-date data.',
-            action='store_true',
-            dest='refresh_pairs',
-        )
         parser.add_argument(
             '--stoplosses',
             help='Defines a range of stoploss against which edge will assess the strategy '
@@ -226,47 +255,9 @@ class Arguments(object):
         )
 
     @staticmethod
-    def optimizer_shared_options(parser: argparse.ArgumentParser) -> None:
-        """
-        Parses given common arguments for Backtesting and Hyperopt scripts.
-        :param parser:
-        :return:
-        """
-        parser.add_argument(
-            '-i', '--ticker-interval',
-            help='Specify ticker interval (1m, 5m, 30m, 1h, 1d).',
-            dest='ticker_interval',
-            type=str,
-        )
-
-        parser.add_argument(
-            '--timerange',
-            help='Specify what timerange of data to use.',
-            default=None,
-            type=str,
-            dest='timerange',
-        )
-
-        parser.add_argument(
-            '--max_open_trades',
-            help='Specify max_open_trades to use.',
-            default=None,
-            type=int,
-            dest='max_open_trades',
-        )
-
-        parser.add_argument(
-            '--stake_amount',
-            help='Specify stake_amount.',
-            default=None,
-            type=float,
-            dest='stake_amount',
-        )
-
-    @staticmethod
     def hyperopt_options(parser: argparse.ArgumentParser) -> None:
         """
-        Parses given arguments for Hyperopt scripts.
+        Parses given arguments for Hyperopt module.
         """
         parser.add_argument(
             '--customhyperopt',

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -324,6 +324,11 @@ class Configuration(object):
             config.update({'print_all': self.args.print_all})
             logger.info('Parameter --print-all detected: %s', config.get('print_all'))
 
+        # If -r/--refresh-pairs-cached is used we add it to the configuration
+        if 'refresh_pairs' in self.args and self.args.refresh_pairs:
+            config.update({'refresh_pairs': True})
+            logger.info('Parameter -r/--refresh-pairs-cached detected ...')
+
         return config
 
     def _validate_config_schema(self, conf: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -116,7 +116,8 @@ def load_pair_history(pair: str,
         return parse_ticker_dataframe(pairdata, ticker_interval, fill_up_missing)
     else:
         logger.warning('No data for pair: "%s", Interval: %s. '
-                       'Use --refresh-pairs-cached to download the data',
+                       'Use --refresh-pairs-cached option or download_backtest_data.py '
+                       'script to download the data',
                        pair, ticker_interval)
         return None
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -516,6 +516,7 @@ def start(args: Namespace) -> None:
     """
     # Initialize configuration
     config = setup_configuration(args)
+
     logger.info('Starting freqtrade in Backtesting mode')
 
     # Initialize backtesting object

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -68,7 +68,10 @@ def test_load_data_7min_ticker(mocker, caplog, default_conf) -> None:
     assert ld is None
     assert log_has(
         'No data for pair: "UNITTEST/BTC", Interval: 7m. '
-        'Use --refresh-pairs-cached to download the data', caplog.record_tuples)
+        'Use --refresh-pairs-cached option or download_backtest_data.py '
+        'script to download the data',
+        caplog.record_tuples
+    )
 
 
 def test_load_data_1min_ticker(ticker_history, mocker, caplog) -> None:
@@ -96,9 +99,12 @@ def test_load_data_with_new_pair_1min(ticker_history_list, mocker, caplog, defau
                               refresh_pairs=False,
                               pair='MEME/BTC')
     assert os.path.isfile(file) is False
-    assert log_has('No data for pair: "MEME/BTC", Interval: 1m. '
-                   'Use --refresh-pairs-cached to download the data',
-                   caplog.record_tuples)
+    assert log_has(
+        'No data for pair: "MEME/BTC", Interval: 1m. '
+        'Use --refresh-pairs-cached option or download_backtest_data.py '
+        'script to download the data',
+        caplog.record_tuples
+    )
 
     # download a new pair if refresh_pairs is set
     history.load_pair_history(datadir=None,

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -260,6 +260,7 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
 
     assert 'refresh_pairs' in config
     assert log_has('Parameter -r/--refresh-pairs-cached detected ...', caplog.record_tuples)
+
     assert 'timerange' in config
     assert log_has(
         'Parameter --timerange detected: {} ...'.format(config['timerange']),


### PR DESCRIPTION
A part of #1775.

Current bahaviour is non-logical: a user who optimizes parameters with hyperopt is asked to run the bot with the --refresh-pairs-cached, but it's not available for the hyperopt command. She needs to run backtesting or edge command just due to this deficiency in the implementation.

Since hyperopt class is inherited from backtesting, it already has an initialized instance of exchange class inside self (not used in hyperopt and later set to None in hyperopt start()). We can use it to download refreshed data before it's set to None.

* --refresh-pairs-cached is now a common option for all optimization bot commands;
* The message changed, now it suggests to run the script in addition to stating this option;
* Tests for hyperopt added. adopted from backtesting;
* set_configuration() function added for hyperopt: for tests and in order to make the hyperopt and backtesting codebase closer to each other;
* ValueError raised from hyperopt's start() changed to DependencyException, as in the backtesting start(); this seems to be more correct. Tests adjusted.
* minor cosmetic improvements
