### PR TITLE
Enhance check_exchange()

### DIFF
--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -397,20 +397,19 @@ class Configuration(object):
                     f'{", ".join(available_exchanges())}'
             )
 
-        logger.info(f'Exchange "{exchange}" is supported by ccxt '
-                    f'and therefore available for the bot.')
+        if check_for_bad and is_exchange_bad(exchange):
+            logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
+                           f'Use it only for development and testing purposes.')
+            return False
 
         if is_exchange_officially_supported(exchange):
             logger.info(f'Exchange "{exchange}" is officially supported '
                         f'by the Freqtrade development team.')
         else:
-            logger.warning(f'Exchange "{exchange}" is not officially supported. '
+            logger.warning(f'Exchange "{exchange}" is supported by ccxt '
+                           f'and therefore available for the bot but not officially supported '
+                           f'by the Freqtrade development team. '
                            f'It may work flawlessly (please report back) or have serious issues. '
                            f'Use it at your own discretion.')
-
-        if check_for_bad and is_exchange_bad(exchange):
-            logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
-                           f'Use it only for development and testing purposes.')
-            return False
 
         return True

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -13,8 +13,8 @@ from jsonschema import Draft4Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
 
 from freqtrade import OperationalException, constants
-from freqtrade.exchange import (is_exchange_bad, is_exchange_known,
-                                is_exchange_officially_supported, known_exchanges)
+from freqtrade.exchange import (is_exchange_bad, is_exchange_available,
+                                is_exchange_officially_supported, available_exchanges)
 from freqtrade.misc import deep_merge_dicts
 from freqtrade.state import RunMode
 
@@ -389,27 +389,27 @@ class Configuration(object):
         logger.info("Checking exchange...")
 
         exchange = config.get('exchange', {}).get('name').lower()
-        if not is_exchange_known(exchange):
+        if not is_exchange_available(exchange):
             raise OperationalException(
                     f'Exchange "{exchange}" is not supported by ccxt '
-                    f'and not known for the bot.\n'
+                    f'and therefore not available for the bot.\n'
                     f'The following exchanges are supported by ccxt: '
-                    f'{", ".join(known_exchanges())}'
+                    f'{", ".join(available_exchanges())}'
             )
 
-        logger.info(f'Exchange "{exchange}" is supported by ccxt and known for the bot.')
+        logger.info(f'Exchange "{exchange}" is supported by ccxt '
+                    f'and therefore available for the bot.')
 
         if is_exchange_officially_supported(exchange):
             logger.info(f'Exchange "{exchange}" is officially supported '
                         f'by the Freqtrade development team.')
         else:
-            logger.warning(f'Exchange "{exchange}" is not officially supported '
-                           f'by the Freqtrade development team. '
-                           f'It may work with serious issues or not work at all. '
+            logger.warning(f'Exchange "{exchange}" is not officially supported. '
+                           f'It may work flawlessly (please report back) or have serious issues. '
                            f'Use it at your own discretion.')
 
         if check_for_bad and is_exchange_bad(exchange):
-            logger.warning(f'Exchange "{exchange}" is known to not work with Freqtrade yet. '
+            logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
                            f'Use it only for development and testing purposes.')
             return False
 

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -390,14 +390,11 @@ class Configuration(object):
 
         exchange = config.get('exchange', {}).get('name').lower()
         if not is_exchange_known(exchange):
-            exception_msg = f'Exchange "{exchange}" is not supported by ccxt ' \
-                            f'and not known for the bot.\n' \
-                            f'The following exchanges are supported by ccxt: ' \
-                            f'{", ".join(known_exchanges())}'
-
-            logger.critical(exception_msg)
             raise OperationalException(
-                exception_msg
+                    f'Exchange "{exchange}" is not supported by ccxt '
+                    f'and not known for the bot.\n'
+                    f'The following exchanges are supported by ccxt: '
+                    f'{", ".join(known_exchanges())}'
             )
 
         logger.info(f'Exchange "{exchange}" is supported by ccxt and known for the bot.')

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,6 +1,8 @@
 from freqtrade.exchange.exchange import Exchange  # noqa: F401
-from freqtrade.exchange.exchange import (is_exchange_supported,  # noqa: F401
-                                         supported_exchanges)
+from freqtrade.exchange.exchange import (is_exchange_bad,  # noqa: F401
+                                         is_exchange_known,
+                                         is_exchange_officially_supported,
+                                         known_exchanges)
 from freqtrade.exchange.exchange import (timeframe_to_seconds,  # noqa: F401
                                          timeframe_to_minutes,
                                          timeframe_to_msecs)

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,8 +1,8 @@
 from freqtrade.exchange.exchange import Exchange  # noqa: F401
 from freqtrade.exchange.exchange import (is_exchange_bad,  # noqa: F401
-                                         is_exchange_known,
+                                         is_exchange_available,
                                          is_exchange_officially_supported,
-                                         known_exchanges)
+                                         available_exchanges)
 from freqtrade.exchange.exchange import (timeframe_to_seconds,  # noqa: F401
                                          timeframe_to_minutes,
                                          timeframe_to_msecs)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -156,8 +156,8 @@ class Exchange(object):
         # Find matching class for the given exchange name
         name = exchange_config['name']
 
-#        if not is_exchange_supported(name, ccxt_module):
-#            raise OperationalException(f'Exchange {name} is not supported')
+        if not is_exchange_known(name, ccxt_module):
+            raise OperationalException(f'Exchange {name} is not supported by ccxt')
 
         ex_config = {
             'apiKey': exchange_config.get('key'),

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -156,8 +156,8 @@ class Exchange(object):
         # Find matching class for the given exchange name
         name = exchange_config['name']
 
-        if not is_exchange_supported(name, ccxt_module):
-            raise OperationalException(f'Exchange {name} is not supported')
+#        if not is_exchange_supported(name, ccxt_module):
+#            raise OperationalException(f'Exchange {name} is not supported')
 
         ex_config = {
             'apiKey': exchange_config.get('key'),
@@ -722,11 +722,19 @@ class Exchange(object):
             raise OperationalException(e)
 
 
-def is_exchange_supported(exchange: str, ccxt_module=None) -> bool:
-    return exchange in supported_exchanges(ccxt_module)
+def is_exchange_bad(exchange: str) -> bool:
+    return exchange in ['bitmex']
 
 
-def supported_exchanges(ccxt_module=None) -> List[str]:
+def is_exchange_known(exchange: str, ccxt_module=None) -> bool:
+    return exchange in known_exchanges(ccxt_module)
+
+
+def is_exchange_officially_supported(exchange: str) -> bool:
+    return exchange in ['bittrex', 'binance']
+
+
+def known_exchanges(ccxt_module=None) -> List[str]:
     return ccxt_module.exchanges if ccxt_module is not None else ccxt.exchanges
 
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -156,7 +156,7 @@ class Exchange(object):
         # Find matching class for the given exchange name
         name = exchange_config['name']
 
-        if not is_exchange_known(name, ccxt_module):
+        if not is_exchange_available(name, ccxt_module):
             raise OperationalException(f'Exchange {name} is not supported by ccxt')
 
         ex_config = {
@@ -726,15 +726,15 @@ def is_exchange_bad(exchange: str) -> bool:
     return exchange in ['bitmex']
 
 
-def is_exchange_known(exchange: str, ccxt_module=None) -> bool:
-    return exchange in known_exchanges(ccxt_module)
+def is_exchange_available(exchange: str, ccxt_module=None) -> bool:
+    return exchange in available_exchanges(ccxt_module)
 
 
 def is_exchange_officially_supported(exchange: str) -> bool:
     return exchange in ['bittrex', 'binance']
 
 
-def known_exchanges(ccxt_module=None) -> List[str]:
+def available_exchanges(ccxt_module=None) -> List[str]:
     return ccxt_module.exchanges if ccxt_module is not None else ccxt.exchanges
 
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -484,7 +484,8 @@ def test_check_exchange(default_conf, caplog) -> None:
 
     with pytest.raises(
         OperationalException,
-        match=r'.*Exchange "unknown_exchange" is not supported by ccxt and not known for the bot.*'
+        match=r'.*Exchange "unknown_exchange" is not supported by ccxt '
+              r'and therefore not available for the bot.*'
     ):
         configuration.check_exchange(default_conf)
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -470,15 +470,27 @@ def test_hyperopt_with_arguments(mocker, default_conf, caplog) -> None:
 def test_check_exchange(default_conf, caplog) -> None:
     configuration = Configuration(Namespace())
 
-    # Test a valid exchange
+    # Test an officially supported by Freqtrade team exchange
     default_conf.get('exchange').update({'name': 'BITTREX'})
     assert configuration.check_exchange(default_conf)
 
-    # Test a valid exchange
+    # Test an officially supported by Freqtrade team exchange
     default_conf.get('exchange').update({'name': 'binance'})
     assert configuration.check_exchange(default_conf)
 
-    # Test a invalid exchange
+    # Test an available exchange, supported by ccxt
+    default_conf.get('exchange').update({'name': 'kraken'})
+    assert configuration.check_exchange(default_conf)
+
+    # Test a 'bad' exchange, which known to have serious problems
+    default_conf.get('exchange').update({'name': 'bitmex'})
+    assert not configuration.check_exchange(default_conf)
+
+    # Test a 'bad' exchange with check_for_bad=False
+    default_conf.get('exchange').update({'name': 'bitmex'})
+    assert configuration.check_exchange(default_conf, False)
+
+    # Test an invalid exchange
     default_conf.get('exchange').update({'name': 'unknown_exchange'})
     configuration.config = default_conf
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -484,7 +484,7 @@ def test_check_exchange(default_conf, caplog) -> None:
 
     with pytest.raises(
         OperationalException,
-        match=r'.*Exchange "unknown_exchange" not supported.*'
+        match=r'.*Exchange "unknown_exchange" is not supported by ccxt and not known for the bot.*'
     ):
         configuration.check_exchange(default_conf)
 


### PR DESCRIPTION
Check exchange name against:
* list of 'bad' exchanges, known to have critical problems with the bot. Warns user. Set currently to `['bitmex',]`, extend it if you know of other bad exchanges.
* list of officially supported exchanges (`['binance', 'bittrex']`), Warns user to be careful running the bot if exchange is not in this list.
* list of exchanges, supported by ccxt (i.e. 'known' for the bot). Current behaviour is kept (raises exception if misspelled or not supported by ccxt), wording changed ('supported' --> 'known').

The check_for_bad parameter is left for scripts -- if set to False, it will allow to run the download script for 'bad' exchanges and not to warn the user of it.

TODO:
* a couple of more tests for all cases (know but not officially supported exchange, etc.)
