### PR TITLE
hyperopt --min-trades parameter

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -325,6 +325,15 @@ class Arguments(object):
             type=Arguments.check_int_positive,
             metavar='INT',
         )
+        parser.add_argument(
+            '--min-trades',
+            help="Set minimal desired number of trades for evaluations in the hyperopt "
+                 "optimization path (default: 1).",
+            dest='hyperopt_min_trades',
+            default=1,
+            type=Arguments.check_int_positive,
+            metavar='INT',
+        )
 
     def _build_subcommands(self) -> None:
         """

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -312,6 +312,10 @@ class Configuration(object):
 
         self._args_to_config(config, argname='hyperopt_random_state',
                              logstring='Parameter --random-state detected: {}')
+
+        self._args_to_config(config, argname='hyperopt_min_trades',
+                             logstring='Parameter --min-trades detected: {}')
+
         return config
 
     def _validate_config_schema(self, conf: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -204,7 +204,11 @@ class Hyperopt(Backtesting):
         trade_count = len(results.index)
         trade_duration = results.trade_duration.mean()
 
-        if trade_count == 0:
+        # If this evaluation contains too short small amount of trades
+        # to be interesting -- consider it as 'bad' (assign max. loss value)
+        # in order to cast this hyperspace point away from optimization
+        # path. We do not want to optimize 'hodl' strategies.
+        if trade_count < self.config['hyperopt_min_trades']:
             return {
                 'loss': MAX_LOSS,
                 'params': params,

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -410,6 +410,7 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     default_conf.update({'config': 'config.json.example'})
     default_conf.update({'timerange': None})
     default_conf.update({'spaces': 'all'})
+    default_conf.update({'hyperopt_min_trades': 1})
 
     trades = [
         ('POWR/BTC', 0.023117, 0.000233, 100)


### PR DESCRIPTION
Usage:
freqtrade hyperopt --min-trades=N

This enhancement allows to mark hyperopt evaluations with number of trades less then N as 'bad', i.e. assigns them the maximal loss value. 

It helps optimization process to not descend in the hyperspace to points with 1 successfull trade and to not start optimizing around it as a local minimum of the target (loss) function. 

We don't have to and usually don't wish to optimize 'hodl' strategies indeed. 😃 

Now, in the current develop implementation, only points in the hyperspace (evaluations) that contain no trades are considered as such 'bad' points. With the default hyperopt, it (almost) always starts optimizing around a point with a single successful trade after several hundreds of evals (epochs)...

How to see difference: compare output (notice the number of trades column) after 500-700 evals:
```
freqtrade hyperopt -e 2000 --print-all
freqtrade hyperopt -e 2000 --print-all --min-trades=10
```

Default for this option is set to 1 (i.e. keep current behaviour).

Part of #1775.

I'll add a wider description of this option in the docs in a sep. PR.
