### PR TITLE
fix validate_timeframes()

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -269,12 +269,15 @@ class Exchange(object):
         """
         Checks if ticker interval from config is a supported timeframe on the exchange
         """
-        if not hasattr(self._api, "timeframes"):
-            # If timeframes is missing, the exchange probably has no fetchOHLCV method.
+        if not hasattr(self._api, "timeframes") or self._api.timeframes is None:
+            # If timeframes attribute is missing (or is None), the exchange probably
+            # has no fetchOHLCV method.
             # Therefore we also show that.
             raise OperationalException(
-                f"This exchange ({self.name}) does not have a `timeframes` attribute and "
-                f"is therefore not supported. fetchOHLCV: {self.exchange_has('fetchOHLCV')}")
+                f"The ccxt library does not provide the list of timeframes "
+                f"for the exchange \"{self.name}\" and this exchange "
+                f"is therefore not supported. ccxt fetchOHLCV: {self.exchange_has('fetchOHLCV')}")
+
         timeframes = self._api.timeframes
         if timeframe not in timeframes:
             raise OperationalException(

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -396,7 +396,7 @@ def test_validate_timeframes_failed(default_conf, mocker):
         Exchange(default_conf)
 
 
-def test_validate_timeframes_emulated_ohlcv(default_conf, mocker):
+def test_validate_timeframes_emulated_ohlcv_1(default_conf, mocker):
     default_conf["ticker_interval"] = "3m"
     api_mock = MagicMock()
     id_mock = PropertyMock(return_value='test_exchange')
@@ -409,7 +409,29 @@ def test_validate_timeframes_emulated_ohlcv(default_conf, mocker):
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     with pytest.raises(OperationalException,
-                       match=r'This exchange (.*) does not have a `timeframes` attribute and*'):
+                       match=r'The ccxt library does not provide the list of timeframes '
+                             r'for the exchange ".*" and this exchange '
+                             r'is therefore not supported. *'):
+        Exchange(default_conf)
+
+
+def test_validate_timeframes_emulated_ohlcvi_2(default_conf, mocker):
+    default_conf["ticker_interval"] = "3m"
+    api_mock = MagicMock()
+    id_mock = PropertyMock(return_value='test_exchange')
+    type(api_mock).id = id_mock
+
+    # delete timeframes so magicmock does not autocreate it
+    del api_mock.timeframes
+
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange._load_markets',
+                 MagicMock(return_value={'timeframes': None}))
+    mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
+    with pytest.raises(OperationalException,
+                       match=r'The ccxt library does not provide the list of timeframes '
+                             r'for the exchange ".*" and this exchange '
+                             r'is therefore not supported. *'):
         Exchange(default_conf)
 
 


### PR DESCRIPTION
* This PR addresses the issue mentioned in #1992 (see https://github.com/freqtrade/freqtrade/issues/1992#issuecomment-507825182): `validate_timeframes()` does not work as intended (it does not issue `OperationalException`) after https://github.com/ccxt/ccxt/commit/2be61d6b80a7e7e9be44ba5fe0f5bcc54997584d made in ccxt.
* The text of the exception message clarified (to cover both cases, when there is no `timeframes` attribute and when it's None), test adjusted with the new exception text.
* Test added for `'timeframes': None` in the markets.
