### PR TITLE
immediately confirm forcesell

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -346,7 +346,7 @@ class RPC(object):
 
         return {'status': 'No more buy will occur from now. Run /reload_conf to reset.'}
 
-    def _rpc_forcesell(self, trade_id) -> None:
+    def _rpc_forcesell(self, trade_id) -> Dict[str, str]:
         """
         Handler for forcesell <id>.
         Sells the given trade at current price
@@ -386,7 +386,7 @@ class RPC(object):
             for trade in Trade.get_open_trades():
                 _exec_forcesell(trade)
             Trade.session.flush()
-            return
+            return {'result': 'Created sell orders for all open trades.'}
 
         # Query for trade
         trade = Trade.query.filter(
@@ -401,6 +401,7 @@ class RPC(object):
 
         _exec_forcesell(trade)
         Trade.session.flush()
+        return {'result': f'Created sell orders for trade {trade_id}.'}
 
     def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:
         """

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -401,7 +401,7 @@ class RPC(object):
 
         _exec_forcesell(trade)
         Trade.session.flush()
-        return {'result': f'Created sell orders for trade {trade_id}.'}
+        return {'result': f'Created sell order for trade {trade_id}.'}
 
     def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -413,7 +413,9 @@ class Telegram(RPC):
 
         trade_id = update.message.text.replace('/forcesell', '').strip()
         try:
-            self._rpc_forcesell(trade_id)
+            msg = self._rpc_forcesell(trade_id)
+            self._send_msg('Forcesell Result: `{result}`'.format(**msg), bot=bot)
+
         except RPCException as e:
             self._send_msg(str(e), bot=bot)
 

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -471,7 +471,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
     msg = rpc._rpc_forcesell('1')
-    assert msg == {'result': 'Created sell orders for trade 1.'}
+    assert msg == {'result': 'Created sell order for trade 1.'}
 
     freqtradebot.state = State.STOPPED
     with pytest.raises(RPCException, match=r'.*trader is not running*'):
@@ -515,7 +515,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     )
     # check that the trade is called, which is done by ensuring exchange.cancel_order is called
     msg = rpc._rpc_forcesell('2')
-    assert msg == {'result': 'Created sell orders for trade 2.'}
+    assert msg == {'result': 'Created sell order for trade 2.'}
     assert cancel_order_mock.call_count == 2
     assert trade.amount == amount
 
@@ -530,7 +530,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
         }
     )
     msg = rpc._rpc_forcesell('3')
-    assert msg == {'result': 'Created sell orders for trade 3.'}
+    assert msg == {'result': 'Created sell order for trade 3.'}
     # status quo, no exchange calls
     assert cancel_order_mock.call_count == 2
 

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -463,12 +463,15 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     with pytest.raises(RPCException, match=r'.*invalid argument*'):
         rpc._rpc_forcesell(None)
 
-    rpc._rpc_forcesell('all')
+    msg = rpc._rpc_forcesell('all')
+    assert msg == {'result': 'Created sell orders for all open trades.'}
 
     freqtradebot.create_trade()
-    rpc._rpc_forcesell('all')
+    msg = rpc._rpc_forcesell('all')
+    assert msg == {'result': 'Created sell orders for all open trades.'}
 
-    rpc._rpc_forcesell('1')
+    msg = rpc._rpc_forcesell('1')
+    assert msg == {'result': 'Created sell orders for trade 1.'}
 
     freqtradebot.state = State.STOPPED
     with pytest.raises(RPCException, match=r'.*trader is not running*'):
@@ -511,7 +514,8 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
         }
     )
     # check that the trade is called, which is done by ensuring exchange.cancel_order is called
-    rpc._rpc_forcesell('2')
+    msg = rpc._rpc_forcesell('2')
+    assert msg == {'result': 'Created sell orders for trade 2.'}
     assert cancel_order_mock.call_count == 2
     assert trade.amount == amount
 
@@ -525,7 +529,8 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
             'side': 'sell'
         }
     )
-    rpc._rpc_forcesell('3')
+    msg = rpc._rpc_forcesell('3')
+    assert msg == {'result': 'Created sell orders for trade 3.'}
     # status quo, no exchange calls
     assert cancel_order_mock.call_count == 2
 


### PR DESCRIPTION
## Summary
This will return the status of the rpc forcesell call
Currently, when you forcesell, the only feedback you get is once the order is filled.
This may be immediately, but it could also be delayed if the limit-sell order is not filled.

This is dangerous as i tend to make typos on the phone, and having immediate feedback if it worked should improve usability.

## What's new?
![2019-04-30-062933_579x61_scrot](https://user-images.githubusercontent.com/5024695/56940877-553a2200-6b11-11e9-9dec-cefe2cf22a65.png)

![2019-04-30-062849_486x57_scrot](https://user-images.githubusercontent.com/5024695/56940862-46536f80-6b11-11e9-992f-ecf6ca271f44.png)


