### PR TITLE
edge: handle properly the 'No trades' case

### DIFF
--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -139,6 +139,7 @@ class Edge():
 
         # If no trade found then exit
         if len(trades) == 0:
+            logger.info("No trades created.")
             return False
 
         # Fill missing, calculable columns, profit, duration , abs etc.

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -139,7 +139,7 @@ class Edge():
 
         # If no trade found then exit
         if len(trades) == 0:
-            logger.info("No trades created.")
+            logger.info("No trades found.")
             return False
 
         # Fill missing, calculable columns, profit, duration , abs etc.

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -73,9 +73,10 @@ class EdgeCli(object):
                         floatfmt=floatfmt, tablefmt="pipe")
 
     def start(self) -> None:
-        self.edge.calculate()
-        print('')  # blank like for readability
-        print(self._generate_edge_table(self.edge._cached_pairs))
+        result = self.edge.calculate()
+        if result:
+            print('')  # blank like for readability
+            print(self._generate_edge_table(self.edge._cached_pairs))
 
 
 def setup_configuration(args: Namespace) -> Dict[str, Any]:

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -75,7 +75,7 @@ class EdgeCli(object):
     def start(self) -> None:
         result = self.edge.calculate()
         if result:
-            print('')  # blank like for readability
+            print('')  # blank line for readability
             print(self._generate_edge_table(self.edge._cached_pairs))
 
 


### PR DESCRIPTION
When edge calculation produces empty trades list (for instance, if the timerange is too short to contain any trade signals with the strategy used):
* the 'No trades found.' info log message is printed
* the empty edge table is not printed anymore in the edge_cli

How to reproduce:
```
freqtrade --strategy TestStrategy edge -r
```
with `"ticker_interval" : "1d"` in the config (I tested with binance exchange used); clean the exchange datadir before.

Resolves (corrects behaviour) #1869
