### PR TITLE
minor: remove noisy useless debug message

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -238,7 +238,6 @@ class Trade(_DECL_BASE):
         """
         Adjust the max_rate and min_rate.
         """
-        logger.debug("Adjusting min/max rates")
         self.max_rate = max(current_price, self.max_rate or self.open_rate)
         self.min_rate = min(current_price, self.min_rate or self.open_rate)
 


### PR DESCRIPTION
,,,in the persistence module

How to reproduce: run
```
python3 freqtrade -v backtesting
```

The log is filled with noisy message "Adjusting min/max rates", which is printed for every candle for every pair during backtesting and do not provide any useful info.
