### PR TITLE
fix #1978

### DIFF
--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -170,7 +170,7 @@ class Configuration(object):
         self._load_logging_config(config)
 
         # Support for sd_notify
-        if self.args.sd_notify:
+        if 'sd_notify' in self.args and self.args.sd_notify:
             config['internals'].update({'sd_notify': True})
 
         # Add dynamic_whitelist if found
@@ -186,7 +186,8 @@ class Configuration(object):
                 '(not applicable with Backtesting and Hyperopt)'
             )
 
-        if self.args.db_url and self.args.db_url != constants.DEFAULT_DB_PROD_URL:
+        if ('db_url' in self.args and self.args.db_url and
+                self.args.db_url != constants.DEFAULT_DB_PROD_URL):
             config.update({'db_url': self.args.db_url})
             logger.info('Parameter --db-url detected ...')
 


### PR DESCRIPTION
Resolves #1978.

However, plot_dataframe.py still does not work without options:
```
$ ./scripts/plot_dataframe.py
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Verbosity set to 0
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Dry run is enabled
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Using DB: "sqlite://"
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Checking exchange...
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Exchange "bittrex" is officially supported by the Freqtrade development team.
2019-06-28 01:03:29,545 - freqtrade.configuration - INFO - Using max_open_trades: 3 ...
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Using data folder: user_data/data/bittrex ...
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Storing backtest results to user_data/backtest_data/backtest-result.json ...
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Using indicators1: sma,ema3,ema5
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Using indicators2: macd,macdsignal
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Limiting plot to: 750
2019-06-28 01:03:29,546 - freqtrade.configuration - INFO - Using trades from: file
2019-06-28 01:03:29,546 - freqtrade.resolvers.exchange_resolver - INFO - No Bittrex specific subclass found. Using the generic class instead.
2019-06-28 01:03:29,546 - freqtrade.exchange.exchange - INFO - Instance is running with dry_run enabled
2019-06-28 01:03:29,546 - freqtrade.exchange.exchange - INFO - Applying additional ccxt config: {'enableRateLimit': True}
2019-06-28 01:03:29,549 - freqtrade.exchange.exchange - INFO - Applying additional ccxt config: {'enableRateLimit': True, 'rateLimit': 500}
2019-06-28 01:03:29,562 - freqtrade.exchange.exchange - INFO - Using Exchange "Bittrex"
2019-06-28 01:03:31,336 - freqtrade.resolvers.strategy_resolver - INFO - Using resolved strategy DefaultStrategy from '/home/user/freqtrade-wrk/github-hroff-1902/freqtrade/freqtrade/strategy'
2019-06-28 01:03:31,336 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'ticker_interval' with value in config file: 5m.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'trailing_stop' with value in config file: False.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'stake_currency' with value in config file: BTC.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'stake_amount' with value in config file: 0.05.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'use_sell_signal' with value in config file: False.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'sell_profit_only' with value in config file: False.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'ignore_roi_if_buy_signal' with value in config file: False.
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using minimal_roi: {'40': 0.0, '30': 0.01, '20': 0.02, '0': 0.04}
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using ticker_interval: 5m
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stoploss: -0.1
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop: False
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop_positive_offset: 0.0
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_only_offset_is_reached: False
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using process_only_new_candles: False
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_types: {'buy': 'limit', 'sell': 'limit', 'stoploss': 'limit', 'stoploss_on_exchange': False}
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_time_in_force: {'buy': 'gtc', 'sell': 'gtc'}
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stake_currency: BTC
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stake_amount: 0.05
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using use_sell_signal: False
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using sell_profit_only: False
2019-06-28 01:03:31,337 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using ignore_roi_if_buy_signal: False
Traceback (most recent call last):
  File "./scripts/plot_dataframe.py", line 150, in <module>
    main(sys.argv[1:])
  File "./scripts/plot_dataframe.py", line 144, in main
    plot_parse_args(sysargv)
  File "./scripts/plot_dataframe.py", line 80, in analyse_and_plot_pairs
    timerange = Arguments.parse_timerange(config["timerange"])
KeyError: 'timerange'
```
@xmatthias Handling of timerange differ in plot_profit.py and plot_dataframe.py, pls take a look at this.
