### PR TITLE
Modify handling of pip in setup.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ notifications:
 cache:
   pip: True
   directories:
-    - /usr/local/lib
+    - /usr/local/lib/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,11 +4,21 @@ This page explains how to prepare your environment for running the bot.
 
 ## Prerequisite
 
+### Requirements
+
+Click each one for install guide:
+
+* [Python >= 3.6.x](http://docs.python-guide.org/en/latest/starting/installation/)
+* [pip](https://pip.pypa.io/en/stable/installing/)
+* [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
+* [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html) (install instructions below)
+
+### API keys
+
 Before running your bot in production you will need to setup few
 external API. In production mode, the bot will require valid Exchange API
 credentials. We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot) (optional but recommended).
-
-- [Setup your exchange account](#setup-your-exchange-account)
 
 ### Setup your exchange account
 
@@ -33,7 +43,7 @@ git checkout develop
 
 ## Easy Installation - Linux Script
 
-If you are on Debian, Ubuntu or MacOS a freqtrade provides a script to Install, Update, Configure, and Reset your bot.
+If you are on Debian, Ubuntu or MacOS freqtrade provides a script to Install, Update, Configure, and Reset your bot.
 
 ```bash
 $ ./setup.sh
@@ -48,7 +58,7 @@ usage:
 
 This script will install everything you need to run the bot:
 
-* Mandatory software as: `Python3`, `ta-lib`, `wget`
+* Mandatory software as: `ta-lib`
 * Setup your virtualenv
 * Configure your `config.json` file
 
@@ -73,24 +83,16 @@ Config parameter is a `config.json` configurator. This script will ask you quest
 We've included/collected install instructions for Ubuntu 16.04, MacOS, and Windows. These are guidelines and your success may vary with other distros.
 OS Specific steps are listed first, the [Common](#common) section below is necessary for all systems.
 
-### Requirements
-
-Click each one for install guide:
-
-* [Python >= 3.6.x](http://docs.python-guide.org/en/latest/starting/installation/)
-* [pip](https://pip.pypa.io/en/stable/installing/)
-* [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-* [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
-* [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html)
+!!! Note
+    Python3.6 or higher and the corresponding pip are assumed to be available.
 
 ### Linux - Ubuntu 16.04
 
-#### Install Python 3.6, Git, and wget
+#### Install necessary dependencies
 
 ```bash
-sudo add-apt-repository ppa:jonathonf/python-3.6
 sudo apt-get update
-sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
+sudo apt-get install build-essential git
 ```
 
 #### Raspberry Pi / Raspbian
@@ -112,14 +114,6 @@ conda install scipy pandas numpy
 sudo apt install libffi-dev
 python3 -m pip install -r requirements-common.txt
 python3 -m pip install -e .
-```
-
-### MacOS
-
-#### Install Python 3.6, git and wget
-
-```bash
-brew install python3 git wget
 ```
 
 ### Common
@@ -162,7 +156,7 @@ git clone https://github.com/freqtrade/freqtrade.git
 
 ```
 
-Optionally checkout the stable/master branch:
+Optionally checkout the master branch to get the latest stable release:
 
 ```bash
 git checkout master
@@ -180,9 +174,9 @@ cp config.json.example config.json
 #### 5. Install python dependencies
 
 ``` bash
-pip3 install --upgrade pip
-pip3 install -r requirements.txt
-pip3 install -e .
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 ```
 
 #### 6. Run the Bot
@@ -190,7 +184,7 @@ pip3 install -e .
 If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
 
 ```bash
-python3.6 freqtrade -c config.json
+python3 freqtrade -c config.json
 ```
 
 *Note*: If you run the bot on a server, you should consider using [Docker](docker.md) or a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.
@@ -220,7 +214,7 @@ when it changes.
 The `freqtrade.service.watchdog` file contains an example of the service unit configuration file which uses systemd 
 as the watchdog.
 
-!!! Note 
+!!! Note
   The sd_notify communication between the bot and the systemd service manager will not work if the bot runs in a Docker container.
 
 ------
@@ -239,8 +233,6 @@ If that is not available on your system, feel free to try the instructions below
 ```bash
 git clone https://github.com/freqtrade/freqtrade.git
 ```
-
-copy paste `config.json` to ``\path\freqtrade-develop\freqtrade`
 
 #### Install ta-lib
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,9 @@ You will need to create API Keys (Usually you get `key` and `secret`) from the E
 
 Freqtrade provides a Linux/MacOS script to install all dependencies and help you to configure the bot.
 
+!!! Note
+    Python3.6 or higher and the corresponding pip are assumed to be available. The install-script will warn and stop if that's not the case.
+
 ```bash
 git clone git@github.com:freqtrade/freqtrade.git
 cd freqtrade

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 function check_installed_pip() {
    ${PYTHON} -m pip > /dev/null
    if [ $? -ne 0 ]; then
-        echo "pip not found. Please make sure that pip is available for ${PYTHON}."
+        echo "pip not found (called as '${PYTHON} -m pip'). Please make sure that pip is available for ${PYTHON}."
         exit 1
    fi
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 #encoding=utf8
 
+function check_installed_pip() {
+   ${PYTHON} -m pip > /dev/null
+   if [ $? -ne 0 ]; then
+        echo "pip not found. Please make sure that pip is available for ${PYTHON}."
+        exit 1
+   fi
+}
+
 # Check which python version is installed
 function check_installed_python() {
     which python3.7
     if [ $? -eq 0 ]; then
         echo "using Python 3.7"
         PYTHON=python3.7
+        check_installed_pip
         return
     fi
 
@@ -14,6 +23,7 @@ function check_installed_python() {
     if [ $? -eq 0 ]; then
         echo "using Python 3.6"
         PYTHON=python3.6
+        check_installed_pip
         return
    fi
 
@@ -21,7 +31,6 @@ function check_installed_python() {
         echo "No usable python found. Please make sure to have python3.6 or python3.7 installed"
         exit 1
    fi
-
 }
 
 function updateenv() {
@@ -29,21 +38,21 @@ function updateenv() {
     echo "Updating your virtual env"
     echo "-------------------------"
     source .env/bin/activate
-    echo "pip3 install in-progress. Please wait..."
+    echo "pip install in-progress. Please wait..."
     # Install numpy first to have py_find_1st install clean
-    pip3 install --upgrade pip numpy
-    pip3 install --upgrade -r requirements.txt
+    ${PYTHON} -m pip install --upgrade pip numpy
+    ${PYTHON} -m pip install --upgrade -r requirements.txt
 
     read -p "Do you want to install dependencies for dev [y/N]? "
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-        pip3 install --upgrade -r requirements-dev.txt
+        ${PYTHON} -m pip install --upgrade -r requirements-dev.txt
     else
         echo "Dev dependencies ignored."
     fi
 
-    pip3 install --quiet -e .
-    echo "pip3 install completed"
+    ${PYTHON} -m pip install -e .
+    echo "pip install completed"
     echo
 }
 
@@ -74,16 +83,14 @@ function install_macos() {
         echo "-------------------------"
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     fi
-    brew install python3 wget
     install_talib
     test_and_fix_python_on_mac
 }
 
 # Install bot Debian_ubuntu
 function install_debian() {
-    sudo add-apt-repository ppa:jonathonf/python-3.6
     sudo apt-get update
-    sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
+    sudo apt-get install build-essential autoconf libtool pkg-config make wget git
     install_talib
 }
 
@@ -244,7 +251,7 @@ echo "
 Installing dependencies for Plotting scripts
 -----------------------------------------
 "
-pip install plotly --upgrade
+${PYTHON} -m pip install plotly --upgrade
 }
 
 function help() {


### PR DESCRIPTION
## Summary
The install script does not work correctly. 
It checks which python version to use before eventually installing that. 
Also, there are many ways (and even more different systems) to install python to a system, many better than the one we use in the script (pyenv to name one).

We should not install python for users, but instead require python and pip to be there.
We also do some "funny" things to brew on macOS. 
I would appreciate if someone with a Mac could look over that part too, since i think depending on the OS version we may break things.

Resolves #1956
