### PR TITLE
arguments cleanup

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -493,16 +493,16 @@ class Arguments(object):
 
         parser.add_argument(
             '--indicators1',
-            help='Set indicators from your strategy you want in the first row of the graph. Separate '
-                 'them with a coma. E.g: ema3,ema5 (default: %(default)s)',
+            help='Set indicators from your strategy you want in the first row of the graph. '
+                 'Separate them with a coma. E.g: ema3,ema5 (default: %(default)s)',
             default='sma,ema3,ema5',
             dest='indicators1',
         )
 
         parser.add_argument(
             '--indicators2',
-            help='Set indicators from your strategy you want in the third row of the graph. Separate '
-                 'them with a coma. E.g: fastd,fastk (default: %(default)s)',
+            help='Set indicators from your strategy you want in the third row of the graph. '
+                 'Separate them with a coma. E.g: fastd,fastk (default: %(default)s)',
             default='macd,macdsignal',
             dest='indicators2',
         )

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -33,7 +33,8 @@ class Arguments(object):
         self.parser = argparse.ArgumentParser(description=description)
 
     def _load_args(self) -> None:
-        self.common_args_parser()
+        self.common_options()
+        self.main_options()
         self._build_subcommands()
 
     def get_parsed_arg(self) -> argparse.Namespace:
@@ -60,62 +61,65 @@ class Arguments(object):
 
         return parsed_arg
 
-    def common_args_parser(self) -> None:
+    def common_options(self) -> None:
         """
-        Parses given common arguments and returns them as a parsed object.
+        Parses arguments that are common for the main Freqtrade, all subcommands and scripts.
         """
-        self.parser.add_argument(
+        parser = self.parser
+
+        parser.add_argument(
             '-v', '--verbose',
             help='Verbose mode (-vv for more, -vvv to get all messages).',
             action='count',
             dest='loglevel',
             default=0,
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--logfile',
             help='Log to the file specified',
             dest='logfile',
-            type=str,
-            metavar='FILE'
+            metavar='FILE',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--version',
             action='version',
             version=f'%(prog)s {__version__}'
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '-c', '--config',
             help='Specify configuration file (default: %(default)s). '
                  'Multiple --config options may be used.',
             dest='config',
             action='append',
-            type=str,
             metavar='PATH',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '-d', '--datadir',
             help='Path to backtest data.',
             dest='datadir',
-            default=None,
-            type=str,
             metavar='PATH',
         )
-        self.parser.add_argument(
+
+    def main_options(self) -> None:
+        """
+        Parses arguments for the main Freqtrade.
+        """
+        parser = self.parser
+
+        parser.add_argument(
             '-s', '--strategy',
             help='Specify strategy class name (default: %(default)s).',
             dest='strategy',
             default='DefaultStrategy',
-            type=str,
             metavar='NAME',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--strategy-path',
             help='Specify additional strategy lookup path.',
             dest='strategy_path',
-            type=str,
             metavar='PATH',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--dynamic-whitelist',
             help='Dynamically generate and update whitelist'
                  ' based on 24h BaseVolume (default: %(const)s).'
@@ -126,52 +130,46 @@ class Arguments(object):
             metavar='INT',
             nargs='?',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--db-url',
             help='Override trades database URL, this is useful if dry_run is enabled'
                  ' or in custom deployments (default: %(default)s).',
             dest='db_url',
-            type=str,
             metavar='PATH',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--sd-notify',
             help='Notify systemd service manager.',
             action='store_true',
             dest='sd_notify',
         )
 
-    @staticmethod
-    def optimizer_shared_options(parser: argparse.ArgumentParser) -> None:
+    def common_optimize_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
-        Parses given common arguments for Backtesting, Edge and Hyperopt modules.
+        Parses arguments common for Backtesting, Edge and Hyperopt modules.
         :param parser:
-        :return:
         """
+        parser = subparser or self.parser
+
         parser.add_argument(
             '-i', '--ticker-interval',
             help='Specify ticker interval (1m, 5m, 30m, 1h, 1d).',
             dest='ticker_interval',
-            type=str,
         )
         parser.add_argument(
             '--timerange',
             help='Specify what timerange of data to use.',
-            default=None,
-            type=str,
             dest='timerange',
         )
         parser.add_argument(
             '--max_open_trades',
             help='Specify max_open_trades to use.',
-            default=None,
             type=int,
             dest='max_open_trades',
         )
         parser.add_argument(
             '--stake_amount',
             help='Specify stake_amount.',
-            default=None,
             type=float,
             dest='stake_amount',
         )
@@ -184,11 +182,12 @@ class Arguments(object):
             dest='refresh_pairs',
         )
 
-    @staticmethod
-    def backtesting_options(parser: argparse.ArgumentParser) -> None:
+    def backtesting_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
         Parses given arguments for Backtesting module.
         """
+        parser = subparser or self.parser
+
         parser.add_argument(
             '--eps', '--enable-position-stacking',
             help='Allow buying the same pair multiple times (position stacking).',
@@ -224,8 +223,6 @@ class Arguments(object):
             '--export',
             help='Export backtest results, argument are: trades. '
                  'Example --export=trades',
-            type=str,
-            default=None,
             dest='export',
         )
         parser.add_argument(
@@ -234,37 +231,36 @@ class Arguments(object):
                   requires --export to be set as well\
                   Example --export-filename=user_data/backtest_data/backtest_today.json\
                   (default: %(default)s)',
-            type=str,
             default=os.path.join('user_data', 'backtest_data', 'backtest-result.json'),
             dest='exportfilename',
             metavar='PATH',
         )
 
-    @staticmethod
-    def edge_options(parser: argparse.ArgumentParser) -> None:
+    def edge_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
         Parses given arguments for Edge module.
         """
+        parser = subparser or self.parser
+
         parser.add_argument(
             '--stoplosses',
             help='Defines a range of stoploss against which edge will assess the strategy '
                  'the format is "min,max,step" (without any space).'
                  'example: --stoplosses=-0.01,-0.1,-0.001',
-            type=str,
             dest='stoploss_range',
         )
 
-    @staticmethod
-    def hyperopt_options(parser: argparse.ArgumentParser) -> None:
+    def hyperopt_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
         Parses given arguments for Hyperopt module.
         """
+        parser = subparser or self.parser
+
         parser.add_argument(
             '--customhyperopt',
             help='Specify hyperopt class name (default: %(default)s).',
             dest='hyperopt',
             default=constants.DEFAULT_HYPEROPT,
-            type=str,
             metavar='NAME',
         )
         parser.add_argument(
@@ -321,7 +317,6 @@ class Arguments(object):
             '--random-state',
             help='Set random state to some positive integer for reproducible hyperopt results.',
             dest='hyperopt_random_state',
-            default=None,
             type=Arguments.check_int_positive,
             metavar='INT',
         )
@@ -335,11 +330,12 @@ class Arguments(object):
             metavar='INT',
         )
 
-    @staticmethod
-    def list_exchanges_options(parser: argparse.ArgumentParser) -> None:
+    def list_exchanges_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
         Parses given arguments for the list-exchanges command.
         """
+        parser = subparser or self.parser
+
         parser.add_argument(
             '-1', '--one-column',
             help='Print exchanges in one column',
@@ -349,7 +345,7 @@ class Arguments(object):
 
     def _build_subcommands(self) -> None:
         """
-        Builds and attaches all subcommands
+        Builds and attaches all subcommands.
         :return: None
         """
         from freqtrade.optimize import start_backtesting, start_hyperopt, start_edge
@@ -360,19 +356,19 @@ class Arguments(object):
         # Add backtesting subcommand
         backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.')
         backtesting_cmd.set_defaults(func=start_backtesting)
-        self.optimizer_shared_options(backtesting_cmd)
+        self.common_optimize_options(backtesting_cmd)
         self.backtesting_options(backtesting_cmd)
 
         # Add edge subcommand
         edge_cmd = subparsers.add_parser('edge', help='Edge module.')
         edge_cmd.set_defaults(func=start_edge)
-        self.optimizer_shared_options(edge_cmd)
+        self.common_optimize_options(edge_cmd)
         self.edge_options(edge_cmd)
 
         # Add hyperopt subcommand
         hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.')
         hyperopt_cmd.set_defaults(func=start_hyperopt)
-        self.optimizer_shared_options(hyperopt_cmd)
+        self.common_optimize_options(hyperopt_cmd)
         self.hyperopt_options(hyperopt_cmd)
 
         # Add list-exchanges subcommand
@@ -437,69 +433,43 @@ class Arguments(object):
             )
         return uint
 
-    def scripts_options(self) -> None:
+    def common_scripts_options(self, subparser: argparse.ArgumentParser = None) -> None:
         """
-        Parses given arguments for scripts.
+        Parses arguments common for scripts.
         """
-        self.parser.add_argument(
+        parser = subparser or self.parser
+
+        parser.add_argument(
             '-p', '--pairs',
             help='Show profits for only this pairs. Pairs are comma-separated.',
             dest='pairs',
-            default=None
         )
 
     def download_data_options(self) -> None:
         """
-        Parses given arguments for testdata download
+        Parses given arguments for testdata download script
         """
-        self.parser.add_argument(
-            '-v', '--verbose',
-            help='Verbose mode (-vv for more, -vvv to get all messages).',
-            action='count',
-            dest='loglevel',
-            default=0,
-        )
-        self.parser.add_argument(
-            '--logfile',
-            help='Log to the file specified',
-            dest='logfile',
-            type=str,
-            metavar='FILE',
-        )
-        self.parser.add_argument(
-            '-c', '--config',
-            help='Specify configuration file (default: %(default)s). '
-                 'Multiple --config options may be used.',
-            dest='config',
-            action='append',
-            type=str,
-            metavar='PATH',
-        )
-        self.parser.add_argument(
-            '-d', '--datadir',
-            help='Path to backtest data.',
-            dest='datadir',
-            metavar='PATH',
-        )
-        self.parser.add_argument(
+        parser = self.parser
+
+        parser.add_argument(
             '--pairs-file',
             help='File containing a list of pairs to download.',
             dest='pairs_file',
             metavar='FILE',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--days',
             help='Download data for given number of days.',
             dest='days',
             type=Arguments.check_int_positive,
             metavar='INT',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--exchange',
             help='Exchange name (default: %(default)s). Only valid if no config is provided.',
             dest='exchange',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '-t', '--timeframes',
             help='Specify which tickers to download. Space separated list. \
                   Default: %(default)s.',
@@ -508,9 +478,39 @@ class Arguments(object):
             nargs='+',
             dest='timeframes',
         )
-        self.parser.add_argument(
+        parser.add_argument(
             '--erase',
             help='Clean all existing data for the selected exchange/pairs/timeframes.',
             dest='erase',
             action='store_true'
+        )
+
+    def plot_dataframe_options(self) -> None:
+        """
+        Parses given arguments for plot dataframe script
+        """
+        parser = self.parser
+
+        parser.add_argument(
+            '--indicators1',
+            help='Set indicators from your strategy you want in the first row of the graph. Separate '
+                 'them with a coma. E.g: ema3,ema5 (default: %(default)s)',
+            default='sma,ema3,ema5',
+            dest='indicators1',
+        )
+
+        parser.add_argument(
+            '--indicators2',
+            help='Set indicators from your strategy you want in the third row of the graph. Separate '
+                 'them with a coma. E.g: fastd,fastk (default: %(default)s)',
+            default='macd,macdsignal',
+            dest='indicators2',
+        )
+        parser.add_argument(
+            '--plot-limit',
+            help='Specify tick limit for plotting - too high values cause huge files - '
+                 'Default: %(default)s',
+            dest='plot_limit',
+            default=750,
+            type=int,
         )

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -47,9 +47,9 @@ def test_parse_args_verbose() -> None:
     assert args.loglevel == 1
 
 
-def test_scripts_options() -> None:
+def test_common_scripts_options() -> None:
     arguments = Arguments(['-p', 'ETH/BTC'], '')
-    arguments.scripts_options()
+    arguments.common_scripts_options()
     args = arguments.get_parsed_arg()
     assert args.pairs == 'ETH/BTC'
 

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -178,6 +178,7 @@ def test_download_data_options() -> None:
         '--exchange', 'binance'
     ]
     arguments = Arguments(args, '')
+    arguments.common_options()
     arguments.download_data_options()
     args = arguments.parse_args()
     assert args.pairs_file == 'file_with_pairs'

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -20,7 +20,8 @@ logger = logging.getLogger('download_backtest_data')
 
 DEFAULT_DL_PATH = 'user_data/data'
 
-arguments = Arguments(sys.argv[1:], 'download utility')
+arguments = Arguments(sys.argv[1:], 'Download backtest data')
+arguments.common_options()
 arguments.download_data_options()
 
 # Do not read the default config if config is not specified

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -349,35 +349,12 @@ def plot_parse_args(args: List[str]) -> Namespace:
     :return: args: Array with all arguments
     """
     arguments = Arguments(args, 'Graph dataframe')
-    arguments.scripts_options()
-    arguments.parser.add_argument(
-        '--indicators1',
-        help='Set indicators from your strategy you want in the first row of the graph. Separate '
-             'them with a coma. E.g: ema3,ema5 (default: %(default)s)',
-        type=str,
-        default='sma,ema3,ema5',
-        dest='indicators1',
-    )
-
-    arguments.parser.add_argument(
-        '--indicators2',
-        help='Set indicators from your strategy you want in the third row of the graph. Separate '
-             'them with a coma. E.g: fastd,fastk (default: %(default)s)',
-        type=str,
-        default='macd,macdsignal',
-        dest='indicators2',
-    )
-    arguments.parser.add_argument(
-        '--plot-limit',
-        help='Specify tick limit for plotting - too high values cause huge files - '
-             'Default: %(default)s',
-        dest='plot_limit',
-        default=750,
-        type=int,
-    )
-    arguments.common_args_parser()
-    arguments.optimizer_shared_options(arguments.parser)
-    arguments.backtesting_options(arguments.parser)
+    arguments.common_options()
+    arguments.main_options()
+    arguments.common_optimize_options()
+    arguments.backtesting_options()
+    arguments.common_scripts_options()
+    arguments.plot_dataframe_options()
     return arguments.parse_args()
 
 

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -206,10 +206,11 @@ def plot_parse_args(args: List[str]) -> Namespace:
     :return: args: Array with all arguments
     """
     arguments = Arguments(args, 'Graph profits')
-    arguments.scripts_options()
-    arguments.common_args_parser()
-    arguments.optimizer_shared_options(arguments.parser)
-    arguments.backtesting_options(arguments.parser)
+    arguments.common_options()
+    arguments.main_options()
+    arguments.common_optimize_options()
+    arguments.backtesting_options()
+    arguments.common_scripts_options()
 
     return arguments.parse_args()
 


### PR DESCRIPTION
An attempt to improve arguments handling without big redesign,

* interfaces of methods unified -- they all made non-static back and call `parser.add_argument()` in a unified manner;

* names of the methods unified: `common_args_parser()` --> `common_options()`, `optimizer_shared_options()` --> `common_optimize_options()`, `scripts_options()` --> `common_scripts_options()`;

* `plot_dataframe.py` specific arguments moved to `arguments.py` (see `plot_dataframe_options()`);

When this script is ready to become a subcommand, that will be enough to add a subparser parameter to this method and change `parser = self.parser` to `parser = subparser or self.parser` in it.

* duplicated arguments in `download_data_options()` removed; 

The script (and then the subcommand) should call the `common_options()` method for common options instead of duplicating the code.

* `common_args_parser()` is split into `common_options()` and `main_options()` (options specific for the live running bot);

* calls to `parser.add_argument()` simplified: removed all appearences of `type=str` and `default=None` as these are default values;

* minor improvements and fixes in comments;

* tests adjusted;
