### PR TITLE
Metadata timeframe

### DIFF
--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -230,12 +230,16 @@ Common values are `"1m"`, `"5m"`, `"15m"`, `"1h"`, however all values supported 
 Please note that the same buy/sell signals may work with one interval, but not the other.
 This setting is accessible within the strategy by using `self.ticker_interval`.
 
-### Metadata dict
+### Metadata dictionary
 
-The metadata-dict (available for `populate_buy_trend`, `populate_sell_trend`, `populate_indicators`) contains additional information.
-Currently this is `pair`, which can be accessed using `metadata['pair']` - and will return a pair in the format `XRP/BTC`.
+The metadata dictionary (available for `populate_buy_trend`, `populate_sell_trend`, `populate_indicators`) contains additional information.
 
-The Metadata-dict should not be modified and does not persist information across multiple calls.
+Currently this is:
+
+- Currency pair in the format `XRP/BTC`, which can be accessed using `metadata['pair']`.
+- Timeframe used by the bot in its string form (`5m`, `1h`), which can be accessed as `metadata['timeframe']`.
+
+The metadata dictionary should not be modified and does not persist information across multiple calls.
 Instead, have a look at the section [Storing information](#Storing-information)
 
 ### Storing information

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -47,7 +47,6 @@ class Edge():
         self.exchange = exchange
         self.strategy = strategy
         self.ticker_interval = self.strategy.ticker_interval
-        self.tickerdata_to_dataframe = self.strategy.tickerdata_to_dataframe
         self.advise_sell = self.strategy.advise_sell
         self.advise_buy = self.strategy.advise_buy
 
@@ -112,7 +111,7 @@ class Edge():
             logger.critical("No data found. Edge is stopped ...")
             return False
 
-        preprocessed = self.tickerdata_to_dataframe(data)
+        preprocessed = self.strategy.tickerdata_to_dataframe(data, self.ticker_interval)
 
         # Print timeframe
         min_date, max_date = history.get_timeframe(preprocessed)
@@ -130,8 +129,9 @@ class Edge():
             pair_data = pair_data.sort_values(by=['date'])
             pair_data = pair_data.reset_index(drop=True)
 
+            metadata = {'pair': pair, 'timeframe': self.ticker_interval}
             ticker_data = self.advise_sell(
-                self.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()
+                self.advise_buy(pair_data, metadata), metadata)[headers].copy()
 
             trades += self._find_trades_for_stoploss_range(ticker_data, pair, self._stoploss_range)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -94,7 +94,6 @@ class Backtesting(object):
 
         self.ticker_interval = self.config.get('ticker_interval')
         self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)
-        self.tickerdata_to_dataframe = strategy.tickerdata_to_dataframe
         self.advise_buy = strategy.advise_buy
         self.advise_sell = strategy.advise_sell
         # Set stoploss_on_exchange to false for backtesting,
@@ -219,8 +218,9 @@ class Backtesting(object):
         for pair, pair_data in processed.items():
             pair_data['buy'], pair_data['sell'] = 0, 0  # cleanup from previous run
 
+            metadata = {'pair': pair, 'timeframe': self.ticker_interval}
             ticker_data = self.advise_sell(
-                self.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()
+                self.advise_buy(pair_data, metadata), metadata)[headers].copy()
 
             # to avoid using data from future, we buy/sell with signal from previous candle
             ticker_data.loc[:, 'buy'] = ticker_data['buy'].shift(1)
@@ -439,7 +439,7 @@ class Backtesting(object):
                 (max_date - min_date).days
             )
             # need to reprocess data every time to populate signals
-            preprocessed = self.strategy.tickerdata_to_dataframe(data)
+            preprocessed = self.strategy.tickerdata_to_dataframe(data, self.ticker_interval)
 
             # Execute backtest and print results
             all_results[self.strategy.get_strategy_name()] = self.backtest(

--- a/freqtrade/optimize/default_hyperopt.py
+++ b/freqtrade/optimize/default_hyperopt.py
@@ -105,7 +105,6 @@ class DefaultHyperOpts(IHyperOpt):
             """
             Sell strategy Hyperopt will build and use
             """
-            # print(params)
             conditions = []
             # GUARDS AND TRENDS
             if 'sell-mfi-enabled' in params and params['sell-mfi-enabled']:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -296,7 +296,7 @@ class Hyperopt(Backtesting):
             self.strategy.advise_indicators = \
                 self.custom_hyperopt.populate_indicators  # type: ignore
 
-        dump(self.strategy.tickerdata_to_dataframe(data), TICKERDATA_PICKLE)
+        dump(self.strategy.tickerdata_to_dataframe(data, self.ticker_interval), TICKERDATA_PICKLE)
 
         # We don't need exchange instance anymore while running hyperopt
         self.exchange = None  # type: ignore

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -198,7 +198,7 @@ class IStrategy(ABC):
             return False, False
 
         try:
-            dataframe = self.analyze_ticker(dataframe, {'pair': pair})
+            dataframe = self.analyze_ticker(dataframe, {'pair': pair, 'timeframe': interval})
         except ValueError as error:
             logger.warning(
                 'Unable to analyze ticker for pair %s: %s',
@@ -362,11 +362,13 @@ class IStrategy(ABC):
 
         return False
 
-    def tickerdata_to_dataframe(self, tickerdata: Dict[str, List]) -> Dict[str, DataFrame]:
+    def tickerdata_to_dataframe(self, tickerdata: Dict[str, List],
+                                ticker_interval: str) -> Dict[str, DataFrame]:
         """
         Creates a dataframe and populates indicators for given ticker data
         """
-        return {pair: self.advise_indicators(pair_data, {'pair': pair})
+        return {pair: self.advise_indicators(pair_data,
+                {'pair': pair, 'timeframe': ticker_interval})
                 for pair, pair_data in tickerdata.items()}
 
     def advise_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -379,6 +379,8 @@ class IStrategy(ABC):
         :param metadata: Additional information, like the currently traded pair
         :return: a Dataframe with all mandatory indicators for the strategies
         """
+        logger.debug(f"Populating indicators: "
+                     f"pair {metadata.get('pair')}, timeframe {metadata.get('timeframe')}")
         if self._populate_fun_len == 2:
             warnings.warn("deprecated - check out the Sample strategy to see "
                           "the current function headers!", DeprecationWarning)
@@ -394,6 +396,8 @@ class IStrategy(ABC):
         :param pair: Additional information, like the currently traded pair
         :return: DataFrame with buy column
         """
+        logger.debug(f"Populating buy signals: "
+                     f"pair {metadata.get('pair')}, timeframe {metadata.get('timeframe')}")
         if self._buy_fun_len == 2:
             warnings.warn("deprecated - check out the Sample strategy to see "
                           "the current function headers!", DeprecationWarning)
@@ -409,6 +413,8 @@ class IStrategy(ABC):
         :param pair: Additional information, like the currently traded pair
         :return: DataFrame with sell column
         """
+        logger.debug(f"Populating sell signals: "
+                     f"pair {metadata.get('pair')}, timeframe {metadata.get('timeframe')}")
         if self._sell_fun_len == 2:
             warnings.warn("deprecated - check out the Sample strategy to see "
                           "the current function headers!", DeprecationWarning)

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -534,7 +534,7 @@ def test_get_timeframe(default_conf, mocker) -> None:
             datadir=None,
             ticker_interval='1m',
             pairs=['UNITTEST/BTC']
-        )
+        ), '1m'
     )
     min_date, max_date = history.get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
@@ -551,7 +551,7 @@ def test_validate_backtest_data_warn(default_conf, mocker, caplog) -> None:
             ticker_interval='1m',
             pairs=['UNITTEST/BTC'],
             fill_up_missing=False
-        )
+        ), '1m'
     )
     min_date, max_date = history.get_timeframe(data)
     caplog.clear()
@@ -574,7 +574,7 @@ def test_validate_backtest_data(default_conf, mocker, caplog) -> None:
             ticker_interval='5m',
             pairs=['UNITTEST/BTC'],
             timerange=timerange
-        )
+        ), '5m'
     )
 
     min_date, max_date = history.get_timeframe(data)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -87,7 +87,7 @@ def simple_backtest(config, contour, num_results, mocker) -> None:
     backtesting = Backtesting(config)
 
     data = load_data_test(contour)
-    processed = backtesting.strategy.tickerdata_to_dataframe(data)
+    processed = backtesting.strategy.tickerdata_to_dataframe(data, '1m')
     min_date, max_date = get_timeframe(processed)
     assert isinstance(processed, dict)
     results = backtesting.backtest(
@@ -124,7 +124,7 @@ def _make_backtest_conf(mocker, conf=None, pair='UNITTEST/BTC', record=None):
     data = trim_dictlist(data, -201)
     patch_exchange(mocker)
     backtesting = Backtesting(conf)
-    processed = backtesting.strategy.tickerdata_to_dataframe(data)
+    processed = backtesting.strategy.tickerdata_to_dataframe(data, '1m')
     min_date, max_date = get_timeframe(processed)
     return {
         'stake_amount': conf['stake_amount'],
@@ -358,12 +358,12 @@ def test_tickerdata_to_dataframe_bt(default_conf, mocker) -> None:
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', fill_missing=True)}
 
     backtesting = Backtesting(default_conf)
-    data = backtesting.strategy.tickerdata_to_dataframe(tickerlist)
+    data = backtesting.strategy.tickerdata_to_dataframe(tickerlist, '1m')
     assert len(data['UNITTEST/BTC']) == 102
 
     # Load strategy to compare the result between Backtesting function and strategy are the same
     strategy = DefaultStrategy(default_conf)
-    data2 = strategy.tickerdata_to_dataframe(tickerlist)
+    data2 = strategy.tickerdata_to_dataframe(tickerlist, '1m')
     assert data['UNITTEST/BTC'].equals(data2['UNITTEST/BTC'])
 
 
@@ -537,7 +537,7 @@ def test_backtest(default_conf, fee, mocker) -> None:
     timerange = TimeRange(None, 'line', 0, -201)
     data = history.load_data(datadir=None, ticker_interval='5m', pairs=['UNITTEST/BTC'],
                              timerange=timerange)
-    data_processed = backtesting.strategy.tickerdata_to_dataframe(data)
+    data_processed = backtesting.strategy.tickerdata_to_dataframe(data, '1m')
     min_date, max_date = get_timeframe(data_processed)
     results = backtesting.backtest(
         {
@@ -592,7 +592,7 @@ def test_backtest_1min_ticker_interval(default_conf, fee, mocker) -> None:
     timerange = TimeRange(None, 'line', 0, -200)
     data = history.load_data(datadir=None, ticker_interval='1m', pairs=['UNITTEST/BTC'],
                              timerange=timerange)
-    processed = backtesting.strategy.tickerdata_to_dataframe(data)
+    processed = backtesting.strategy.tickerdata_to_dataframe(data, '1m')
     min_date, max_date = get_timeframe(processed)
     results = backtesting.backtest(
         {
@@ -613,7 +613,7 @@ def test_processed(default_conf, mocker) -> None:
     backtesting = Backtesting(default_conf)
 
     dict_of_tickerrows = load_data_test('raise')
-    dataframes = backtesting.strategy.tickerdata_to_dataframe(dict_of_tickerrows)
+    dataframes = backtesting.strategy.tickerdata_to_dataframe(dict_of_tickerrows, '1m')
     dataframe = dataframes['UNITTEST/BTC']
     cols = dataframe.columns
     # assert the dataframe got some of the indicator columns
@@ -716,7 +716,7 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair):
     backtesting.advise_buy = _trend_alternate_hold  # Override
     backtesting.advise_sell = _trend_alternate_hold  # Override
 
-    data_processed = backtesting.strategy.tickerdata_to_dataframe(data)
+    data_processed = backtesting.strategy.tickerdata_to_dataframe(data, '5m')
     min_date, max_date = get_timeframe(data_processed)
     backtest_conf = {
         'stake_amount': default_conf['stake_amount'],

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -427,7 +427,7 @@ def test_has_space(hyperopt):
 def test_populate_indicators(hyperopt) -> None:
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m')
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', fill_missing=True)}
-    dataframes = hyperopt.strategy.tickerdata_to_dataframe(tickerlist)
+    dataframes = hyperopt.strategy.tickerdata_to_dataframe(tickerlist, '1m')
     dataframe = hyperopt.custom_hyperopt.populate_indicators(dataframes['UNITTEST/BTC'],
                                                              {'pair': 'UNITTEST/BTC'})
 
@@ -440,7 +440,7 @@ def test_populate_indicators(hyperopt) -> None:
 def test_buy_strategy_generator(hyperopt) -> None:
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m')
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', fill_missing=True)}
-    dataframes = hyperopt.strategy.tickerdata_to_dataframe(tickerlist)
+    dataframes = hyperopt.strategy.tickerdata_to_dataframe(tickerlist, '1m')
     dataframe = hyperopt.custom_hyperopt.populate_indicators(dataframes['UNITTEST/BTC'],
                                                              {'pair': 'UNITTEST/BTC'})
 

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -112,7 +112,7 @@ def test_tickerdata_to_dataframe(default_conf) -> None:
     timerange = TimeRange(None, 'line', 0, -100)
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m', timerange=timerange)
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', True)}
-    data = strategy.tickerdata_to_dataframe(tickerlist)
+    data = strategy.tickerdata_to_dataframe(tickerlist, '1m')
     assert len(data['UNITTEST/BTC']) == 102       # partial candle was removed
 
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -63,7 +63,7 @@ def test_search_strategy():
 
 def test_load_strategy(result):
     resolver = StrategyResolver({'strategy': 'TestStrategy'})
-    metadata = {'pair': 'ETH/BTC'}
+    metadata = {'pair': 'ETH/BTC', 'timeframe': '1m'}
     assert 'adx' in resolver.strategy.advise_indicators(result, metadata=metadata)
 
 
@@ -110,7 +110,7 @@ def test_strategy(result):
     config = {'strategy': 'DefaultStrategy'}
 
     resolver = StrategyResolver(config)
-    metadata = {'pair': 'ETH/BTC'}
+    metadata = {'pair': 'ETH/BTC', 'timeframe': '5m'}
     assert resolver.strategy.minimal_roi[0] == 0.04
     assert config["minimal_roi"]['0'] == 0.04
 
@@ -400,7 +400,7 @@ def test_call_deprecated_function(result, monkeypatch):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     resolver = StrategyResolver({'strategy': 'TestStrategyLegacy',
                                  'strategy_path': default_location})
-    metadata = {'pair': 'ETH/BTC'}
+    metadata = {'pair': 'ETH/BTC', 'timeframe': '5m'}
 
     # Make sure we are using a legacy function
     assert resolver.strategy._populate_fun_len == 2

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -35,7 +35,7 @@ def test_common_datearray(default_conf) -> None:
     strategy = DefaultStrategy(default_conf)
     tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m')
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, "1m", fill_missing=True)}
-    dataframes = strategy.tickerdata_to_dataframe(tickerlist)
+    dataframes = strategy.tickerdata_to_dataframe(tickerlist, '1m')
 
     dates = common_datearray(dataframes)
 


### PR DESCRIPTION
Resolves #1900 

This PR adds timeframe used (in the str form, i.e. "1m", "1h", etc) to the metadata, passed to the populate_*() methods in the strategies and hyperopts.

You can access it in the populate_*() methods as simple as
```
timeframe = metadata['timeframe']
```

TODO:
* [x] adjust docs
* [ ] adjust existing tests to check for it in the metadata passed to the populate_*() methods
* [ ] (?) add new tests
