### PR TITLE
list-exchanges subcommand added

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -341,7 +341,7 @@ class Arguments(object):
         Parses given arguments for the list-exchanges command.
         """
         parser.add_argument(
-            '-1',
+            '-1', '--one-column',
             help='Print exchanges in one column',
             action='store_true',
             dest='print_one_column',
@@ -376,7 +376,7 @@ class Arguments(object):
         self.hyperopt_options(hyperopt_cmd)
 
         # Add list-exchanges subcommand
-        list_exchanges_cmd = subparsers.add_parser('list-exchanges', help='List known exchanges.')
+        list_exchanges_cmd = subparsers.add_parser('list-exchanges', help='Print available exchanges.')
         list_exchanges_cmd.set_defaults(func=start_list_exchanges)
         self.list_exchanges_options(list_exchanges_cmd)
 

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -376,7 +376,10 @@ class Arguments(object):
         self.hyperopt_options(hyperopt_cmd)
 
         # Add list-exchanges subcommand
-        list_exchanges_cmd = subparsers.add_parser('list-exchanges', help='Print available exchanges.')
+        list_exchanges_cmd = subparsers.add_parser(
+            'list-exchanges',
+            help='Print available exchanges.'
+        )
         list_exchanges_cmd.set_defaults(func=start_list_exchanges)
         self.list_exchanges_options(list_exchanges_cmd)
 

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -335,12 +335,25 @@ class Arguments(object):
             metavar='INT',
         )
 
+    @staticmethod
+    def list_exchanges_options(parser: argparse.ArgumentParser) -> None:
+        """
+        Parses given arguments for the list-exchanges command.
+        """
+        parser.add_argument(
+            '-1',
+            help='Print exchanges in one column',
+            action='store_true',
+            dest='print_one_column',
+        )
+
     def _build_subcommands(self) -> None:
         """
         Builds and attaches all subcommands
         :return: None
         """
         from freqtrade.optimize import start_backtesting, start_hyperopt, start_edge
+        from freqtrade.utils import start_list_exchanges
 
         subparsers = self.parser.add_subparsers(dest='subparser')
 
@@ -361,6 +374,11 @@ class Arguments(object):
         hyperopt_cmd.set_defaults(func=start_hyperopt)
         self.optimizer_shared_options(hyperopt_cmd)
         self.hyperopt_options(hyperopt_cmd)
+
+        # Add list-exchanges subcommand
+        list_exchanges_cmd = subparsers.add_parser('list-exchanges', help='List known exchanges.')
+        list_exchanges_cmd.set_defaults(func=start_list_exchanges)
+        self.list_exchanges_options(list_exchanges_cmd)
 
     @staticmethod
     def parse_timerange(text: Optional[str]) -> TimeRange:

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime
 from functools import reduce
+from typing import List
 from unittest.mock import MagicMock, PropertyMock
 
 import arrow
@@ -11,6 +12,7 @@ import pytest
 from telegram import Chat, Message, Update
 
 from freqtrade import constants, persistence
+from freqtrade.arguments import Arguments
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.edge import Edge, PairInfo
 from freqtrade.exchange import Exchange
@@ -33,6 +35,10 @@ def log_has_re(line, logs):
     return reduce(lambda a, b: a or b,
                   filter(lambda x: re.match(line, x[2]), logs),
                   False)
+
+
+def get_args(args) -> List[str]:
+    return Arguments(args, '').get_parsed_arg()
 
 
 def patch_exchange(mocker, api_mock=None, id='bittrex') -> None:

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -3,7 +3,6 @@
 import json
 import math
 import random
-from typing import List
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -12,7 +11,7 @@ import pytest
 from arrow import Arrow
 
 from freqtrade import DependencyException, constants
-from freqtrade.arguments import Arguments, TimeRange
+from freqtrade.arguments import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import evaluate_result_multi
 from freqtrade.data.converter import parse_ticker_dataframe
@@ -23,11 +22,7 @@ from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
-from freqtrade.tests.conftest import log_has, log_has_re, patch_exchange
-
-
-def get_args(args) -> List[str]:
-    return Arguments(args, '').get_parsed_arg()
+from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
 
 
 def trim_dictlist(dict_list, num):

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -2,19 +2,13 @@
 # pragma pylint: disable=protected-access, too-many-lines, invalid-name, too-many-arguments
 
 import json
-from typing import List
 from unittest.mock import MagicMock
 
-from freqtrade.arguments import Arguments
 from freqtrade.edge import PairInfo
-from freqtrade.optimize import start_edge, setup_configuration
+from freqtrade.optimize import setup_configuration, start_edge
 from freqtrade.optimize.edge_cli import EdgeCli
 from freqtrade.state import RunMode
-from freqtrade.tests.conftest import log_has, log_has_re, patch_exchange
-
-
-def get_args(args) -> List[str]:
-    return Arguments(args, '').get_parsed_arg()
+from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
 
 
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -16,8 +16,7 @@ from freqtrade.optimize.hyperopt import Hyperopt, HYPEROPT_LOCKFILE
 from freqtrade.optimize import setup_configuration, start_hyperopt
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
 from freqtrade.state import RunMode
-from freqtrade.tests.conftest import log_has, log_has_re, patch_exchange
-from freqtrade.tests.optimize.test_backtesting import get_args
+from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
 
 
 @pytest.fixture(scope='function')

--- a/freqtrade/tests/test_utils.py
+++ b/freqtrade/tests/test_utils.py
@@ -1,5 +1,5 @@
 from freqtrade.utils import setup_configuration, start_list_exchanges
-from freqtrade.tests.conftest import get_args, log_has, log_has_re
+from freqtrade.tests.conftest import get_args
 from freqtrade.state import RunMode
 
 import re

--- a/freqtrade/tests/test_utils.py
+++ b/freqtrade/tests/test_utils.py
@@ -1,0 +1,41 @@
+from freqtrade.utils import setup_configuration, start_list_exchanges
+from freqtrade.tests.conftest import get_args, log_has, log_has_re
+from freqtrade.state import RunMode
+
+import re
+
+
+def test_setup_configuration():
+    args = [
+        '--config', 'config.json.example',
+    ]
+
+    config = setup_configuration(get_args(args), RunMode.OTHER)
+    assert "exchange" in config
+    assert config['exchange']['key'] == ''
+    assert config['exchange']['secret'] == ''
+
+
+def test_list_exchanges(capsys):
+
+    args = [
+        "list-exchanges",
+    ]
+
+    start_list_exchanges(get_args(args))
+    captured = capsys.readouterr()
+    assert re.match(r"Exchanges supported by ccxt and available.*", captured.out)
+    assert re.match(r".*binance,.*", captured.out)
+    assert re.match(r".*bittrex,.*", captured.out)
+
+    # Test with --one-column
+    args = [
+        "list-exchanges",
+        "--one-column",
+    ]
+
+    start_list_exchanges(get_args(args))
+    captured = capsys.readouterr()
+    assert not re.match(r"Exchanges supported by ccxt and available.*", captured.out)
+    assert re.search(r"^binance$", captured.out, re.MULTILINE)
+    assert re.search(r"^bittrex$", captured.out, re.MULTILINE)

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from typing import Any, Dict
 
 from freqtrade.configuration import Configuration
-from freqtrade.exchange import supported_exchanges
+from freqtrade.exchange import available_exchanges
 from freqtrade.state import RunMode
 
 
@@ -34,7 +34,7 @@ def start_list_exchanges(args: Namespace) -> None:
     """
 
     if args.print_one_column:
-        print('\n'.join(supported_exchanges()))
+        print('\n'.join(available_exchanges()))
     else:
         print(f"Exchanges supported by ccxt and available for Freqtrade: "
-              f"{', '.join(supported_exchanges())}")
+              f"{', '.join(available_exchanges())}")

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -1,0 +1,44 @@
+import logging
+from argparse import Namespace
+from typing import Any, Dict
+
+from freqtrade.configuration import Configuration
+from freqtrade.exchange import supported_exchanges
+from freqtrade.state import RunMode
+
+
+logger = logging.getLogger(__name__)
+
+
+def setup_configuration(args: Namespace, method: RunMode) -> Dict[str, Any]:
+    """
+    Prepare the configuration for the Hyperopt module
+    :param args: Cli args from Arguments()
+    :return: Configuration
+    """
+    configuration = Configuration(args, method)
+    config = configuration.load_config()
+
+    # Ensure we do not use Exchange credentials
+    config['exchange']['key'] = ''
+    config['exchange']['secret'] = ''
+
+    return config
+
+
+def start_list_exchanges(args: Namespace) -> None:
+    """
+    Start listing known exchanges
+    :param args: Cli args from Arguments()
+    :return: None
+    """
+
+    # Initialize configuration
+    config = setup_configuration(args, RunMode.OTHER)
+
+    logger.debug('Starting freqtrade in cli-util mode')
+
+    if args.print_one_column:
+        print('\n'.join(supported_exchanges()))
+    else:
+        print(f"Supported exchanges: {', '.join(supported_exchanges())}")

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -28,17 +28,13 @@ def setup_configuration(args: Namespace, method: RunMode) -> Dict[str, Any]:
 
 def start_list_exchanges(args: Namespace) -> None:
     """
-    Start listing known exchanges
+    Print available exchanges
     :param args: Cli args from Arguments()
     :return: None
     """
 
-    # Initialize configuration
-    _ = setup_configuration(args, RunMode.OTHER)
-
-    logger.debug('Starting freqtrade in cli-util mode')
-
     if args.print_one_column:
         print('\n'.join(supported_exchanges()))
     else:
-        print(f"Supported exchanges: {', '.join(supported_exchanges())}")
+        print(f"Exchanges supported by ccxt and available for Freqtrade: "
+              f"{', '.join(supported_exchanges())}")

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -34,7 +34,7 @@ def start_list_exchanges(args: Namespace) -> None:
     """
 
     # Initialize configuration
-    config = setup_configuration(args, RunMode.OTHER)
+    _ = setup_configuration(args, RunMode.OTHER)
 
     logger.debug('Starting freqtrade in cli-util mode')
 


### PR DESCRIPTION
In order to get rid of awful `scripts/get_market_pairs.py`. Other scripts can also be moved to main freqtrade subcommands.

Done:

* `list-exchanges` subcommand added; was part of scripts/get_market_pairs.py functionality
```
freqtrade list-exchanges
freqtrade list-exchanges -1
```

Todo:
* `list-pairs` subcommand with `--exchange`, `--quote-currency`, `--base-currency` options.

@xmatthias pls review it. It in principle is a template for moving other scripts to subcommands.
I think there should be an additional directory `utils` created for all this stuff with every subcommand in a diff. file.
Maybe `cli-utils` should be used everywhere in the code to name it instead of `utils`.
