### PR TITLE
fix TypeError from reduce() in hyperopts

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -122,9 +122,10 @@ So let's write the buy strategy using these values:
                         dataframe['macd'], dataframe['macdsignal']
                     ))
 
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'buy'] = 1
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'buy'] = 1
 
             return dataframe
 

--- a/freqtrade/optimize/default_hyperopt.py
+++ b/freqtrade/optimize/default_hyperopt.py
@@ -70,9 +70,10 @@ class DefaultHyperOpts(IHyperOpt):
                         dataframe['close'], dataframe['sar']
                     ))
 
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'buy'] = 1
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'buy'] = 1
 
             return dataframe
 
@@ -129,9 +130,10 @@ class DefaultHyperOpts(IHyperOpt):
                         dataframe['sar'], dataframe['close']
                     ))
 
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'sell'] = 1
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'sell'] = 1
 
             return dataframe
 

--- a/user_data/hyperopts/sample_hyperopt.py
+++ b/user_data/hyperopts/sample_hyperopt.py
@@ -79,9 +79,10 @@ class SampleHyperOpts(IHyperOpt):
                         dataframe['close'], dataframe['sar']
                     ))
 
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'buy'] = 1
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'buy'] = 1
 
             return dataframe
 
@@ -138,9 +139,10 @@ class SampleHyperOpts(IHyperOpt):
                         dataframe['sar'], dataframe['close']
                     ))
 
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'sell'] = 1
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'sell'] = 1
 
             return dataframe
 


### PR DESCRIPTION
Resolves the problem reported in #1872.

If for any reason -- wide hyperoptimization parameters space when it contains many points with no trades, short timerange which does not fit any trades, inactive pairs in the whitelist, unlucky point in the optimization hyperspace or simply a buggy strategy defined in the custom (or even default) hyperopt -- if for any reason the `conditions` list defined in the populate_buy_trend() and in populate_sell_trend() (those inside buy_strategy_generator() and sell_strategy_generator() respectively) is empty, the bot crashes with the following exception:
```
TypeError: reduce() of empty sequence with no initial value
```

This PR fixes it.

TODO (sep. PR): This PR can be considered as first workaround. Further, exceptions from Backtesting.backtest() should be catched in Hyperopt.generate_optimizer(), the objective function for such evals should be assigned the MAX_LOSS value and printed gracefully. Hyperopt should not stop iterating evaluations if one of them generated an exception.
