### PR TITLE
refactor `--live` handling

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -129,11 +129,16 @@ def load_data(datadir: Optional[Path],
     Loads ticker history data for a list of pairs the given parameters
     :return: dict(<pair>:<tickerlist>)
     """
-    result = {}
+    result: Dict[str, DataFrame] = {}
     if live:
-        logger.info('Live: Downloading data for all defined pairs ...')
-        exchange.refresh_latest_ohlcv([(pair, ticker_interval) for pair in pairs])
-        result = {key[0]: value for key, value in exchange._klines.items() if value is not None}
+        if exchange:
+            logger.info('Live: Downloading data for all defined pairs ...')
+            exchange.refresh_latest_ohlcv([(pair, ticker_interval) for pair in pairs])
+            result = {key[0]: value for key, value in exchange._klines.items() if value is not None}
+        else:
+            raise OperationalException(
+                "Exchange needs to be initialized when using live data."
+            )
     else:
         logger.info('Using local backtesting data ...')
 

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -122,21 +122,29 @@ def load_data(datadir: Optional[Path],
               refresh_pairs: bool = False,
               exchange: Optional[Exchange] = None,
               timerange: TimeRange = TimeRange(None, None, 0, 0),
-              fill_up_missing: bool = True) -> Dict[str, DataFrame]:
+              fill_up_missing: bool = True,
+              live: bool = False
+              ) -> Dict[str, DataFrame]:
     """
     Loads ticker history data for a list of pairs the given parameters
     :return: dict(<pair>:<tickerlist>)
     """
     result = {}
+    if live:
+        logger.info('Live: Downloading data for all defined pairs ...')
+        exchange.refresh_latest_ohlcv([(pair, ticker_interval) for pair in pairs])
+        result = {key[0]: value for key, value in exchange._klines.items() if value is not None}
+    else:
+        logger.info('Using local backtesting data ...')
 
-    for pair in pairs:
-        hist = load_pair_history(pair=pair, ticker_interval=ticker_interval,
-                                 datadir=datadir, timerange=timerange,
-                                 refresh_pairs=refresh_pairs,
-                                 exchange=exchange,
-                                 fill_up_missing=fill_up_missing)
-        if hist is not None:
-            result[pair] = hist
+        for pair in pairs:
+            hist = load_pair_history(pair=pair, ticker_interval=ticker_interval,
+                                     datadir=datadir, timerange=timerange,
+                                     refresh_pairs=refresh_pairs,
+                                     exchange=exchange,
+                                     fill_up_missing=fill_up_missing)
+            if hist is not None:
+                result[pair] = hist
     return result
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -401,24 +401,17 @@ class Backtesting(object):
         logger.info('Using stake_currency: %s ...', self.config['stake_currency'])
         logger.info('Using stake_amount: %s ...', self.config['stake_amount'])
 
-        if self.config.get('live'):
-            logger.info('Downloading data for all pairs in whitelist ...')
-            self.exchange.refresh_latest_ohlcv([(pair, self.ticker_interval) for pair in pairs])
-            data = {key[0]: value for key, value in self.exchange._klines.items()}
-
-        else:
-            logger.info('Using local backtesting data (using whitelist in given config) ...')
-
-            timerange = Arguments.parse_timerange(None if self.config.get(
-                'timerange') is None else str(self.config.get('timerange')))
-            data = history.load_data(
-                datadir=Path(self.config['datadir']) if self.config.get('datadir') else None,
-                pairs=pairs,
-                ticker_interval=self.ticker_interval,
-                refresh_pairs=self.config.get('refresh_pairs', False),
-                exchange=self.exchange,
-                timerange=timerange
-            )
+        timerange = Arguments.parse_timerange(None if self.config.get(
+            'timerange') is None else str(self.config.get('timerange')))
+        data = history.load_data(
+            datadir=Path(self.config['datadir']) if self.config.get('datadir') else None,
+            pairs=pairs,
+            ticker_interval=self.ticker_interval,
+            refresh_pairs=self.config.get('refresh_pairs', False),
+            exchange=self.exchange,
+            timerange=timerange,
+            live=self.config.get('live', False)
+        )
 
         if not data:
             logger.critical("No data found. Terminating.")

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -105,7 +105,7 @@ def simple_backtest(config, contour, num_results, mocker) -> None:
 
 
 def mocked_load_data(datadir, pairs=[], ticker_interval='0m', refresh_pairs=False,
-                     timerange=None, exchange=None):
+                     timerange=None, exchange=None, live=False):
     tickerdata = history.load_tickerdata_file(datadir, 'UNITTEST/BTC', '1m', timerange=timerange)
     pairdata = {'UNITTEST/BTC': parse_ticker_dataframe(tickerdata, '1m', fill_missing=True)}
     return pairdata
@@ -492,7 +492,6 @@ def test_backtesting_start(default_conf, mocker, caplog) -> None:
     backtesting.start()
     # check the logs, that will contain the backtest result
     exists = [
-        'Using local backtesting data (using whitelist in given config) ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
         'Backtesting with data from 2017-11-14T21:17:00+00:00 '
@@ -857,7 +856,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         'Using data folder: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
-        'Downloading data for all pairs in whitelist ...',
+        'Live: Downloading data for all defined pairs ...',
         'Backtesting with data from 2017-11-14T19:31:00+00:00 '
         'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...'
@@ -916,7 +915,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
         'Using data folder: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
-        'Downloading data for all pairs in whitelist ...',
+        'Live: Downloading data for all defined pairs ...',
         'Backtesting with data from 2017-11-14T19:31:00+00:00 '
         'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...',

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -139,21 +139,15 @@ def get_tickers_data(strategy, exchange, pairs: List[str], args):
     ticker_interval = strategy.ticker_interval
     timerange = Arguments.parse_timerange(args.timerange)
 
-    tickers = {}
-    if args.live:
-        logger.info('Downloading pairs.')
-        exchange.refresh_latest_ohlcv([(pair, ticker_interval) for pair in pairs])
-        for pair in pairs:
-            tickers[pair] = exchange.klines((pair, ticker_interval))
-    else:
-        tickers = history.load_data(
-            datadir=Path(str(_CONF.get("datadir"))),
-            pairs=pairs,
-            ticker_interval=ticker_interval,
-            refresh_pairs=_CONF.get('refresh_pairs', False),
-            timerange=timerange,
-            exchange=Exchange(_CONF)
-        )
+    tickers = history.load_data(
+        datadir=Path(str(_CONF.get("datadir"))),
+        pairs=pairs,
+        ticker_interval=ticker_interval,
+        refresh_pairs=_CONF.get('refresh_pairs', False),
+        timerange=timerange,
+        exchange=Exchange(_CONF),
+        live=args.live,
+    )
 
     # No ticker found, impossible to download, len mismatch
     for pair, data in tickers.copy().items():


### PR DESCRIPTION
## Summary
Remove duplication of --live parameter,which is used in backtesting and the plot_dataframe script (don't ask me why `plot_profit.py` does not support this)
it's part of a larger plot_script refactoring - so i'll add support for this later.
