### PR TITLE
Suppress scikit-learn deprecation warning in hyperopt

### DIFF
--- a/freqtrade/optimize/default_hyperopt.py
+++ b/freqtrade/optimize/default_hyperopt.py
@@ -5,10 +5,10 @@ from pandas import DataFrame
 from typing import Dict, Any, Callable, List
 from functools import reduce
 
-from skopt.space import Categorical, Dimension, Integer, Real
-
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
+from freqtrade.optimize.hyperopt_interface import Categorical, Dimension, Integer, Real
+
 
 class_name = 'DefaultHyperOpts'
 

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -2,7 +2,6 @@
 IHyperOpt interface
 This module defines the interface to apply for hyperopts
 """
-
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Callable, List
 
@@ -30,11 +29,15 @@ from pandas import DataFrame
 # where it will probably be eliminated...
 #
 import warnings
+
+
 def warn(*args, **kwargs):
     pass
+
+
 old_warn = warnings.showwarning
 warnings.showwarning = warn
-from skopt.space import Categorical, Dimension, Integer, Real
+from skopt.space import Categorical, Dimension, Integer, Real  # noqa: F401
 warnings.showwarning = old_warn
 
 

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -7,7 +7,35 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, Callable, List
 
 from pandas import DataFrame
-from skopt.space import Dimension
+
+#
+# Filter warnings from importing scikit-learn via skopt.
+# scikit-learn specifically forces warnings to be displayed, which we don't like.
+#
+# See:
+# https://github.com/scikit-learn/scikit-learn/issues/2531
+# https://github.com/ims-tcl/DeRE/commit/cb865fedddf6977cb7536b8c4334dc2325d09e53
+# https://stackoverflow.com/questions/32612180/eliminating-warnings-from-scikit-learn
+# for more details.
+#
+# Use
+# from freqtrade.optimize.hyperopt_interface import Categorical, Dimension, Integer, Real
+# instead of
+# from skopt.space import Categorical, Dimension, Integer, Real
+# in the custom HyperOpts to get rid of this deprecation warning
+# (refer to default_hyperopt.py for example) without implementing this ugly
+# workaround in every custom HyperOpts.
+#
+# Let's wait till scikit-learn v0.23 and skopt using it
+# where it will probably be eliminated...
+#
+import warnings
+def warn(*args, **kwargs):
+    pass
+old_warn = warnings.showwarning
+warnings.showwarning = warn
+from skopt.space import Categorical, Dimension, Integer, Real
+warnings.showwarning = old_warn
 
 
 class IHyperOpt(ABC):

--- a/user_data/hyperopts/sample_hyperopt.py
+++ b/user_data/hyperopts/sample_hyperopt.py
@@ -6,10 +6,11 @@ from typing import Dict, Any, Callable, List
 from functools import reduce
 
 import numpy
-from skopt.space import Categorical, Dimension, Integer, Real
 
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
+from freqtrade.optimize.hyperopt_interface import Categorical, Dimension, Integer, Real
+
 
 class_name = 'SampleHyperOpts'
 


### PR DESCRIPTION
That was not as easy... 😃 

scikit-learn specifically forces warnings to be displayed, which we don't like.
Plus, it is not used by freqtrade directly but via skopt...

See #1853 for examples of the warning.

See:
* https://github.com/scikit-learn/scikit-learn/issues/2531
* https://github.com/ims-tcl/DeRE/commit/cb865fedddf6977cb7536b8c4334dc2325d09e53
* https://stackoverflow.com/questions/32612180/eliminating-warnings-from-scikit-learn

for more details.

Use
```
from freqtrade.optimize.hyperopt_interface import Categorical, Dimension, Integer, Real
```
instead of
```
from skopt.space import Categorical, Dimension, Integer, Real
```
in the custom HyperOpts to get rid of this deprecation warning
(refer to default_hyperopt.py for example) without implementing this ugly
workaround in every custom HyperOpts.

Let's wait till scikit-learn v0.23 released and skopt using it
where it will probably be eliminated...
