### PR TITLE
Minor: hyperopt verify ticker data

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -445,7 +445,7 @@ class Backtesting(object):
             optimize.validate_backtest_data(data, min_date, max_date,
                                             timeframe_to_minutes(self.ticker_interval))
             logger.info(
-                'Measuring data from %s up to %s (%s days)..',
+                'Backtesting with data from %s up to %s (%s days)..',
                 min_date.isoformat(),
                 max_date.isoformat(),
                 (max_date - min_date).days

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -292,7 +292,7 @@ class Hyperopt(Backtesting):
         validate_backtest_data(data, min_date, max_date,
                                timeframe_to_minutes(self.ticker_interval))
         logger.info(
-            'Backtesting data from %s up to %s (%s days)..',
+            'Hyperopting with data from %s up to %s (%s days)..',
             min_date.isoformat(),
             max_date.isoformat(),
             (max_date - min_date).days

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -495,7 +495,7 @@ def test_backtesting_start(default_conf, mocker, caplog) -> None:
         'Using local backtesting data (using whitelist in given config) ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
-        'Measuring data from 2017-11-14T21:17:00+00:00 '
+        'Backtesting with data from 2017-11-14T21:17:00+00:00 '
         'up to 2017-11-14T22:59:00+00:00 (0 days)..'
     ]
     for line in exists:
@@ -858,7 +858,8 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
         'Downloading data for all pairs in whitelist ...',
-        'Measuring data from 2017-11-14T19:31:00+00:00 up to 2017-11-14T22:58:00+00:00 (0 days)..',
+        'Backtesting with data from 2017-11-14T19:31:00+00:00 '
+        'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...'
     ]
 
@@ -916,7 +917,8 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
         'Downloading data for all pairs in whitelist ...',
-        'Measuring data from 2017-11-14T19:31:00+00:00 up to 2017-11-14T22:58:00+00:00 (0 days)..',
+        'Backtesting with data from 2017-11-14T19:31:00+00:00 '
+        'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...',
         'Running backtesting for Strategy DefaultStrategy',
         'Running backtesting for Strategy TestStrategy',


### PR DESCRIPTION
* Verification of the loaded ticker data. Taken and slightly adapted from backtesting part.
* Log time interval (min_date, max_date, duration) used for backtesting.
* New test for no data case added.

Part of #1775.
