### PR TITLE
persistence.init does not need the config dict

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -73,7 +73,8 @@ class FreqtradeBot(object):
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
 
-        persistence.init(self.config.get('db_url', None), self.config.get('dry_run'))
+        persistence.init(self.config.get('db_url', None),
+                         clean_open_orders=self.config.get('dry_run', False))
 
         # Set initial bot state from config
         initial_state = self.config.get('initial_state')

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -73,7 +73,7 @@ class FreqtradeBot(object):
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
 
-        persistence.init(self.config.get('db_url', None), self.config.get('dry_run', False))
+        persistence.init(self.config.get('db_url', None), self.config.get('dry_run'))
 
         # Set initial bot state from config
         initial_state = self.config.get('initial_state')

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -73,7 +73,7 @@ class FreqtradeBot(object):
 
         self.active_pair_whitelist: List[str] = self.config['exchange']['pair_whitelist']
 
-        persistence.init(self.config)
+        persistence.init(self.config.get('db_url', None), self.config.get('dry_run', False))
 
         # Set initial bot state from config
         initial_state = self.config.get('initial_state')

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -25,7 +25,7 @@ _DECL_BASE: Any = declarative_base()
 _SQL_DOCS_URL = 'http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls'
 
 
-def init(config: Dict) -> None:
+def init(db_url: str, dry_run: bool = False) -> None:
     """
     Initializes this module with the given config,
     registers all known command handlers
@@ -33,7 +33,6 @@ def init(config: Dict) -> None:
     :param config: config to use
     :return: None
     """
-    db_url = config.get('db_url', None)
     kwargs = {}
 
     # Take care of thread ownership if in-memory db
@@ -57,7 +56,7 @@ def init(config: Dict) -> None:
     check_migrate(engine)
 
     # Clean dry_run DB if the db is not in-memory
-    if config.get('dry_run', False) and db_url != 'sqlite://':
+    if dry_run and db_url != 'sqlite://':
         clean_dry_run_db()
 
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -25,12 +25,14 @@ _DECL_BASE: Any = declarative_base()
 _SQL_DOCS_URL = 'http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls'
 
 
-def init(db_url: str, dry_run: bool = False) -> None:
+def init(db_url: str, clean_open_orders: bool = False) -> None:
     """
     Initializes this module with the given config,
     registers all known command handlers
     and starts polling for message updates
-    :param config: config to use
+    :param db_url: Database to use
+    :param clean_open_orders: Remove open orders from the database.
+        Useful for dry-run or if all orders have been reset on the exchange.
     :return: None
     """
     kwargs = {}
@@ -56,7 +58,7 @@ def init(db_url: str, dry_run: bool = False) -> None:
     check_migrate(engine)
 
     # Clean dry_run DB if the db is not in-memory
-    if dry_run and db_url != 'sqlite://':
+    if clean_open_orders and db_url != 'sqlite://':
         clean_dry_run_db()
 
 

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -55,7 +55,7 @@ timeZone = pytz.UTC
 def load_trades(args: Namespace, pair: str, timerange: TimeRange) -> pd.DataFrame:
     trades: pd.DataFrame = pd.DataFrame()
     if args.db_url:
-        persistence.init(_CONF)
+        persistence.init(args.db_url, True)
         columns = ["pair", "profit", "open_time", "close_time",
                    "open_rate", "close_rate", "duration"]
 

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -55,7 +55,8 @@ timeZone = pytz.UTC
 def load_trades(args: Namespace, pair: str, timerange: TimeRange) -> pd.DataFrame:
     trades: pd.DataFrame = pd.DataFrame()
     if args.db_url:
-        persistence.init(args.db_url, False)
+        persistence.init(args.db_url, clean_open_orders=False)
+
         columns = ["pair", "profit", "open_time", "close_time",
                    "open_rate", "close_rate", "duration"]
 

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -55,7 +55,7 @@ timeZone = pytz.UTC
 def load_trades(args: Namespace, pair: str, timerange: TimeRange) -> pd.DataFrame:
     trades: pd.DataFrame = pd.DataFrame()
     if args.db_url:
-        persistence.init(args.db_url, True)
+        persistence.init(args.db_url, False)
         columns = ["pair", "profit", "open_time", "close_time",
                    "open_rate", "close_rate", "duration"]
 


### PR DESCRIPTION
## Summary
This will simplify the call to persistence.init() by not requiring a configuration dict.

It may not make sense now, but it's an extracted part from a larger refactoring of the plot-scripts (which do REALLY need a lot of love!!) 

