### PR TITLE
minor: setup_configuration() cleanup

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -5,8 +5,9 @@ from typing import Any, Dict
 from filelock import FileLock, Timeout
 
 from freqtrade import DependencyException, constants
-from freqtrade.configuration import Configuration
 from freqtrade.state import RunMode
+from freqtrade.utils import setup_utils_configuration
+
 
 logger = logging.getLogger(__name__)
 
@@ -17,12 +18,7 @@ def setup_configuration(args: Namespace, method: RunMode) -> Dict[str, Any]:
     :param args: Cli args from Arguments()
     :return: Configuration
     """
-    configuration = Configuration(args, method)
-    config = configuration.load_config()
-
-    # Ensure we do not use Exchange credentials
-    config['exchange']['key'] = ''
-    config['exchange']['secret'] = ''
+    config = setup_utils_configuration(args, method)
 
     if method == RunMode.BACKTEST:
         if config['stake_amount'] == constants.UNLIMITED_STAKE_AMOUNT:

--- a/freqtrade/tests/test_utils.py
+++ b/freqtrade/tests/test_utils.py
@@ -1,17 +1,18 @@
-from freqtrade.utils import setup_configuration, start_list_exchanges
+from freqtrade.utils import setup_utils_configuration, start_list_exchanges
 from freqtrade.tests.conftest import get_args
 from freqtrade.state import RunMode
 
 import re
 
 
-def test_setup_configuration():
+def test_setup_utils_configuration():
     args = [
         '--config', 'config.json.example',
     ]
 
-    config = setup_configuration(get_args(args), RunMode.OTHER)
+    config = setup_utils_configuration(get_args(args), RunMode.OTHER)
     assert "exchange" in config
+    assert config['exchange']['dry_run'] is True
     assert config['exchange']['key'] == ''
     assert config['exchange']['secret'] == ''
 

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -10,15 +10,16 @@ from freqtrade.state import RunMode
 logger = logging.getLogger(__name__)
 
 
-def setup_configuration(args: Namespace, method: RunMode) -> Dict[str, Any]:
+def setup_utils_configuration(args: Namespace, method: RunMode) -> Dict[str, Any]:
     """
-    Prepare the configuration for the Hyperopt module
+    Prepare the configuration for utils subcommands
     :param args: Cli args from Arguments()
     :return: Configuration
     """
     configuration = Configuration(args, method)
     config = configuration.load_config()
 
+    config['exchange']['dry_run'] = True
     # Ensure we do not use Exchange credentials
     config['exchange']['key'] = ''
     config['exchange']['secret'] = ''


### PR DESCRIPTION
* slip in a comment fixed
* setup_configuration() from utils.py renamed to setup_utils_configuration();
* setting `dry_run = True` added to it;
* use it in `optimize/__init__.py` to avoid duplication of the code;
* test adjusted

This function is intended for the use in all other new utility subcommands that require configuration in the dry_run mode without real exchange key and secret (i.e. all besides simple list-exchanges which runs without configuration).
