### PR TITLE
minor: inherit freqtrade exceptions from Exception instead of BaseException

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -2,14 +2,14 @@
 __version__ = '0.18.5-dev'
 
 
-class DependencyException(BaseException):
+class DependencyException(Exception):
     """
-    Indicates that a assumed dependency is not met.
+    Indicates that an assumed dependency is not met.
     This could happen when there is currently not enough money on the account.
     """
 
 
-class OperationalException(BaseException):
+class OperationalException(Exception):
     """
     Requires manual intervention.
     This happens when an exchange returns an unexpected error during runtime
@@ -17,7 +17,7 @@ class OperationalException(BaseException):
     """
 
 
-class InvalidOrderException(BaseException):
+class InvalidOrderException(Exception):
     """
     This is returned when the order is not valid. Example:
     If stoploss on exchange order is hit, then trying to cancel the order
@@ -25,7 +25,7 @@ class InvalidOrderException(BaseException):
     """
 
 
-class TemporaryError(BaseException):
+class TemporaryError(Exception):
     """
     Temporary network or exchange related error.
     This could happen when an exchange is congested, unavailable, or the user


### PR DESCRIPTION
https://docs.python.org/3/library/exceptions.html#BaseException:

> exception BaseException ... It is not meant to be directly inherited by user-defined classes (for that, use Exception).

https://docs.python.org/3/library/exceptions.html#built-in-exceptions

> programmers are encouraged to derive new exceptions from the Exception class or one of its subclasses, and not from BaseException.

In one of the next PRs I'll show why this has actually sence for freqtrade codebase.

In RPC module, for example, the RPCException is inherited from Exception, which is correct.
