### PR TITLE
Ticker interval to hyperopt

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -12,7 +12,7 @@ and still take a long time.
 ## Prepare Hyperopting
 
 Before we start digging into Hyperopt, we recommend you to take a look at
-an example hyperopt file located into [user_data/hyperopts/](https://github.com/freqtrade/freqtrade/blob/develop/user_data/hyperopts/test_hyperopt.py)
+an example hyperopt file located into [user_data/hyperopts/](https://github.com/freqtrade/freqtrade/blob/develop/user_data/hyperopts/sample_hyperopt.py)
 
 Configuring hyperopt is similar to writing your own strategy, and many tasks will be similar and a lot of code can be copied across from the strategy.
 
@@ -70,6 +70,11 @@ Place the corresponding settings into the following methods
 
 The configuration and rules are the same than for buy signals.
 To avoid naming collisions in the search-space, please prefix all sell-spaces with `sell-`.
+
+#### Using ticker-interval as part of the Strategy
+
+The Strategy exposes the ticker-interval as `self.ticker_interval`. The same value is available as class-attribute `HyperoptName.ticker_interval`.
+In the case of the linked sample-value this would be `SampleHyperOpts.ticker_interval`.
 
 ## Solving a Mystery
 

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -20,6 +20,7 @@ class IHyperOpt(ABC):
         stoploss -> float: optimal stoploss designed for the strategy
         ticker_interval -> int: value of the ticker interval to use for the strategy
     """
+    ticker_interval: str
 
     @staticmethod
     @abstractmethod

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -33,7 +33,7 @@ class HyperOptResolver(IResolver):
         self.hyperopt = self._load_hyperopt(hyperopt_name, extra_dir=config.get('hyperopt_path'))
 
         # Assign ticker_interval to be used in hyperopt
-        self.hyperopt.__class__.ticker_interval = config.get('ticker_interval')
+        self.hyperopt.__class__.ticker_interval = str(config['ticker_interval'])
 
         if not hasattr(self.hyperopt, 'populate_buy_trend'):
             logger.warning("Custom Hyperopt does not provide populate_buy_trend. "

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -32,6 +32,9 @@ class HyperOptResolver(IResolver):
         hyperopt_name = config.get('hyperopt') or DEFAULT_HYPEROPT
         self.hyperopt = self._load_hyperopt(hyperopt_name, extra_dir=config.get('hyperopt_path'))
 
+        # Assign ticker_interval to be used in hyperopt
+        self.hyperopt.__class__.ticker_interval = config.get('ticker_interval')
+
         if not hasattr(self.hyperopt, 'populate_buy_trend'):
             logger.warning("Custom Hyperopt does not provide populate_buy_trend. "
                            "Using populate_buy_trend from DefaultStrategy.")

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -167,6 +167,7 @@ def test_hyperoptresolver(mocker, default_conf, caplog) -> None:
                    "Using populate_sell_trend from DefaultStrategy.", caplog.record_tuples)
     assert log_has("Custom Hyperopt does not provide populate_buy_trend. "
                    "Using populate_buy_trend from DefaultStrategy.", caplog.record_tuples)
+    assert hasattr(x, "ticker_interval")
 
 
 def test_start(mocker, default_conf, caplog) -> None:


### PR DESCRIPTION

## Summary
Make ticker-interval available to hyperopt.
Since Hyperopt does mostly use static methods it needs to be assigned as a class attribute.

It's then available as `HyperoptName.ticker_interval`.

Closes #1900
