### PR TITLE
Update pyup only weekly

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -11,7 +11,10 @@ update: all
 # allowed: True, False
 pin: True
 
-schedule: "every day"
+# update schedule
+# default: empty
+# allowed: "every day", "every week", ..
+schedule: "every week"
 
 
 search: False


### PR DESCRIPTION
## Summary
Only update pyup once per week.
I don't think we care about the weekday, so i've not explicitly configured that - but we could if we don't like the day we get randomly.

Solves #1849

