### PR TITLE
Don't run the bot with python3 freqtrade

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -24,37 +24,37 @@ The backtesting is very easy with freqtrade.
 #### With 5 min tickers (Per default)
 
 ```bash
-python3 freqtrade backtesting
+freqtrade backtesting
 ```
 
 #### With 1 min tickers
 
 ```bash
-python3 freqtrade backtesting --ticker-interval 1m
+freqtrade backtesting --ticker-interval 1m
 ```
 
 #### Update cached pairs with the latest data
 
 ```bash
-python3 freqtrade backtesting --refresh-pairs-cached
+freqtrade backtesting --refresh-pairs-cached
 ```
 
 #### With live data (do not alter your testdata files)
 
 ```bash
-python3 freqtrade backtesting --live
+freqtrade backtesting --live
 ```
 
 #### Using a different on-disk ticker-data source
 
 ```bash
-python3 freqtrade backtesting --datadir freqtrade/tests/testdata-20180101
+freqtrade backtesting --datadir freqtrade/tests/testdata-20180101
 ```
 
 #### With a (custom) strategy file
 
 ```bash
-python3 freqtrade -s TestStrategy backtesting
+freqtrade -s TestStrategy backtesting
 ```
 
 Where `-s TestStrategy` refers to the class name within the strategy file `test_strategy.py` found in the `freqtrade/user_data/strategies` directory
@@ -62,7 +62,7 @@ Where `-s TestStrategy` refers to the class name within the strategy file `test_
 #### Exporting trades to file
 
 ```bash
-python3 freqtrade backtesting --export trades
+freqtrade backtesting --export trades
 ```
 
 The exported trades can be used for [further analysis](#further-backtest-result-analysis), or can be used by the plotting script `plot_dataframe.py` in the scripts directory.
@@ -70,7 +70,7 @@ The exported trades can be used for [further analysis](#further-backtest-result-
 #### Exporting trades to file specifying a custom filename
 
 ```bash
-python3 freqtrade backtesting --export trades --export-filename=backtest_teststrategy.json
+freqtrade backtesting --export trades --export-filename=backtest_teststrategy.json
 ```
 
 #### Running backtest with smaller testset
@@ -81,7 +81,7 @@ you want to use. The last N ticks/timeframes will be used.
 Example:
 
 ```bash
-python3 freqtrade backtesting --timerange=-200
+freqtrade backtesting --timerange=-200
 ```
 
 #### Advanced use of timerange

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -49,7 +49,7 @@ The bot allows you to select which configuration file you want to use. Per
 default, the bot will load the file `./config.json`
 
 ```bash
-python3 freqtrade -c path/far/far/away/config.json
+freqtrade -c path/far/far/away/config.json
 ```
 
 ### How to use multiple configuration files?
@@ -65,13 +65,13 @@ empty key and secrete values while running in the Dry Mode (which does not actua
 require them):
 
 ```bash
-python3 freqtrade -c ./config.json
+freqtrade -c ./config.json
 ```
 
 and specify both configuration files when running in the normal Live Trade Mode:
 
 ```bash
-python3 freqtrade -c ./config.json -c path/to/secrets/keys.config.json
+freqtrade -c ./config.json -c path/to/secrets/keys.config.json
 ```
 
 This could help you hide your private Exchange key and Exchange secrete on you local machine
@@ -97,7 +97,7 @@ In `user_data/strategies` you have a file `my_awesome_strategy.py` which has
 a strategy class called `AwesomeStrategy` to load it:
 
 ```bash
-python3 freqtrade --strategy AwesomeStrategy
+freqtrade --strategy AwesomeStrategy
 ```
 
 If the bot does not find your strategy file, it will display in an error
@@ -111,7 +111,7 @@ Learn more about strategy file in
 This parameter allows you to add an additional strategy lookup path, which gets
 checked before the default locations (The passed path must be a directory!):
 ```bash
-python3 freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
+freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
 ```
 
 #### How to install a strategy?
@@ -138,7 +138,7 @@ using `--db-url`. This can also be used to specify a custom database
 in production mode. Example command:
 
 ```bash
-python3 freqtrade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
+freqtrade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 ```
 
 ## Backtesting commands

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -13,14 +13,14 @@ on BaseVolume. This value can be changed when you run the script.
 Get the 20 currencies based on BaseVolume.
 
 ```bash
-python3 freqtrade --dynamic-whitelist
+freqtrade --dynamic-whitelist
 ```
 
 **Customize the number of currencies to retrieve**
 Get the 30 currencies based on BaseVolume.
 
 ```bash
-python3 freqtrade --dynamic-whitelist 30
+freqtrade --dynamic-whitelist 30
 ```
 
 **Exception**

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -209,7 +209,7 @@ Edge will remove sudden pumps in a given market while going through historical d
 You can run Edge independently in order to see in details the result. Here is an example:
 
 ```bash
-python3 freqtrade edge
+freqtrade edge
 ```
 
 An example of its output:
@@ -235,19 +235,19 @@ An example of its output:
 ### Update cached pairs with the latest data
 
 ```bash
-python3 freqtrade edge --refresh-pairs-cached
+freqtrade edge --refresh-pairs-cached
 ```
 
 ### Precising stoploss range
 
 ```bash
-python3 freqtrade edge --stoplosses=-0.01,-0.1,-0.001 #min,max,step
+freqtrade edge --stoplosses=-0.01,-0.1,-0.001 #min,max,step
 ```
 
 ### Advanced use of timerange
 
 ```bash
-python3 freqtrade edge --timerange=20181110-20181113
+freqtrade edge --timerange=20181110-20181113
 ```
 
 Doing `--timerange=-200` will get the last 200 timeframes from your inputdata. You can also specify specific dates, or a range span indexed by start and stop.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,14 +1,25 @@
 # Freqtrade FAQ
 
-### Freqtrade commons
+## Freqtrade common issues
 
-#### I have waited 5 minutes, why hasn't the bot made any trades yet?!
+### The bot does not start
+
+Running the bot with `freqtrade --config config.json` does show the output `freqtrade: command not found`.
+
+This could have the following reasons:
+
+* The virtual environment is not active
+  * run `source .env/bin/activate` to activate the virtual environment
+* The installation did not work correctly.
+  * Please check the [Installation documentation](installation.md).
+
+### I have waited 5 minutes, why hasn't the bot made any trades yet?!
 
 Depending on the buy strategy, the amount of whitelisted coins, the
 situation of the market etc, it can take up to hours to find good entry
 position for a trade. Be patient!
 
-#### I have made 12 trades already, why is my total profit negative?!
+### I have made 12 trades already, why is my total profit negative?!
 
 I understand your disappointment but unfortunately 12 trades is just
 not enough to say anything. If you run backtesting, you can see that our
@@ -19,24 +30,24 @@ of course constantly aim to improve the bot but it will _always_ be a
 gamble, which should leave you with modest wins on monthly basis but
 you can't say much from few trades.
 
-#### I’d like to change the stake amount. Can I just stop the bot with /stop and then change the config.json and run it again?
+### I’d like to change the stake amount. Can I just stop the bot with /stop and then change the config.json and run it again?
 
 Not quite. Trades are persisted to a database but the configuration is
 currently only read when the bot is killed and restarted. `/stop` more
 like pauses. You can stop your bot, adjust settings and start it again.
 
-#### I want to improve the bot with a new strategy
+### I want to improve the bot with a new strategy
 
 That's great. We have a nice backtesting and hyperoptimizing setup. See
 the tutorial [here|Testing-new-strategies-with-Hyperopt](bot-usage.md#hyperopt-commands).
 
-#### Is there a setting to only SELL the coins being held and not perform anymore BUYS?
+### Is there a setting to only SELL the coins being held and not perform anymore BUYS?
 
 You can use the `/forcesell all` command from Telegram.
 
-### Hyperopt module
+## Hyperopt module
 
-#### How many epoch do I need to get a good Hyperopt result?
+### How many epoch do I need to get a good Hyperopt result?
 
 Per default Hyperopts without `-e` or `--epochs` parameter will only
 run 100 epochs, means 100 evals of your triggers, guards, ... Too few
@@ -56,7 +67,7 @@ or if you want intermediate result to see
 for i in {1..100}; do freqtrade hyperopt -e 100; done
 ```
 
-#### Why it is so long to run hyperopt?
+### Why it is so long to run hyperopt?
 
 Finding a great Hyperopt results takes time.
 
@@ -74,13 +85,14 @@ already 8\*10^9\*10 evaluations. A roughly total of 80 billion evals.
 Did you run 100 000 evals? Congrats, you've done roughly 1 / 100 000 th
 of the search space.
 
-### Edge module
+## Edge module
 
-#### Edge implements interesting approach for controlling position size, is there any theory behind it?
+### Edge implements interesting approach for controlling position size, is there any theory behind it?
 
 The Edge module is mostly a result of brainstorming of [@mishaker](https://github.com/mishaker) and [@creslinux](https://github.com/creslinux) freqtrade team members.
 
 You can find further info on expectancy, winrate, risk management and position size in the following sources:
+
 - https://www.tradeciety.com/ultimate-math-guide-for-traders/
 - http://www.vantharp.com/tharp-concepts/expectancy.asp
 - https://samuraitradingacademy.com/trading-expectancy/

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,13 +47,13 @@ compute.
 We recommend you to run it at least 10.000 epochs:
 
 ```bash
-python3 freqtrade hyperopt -e 10000
+freqtrade hyperopt -e 10000
 ```
 
 or if you want intermediate result to see
 
 ```bash
-for i in {1..100}; do python3 freqtrade hyperopt -e 100; done
+for i in {1..100}; do freqtrade hyperopt -e 100; done
 ```
 
 #### Why it is so long to run hyperopt?

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -158,7 +158,7 @@ Because hyperopt tries a lot of combinations to find the best parameters it will
 We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 
 ```bash
-python3 freqtrade -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
+freqtrade -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
 Use  `<hyperoptname>` as the name of the custom hyperopt used.
@@ -184,7 +184,7 @@ you want to use. The last N ticks/timeframes will be used.
 Example:
 
 ```bash
-python3 freqtrade hyperopt --timerange -200
+freqtrade hyperopt --timerange -200
 ```
 
 ### Running Hyperopt with Smaller Search Space

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -184,7 +184,7 @@ python3 -m pip install -e .
 If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
 
 ```bash
-python3 freqtrade -c config.json
+freqtrade -c config.json
 ```
 
 *Note*: If you run the bot on a server, you should consider using [Docker](docker.md) or a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -13,7 +13,7 @@ Let assume you have a class called `AwesomeStrategy` in the file `awesome-strate
 2. Start the bot with the param `--strategy AwesomeStrategy` (the parameter is the class name)
 
 ```bash
-python3 freqtrade --strategy AwesomeStrategy
+freqtrade --strategy AwesomeStrategy
 ```
 
 ## Change your strategy
@@ -40,7 +40,7 @@ The bot also include a sample strategy called `TestStrategy` you can update: `us
 You can test it with the parameter: `--strategy TestStrategy`
 
 ```bash
-python3 freqtrade --strategy AwesomeStrategy
+freqtrade --strategy AwesomeStrategy
 ```
 
 **For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
@@ -400,7 +400,7 @@ The default buy strategy is located in the file
 If you want to use a strategy from a different directory you can pass `--strategy-path`
 
 ```bash
-python3 freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
+freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
 ```
 
 ### Further strategy ideas

--- a/setup.sh
+++ b/setup.sh
@@ -242,7 +242,7 @@ function install() {
     echo "-------------------------"
     echo "Run the bot !"
     echo "-------------------------"
-    echo "You can now use the bot by executing 'source .env/bin/activate; python freqtrade'."
+    echo "You can now use the bot by executing 'source .env/bin/activate; freqtrade'."
 }
 
 function plot() {


### PR DESCRIPTION
we can either use `python3 -m freqtrade ...` or `freqtrade ...` to run the bot (`python3 freqtrade` requires some ugly hacks with PYTHON_PATH.

- and shorter should be better.

## Summary
Explain in one sentence the goal of this PR

closes #1990 

## Details:

if `freqtrade` is not available as binary - then the installation did not go well or the virtual Environment has not been activated.

