### PR TITLE
minor: typos in docstrings fixed

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -23,7 +23,7 @@ def load_backtest_data(filename) -> pd.DataFrame:
     """
     Load backtest data file.
     :param filename: pathlib.Path object, or string pointing to the file.
-    :return a dataframe with the analysis results
+    :return: a dataframe with the analysis results
     """
     if isinstance(filename, str):
         filename = Path(filename)
@@ -78,7 +78,7 @@ def load_trades(db_url: str = None, exportfilename: str = None) -> pd.DataFrame:
     Load trades, either from a DB (using dburl) or via a backtest export file.
     :param db_url: Sqlite url (default format sqlite:///tradesv3.dry-run.sqlite)
     :param exportfilename: Path to a file exported from backtesting
-    :returns: Dataframe containing Trades
+    :return: Dataframe containing Trades
     """
     timeZone = pytz.UTC
 

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -63,7 +63,7 @@ def load_tickerdata_file(
         timerange: Optional[TimeRange] = None) -> Optional[list]:
     """
     Load a pair from file, either .json.gz or .json
-    :return tickerlist or None if unsuccesful
+    :return: tickerlist or None if unsuccesful
     """
     filename = pair_data_filename(datadir, pair, ticker_interval)
     pairdata = misc.file_load_json(filename)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -158,7 +158,7 @@ class IStrategy(ABC):
         """
         Parses the given ticker history and returns a populated DataFrame
         add several TA indicators and buy signal to it
-        :return DataFrame with ticker data and indicator data
+        :return: DataFrame with ticker data and indicator data
         """
 
         pair = str(metadata.get('pair'))
@@ -351,7 +351,7 @@ class IStrategy(ABC):
         """
         Based an earlier trade and current price and ROI configuration, decides whether bot should
         sell. Requires current_profit to be in percent!!
-        :return True if bot should sell at current rate
+        :return: True if bot should sell at current rate
         """
 
         # Check if time matches and current rate is above threshold

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -65,14 +65,14 @@ class FtRestClient():
     def start(self):
         """
         Start the bot if it's in stopped state.
-        :returns: json object
+        :return: json object
         """
         return self._post("start")
 
     def stop(self):
         """
         Stop the bot. Use start to restart
-        :returns: json object
+        :return: json object
         """
         return self._post("stop")
 
@@ -80,77 +80,77 @@ class FtRestClient():
         """
         Stop buying (but handle sells gracefully).
         use reload_conf to reset
-        :returns: json object
+        :return: json object
         """
         return self._post("stopbuy")
 
     def reload_conf(self):
         """
         Reload configuration
-        :returns: json object
+        :return: json object
         """
         return self._post("reload_conf")
 
     def balance(self):
         """
         Get the account balance
-        :returns: json object
+        :return: json object
         """
         return self._get("balance")
 
     def count(self):
         """
         Returns the amount of open trades
-        :returns: json object
+        :return: json object
         """
         return self._get("count")
 
     def daily(self, days=None):
         """
         Returns the amount of open trades
-        :returns: json object
+        :return: json object
         """
         return self._get("daily", params={"timescale": days} if days else None)
 
     def edge(self):
         """
         Returns information about edge
-        :returns: json object
+        :return: json object
         """
         return self._get("edge")
 
     def profit(self):
         """
         Returns the profit summary
-        :returns: json object
+        :return: json object
         """
         return self._get("profit")
 
     def performance(self):
         """
         Returns the performance of the different coins
-        :returns: json object
+        :return: json object
         """
         return self._get("performance")
 
     def status(self):
         """
         Get the status of open trades
-        :returns: json object
+        :return: json object
         """
         return self._get("status")
 
     def version(self):
         """
         Returns the version of the bot
-        :returns: json object containing the version
+        :return: json object containing the version
         """
         return self._get("version")
 
     def whitelist(self):
         """
         Show the current whitelist
-        :returns: json object
+        :return: json object
         """
         return self._get("whitelist")
 
@@ -158,7 +158,7 @@ class FtRestClient():
         """
         Show the current blacklist
         :param add: List of coins to add (example: "BNB/BTC")
-        :returns: json object
+        :return: json object
         """
         if not args:
             return self._get("blacklist")
@@ -170,7 +170,7 @@ class FtRestClient():
         Buy an asset
         :param pair: Pair to buy (ETH/BTC)
         :param price: Optional - price to buy
-        :returns: json object of the trade
+        :return: json object of the trade
         """
         data = {"pair": pair,
                 "price": price
@@ -181,7 +181,7 @@ class FtRestClient():
         """
         Force-sell a trade
         :param tradeid: Id of the trade (can be received via status command)
-        :returns: json object
+        :return: json object
         """
 
         return self._post("forcesell", data={"tradeid": tradeid})


### PR DESCRIPTION
minor cosmetics
(typos in ':return:', as grepped out)
