### PR TITLE
Edge cli should override stake_amount

### DIFF
--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -6,6 +6,7 @@ This module contains the edge backtesting interface
 import logging
 from typing import Dict, Any
 from tabulate import tabulate
+from freqtrade import constants
 from freqtrade.edge import Edge
 
 from freqtrade.arguments import Arguments
@@ -32,6 +33,7 @@ class EdgeCli(object):
         self.config['exchange']['secret'] = ''
         self.config['exchange']['password'] = ''
         self.config['exchange']['uid'] = ''
+        self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
         self.config['dry_run'] = True
         self.exchange = Exchange(self.config)
         self.strategy = StrategyResolver(self.config).strategy

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -117,8 +117,10 @@ def test_start(mocker, fee, edge_conf, caplog) -> None:
 
 def test_edge_init(mocker, edge_conf) -> None:
     patch_exchange(mocker)
+    edge_conf['stake_amount'] = 20
     edge_cli = EdgeCli(edge_conf)
     assert edge_cli.config == edge_conf
+    assert edge_cli.config['stake_amount'] == 'unlimited'
     assert callable(edge_cli.edge.calculate)
 
 


### PR DESCRIPTION
## Summary
When running edge cli if the stake amount is not "unlimited" we have: 
```
ERROR - Edge works only with unlimited stake amount
```

This is not necessary as edge cli is just informative and does nothing in live.

The stake amount should be set to unlimited before running egde cli.