### PR TITLE
hyperopt: print optimizer state in debug log messages

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -288,6 +288,9 @@ class Hyperopt(Backtesting):
                             'total_tries': self.total_tries,
                             'result': f_val[j]['result'],
                         })
+                        logger.debug(f"Optimizer params: {f_val[j]['params']}")
+                    for j in range(cpus):
+                        logger.debug(f"Opimizer state: Xi: {opt.Xi[-j-1]}, yi: {opt.yi[-j-1]}")
         except KeyboardInterrupt:
             print('User interrupted..')
 


### PR DESCRIPTION
A part of #1775.

Run the bot with the `-v` command line option to see the data.

Internal optimizer state and the points from the hyperspace ('params' in result dict) are printed in different loops since they have (may have) different order.
