### PR TITLE
[proposal] Eliminate bin/freqtrade

### DIFF
--- a/bin/freqtrade
+++ b/bin/freqtrade
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+import warnings
+
+from freqtrade.main import main, set_loggers
+
+set_loggers()
+
+warnings.warn(
+    "Deprecated - To continue to run the bot like this, please run `pip install -e .` again.",
+    DeprecationWarning)
+main(sys.argv[1:])

--- a/bin/freqtrade
+++ b/bin/freqtrade
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-from freqtrade.main import main, set_loggers
-set_loggers()
-main(sys.argv[1:])

--- a/freqtrade/__main__.py
+++ b/freqtrade/__main__.py
@@ -6,9 +6,7 @@ To launch Freqtrade as a module
 > python -m freqtrade (with Python >= 3.6)
 """
 
-import sys
-
 from freqtrade import main
 
 if __name__ == '__main__':
-    main.main(sys.argv[1:])
+    main.main()

--- a/freqtrade/__main__.py
+++ b/freqtrade/__main__.py
@@ -11,5 +11,4 @@ import sys
 from freqtrade import main
 
 if __name__ == '__main__':
-    main.set_loggers()
     main.main(sys.argv[1:])

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -27,7 +27,7 @@ class Arguments(object):
     Arguments Class. Manage the arguments received by the cli
     """
 
-    def __init__(self, args: List[str], description: str) -> None:
+    def __init__(self, args: Optional[List[str]], description: str) -> None:
         self.args = args
         self.parsed_arg: Optional[argparse.Namespace] = None
         self.parser = argparse.ArgumentParser(description=description)

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -28,21 +28,7 @@ def main(sysargv: List[str] = None) -> None:
     This function will initiate the bot and start the trading loop.
     :return: None
     """
-    set_loggers()
-    arguments = Arguments(
-        sysargv,
-        'Free, open source crypto trading bot'
-    )
-    args: Namespace = arguments.get_parsed_arg()
 
-    # A subcommand has been issued.
-    # Means if Backtesting or Hyperopt have been called we exit the bot
-    if hasattr(args, 'func'):
-        args.func(args)
-        return
-
-    worker = None
-    return_code = 1
     try:
         set_loggers()
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -23,7 +23,7 @@ from freqtrade.worker import Worker
 logger = logging.getLogger('freqtrade')
 
 
-def main(sysargv: List[str]) -> None:
+def main(sysargv: List[str] = None) -> None:
     """
     This function will initiate the bot and start the trading loop.
     :return: None
@@ -81,4 +81,4 @@ def main(sysargv: List[str]) -> None:
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -28,7 +28,24 @@ def main(sysargv: List[str]) -> None:
     This function will initiate the bot and start the trading loop.
     :return: None
     """
+    set_loggers()
+    arguments = Arguments(
+        sysargv,
+        'Free, open source crypto trading bot'
+    )
+    args: Namespace = arguments.get_parsed_arg()
+
+    # A subcommand has been issued.
+    # Means if Backtesting or Hyperopt have been called we exit the bot
+    if hasattr(args, 'func'):
+        args.func(args)
+        return
+
+    worker = None
+    return_code = 1
     try:
+        set_loggers()
+
         worker = None
         return_code = 1
 
@@ -64,5 +81,4 @@ def main(sysargv: List[str]) -> None:
 
 
 if __name__ == '__main__':
-    set_loggers()
     main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(name='freqtrade',
       author_email='michael.egger@tsn.at',
       license='GPLv3',
       packages=['freqtrade'],
-      scripts=['bin/freqtrade'],
       setup_requires=['pytest-runner', 'numpy'],
       tests_require=['pytest', 'pytest-mock', 'pytest-cov'],
       install_requires=[
@@ -43,6 +42,11 @@ setup(name='freqtrade',
       ],
       include_package_data=True,
       zip_safe=False,
+      entry_points={
+          'console_scripts': [
+              'freqtrade = freqtrade.main:main',
+          ],
+      },
       classifiers=[
           'Programming Language :: Python :: 3.6',
           'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
## Summary
Remove the "binary" script we had and replace it with the "entrypoint" logic (which automatically generates an executable file in the installation folder).

## Quick changelog

- Remove bin/freqtrade helper file
- Rely on setuptools "entrypoint" feature
- All methods of execution i'm aware of still work `python -m freqtrade`, `freqtrade --help` `python freqtrade/main.py --help` ...

In the future, this method would allow us to specify more entry points (ft_download) for the download script, for example.

## caveats 
I'm putting this as proposal since it will break existing "linked" installations (installed with `pip install -e .`) with the following error:

```
 Traceback (most recent call last):
  File ".../bin/freqtrade", line 6, in <module>
    with open(__file__) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/xmatt/development/python/freqtrade/bin/freqtrade
```