### PR TITLE
Fix #1840 - Support balances other than USDT

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -276,11 +276,12 @@ class RPC(object):
                 rate = 1.0
             else:
                 try:
-                    if coin == 'USDT':
-                        rate = 1.0 / self._freqtrade.get_sell_rate('BTC/USDT', False)
+                    if coin in('USDT', 'USD', 'EUR'):
+                        rate = 1.0 / self._freqtrade.get_sell_rate('BTC/' + coin, False)
                     else:
                         rate = self._freqtrade.get_sell_rate(coin + '/BTC', False)
                 except (TemporaryError, DependencyException):
+                    logger.warning(f" Could not get rate for pair {coin}.")
                     continue
             est_btc: float = rate * balance['total']
             total = total + est_btc

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -522,6 +522,11 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
             'total': 1.0,
             'free': 1.0,
             'used': 0.0
+            },
+        'EUR': {
+            'total': 10.0,
+            'free': 10.0,
+            'used': 0.0
             }
     }
 
@@ -565,6 +570,7 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     assert '*BTC:*' in result
     assert '*ETH:*' not in result
     assert '*USDT:*' in result
+    assert '*EUR:*' in result
     assert 'Balance:' in result
     assert 'Est. BTC:' in result
     assert 'BTC:  12.00000000' in result


### PR DESCRIPTION
## Summary
Getting the balance for some currencies (EUR / USD) needs to invert the pair.


Fixes: #1840

## Quick changelog

- Add EUR and USD to the inverted pairs