### PR TITLE
hyperopt: -j/--job-workers command line option added

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -206,8 +206,11 @@ to find optimal parameter values for your stategy.
 
 ```
 usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                          [--customhyperopt NAME] [--eps] [--dmmp] [-e INT]
-                          [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
+                        [--max_open_trades MAX_OPEN_TRADES]
+                        [--stake_amount STAKE_AMOUNT] [--customhyperopt NAME]
+                        [--eps] [--dmmp] [-e INT]
+                        [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
+                        [--print-all] [-j JOBS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -215,6 +218,10 @@ optional arguments:
                         Specify ticker interval (1m, 5m, 30m, 1h, 1d).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
+  --max_open_trades MAX_OPEN_TRADES
+                        Specify max_open_trades to use.
+  --stake_amount STAKE_AMOUNT
+                        Specify stake_amount.
   --customhyperopt NAME
                         Specify hyperopt class name (default:
                         DefaultHyperOpts).
@@ -229,7 +236,13 @@ optional arguments:
   -s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...], --spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]
                         Specify which parameters to hyperopt. Space separate
                         list. Default: all.
-
+  --print-all           Print all results, not only the best ones.
+  -j JOBS, --job-workers JOBS
+                        The number of concurrently running jobs for
+                        hyperoptimization (hyperopt worker processes). If -1
+                        (default), all CPUs are used, for -2, all CPUs but one
+                        are used, etc. If 1 is given, no parallel computing
+                        code is used at all.
 ```
 
 ## Edge commands

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -315,6 +315,17 @@ class Arguments(object):
             dest='print_all',
             default=False
         )
+        parser.add_argument(
+            '-j', '--job-workers',
+            help='The number of concurrently running jobs for hyperoptimization '
+                 '(hyperopt worker processes). '
+                 'If -1 (default), all CPUs are used, for -2, all CPUs but one are used, etc. '
+                 'If 1 is given, no parallel computing code is used at all.',
+            dest='hyperopt_jobs',
+            default=-1,
+            type=int,
+            metavar='JOBS',
+        )
 
     def _build_subcommands(self) -> None:
         """

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -208,17 +208,14 @@ class Configuration(object):
             logger.info('Parameter -i/--ticker-interval detected ...')
             logger.info('Using ticker_interval: %s ...', config.get('ticker_interval'))
 
-        # If -l/--live is used we add it to the configuration
         if 'live' in self.args and self.args.live:
             config.update({'live': True})
             logger.info('Parameter -l/--live detected ...')
 
-        # If --enable-position-stacking is used we add it to the configuration
         if 'position_stacking' in self.args and self.args.position_stacking:
             config.update({'position_stacking': True})
             logger.info('Parameter --enable-position-stacking detected ...')
 
-        # If --disable-max-market-positions or --max_open_trades is used we update configuration
         if 'use_max_market_positions' in self.args and not self.args.use_max_market_positions:
             config.update({'use_max_market_positions': False})
             logger.info('Parameter --disable-max-market-positions detected ...')
@@ -230,25 +227,21 @@ class Configuration(object):
         else:
             logger.info('Using max_open_trades: %s ...', config.get('max_open_trades'))
 
-        # If --stake_amount is used we update configuration
         if 'stake_amount' in self.args and self.args.stake_amount:
             config.update({'stake_amount': self.args.stake_amount})
             logger.info('Parameter --stake_amount detected, overriding stake_amount to: %s ...',
                         config.get('stake_amount'))
 
-        # If --timerange is used we add it to the configuration
         if 'timerange' in self.args and self.args.timerange:
             config.update({'timerange': self.args.timerange})
             logger.info('Parameter --timerange detected: %s ...', self.args.timerange)
 
-        # If --datadir is used we add it to the configuration
         if 'datadir' in self.args and self.args.datadir:
             config.update({'datadir': self._create_datadir(config, self.args.datadir)})
         else:
             config.update({'datadir': self._create_datadir(config, None)})
         logger.info('Using data folder: %s ...', config.get('datadir'))
 
-        # If -r/--refresh-pairs-cached is used we add it to the configuration
         if 'refresh_pairs' in self.args and self.args.refresh_pairs:
             config.update({'refresh_pairs': True})
             logger.info('Parameter -r/--refresh-pairs-cached detected ...')
@@ -261,12 +254,10 @@ class Configuration(object):
             config.update({'ticker_interval': self.args.ticker_interval})
             logger.info('Overriding ticker interval with Command line argument')
 
-        # If --export is used we add it to the configuration
         if 'export' in self.args and self.args.export:
             config.update({'export': self.args.export})
             logger.info('Parameter --export detected: %s ...', self.args.export)
 
-        # If --export-filename is used we add it to the configuration
         if 'export' in config and 'exportfilename' in self.args and self.args.exportfilename:
             config.update({'exportfilename': self.args.exportfilename})
             logger.info('Storing backtest results to %s ...', self.args.exportfilename)
@@ -279,12 +270,10 @@ class Configuration(object):
         :return: configuration as dictionary
         """
 
-        # If --timerange is used we add it to the configuration
         if 'timerange' in self.args and self.args.timerange:
             config.update({'timerange': self.args.timerange})
             logger.info('Parameter --timerange detected: %s ...', self.args.timerange)
 
-        # If --timerange is used we add it to the configuration
         if 'stoploss_range' in self.args and self.args.stoploss_range:
             txt_range = eval(self.args.stoploss_range)
             config['edge'].update({'stoploss_range_min': txt_range[0]})
@@ -292,7 +281,6 @@ class Configuration(object):
             config['edge'].update({'stoploss_range_step': txt_range[2]})
             logger.info('Parameter --stoplosses detected: %s ...', self.args.stoploss_range)
 
-        # If -r/--refresh-pairs-cached is used we add it to the configuration
         if 'refresh_pairs' in self.args and self.args.refresh_pairs:
             config.update({'refresh_pairs': True})
             logger.info('Parameter -r/--refresh-pairs-cached detected ...')
@@ -309,13 +297,11 @@ class Configuration(object):
             # Add the hyperopt file to use
             config.update({'hyperopt': self.args.hyperopt})
 
-        # If --epochs is used we add it to the configuration
         if 'epochs' in self.args and self.args.epochs:
             config.update({'epochs': self.args.epochs})
             logger.info('Parameter --epochs detected ...')
             logger.info('Will run Hyperopt with for %s epochs ...', config.get('epochs'))
 
-        # If --spaces is used we add it to the configuration
         if 'spaces' in self.args and self.args.spaces:
             config.update({'spaces': self.args.spaces})
             logger.info('Parameter -s/--spaces detected: %s', config.get('spaces'))
@@ -323,6 +309,10 @@ class Configuration(object):
         if 'print_all' in self.args and self.args.print_all:
             config.update({'print_all': self.args.print_all})
             logger.info('Parameter --print-all detected: %s', config.get('print_all'))
+
+        if 'hyperopt_jobs' in self.args and self.args.hyperopt_jobs:
+            config.update({'hyperopt_jobs': self.args.hyperopt_jobs})
+            logger.info('Parameter -j/--job-workers detected: %s', config.get('hyperopt_jobs'))
 
         return config
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -5,7 +5,6 @@ This module contains the hyperopt logic
 """
 
 import logging
-import multiprocessing
 import os
 import sys
 from argparse import Namespace
@@ -15,7 +14,7 @@ from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List
 
-from joblib import Parallel, delayed, dump, load, wrap_non_picklable_objects
+from joblib import Parallel, delayed, dump, load, wrap_non_picklable_objects, cpu_count
 from pandas import DataFrame
 from skopt import Optimizer
 from skopt.space import Dimension
@@ -268,7 +267,7 @@ class Hyperopt(Backtesting):
         self.exchange = None  # type: ignore
         self.load_previous_results()
 
-        cpus = multiprocessing.cpu_count()
+        cpus = cpu_count()
         logger.info(f'Found {cpus} CPU cores. Let\'s make them scream!')
         config_jobs = self.config.get('hyperopt_jobs', -1)
         logger.info(f'Number of parallel jobs set as: {config_jobs}')

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -299,7 +299,7 @@ class Hyperopt(Backtesting):
                             'result': f_val[j]['result'],
                         })
                         logger.debug(f"Optimizer params: {f_val[j]['params']}")
-                    for j in range(cpus):
+                    for j in range(jobs):
                         logger.debug(f"Opimizer state: Xi: {opt.Xi[-j-1]}, yi: {opt.yi[-j-1]}")
         except KeyboardInterrupt:
             print('User interrupted..')

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -314,7 +314,7 @@ def test_roi_table_generation(hyperopt) -> None:
 def test_start_calls_optimizer(mocker, default_conf, caplog) -> None:
     dumper = mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock())
-    mocker.patch('freqtrade.optimize.hyperopt.multiprocessing.cpu_count', MagicMock(return_value=1))
+    mocker.patch('freqtrade.optimize.hyperopt.joblib.cpu_count', MagicMock(return_value=1))
     parallel = mocker.patch(
         'freqtrade.optimize.hyperopt.Hyperopt.run_optimizer_parallel',
         MagicMock(return_value=[{'loss': 1, 'result': 'foo result', 'params': {}}])

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -314,7 +314,6 @@ def test_roi_table_generation(hyperopt) -> None:
 def test_start_calls_optimizer(mocker, default_conf, caplog) -> None:
     dumper = mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock())
-    mocker.patch('freqtrade.optimize.hyperopt.cpu_count', MagicMock(return_value=1))
     parallel = mocker.patch(
         'freqtrade.optimize.hyperopt.Hyperopt.run_optimizer_parallel',
         MagicMock(return_value=[{'loss': 1, 'result': 'foo result', 'params': {}}])
@@ -325,6 +324,7 @@ def test_start_calls_optimizer(mocker, default_conf, caplog) -> None:
     default_conf.update({'epochs': 1})
     default_conf.update({'timerange': None})
     default_conf.update({'spaces': 'all'})
+    default_conf.update({'hyperopt_jobs': 1})
 
     hyperopt = Hyperopt(default_conf)
     hyperopt.strategy.tickerdata_to_dataframe = MagicMock()

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -314,7 +314,7 @@ def test_roi_table_generation(hyperopt) -> None:
 def test_start_calls_optimizer(mocker, default_conf, caplog) -> None:
     dumper = mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock())
-    mocker.patch('freqtrade.optimize.hyperopt.joblib.cpu_count', MagicMock(return_value=1))
+    mocker.patch('freqtrade.optimize.hyperopt.cpu_count', MagicMock(return_value=1))
     parallel = mocker.patch(
         'freqtrade.optimize.hyperopt.Hyperopt.run_optimizer_parallel',
         MagicMock(return_value=[{'loss': 1, 'result': 'foo result', 'params': {}}])


### PR DESCRIPTION
A part of #1775.

This option allows to control the number of the joblib.parallel worker processes used in the hyperopt.

If set to -1 (default), all CPUs are used (joblib parallel backend determines the number of the worker processes automatically), for -2, all CPUs but one are used, etc. If 1 is given, no parallel computing code is used at all.

Needs to be tested additionally on Windows and on VPS or virtual machines with 1 CPU. Please verify the solution in these conditions before merge.

* Docs adjusted as well. No tests added.
* As an additional minor cosmetics, redundant comments that do not apply any additional useful information but require attention while copying/extending options were removed from freqtrade/configuration.py
