### PR TITLE
adding bitstamp to list of bad exchanges.

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -723,7 +723,7 @@ class Exchange(object):
 
 
 def is_exchange_bad(exchange: str) -> bool:
-    return exchange in ['bitmex']
+    return exchange in ['bitmex', 'bitstamp']
 
 
 def is_exchange_available(exchange: str, ccxt_module=None) -> bool:


### PR DESCRIPTION
## Summary
adding bitstamp to list of bad exchanges.

Address the issue: #1983

## Quick changelog

- added bitstamp to the list of known bad exchanges

## What's new?

I now see : 
```
2019-06-29 17:18:32,056 - freqtrade.configuration - WARNING - Exchange "bitstamp" is known to not work with the bot yet. Use it only for development and testing purposes.
```
