### PR TITLE
hyperopt: --random-state for optimizer to get reproducible results

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -311,7 +311,7 @@ class Arguments(object):
             help='Set random state to some positive integer for reproducible hyperopt results.',
             dest='hyperopt_random_state',
             default=None,
-            type=Arguments.check_positive,
+            type=Arguments.check_int_positive,
             metavar='INT',
         )
 
@@ -385,13 +385,15 @@ class Arguments(object):
         raise Exception('Incorrect syntax for timerange "%s"' % text)
 
     @staticmethod
-    def check_positive(value) -> int:
+    def check_int_positive(value) -> int:
         try:
             uint = int(value)
             if uint <= 0:
                 raise ValueError
-        except:
-            raise argparse.ArgumentTypeError(f"{value} is invalid for this parameter, should be a positive integer value")
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"{value} is invalid for this parameter, should be a positive integer value"
+            )
         return uint
 
     def scripts_options(self) -> None:

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -315,6 +315,14 @@ class Arguments(object):
             dest='print_all',
             default=False
         )
+        parser.add_argument(
+            '--random-state',
+            help='Set random state to some positive integer for reproducible hyperopt results.',
+            dest='hyperopt_random_state',
+            default=None,
+            type=Arguments.check_positive,
+            metavar='INT',
+        )
 
     def _build_subcommands(self) -> None:
         """
@@ -384,6 +392,16 @@ class Arguments(object):
                         stop = int(stops)
                 return TimeRange(stype[0], stype[1], start, stop)
         raise Exception('Incorrect syntax for timerange "%s"' % text)
+
+    @staticmethod
+    def check_positive(value) -> int:
+        try:
+            uint = int(value)
+            if uint <= 0:
+                raise ValueError
+        except:
+            raise argparse.ArgumentTypeError(f"{value} is invalid for this parameter, should be a positive integer value")
+        return uint
 
     def scripts_options(self) -> None:
         """

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -315,7 +315,8 @@ class Configuration(object):
 
         if 'hyperopt_random_state' in self.args and self.args.hyperopt_random_state is not None:
             config.update({'hyperopt_random_state': self.args.hyperopt_random_state})
-            logger.info("Parameter --random-state detected: %s", config.get('hyperopt_random_state'))
+            logger.info("Parameter --random-state detected: %s",
+                        config.get('hyperopt_random_state'))
 
         return config
 

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -324,6 +324,10 @@ class Configuration(object):
             config.update({'print_all': self.args.print_all})
             logger.info('Parameter --print-all detected: %s', config.get('print_all'))
 
+        if 'hyperopt_random_state' in self.args and self.args.hyperopt_random_state is not None:
+            config.update({'hyperopt_random_state': self.args.hyperopt_random_state})
+            logger.info("Parameter --random-state detected: %s", config.get('hyperopt_random_state'))
+
         return config
 
     def _validate_config_schema(self, conf: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -235,7 +235,8 @@ class Hyperopt(Backtesting):
             base_estimator="ET",
             acq_optimizer="auto",
             n_initial_points=30,
-            acq_optimizer_kwargs={'n_jobs': cpu_count}
+            acq_optimizer_kwargs={'n_jobs': cpu_count},
+            random_state=self.config.get('hyperopt_random_state', None)
         )
 
     def run_optimizer_parallel(self, parallel, asked) -> List:


### PR DESCRIPTION
A part of #1775.

This new parameter allows to pass a value for the random_state argument of the skopt optimizer to get reproducible optimization path.

Use it defining any positive integer value, for example:
```
python freqtrade hyperopt --random-state=33
```
Non-integer AND zero are invalid and rejected.

The check_int_positive() method was added to the Arguments class, which validates the parameter value at early stage. Can further be used in freqtrade/arguments.py for validation of other integer parameters where a positive value is expected.
