### PR TITLE
Show different message for balance during dry-run

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -298,7 +298,10 @@ class RPC(object):
                 'est_btc': est_btc,
             })
         if total == 0.0:
-            raise RPCException('all balances are zero')
+            if self._freqtrade.config.get('dry_run', False):
+                raise RPCException('Running in Dry Run, balances are not available.')
+            else:
+                raise RPCException('All balances are zero.')
 
         symbol = fiat_display_currency
         value = self._fiat_converter.convert_amount(total, 'BTC',

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -559,10 +559,32 @@ def test_balance_handle_empty_response(default_conf, update, mocker) -> None:
 
     telegram = Telegram(freqtradebot)
 
+    freqtradebot.config['dry_run'] = False
     telegram._balance(bot=MagicMock(), update=update)
     result = msg_mock.call_args_list[0][0][0]
     assert msg_mock.call_count == 1
-    assert 'all balances are zero' in result
+    assert 'All balances are zero.' in result
+
+
+def test_balance_handle_empty_response_dry(default_conf, update, mocker) -> None:
+    mocker.patch('freqtrade.exchange.Exchange.get_balances', return_value={})
+
+    msg_mock = MagicMock()
+    mocker.patch.multiple(
+        'freqtrade.rpc.telegram.Telegram',
+        _init=MagicMock(),
+        _send_msg=msg_mock
+    )
+
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+    patch_get_signal(freqtradebot, (True, False))
+
+    telegram = Telegram(freqtradebot)
+
+    telegram._balance(bot=MagicMock(), update=update)
+    result = msg_mock.call_args_list[0][0][0]
+    assert msg_mock.call_count == 1
+    assert "Running in Dry Run, balances are not available." in result
 
 
 def test_balance_handle_too_large_response(default_conf, update, mocker) -> None:


### PR DESCRIPTION
## Summary
Showing `all balances are zero` during dry-run is confusing. We should be clear that we're in dry-run.

Closes #1542

## Quick changelog

- Show different message for `/balance` during dry-run

## What's new?

![2019-06-27-070708_587x126_scrot](https://user-images.githubusercontent.com/5024695/60236046-35717100-98aa-11e9-8dfb-8efb30a2f6a2.png)
