### PR TITLE
fix #1963

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -478,8 +478,11 @@ class FreqtradeBot(object):
             return order_amount
 
         # use fee from order-dict if possible
-        if 'fee' in order and order['fee'] and (order['fee'].keys() >= {'currency', 'cost'}):
-            if trade.pair.startswith(order['fee']['currency']):
+        if 'fee' in order and order['fee'] is not None and \
+                (order['fee'].keys() >= {'currency', 'cost'}):
+            if order['fee']['currency'] is not None and \
+                    order['fee']['cost'] is not None and \
+                    trade.pair.startswith(order['fee']['currency']):
                 new_amount = order_amount - order['fee']['cost']
                 logger.info("Applying fee on amount for %s (from %s to %s) from Order",
                             trade, order['amount'], new_amount)
@@ -496,9 +499,12 @@ class FreqtradeBot(object):
         fee_abs = 0
         for exectrade in trades:
             amount += exectrade['amount']
-            if "fee" in exectrade and (exectrade['fee'].keys() >= {'currency', 'cost'}):
+            if "fee" in exectrade and exectrade['fee'] is not None and \
+                    (exectrade['fee'].keys() >= {'currency', 'cost'}):
                 # only applies if fee is in quote currency!
-                if trade.pair.startswith(exectrade['fee']['currency']):
+                if exectrade['fee']['currency'] is not None and \
+                        exectrade['fee']['cost'] is not None and \
+                        trade.pair.startswith(exectrade['fee']['currency']):
                     fee_abs += exectrade['fee']['cost']
 
         if amount != order_amount:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -478,11 +478,11 @@ class FreqtradeBot(object):
             return order_amount
 
         # use fee from order-dict if possible
-        if 'fee' in order and order['fee'] is not None and \
-                (order['fee'].keys() >= {'currency', 'cost'}):
-            if order['fee']['currency'] is not None and \
-                    order['fee']['cost'] is not None and \
-                    trade.pair.startswith(order['fee']['currency']):
+        if ('fee' in order and order['fee'] is not None and
+                (order['fee'].keys() >= {'currency', 'cost'})):
+            if (order['fee']['currency'] is not None and
+                    order['fee']['cost'] is not None and
+                    trade.pair.startswith(order['fee']['currency'])):
                 new_amount = order_amount - order['fee']['cost']
                 logger.info("Applying fee on amount for %s (from %s to %s) from Order",
                             trade, order['amount'], new_amount)
@@ -499,12 +499,12 @@ class FreqtradeBot(object):
         fee_abs = 0
         for exectrade in trades:
             amount += exectrade['amount']
-            if "fee" in exectrade and exectrade['fee'] is not None and \
-                    (exectrade['fee'].keys() >= {'currency', 'cost'}):
+            if ("fee" in exectrade and exectrade['fee'] is not None and
+                    (exectrade['fee'].keys() >= {'currency', 'cost'})):
                 # only applies if fee is in quote currency!
-                if exectrade['fee']['currency'] is not None and \
-                        exectrade['fee']['cost'] is not None and \
-                        trade.pair.startswith(exectrade['fee']['currency']):
+                if (exectrade['fee']['currency'] is not None and
+                        exectrade['fee']['cost'] is not None and
+                        trade.pair.startswith(exectrade['fee']['currency'])):
                     fee_abs += exectrade['fee']['cost']
 
         if amount != order_amount:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2886,6 +2886,30 @@ def test_get_real_amount_stake(default_conf, trades_for_order, buy_order_fee, mo
     assert freqtrade.get_real_amount(trade, buy_order_fee) == amount
 
 
+def test_get_real_amount_no_currency_in_fee(default_conf, trades_for_order, buy_order_fee, mocker):
+
+    limit_buy_order = deepcopy(buy_order_fee)
+    limit_buy_order['fee'] = {'cost': 0.004, 'currency': None}
+    trades_for_order[0]['fee']['currency'] = None
+
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    mocker.patch('freqtrade.exchange.Exchange.get_trades_for_order', return_value=trades_for_order)
+    amount = sum(x['amount'] for x in trades_for_order)
+    trade = Trade(
+        pair='LTC/ETH',
+        amount=amount,
+        exchange='binance',
+        open_rate=0.245441,
+        open_order_id="123456"
+    )
+    freqtrade = FreqtradeBot(default_conf)
+    patch_get_signal(freqtrade)
+
+    # Amount does not change
+    assert freqtrade.get_real_amount(trade, limit_buy_order) == amount
+
+
 def test_get_real_amount_BNB(default_conf, trades_for_order, buy_order_fee, mocker):
     trades_for_order[0]['fee']['currency'] = 'BNB'
     trades_for_order[0]['fee']['cost'] = 0.00094518


### PR DESCRIPTION
Resolves #1963 

['fee']['cost'] (and probably ['fee']['currency']) from ccxt may exist and may be None for some exchanges (e.g. Coinbase Pro).
Protect against it.
