### PR TITLE
allow reading config from stdin

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -26,7 +26,8 @@ optional arguments:
   --version             show program's version number and exit
   -c PATH, --config PATH
                         Specify configuration file (default: None). Multiple
-                        --config options may be used.
+                        --config options may be used. Can be set to '-' to
+                        read config from stdin.
   -d PATH, --datadir PATH
                         Path to backtest data.
   -s NAME, --strategy NAME

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -85,8 +85,9 @@ class Arguments(object):
         )
         self.parser.add_argument(
             '-c', '--config',
-            help='Specify configuration file (default: %(default)s). '
-                 'Multiple --config options may be used.',
+            help="Specify configuration file (default: %(default)s). "
+                 "Multiple --config options may be used. "
+                 "Can be set to '-' to read config from stdin.",
             dest='config',
             action='append',
             type=str,

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -79,6 +79,7 @@ class Configuration(object):
         # Now expecting a list of config filenames here, not a string
         for path in self.args.config:
             logger.info('Using config: %s ...', path)
+
             # Merge config options, overwriting old values
             config = deep_merge_dicts(self._load_config_file(path), config)
 
@@ -118,7 +119,8 @@ class Configuration(object):
         :return: configuration as dictionary
         """
         try:
-            with open(path) as file:
+            # Read config from stdin if requested in the options
+            with open(path) if path != '-' else sys.stdin as file:
                 conf = json.load(file)
         except FileNotFoundError:
             raise OperationalException(


### PR DESCRIPTION
This allows piping the config. May be useful for advanced techniques, when you need to iterate though a parameter in the config, which cannot be redefined in the command line options. (See Examples below)

Short note added to the help string for the `--config` option. Docs updated.

(I don't know how to create a test for this new feature...)

===

### Examples
(from Slack #dev; this can later be posted in a docs/advanced-usage.md when it will be created)

1. Iterate through a range of stoploss values, for backtesting or hyperopts:

* Create a config template: `cp config.json config.json.template`, set `"stoploss": @@stoploss@@,` in it.
* Then iterating through a range of stoploss values for the backtesting command can be simply performed in a single-line bash script:
```
$ for i in `seq -0.03 -0.01 -0.10`; do cat config.json.template|sed -e "s/@@stoploss@@/$i/" | ./freqtrade/main.py -c - backtesting; done
```

2. Iterate through a set of timeframes:
* Similarly, create a config template, set `"ticker_interval": "@@timeframe@@",` in it.
* Then iterate:
```
$ for i in 1w 1d 1h 5m; do cat config.json.template|sed -e "s/@@timeframe@@/$i/" | ./freqtrade/main.py -c - backtesting; done
```

Without support for piping, intermediary config files should be stored somewhere in the file system, be forgotten, obsolete, etc.
