### PR TITLE
Trailing stoploss cancel orders should be handled gracefully

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -843,7 +843,10 @@ class FreqtradeBot(object):
 
         # First cancelling stoploss on exchange ...
         if self.strategy.order_types.get('stoploss_on_exchange') and trade.stoploss_order_id:
-            self.exchange.cancel_order(trade.stoploss_order_id, trade.pair)
+            try:
+                self.exchange.cancel_order(trade.stoploss_order_id, trade.pair)
+            except InvalidOrderException:
+                logger.exception(f"Could not cancel stoploss order {trade.stoploss_order_id}")
 
         # Execute sell and update trade record
         order_id = self.exchange.sell(pair=str(trade.pair),

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -110,11 +110,23 @@ def patch_freqtradebot(mocker, config) -> None:
 
 
 def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
+    """
+    This function patches _init_modules() to not call dependencies
+    :param mocker: a Mocker object to apply patches
+    :param config: Config to pass to the bot
+    :return: FreqtradeBot
+    """
     patch_freqtradebot(mocker, config)
     return FreqtradeBot(config)
 
 
 def get_patched_worker(mocker, config) -> Worker:
+    """
+    This function patches _init_modules() to not call dependencies
+    :param mocker: a Mocker object to apply patches
+    :param config: Config to pass to the bot
+    :return: Worker
+    """
     patch_freqtradebot(mocker, config)
     return Worker(args=None, config=config)
 

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -19,45 +19,12 @@ from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCMessageType
 from freqtrade.state import State
 from freqtrade.strategy.interface import SellCheckTuple, SellType
-from freqtrade.tests.conftest import (log_has, log_has_re, patch_edge,
-                                      patch_exchange, patch_get_signal,
+from freqtrade.tests.conftest import (get_patched_freqtradebot,
+                                      get_patched_worker, log_has, log_has_re,
+                                      patch_edge, patch_exchange,
+                                      patch_freqtradebot, patch_get_signal,
                                       patch_wallet)
 from freqtrade.worker import Worker
-
-
-# Functions for recurrent object patching
-def patch_freqtradebot(mocker, config) -> None:
-    """
-    This function patches _init_modules() to not call dependencies
-    :param mocker: a Mocker object to apply patches
-    :param config: Config to pass to the bot
-    :return: None
-    """
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
-    patch_exchange(mocker)
-
-
-def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
-    """
-    This function patches _init_modules() to not call dependencies
-    :param mocker: a Mocker object to apply patches
-    :param config: Config to pass to the bot
-    :return: FreqtradeBot
-    """
-    patch_freqtradebot(mocker, config)
-    return FreqtradeBot(config)
-
-
-def get_patched_worker(mocker, config) -> Worker:
-    """
-    This function patches _init_modules() to not call dependencies
-    :param mocker: a Mocker object to apply patches
-    :param config: Config to pass to the bot
-    :return: Worker
-    """
-    patch_freqtradebot(mocker, config)
-    return Worker(args=None, config=config)
 
 
 def patch_RPCManager(mocker) -> MagicMock:


### PR DESCRIPTION
## Summary
We should handle InvalidOrderExceptions gracefully (currently they Fatal-error stop the bot).


Closes #1933 

## Quick changelog

- Remove some duplicate test inits
- Add tests for the error-cases
- Add exception-handlers and log-output

