### PR TITLE
Fix/trailing stoploss offset

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -308,14 +308,16 @@ class IStrategy(ABC):
 
         if trailing_stop:
             # trailing stoploss handling
-
             sl_offset = self.config.get('trailing_stop_positive_offset') or 0.0
             tsl_only_offset = self.config.get('trailing_only_offset_is_reached', False)
 
+            # Make sure current_profit is calculated using high for backtesting.
+            high_profit = current_profit if not high else trade.calc_profit_percent(high)
+
             # Don't update stoploss if trailing_only_offset_is_reached is true.
-            if not (tsl_only_offset and current_profit < sl_offset):
+            if not (tsl_only_offset and high_profit < sl_offset):
                 # Specific handling for trailing_stop_positive
-                if 'trailing_stop_positive' in self.config and current_profit > sl_offset:
+                if 'trailing_stop_positive' in self.config and high_profit > sl_offset:
                     # Ignore mypy error check in configuration that this is a float
                     stop_loss_value = self.config.get('trailing_stop_positive')  # type: ignore
                     logger.debug(f"using positive stop loss: {stop_loss_value} "

--- a/freqtrade/tests/optimize/__init__.py
+++ b/freqtrade/tests/optimize/__init__.py
@@ -29,6 +29,10 @@ class BTContainer(NamedTuple):
     trades: List[BTrade]
     profit_perc: float
     trailing_stop: bool = False
+    trailing_only_offset_is_reached: bool = False
+    trailing_stop_positive: float = None
+    trailing_stop_positive_offset: float = 0.0
+    use_sell_signal: bool = False
 
 
 def _get_frame_time_from_offset(offset):

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -173,6 +173,57 @@ tc9 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=3)]
 )
 
+# Test 10 - trailing_stop should raise so candle 3 causes a stoploss
+# without applying trailing_stop_positive since stoploss_offset is at 10%.
+# Set stop-loss at 10%, ROI at 10% (should not apply)
+# TC10: Trailing stoploss - stoploss should be adjusted candle 2
+tc10 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 5100, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi=0.10, profit_perc=-0.1, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.10,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=4)]
+)
+
+# Test 11 - trailing_stop should raise so candle 3 causes a stoploss
+# applying a positive trailing stop of 3% since stop_positive_offset is reached.
+# Set stop-loss at 10%, ROI at 10% (should not apply)
+# TC11: Trailing stoploss - stoploss should be adjusted candle 2,
+tc11 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 5100, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi=0.10, profit_perc=0.019, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=3)]
+)
+
+# Test 12 - trailing_stop should raise in candle 2 and cause a stoploss in the same candle
+# applying a positive trailing stop of 3% since stop_positive_offset is reached.
+# Set stop-loss at 10%, ROI at 10% (should not apply)
+# TC12: Trailing stoploss - stoploss should be adjusted candle 2,
+tc12 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 4650, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi=0.10, profit_perc=0.019, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=2)]
+)
+
 TESTS = [
     tc0,
     tc1,
@@ -184,6 +235,9 @@ TESTS = [
     tc7,
     tc8,
     tc9,
+    tc10,
+    tc11,
+    tc12,
 ]
 
 

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -44,8 +44,8 @@ class TestStrategy(IStrategy):
 
     # trailing stoploss
     trailing_stop = False
-    trailing_stop_positive = 0.01
-    trailing_stop_positive_offset = 0.0  # Disabled / not configured
+    # trailing_stop_positive = 0.01
+    # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
     # Optimal ticker interval for the strategy
     ticker_interval = '5m'


### PR DESCRIPTION
## Summary
The calculation of stoploss_offset (and stoploss offset positive) should use high, not open of the candle during backtesting.

closes: #1928

## Quick changelog

- add detail-testcases
- add detail-testcase for sell-signal (to align numbering tbh)
- Calculate high_profit for comparisons of "stoploss_offset" reached calculations

