### PR TITLE
Update plot-script to work with exported trades

### DIFF
--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -74,7 +74,7 @@ def load_trades(args: Namespace, pair: str, timerange: TimeRange) -> pd.DataFram
 
         file = Path(args.exportfilename)
         if file.exists():
-            load_backtest_data(file)
+            trades = load_backtest_data(file)
 
         else:
             trades = pd.DataFrame([], columns=BT_DATA_COLUMNS)


### PR DESCRIPTION
## Summary
Fix the plot-dataframe script when running with exported trades (
`python3 scripts/plot_dataframe.py --export trades --export-filename user_data/backtest_data-Strategy.json`

Solve the issue: (From Slack)

Appearing error (before)
``` 
Traceback (most recent call last):
  File "/home/xmatt/.pyenv/versions/trade3.7/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 2657, in get_loc
    return self._engine.get_loc(key)
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 132, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1601, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1608, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'open_time'

```
