### PR TITLE
prevent hyperopt from running multiple instances simultaneously

### DIFF
--- a/requirements-pi.txt
+++ b/requirements-pi.txt
@@ -17,6 +17,7 @@ coinmarketcap==5.0.3
 
 # Required for hyperopt
 scikit-optimize==0.5.2
+filelock==3.0.10
 
 # find first, C search in arrays
 py_find_1st==1.1.3


### PR DESCRIPTION
Set and check the lock.

Inspired by #1803.

A universal approach (py-filelock) was choosen because a custom one with fcntl/flock is 1) platform specific, 2) a lock set on the results pickle file can persist in case the app was killed in the middle. Can be problematic for an inexperienced user to remove the lock.

* I tested it with graceful hyperopt exit, `Ctrl+C`, `kill` and `kill -9` (Ubuntu).
* @xmatthias, you can adjust the log messages if you wish.
* Please test it on Windows.
* A test for it should probably be added. Too complicated for me, I'm still not quite familiar with all that mocking stuff...
* Docs should mention it somehow if recently added sentence about multiple Heperopts does not suffice.
* TODO (sep. PR, future): start() for Backtesting, Edge and Hyperopt should return boolean in order to return non-zero exit code in some cases. (or simply raise an exception to freqtrade here if the lock is detected?)
