### PR TITLE
Plot datafame simplification

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -53,8 +53,7 @@ class FreqtradeBot(object):
 
         self.rpc: RPCManager = RPCManager(self)
 
-        exchange_name = self.config.get('exchange', {}).get('name').title()
-        self.exchange = ExchangeResolver(exchange_name, self.config).exchange
+        self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
 
         self.wallets = Wallets(self.config, self.exchange)
         self.dataprovider = DataProvider(self.config, self.exchange)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -63,8 +63,7 @@ class Backtesting(object):
         self.config['dry_run'] = True
         self.strategylist: List[IStrategy] = []
 
-        exchange_name = self.config.get('exchange', {}).get('name').title()
-        self.exchange = ExchangeResolver(exchange_name, self.config).exchange
+        self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
         self.fee = self.exchange.get_fee()
 
         if self.config.get('runmode') != RunMode.HYPEROPT:

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -22,6 +22,7 @@ class ExchangeResolver(IResolver):
         Load the custom class from config parameter
         :param config: configuration dictionary
         """
+        exchange_name = exchange_name.title()
         try:
             self.exchange = self._load_exchange(exchange_name, kwargs={'config': config})
         except ImportError:

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -60,7 +60,7 @@ def get_patched_exchange(mocker, config, api_mock=None, id='bittrex') -> Exchang
     patch_exchange(mocker, api_mock, id)
     config["exchange"]["name"] = id
     try:
-        exchange = ExchangeResolver(id.title(), config).exchange
+        exchange = ExchangeResolver(id, config).exchange
     except ImportError:
         exchange = Exchange(config)
     return exchange

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -124,14 +124,14 @@ def test_exchange_resolver(default_conf, mocker, caplog):
                       caplog.record_tuples)
     caplog.clear()
 
-    exchange = ExchangeResolver('Kraken', default_conf).exchange
+    exchange = ExchangeResolver('kraken', default_conf).exchange
     assert isinstance(exchange, Exchange)
     assert isinstance(exchange, Kraken)
     assert not isinstance(exchange, Binance)
     assert not log_has_re(r"No .* specific subclass found. Using the generic class instead.",
                           caplog.record_tuples)
 
-    exchange = ExchangeResolver('Binance', default_conf).exchange
+    exchange = ExchangeResolver('binance', default_conf).exchange
     assert isinstance(exchange, Exchange)
     assert isinstance(exchange, Binance)
     assert not isinstance(exchange, Kraken)

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -68,8 +68,7 @@ def analyse_and_plot_pairs(config: Dict[str, Any]):
     -Generate plot files
     :return: None
     """
-    exchange_name = config.get('exchange', {}).get('name').title()
-    exchange = ExchangeResolver(exchange_name, config).exchange
+    exchange = ExchangeResolver(config.get('exchange', {}).get('name'), config).exchange
 
     strategy = StrategyResolver(config).strategy
     if "pairs" in config:

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from freqtrade.arguments import Arguments, TimeRange
+from freqtrade.arguments import Arguments
 from freqtrade.data import history
 from freqtrade.data.btanalysis import load_trades, extract_trades_of_period
 from freqtrade.optimize import setup_configuration
@@ -41,38 +41,6 @@ from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
-
-
-def get_tickers_data(strategy, exchange, pairs: List[str], timerange: TimeRange,
-                     datadir: Path, refresh_pairs: bool, live: bool):
-    """
-    Get tickers data for each pairs on live or local, option defined in args
-    :return: dictionary of tickers. output format: {'pair': tickersdata}
-    """
-
-    ticker_interval = strategy.ticker_interval
-
-    tickers = history.load_data(
-        datadir=datadir,
-        pairs=pairs,
-        ticker_interval=ticker_interval,
-        refresh_pairs=refresh_pairs,
-        timerange=timerange,
-        exchange=exchange,
-        live=live,
-    )
-
-    # No ticker found, impossible to download, len mismatch
-    for pair, data in tickers.copy().items():
-        logger.debug("checking tickers data of pair: %s", pair)
-        logger.debug("data.empty: %s", data.empty)
-        logger.debug("len(data): %s", len(data))
-        if data.empty:
-            del tickers[pair]
-            logger.info(
-                'An issue occured while retreiving data of %s pair, please retry '
-                'using -l option for live or --refresh-pairs-cached', pair)
-    return tickers
 
 
 def generate_dataframe(strategy, tickers, pair) -> pd.DataFrame:
@@ -113,10 +81,16 @@ def analyse_and_plot_pairs(config: Dict[str, Any]):
     timerange = Arguments.parse_timerange(config["timerange"])
     ticker_interval = strategy.ticker_interval
 
-    tickers = get_tickers_data(strategy, exchange, pairs, timerange,
-                               datadir=Path(str(config.get("datadir"))),
-                               refresh_pairs=config.get('refresh_pairs', False),
-                               live=config.get("live", False))
+    tickers = history.load_data(
+        datadir=Path(str(config.get("datadir"))),
+        pairs=pairs,
+        ticker_interval=config['ticker_interval'],
+        refresh_pairs=config.get('refresh_pairs', False),
+        timerange=timerange,
+        exchange=exchange,
+        live=config.get("live", False),
+    )
+
     pair_counter = 0
     for pair, data in tickers.items():
         pair_counter += 1


### PR DESCRIPTION
## Summary
- Move capitalizing exchange into strategyResolver, it's needed EVERY time and we use it 5+ times.
- remoe get_tickers_history - it's only passing arguments to history.load_data.

This is part of my "asset stripping" project for this script, which should become a subcommand soonish.
