### PR TITLE
Catch errors on reload_markets

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -222,8 +222,11 @@ class Exchange(object):
                 > arrow.utcnow().timestamp):
             return None
         logger.debug("Performing scheduled market reload..")
-        self._api.load_markets(reload=True)
-        self._last_markets_refresh = arrow.utcnow().timestamp
+        try:
+            self._api.load_markets(reload=True)
+            self._last_markets_refresh = arrow.utcnow().timestamp
+        except ccxt.NetworkError:
+            logger.exception("Could not reload markets.")
 
     def validate_pairs(self, pairs: List[str]) -> None:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -225,7 +225,7 @@ class Exchange(object):
         try:
             self._api.load_markets(reload=True)
             self._last_markets_refresh = arrow.utcnow().timestamp
-        except ccxt.NetworkError:
+        except ccxt.BaseError:
             logger.exception("Could not reload markets.")
 
     def validate_pairs(self, pairs: List[str]) -> None:


### PR DESCRIPTION
## Summary
We should catch network-errors from the exchange for regular calls.

Resolves #1789

## Quick changelog

- Catch errors and log them as exception
- Should prevent the bot from crashing regularily.
