### PR TITLE
Cleanup installation documentation

### DIFF
--- a/Dockerfile.technical
+++ b/Dockerfile.technical
@@ -3,4 +3,4 @@ FROM freqtradeorg/freqtrade:develop
 RUN apt-get update \
     && apt-get -y install git \
     && apt-get clean \
-    && pip install git+https://github.com/berlinguyinca/technical
+    && pip install git+https://github.com/freqtrade/technical

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ The project is currently setup in two main branches:
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
 - `feat/*` - These are feature branches, which are being worked on heavily. Please don't use these unless you want to test a specific feature.
 
-
 ## A note on Binance
 
 For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -8,7 +8,7 @@ Start by downloading and installing Docker CE for your platform:
 * [Windows](https://docs.docker.com/docker-for-windows/install/)
 * [Linux](https://docs.docker.com/install/)
 
-Once you have Docker installed, simply create the config file (e.g. `config.json`) and run the image for `freqtrade` as explained below.
+Once you have Docker installed, simply prepare the config file (e.g. `config.json`) and run the image for `freqtrade` as explained below.
 
 ## Download the official FreqTrade docker image
 
@@ -74,7 +74,7 @@ touch tradesv3.dryrun.sqlite
 
 Best start by pulling the official docker image from dockerhub as explained [here](#download-the-official-docker-image) to speed up building.
 
-To add additional libaries to your docker image, best check out [Dockerfile.technical](https://github.com/freqtrade/freqtrade/blob/develop/Dockerfile.technical) which adds the [technical](https://github.com/freqtrade/technical) module to the image.
+To add additional libraries to your docker image, best check out [Dockerfile.technical](https://github.com/freqtrade/freqtrade/blob/develop/Dockerfile.technical) which adds the [technical](https://github.com/freqtrade/technical) module to the image.
 
 ```bash
 docker build -t freqtrade -f Dockerfile.technical .
@@ -164,7 +164,7 @@ docker run -d \
     To override this behaviour use a custom db-url value: i.e.: `--db-url sqlite:///tradesv3.dryrun.sqlite`
 
 !!! Note
-    All available command line arguments can be added to the end of the `docker run` command.
+    All available bot command line parameters can be added to the end of the `docker run` command.
 
 ### Monitor your Docker instance
 
@@ -201,4 +201,4 @@ docker run -d \
 Head over to the [Backtesting Documentation](backtesting.md) for more details.
 
 !!! Note
-    Additional parameters can be appended after the image name (`freqtrade` in the above example).
+    Additional bot command line parameters can be appended after the image name (`freqtrade` in the above example).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,204 @@
+# Using FreqTrade with Docker
+
+## Install Docker
+
+Start by downloading and installing Docker CE for your platform:
+
+* [Mac](https://docs.docker.com/docker-for-mac/install/)
+* [Windows](https://docs.docker.com/docker-for-windows/install/)
+* [Linux](https://docs.docker.com/install/)
+
+Once you have Docker installed, simply create the config file (e.g. `config.json`) and run the image for `freqtrade` as explained below.
+
+## Download the official FreqTrade docker image
+
+Pull the image from docker hub.
+
+Branches / tags available can be checked out on [Dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/tags/).
+
+```bash
+docker pull freqtradeorg/freqtrade:develop
+# Optionally tag the repository so the run-commands remain shorter
+docker tag freqtradeorg/freqtrade:develop freqtrade
+```
+
+To update the image, simply run the above commands again and restart your running container.
+
+Should you require additional libraries, please [build the image yourself](#build-your-own-docker-image).
+
+### Prepare the configuration files
+
+Even though you will use docker, you'll still need some files from the github repository.
+
+#### Clone the git repository
+
+Linux/Mac/Windows with WSL
+
+```bash
+git clone https://github.com/freqtrade/freqtrade.git
+```
+
+Windows with docker
+
+```bash
+git clone --config core.autocrlf=input https://github.com/freqtrade/freqtrade.git
+```
+
+#### Copy `config.json.example` to `config.json`
+
+```bash
+cd freqtrade
+cp -n config.json.example config.json
+```
+
+> To understand the configuration options, please refer to the [Bot Configuration](configuration.md) page.
+
+#### Create your database file
+
+Production
+
+```bash
+touch tradesv3.sqlite
+````
+
+Dry-Run
+
+```bash
+touch tradesv3.dryrun.sqlite
+```
+
+!!! Note
+    Make sure to use the path to this file when starting the bot in docker.
+
+### Build your own Docker image
+
+Best start by pulling the official docker image from dockerhub as explained [here](#download-the-official-docker-image) to speed up building.
+
+To add additional libaries to your docker image, best check out [Dockerfile.technical](https://github.com/freqtrade/freqtrade/blob/develop/Dockerfile.technical) which adds the [technical](https://github.com/freqtrade/technical) module to the image.
+
+```bash
+docker build -t freqtrade -f Dockerfile.technical .
+```
+
+If you are developing using Docker, use `Dockerfile.develop` to build a dev Docker image, which will also set up develop dependencies:
+
+```bash
+docker build -f Dockerfile.develop -t freqtrade-dev .
+```
+
+!!! Note
+    For security reasons, your configuration file will not be included in the image, you will need to bind mount it. It is also advised to bind mount an SQLite database file (see the "5. Run a restartable docker image" section) to keep it between  updates.
+
+#### Verify the Docker image
+
+After the build process you can verify that the image was created with:
+
+```bash
+docker images
+```
+
+The output should contain the freqtrade image.
+
+### Run the Docker image
+
+You can run a one-off container that is immediately deleted upon exiting with the following command (`config.json` must be in the current working directory):
+
+```bash
+docker run --rm -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+```
+
+!!! Warning
+    In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
+
+#### Adjust timezone
+
+By default, the container will use UTC timezone.
+Should you find this irritating please add the following to your docker commands:
+
+##### Linux
+
+``` bash
+-v /etc/timezone:/etc/timezone:ro
+
+# Complete command:
+docker run --rm -v /etc/timezone:/etc/timezone:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+```
+
+##### MacOS
+
+There is known issue in OSX Docker versions after 17.09.1, whereby `/etc/localtime` cannot be shared causing Docker to not start. A work-around for this is to start with the following cmd.
+
+```bash
+docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+```
+
+More information on this docker issue and work-around can be read [here](https://github.com/docker/for-mac/issues/2396).
+
+### Run a restartable docker image
+
+To run a restartable instance in the background (feel free to place your configuration and database files wherever it feels comfortable on your filesystem).
+
+#### Move your config file and database
+
+The following will assume that you place your configuration / database files to `~/.freqtrade`, which is a hidden folder in your home directory. Feel free to use a different folder and replace the folder in the upcomming commands.
+
+```bash
+mkdir ~/.freqtrade
+mv config.json ~/.freqtrade
+mv tradesv3.sqlite ~/.freqtrade
+```
+
+#### Run the docker image
+
+```bash
+docker run -d \
+  --name freqtrade \
+  -v ~/.freqtrade/config.json:/freqtrade/config.json \
+  -v ~/.freqtrade/user_data/:/freqtrade/user_data \
+  -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
+  freqtrade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
+```
+
+!!! Note
+    db-url defaults to `sqlite:///tradesv3.sqlite` but it defaults to `sqlite://` if `dry_run=True` is being used.
+    To override this behaviour use a custom db-url value: i.e.: `--db-url sqlite:///tradesv3.dryrun.sqlite`
+
+!!! Note
+    All available command line arguments can be added to the end of the `docker run` command.
+
+### Monitor your Docker instance
+
+You can use the following commands to monitor and manage your container:
+
+```bash
+docker logs freqtrade
+docker logs -f freqtrade
+docker restart freqtrade
+docker stop freqtrade
+docker start freqtrade
+```
+
+For more information on how to operate Docker, please refer to the [official Docker documentation](https://docs.docker.com/).
+
+!!! Note
+    You do not need to rebuild the image for configuration changes, it will suffice to edit `config.json` and restart the container.
+
+### Backtest with docker
+
+The following assumes that the download/setup of the docker image have been completed successfully.
+Also, backtest-data should be available at `~/.freqtrade/user_data/`.
+
+```bash
+docker run -d \
+  --name freqtrade \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v ~/.freqtrade/config.json:/freqtrade/config.json \
+  -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
+  -v ~/.freqtrade/user_data/:/freqtrade/user_data/ \
+  freqtrade --strategy AwsomelyProfitableStrategy backtesting
+```
+
+Head over to the [Backtesting Documentation](backtesting.md) for more details.
+
+!!! Note
+    Additional parameters can be appended after the image name (`freqtrade` in the above example).

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,12 +36,14 @@ Freqtrade is a cryptocurrency trading bot written in Python.
  - Daily summary of profit/loss: Receive the daily summary of your profit/loss.
  - Performance status report: Receive the performance status of your current trades.
 
-
 ## Requirements
+
 ### Up to date clock
+
 The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
 
 ### Hardware requirements
+
 To run this bot we recommend you a cloud instance with a minimum of:
 
 - 2GB RAM
@@ -49,6 +51,7 @@ To run this bot we recommend you a cloud instance with a minimum of:
 - 2vCPU
 
 ### Software requirements
+
 - Python 3.6.x
 - pip (pip3)
 - git
@@ -58,10 +61,12 @@ To run this bot we recommend you a cloud instance with a minimum of:
 
 
 ## Support
+
 Help / Slack
 For any questions not covered by the documentation or for further information about the bot, we encourage you to join our Slack channel.
 
 Click [here](https://join.slack.com/t/highfrequencybot/shared_invite/enQtMjQ5NTM0OTYzMzY3LWMxYzE3M2MxNDdjMGM3ZTYwNzFjMGIwZGRjNTc3ZGU3MGE3NzdmZGMwNmU3NDM5ZTNmM2Y3NjRiNzk4NmM4OGE) to join Slack channel.
 
 ## Ready to try?
+
 Begin by reading our installation guide [here](installation).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,9 @@
 # Installation
+
 This page explains how to prepare your environment for running the bot.
 
 ## Prerequisite
+
 Before running your bot in production you will need to setup few
 external API. In production mode, the bot required valid Bittrex API
 credentials and a Telegram bot (optional but recommended).
@@ -10,9 +12,11 @@ credentials and a Telegram bot (optional but recommended).
 - [Backtesting commands](#setup-your-telegram-bot)
 
 ### Setup your exchange account
+
 *To be completed, please feel free to complete this section.*
 
 ### Setup your Telegram bot
+
 The only things you need is a working Telegram bot and its API token.
 Below we explain how to create your Telegram Bot, and how to get your
 Telegram user id.
@@ -35,7 +39,9 @@ Good. Now let's choose a username for your bot. It must end in `bot`. Like this,
 
 **1.5. Father bot will return you the token (API key)**<br/>
 Copy it and keep it you will use it for the config parameter `token`.
+
 *BotFather response:*
+
 ```hl_lines="4"
 Done! Congratulations on your new bot. You will find it at t.me/My_own_freqtrade_bot. You can now add a description, about section and profile picture for your bot, see /help for a list of commands. By the way, when you've finished creating your cool bot, ping our Bot Support if you want a better username for it. Just make sure the bot is fully operational before you do this.
 
@@ -44,15 +50,18 @@ Use this token to access the HTTP API:
 
 For a description of the Bot API, see this page: https://core.telegram.org/bots/api
 ```
+
 **1.6. Don't forget to start the conversation with your bot, by clicking /START button**
 
 ### 2. Get your user id
+
 **2.1. Talk to https://telegram.me/userinfobot**
 
 **2.2. Get your "Id", you will use it for the config parameter
 `chat_id`.**
-<hr/>
+
 ## Quick start
+
 Freqtrade provides a Linux/MacOS script to install all dependencies and help you to configure the bot.
 
 ```bash
@@ -61,9 +70,10 @@ cd freqtrade
 git checkout develop
 ./setup.sh --install
 ```
+
 !!! Note
     Windows installation is explained [here](#windows).
-<hr/>
+
 ## Easy Installation - Linux Script
 
 If you are on Debian, Ubuntu or MacOS a freqtrade provides a script to Install, Update, Configure, and Reset your bot.
@@ -98,193 +108,6 @@ Reset parameter will hard reset your branch (only if you are on `master` or `dev
 ** --config **
 
 Config parameter is a `config.json` configurator. This script will ask you questions to setup your bot and create your `config.json`.
-
-------
-
-## Automatic Installation - Docker
-
-Start by downloading Docker for your platform:
-
-* [Mac](https://www.docker.com/products/docker#/mac)
-* [Windows](https://www.docker.com/products/docker#/windows)
-* [Linux](https://www.docker.com/products/docker#/linux)
-
-Once you have Docker installed, simply create the config file (e.g. `config.json`) and then create a Docker image for `freqtrade` using the Dockerfile in this repo.
-
-### 1. Prepare the Bot
-
-**1.1. Clone the git repository**
-
-Linux/Mac/Windows with WSL
-```bash
-git clone https://github.com/freqtrade/freqtrade.git
-```
-
-Windows with docker
-```bash
-git clone --config core.autocrlf=input https://github.com/freqtrade/freqtrade.git
-```
-
-**1.2. (Optional) Checkout the develop branch**
-
-```bash
-git checkout develop
-```
-
-**1.3. Go into the new directory**
-
-```bash
-cd freqtrade
-```
-
-**1.4. Copy `config.json.example` to `config.json`**
-
-```bash
-cp -n config.json.example config.json
-```
-
-> To edit the config please refer to the [Bot Configuration](configuration.md) page.
-
-**1.5. Create your database file *(optional - the bot will create it if it is missing)**
-
-Production
-
-```bash
-touch tradesv3.sqlite
-````
-
-Dry-Run
-
-```bash
-touch tradesv3.dryrun.sqlite
-```
-
-### 2. Download or build the docker image
-
-Either use the prebuilt image from docker hub - or build the image yourself if you would like more control on which version is used.
-
-Branches / tags available can be checked out on [Dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/tags/).
-
-**2.1. Download the docker image**
-
-Pull the image from docker hub and (optionally) change the name of the image
-
-```bash
-docker pull freqtradeorg/freqtrade:develop
-# Optionally tag the repository so the run-commands remain shorter
-docker tag freqtradeorg/freqtrade:develop freqtrade
-```
-
-To update the image, simply run the above commands again and restart your running container.
-
-**2.2. Build the Docker image**
-
-```bash
-cd freqtrade
-docker build -t freqtrade .
-```
-
-If you are developing using Docker, use `Dockerfile.develop` to build a dev Docker image, which will also set up develop dependencies:
-
-```bash
-docker build -f ./Dockerfile.develop -t freqtrade-dev .
-```
-
-For security reasons, your configuration file will not be included in the image, you will need to bind mount it. It is also advised to bind mount an SQLite database file (see the "5. Run a restartable docker image" section) to keep it between  updates.
-
-### 3. Verify the Docker image
-
-After the build process you can verify that the image was created with:
-
-```bash
-docker images
-```
-
-### 4. Run the Docker image
-
-You can run a one-off container that is immediately deleted upon exiting with the following command (`config.json` must be in the current working directory):
-
-```bash
-docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
-```
-
-There is known issue in OSX Docker versions after 17.09.1, whereby /etc/localtime cannot be shared causing Docker to not start. A work-around for this is to start with the following cmd.
-
-```bash
-docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
-```
-
-More information on this docker issue and work-around can be read [here](https://github.com/docker/for-mac/issues/2396).
-
-In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
-
-### 5. Run a restartable docker image
-
-To run a restartable instance in the background (feel free to place your configuration and database files wherever it feels comfortable on your filesystem).
-
-**5.1. Move your config file and database**
-
-```bash
-mkdir ~/.freqtrade
-mv config.json ~/.freqtrade
-mv tradesv3.sqlite ~/.freqtrade
-```
-
-**5.2. Run the docker image**
-
-```bash
-docker run -d \
-  --name freqtrade \
-  -v /etc/localtime:/etc/localtime:ro \
-  -v ~/.freqtrade/config.json:/freqtrade/config.json \
-  -v ~/.freqtrade/user_data/:/freqtrade/user_data \
-  -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
-  freqtrade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
-```
-
-!!! Note
-    db-url defaults to `sqlite:///tradesv3.sqlite` but it defaults to `sqlite://` if `dry_run=True` is being used.
-    To override this behaviour use a custom db-url value: i.e.: `--db-url sqlite:///tradesv3.dryrun.sqlite`
-
-!!! Note
-    All command line arguments can be added to the end of the `docker run` command.
-
-### 6. Monitor your Docker instance
-
-You can then use the following commands to monitor and manage your container:
-
-```bash
-docker logs freqtrade
-docker logs -f freqtrade
-docker restart freqtrade
-docker stop freqtrade
-docker start freqtrade
-```
-
-For more information on how to operate Docker, please refer to the [official Docker documentation](https://docs.docker.com/).
-
-!!! Note
-    You do not need to rebuild the image for configuration changes, it will suffice to edit `config.json` and restart the container.
-
-### 7. Backtest with docker
-
-The following assumes that the above steps (1-4) have been completed successfully.
-Also, backtest-data should be available at `~/.freqtrade/user_data/`.
-
-```bash
-docker run -d \
-  --name freqtrade \
-  -v /etc/localtime:/etc/localtime:ro \
-  -v ~/.freqtrade/config.json:/freqtrade/config.json \
-  -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
-  -v ~/.freqtrade/user_data/:/freqtrade/user_data/ \
-  freqtrade --strategy AwsomelyProfitableStrategy backtesting
-```
-
-Head over to the [Backtesting Documentation](backtesting.md) for more details.
-
-!!! Note
-    Additional parameters can be appended after the image name (`freqtrade` in the above example).
 
 ------
 
@@ -413,7 +236,7 @@ If this is the first time you run the bot, ensure you are running it in Dry-run 
 python3.6 freqtrade -c config.json
 ```
 
-*Note*: If you run the bot on a server, you should consider using [Docker](#automatic-installation---docker) a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.
+*Note*: If you run the bot on a server, you should consider using [Docker](docker.md) or a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.
 
 #### 7. [Optional] Configure `freqtrade` as a `systemd` service
 
@@ -441,14 +264,13 @@ The `freqtrade.service.watchdog` file contains an example of the service unit co
 as the watchdog.
 
 !!! Note 
-  The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a 
-  Docker container.
+  The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a Docker container.
 
 ------
 
 ## Windows
 
-We recommend that Windows users use [Docker](#docker) as this will work much easier and smoother (also more secure).
+We recommend that Windows users use [Docker](docker.md) as this will work much easier and smoother (also more secure).
 
 If that is not possible, try using the Windows Linux subsystem (WSL) - for which the Ubuntu instructions should work.
 If that is not available on your system, feel free to try the instructions below, which led to success for some.
@@ -492,7 +314,7 @@ error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual C++ 
 
 Unfortunately, many packages requiring compilation don't provide a pre-build wheel. It is therefore mandatory to have a C/C++ compiler installed and available for your python environment to use.
 
-The easiest way is to download install Microsoft Visual Studio Community [here](https://visualstudio.microsoft.com/downloads/) and make sure to install "Common Tools for Visual C++" to enable building c code on Windows. Unfortunately, this is a heavy download / dependency (~4Gb) so you might want to consider WSL or docker first.
+The easiest way is to download install Microsoft Visual Studio Community [here](https://visualstudio.microsoft.com/downloads/) and make sure to install "Common Tools for Visual C++" to enable building c code on Windows. Unfortunately, this is a heavy download / dependency (~4Gb) so you might want to consider WSL or [docker](docker.md) first.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,60 +5,14 @@ This page explains how to prepare your environment for running the bot.
 ## Prerequisite
 
 Before running your bot in production you will need to setup few
-external API. In production mode, the bot required valid Bittrex API
-credentials and a Telegram bot (optional but recommended).
+external API. In production mode, the bot will require valid Exchange API
+credentials. We also reccomend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot) (optional but recommended).
 
 - [Setup your exchange account](#setup-your-exchange-account)
-- [Backtesting commands](#setup-your-telegram-bot)
 
 ### Setup your exchange account
 
-*To be completed, please feel free to complete this section.*
-
-### Setup your Telegram bot
-
-The only things you need is a working Telegram bot and its API token.
-Below we explain how to create your Telegram Bot, and how to get your
-Telegram user id.
-
-### 1. Create your Telegram bot
-
-**1.1. Start a chat with https://telegram.me/BotFather**
-
-**1.2. Send the message `/newbot`. ** *BotFather response:*
-```
-Alright, a new bot. How are we going to call it? Please choose a name for your bot.
-```
-
-**1.3. Choose the public name of your bot (e.x. `Freqtrade bot`)**
-*BotFather response:*
-```
-Good. Now let's choose a username for your bot. It must end in `bot`. Like this, for example: TetrisBot or tetris_bot.
-```
-**1.4. Choose the name id of your bot (e.x "`My_own_freqtrade_bot`")**
-
-**1.5. Father bot will return you the token (API key)**<br/>
-Copy it and keep it you will use it for the config parameter `token`.
-
-*BotFather response:*
-
-```hl_lines="4"
-Done! Congratulations on your new bot. You will find it at t.me/My_own_freqtrade_bot. You can now add a description, about section and profile picture for your bot, see /help for a list of commands. By the way, when you've finished creating your cool bot, ping our Bot Support if you want a better username for it. Just make sure the bot is fully operational before you do this.
-
-Use this token to access the HTTP API:
-521095879:AAEcEZEL7ADJ56FtG_qD0bQJSKETbXCBCi0
-
-For a description of the Bot API, see this page: https://core.telegram.org/bots/api
-```
-
-**1.6. Don't forget to start the conversation with your bot, by clicking /START button**
-
-### 2. Get your user id
-
-**2.1. Talk to https://telegram.me/userinfobot**
-
-**2.2. Get your "Id", you will use it for the config parameter
-`chat_id`.**
+You will need to create API Keys (Usually you get `key` and `secret`) from the Exchange website and insert this into the appropriate fields in the configuration or when asked by the installation script.
 
 ## Quick start
 

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -1,10 +1,45 @@
 # Telegram usage
 
-## Prerequisite
+## Setup your Telegram bot
 
-To control your bot with Telegram, you need first to
-[set up a Telegram bot](installation.md)
-and add your Telegram API keys into your config file.
+Below we explain how to create your Telegram Bot, and how to get your
+Telegram user id.
+
+### 1. Create your Telegram bot
+
+Start a chat with the [Telegram BotFather](https://telegram.me/BotFather)
+
+Send the message `/newbot`. 
+
+*BotFather response:*
+
+> Alright, a new bot. How are we going to call it? Please choose a name for your bot.
+
+Choose the public name of your bot (e.x. `Freqtrade bot`)
+
+*BotFather response:*
+
+> Good. Now let's choose a username for your bot. It must end in `bot`. Like this, for example: TetrisBot or tetris_bot.
+
+Choose the name id of your bot and send it to the BotFather (e.g. "`My_own_freqtrade_bot`")
+
+*BotFather response:*
+
+> Done! Congratulations on your new bot. You will find it at `t.me/yourbots_name_bot`. You can now add a description, about section and profile picture for your bot, see /help for a list of commands. By the way, when you've finished creating your cool bot, ping our Bot Support if you want a better username for it. Just make sure the bot is fully operational before you do this.
+
+> Use this token to access the HTTP API: `22222222:APITOKEN`
+
+> For a description of the Bot API, see this page: https://core.telegram.org/bots/api Father bot will return you the token (API key)
+
+Copy the API Token (`22222222:APITOKEN` in the above example) and keep use it for the config parameter `token`.
+
+Don't forget to start the conversation with your bot, by clicking `/START` button
+
+### 2. Get your user id
+
+Talk to the [userinfobot](https://telegram.me/userinfobot)
+
+Get your "Id", you will use it for the config parameter `chat_id`.
 
 ## Telegram commands
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Freqtrade
 nav:
     - About: index.md
     - Installation: installation.md
+    - Installation Docker: docker.md
     - Configuration: configuration.md
     - Strategy Customization: strategy-customization.md
     - Stoploss: stoploss.md


### PR DESCRIPTION
## Summary
This should help to clarify some issues around installation by cleaning up the installation document and moving sections to their respective section (telegram, docker).

It should also explain #1860 - which is solved but undocumented (`/etc/timezone` is only needed for users to see the timestamps in their timezone, but not for bot operations (which uses UTC throughout).

## Quick changelog

- improve documentation 
- create dedicated page to install with docker