### PR TITLE
fix #2005

### DIFF
--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -42,7 +42,7 @@ def init_plotscript(config):
         pairs = config["exchange"]["pair_whitelist"]
 
     # Set timerange to use
-    timerange = Arguments.parse_timerange(config["timerange"])
+    timerange = Arguments.parse_timerange(config.get("timerange"))
 
     tickers = history.load_data(
         datadir=Path(str(config.get("datadir"))),


### PR DESCRIPTION
Resolves #2005 in a quick and dirty manner.

@xmatthias, be careful changing `args.attr` to `config['attr']` in the main freqtrade, subcommands and the scripts -- argparse creates `args` attribute as None if an option is not present in the cli, while `args_to_config()` does not create an element in the config in this case...

This fix is stated as quick and dirty above since I'm refactoring the whole attributes/configuration part and this will also be addressed then... For now -- this minor fix is enough to make the script working again.