### PR TITLE
Fix tests on windows

### DIFF
--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -5,6 +5,7 @@ import re
 from copy import deepcopy
 from datetime import datetime
 from functools import reduce
+from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock, PropertyMock
 
@@ -860,7 +861,7 @@ def tickers():
 
 @pytest.fixture
 def result():
-    with open('freqtrade/tests/testdata/UNITTEST_BTC-1m.json') as data_file:
+    with Path('freqtrade/tests/testdata/UNITTEST_BTC-1m.json').open('r') as data_file:
         return parse_ticker_dataframe(json.load(data_file), '1m', fill_missing=True)
 
 # FIX:

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -75,14 +75,10 @@ def test_load_strategy_byte64(result):
 
 def test_load_strategy_invalid_directory(result, caplog):
     resolver = StrategyResolver()
-    extra_dir = path.join('some', 'path')
+    extra_dir = Path.cwd() / 'some/path'
     resolver._load_strategy('TestStrategy', config={}, extra_dir=extra_dir)
 
-    assert (
-        'freqtrade.resolvers.strategy_resolver',
-        logging.WARNING,
-        'Path "{}" does not exist'.format(extra_dir),
-    ) in caplog.record_tuples
+    assert log_has_re(r'Path .*' + r'some.*path.*' + r'.* does not exist', caplog.record_tuples)
 
     assert 'adx' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 


### PR DESCRIPTION
## Summary
Allow tests to run on windows (without WSL).
Even though it's not easy to install - tests should work without errors due to windows paths if the bot itself does work just fine!