### PR TITLE
minor: hyperopt output improvements

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -63,9 +63,11 @@ class Hyperopt(Backtesting):
         # if eval ends with higher value, we consider it a failed eval
         self.max_accepted_trade_duration = 300
 
-        # this is expexted avg profit * expected trade count
-        # for example 3.5%, 1100 trades, self.expected_max_profit = 3.85
-        # check that the reported Σ% values do not exceed this!
+        # This is assumed to be expected avg profit * expected trade count.
+        # For example, for 0.35% avg per trade (or 0.0035 as ratio) and 1100 trades,
+        # self.expected_max_profit = 3.85
+        # Check that the reported Σ% values do not exceed this!
+        # Note, this is ratio. 3.85 stated above means 385Σ%.
         self.expected_max_profit = 3.0
 
         # Previous evaluations
@@ -211,8 +213,8 @@ class Hyperopt(Backtesting):
         trade_count = len(results.index)
         trade_duration = results.trade_duration.mean()
 
-        # If this evaluation contains too short small amount of trades
-        # to be interesting -- consider it as 'bad' (assign max. loss value)
+        # If this evaluation contains too short amount of trades to be
+        # interesting -- consider it as 'bad' (assigned max. loss value)
         # in order to cast this hyperspace point away from optimization
         # path. We do not want to optimize 'hodl' strategies.
         if trade_count < self.config['hyperopt_min_trades']:
@@ -235,15 +237,15 @@ class Hyperopt(Backtesting):
         Return the format result in a string
         """
         trades = len(results.index)
-        avg_profit = results.profit_percent.mean()
+        avg_profit = results.profit_percent.mean() * 100.0
         total_profit = results.profit_abs.sum()
         stake_cur = self.config['stake_currency']
-        profit = results.profit_percent.sum()
+        profit = results.profit_percent.sum() * 100.0
         duration = results.trade_duration.mean()
 
-        return (f'{trades:6d} trades. Avg profit {avg_profit: 9.6f}%. '
+        return (f'{trades:6d} trades. Avg profit {avg_profit: 5.2f}%. '
                 f'Total profit {total_profit: 11.8f} {stake_cur} '
-                f'({profit:.4f}Σ%). Avg duration {duration:5.1f} mins.')
+                f'({profit: 7.2f}Σ%). Avg duration {duration:5.1f} mins.')
 
     def get_optimizer(self, cpu_count) -> Optimizer:
         return Optimizer(
@@ -318,7 +320,7 @@ class Hyperopt(Backtesting):
                         })
                         logger.debug(f"Optimizer params: {f_val[j]['params']}")
                     for j in range(jobs):
-                        logger.debug(f"Opimizer state: Xi: {opt.Xi[-j-1]}, yi: {opt.yi[-j-1]}")
+                        logger.debug(f"Optimizer state: Xi: {opt.Xi[-j-1]}, yi: {opt.yi[-j-1]}")
         except KeyboardInterrupt:
             print('User interrupted..')
 

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -459,8 +459,8 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     }
     response_expected = {
         'loss': 1.9840569076926293,
-        'result': '     1 trades. Avg profit  0.023117%. Total profit  0.00023300 BTC '
-                  '(0.0231Σ%). Avg duration 100.0 mins.',
+        'result': '     1 trades. Avg profit  2.31%. Total profit  0.00023300 BTC '
+                  '(   2.31Σ%). Avg duration 100.0 mins.',
         'params': optimizer_param
     }
 

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -249,11 +249,12 @@ def test_log_results_if_loss_improves(hyperopt, capsys) -> None:
             'loss': 1,
             'current_tries': 1,
             'total_tries': 2,
-            'result': 'foo'
+            'result': 'foo.',
+            'initial_point': False
         }
     )
     out, err = capsys.readouterr()
-    assert '    1/2: foo. Loss 1.00000' in out
+    assert '    2/2: foo. Objective: 1.00000' in out
 
 
 def test_no_log_if_loss_does_not_improve(hyperopt, caplog) -> None:
@@ -458,7 +459,7 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     }
     response_expected = {
         'loss': 1.9840569076926293,
-        'result': '     1 trades. Avg profit  2.31%. Total profit  0.00023300 BTC '
+        'result': '     1 trades. Avg profit  0.023117%. Total profit  0.00023300 BTC '
                   '(0.0231Σ%). Avg duration 100.0 mins.',
         'params': optimizer_param
     }


### PR DESCRIPTION
A set of small improvements to hyperopt:

* Calculation of Avg Profit corrected: it no longer is multiplied by 100 so that
SumProfit% = N_trades * Avg Profit%
* The precision and the length of this printed field adjusted correspondingly.
* Number of initial random points (30) made a named constant. Later (diff. PR) should be adjustable (bigger for long optimization runs)
* A special marker sign ('*') is printed at the begining of the line with results for first N initial points. In order to distinguish random points of the rest in the optimization path. Maybe this should be printed only in the print-all mode, now is printed when no --print-all option was specified as well...
* A redundant dot in the output (noisy double dot after 'mins') removed
* A redundant empty line in the output removed when printing in the print-all mode.
* The 'Loss' term was changed to 'Objective' in the output string for clarity. The Loss term is used in the hyperopt package which is no longer used by the project. Skopt uses 'Objective function' for this.
* Numbering of evals is now human-friendly. Starts from 1 rather than 0 and ends at 1000/1000 rather than 999/1000 in case of 1000 evals.
