### PR TITLE
Downgrade urllib3, cleanup requirements files

### DIFF
--- a/requirements-pi.txt
+++ b/requirements-pi.txt
@@ -1,10 +1,12 @@
+# requirements without requirements installable via conda
+# mainly used for Raspberry pi installs
 ccxt==1.18.486
 SQLAlchemy==1.3.3
 python-telegram-bot==11.1.0
 arrow==0.13.1
 cachetools==3.1.0
 requests==2.21.0
-urllib3==1.25
+urllib3==1.24.2
 wrapt==1.11.1
 scikit-learn==0.20.3
 joblib==0.13.2
@@ -21,3 +23,6 @@ py_find_1st==1.1.3
 
 #Load ticker files 30% faster
 python-rapidjson==0.7.0
+
+# Notify systemd
+sdnotify==0.3.2

--- a/requirements-pi.txt
+++ b/requirements-pi.txt
@@ -6,7 +6,7 @@ python-telegram-bot==11.1.0
 arrow==0.13.1
 cachetools==3.1.0
 requests==2.21.0
-urllib3==1.24.2
+urllib3==1.24.2  # pyup: ignore
 wrapt==1.11.1
 scikit-learn==0.20.3
 joblib==0.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,6 @@
-ccxt==1.18.486
-SQLAlchemy==1.3.3
-python-telegram-bot==11.1.0
-arrow==0.13.1
-cachetools==3.1.0
-requests==2.21.0
-urllib3==1.25
-wrapt==1.11.1
+# Load common requirements
+-r requirements-pi.txt
+
 numpy==1.16.3
 pandas==0.24.2
-scikit-learn==0.20.3
-joblib==0.13.2
 scipy==1.2.1
-jsonschema==3.0.1
-TA-Lib==0.4.17
-tabulate==0.8.3
-coinmarketcap==5.0.3
-
-# Required for hyperopt
-scikit-optimize==0.5.2
-
-# find first, C search in arrays
-py_find_1st==1.1.3
-
-# Load ticker files 30% faster
-python-rapidjson==0.7.0
-
-# Notify systemd
-sdnotify==0.3.2


### PR DESCRIPTION
## Summary
Fix CI failures (https://travis-ci.org/freqtrade/freqtrade/jobs/523902109).

Upgrading urllib3 is blocked by https://github.com/kennethreitz/requests/pull/5063

## Quick changelog

- fix version mismatch until requests is upgraded
- cleanup requirements - every requirement should be there only once

