### PR TITLE
fix #2008

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -216,7 +216,7 @@ some potential trades to be hidden (or masked) by previosly open trades.
 
 The `--eps`/`--enable-position-stacking` argument allows emulation of buying the same pair multiple times,
 while `--dmmp`/`--disable-max-market-positions` disables applying `max_open_trades` 
-during Hyperopt/Backtesting (which is same as setting `max_open_trades` to a very high
+during Hyperopt/Backtesting (which is equal to setting `max_open_trades` to a very high
 number).
 
 !!! Note

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -204,6 +204,27 @@ Legal values are:
 - `stoploss`: search for the best stoploss value
 - space-separated list of any of the above values for example `--spaces roi stoploss`
 
+### Position stacking and disabling max market positions.
+
+In some situations, you may need to run Hyperopt (and Backtesting) with the 
+`--eps`/`--enable-position-staking` and `--dmmp`/`--disable-max-market-positions` arguments.
+
+By default, hyperopt emulates the behavior of the Freqtrade Live Run/Dry Run, where only one
+open trade is allowed for every traded pair. The total number of trades open for all pairs 
+is also limited by the `max_open_trades` setting. During Hyperopt/Backtesting this may lead to
+some potential trades to be hidden (or masked) by previosly open trades.
+
+The `--eps`/`--enable-position-stacking` argument allows emulation of buying the same pair multiple times,
+while `--dmmp`/`--disable-max-market-positions` disables applying `max_open_trades` 
+during Hyperopt/Backtesting (which is same as setting `max_open_trades` to a very high
+number).
+
+!!! Note
+    Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
+
+You can also enable position stacking in the configuration file by explicitly setting 
+`"position_stacking"=true`.
+
 ## Understand the Hyperopt Result
 
 Once Hyperopt is completed you can use the result to create a new strategy.
@@ -288,19 +309,11 @@ This would translate to the following ROI table:
     }
 ```
 
-### Validate backtest result
+### Validate backtesting results
 
 Once the optimized strategy has been implemented into your strategy, you should backtest this strategy to make sure everything is working as expected.
-To archive the same results (number of trades, ...) than during hyperopt, please use the command line flags `--disable-max-market-positions` and `--enable-position-stacking` for backtesting.
 
-This configuration is the default in hyperopt for performance reasons.
-
-You can overwrite position stacking in the configuration by explicitly setting `"position_stacking"=false` or by changing the relevant line in your hyperopt file [here](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/optimize/hyperopt.py#L191).
-
-Enabling the market-position for hyperopt is currently not possible.
-
-!!! Note
-    Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
+To achieve same results (number of trades, their durations, profit, etc.) than during Hyperopt, please use same set of arguments `--dmmp`/`--disable-max-market-positions` and `--eps`/`--enable-position-stacking` for Backtesting.
 
 ## Next Step
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -319,6 +319,9 @@ class Backtesting(object):
             position_stacking: do we allow position stacking? (default: False)
         :return: DataFrame
         """
+        # Arguments are long and noisy, so this is commented out.
+        # Uncomment if you need to debug the backtest() method.
+#        logger.debug(f"Start backtest, args: {args}")
         processed = args['processed']
         stake_amount = args['stake_amount']
         max_open_trades = args.get('max_open_trades', 0)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -190,11 +190,21 @@ class Hyperopt(Backtesting):
             self.strategy.stoploss = params['stoploss']
 
         processed = load(TICKERDATA_PICKLE)
+
+        # Use max_open_trades for hyperopt as well, except --disable-max-market-positions is set
+        if self.config.get('use_max_market_positions', True):
+            max_open_trades = self.config['max_open_trades']
+        else:
+            logger.info('Ignoring max_open_trades (--disable-max-market-positions was used) ...')
+            max_open_trades = 0
+
         min_date, max_date = get_timeframe(processed)
+
         results = self.backtest(
             {
                 'stake_amount': self.config['stake_amount'],
                 'processed': processed,
+                'max_open_trades': max_open_trades,
                 'position_stacking': self.config.get('position_stacking', False),
                 'start_date': min_date,
                 'end_date': max_date,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -195,7 +195,7 @@ class Hyperopt(Backtesting):
             {
                 'stake_amount': self.config['stake_amount'],
                 'processed': processed,
-                'position_stacking': self.config.get('position_stacking', True),
+                'position_stacking': self.config.get('position_stacking', False),
                 'start_date': min_date,
                 'end_date': max_date,
             }

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -195,7 +195,7 @@ class Hyperopt(Backtesting):
         if self.config.get('use_max_market_positions', True):
             max_open_trades = self.config['max_open_trades']
         else:
-            logger.info('Ignoring max_open_trades (--disable-max-market-positions was used) ...')
+            logger.debug('Ignoring max_open_trades (--disable-max-market-positions was used) ...')
             max_open_trades = 0
 
         min_date, max_date = get_timeframe(processed)


### PR DESCRIPTION
Resolves #2008 

(A helping debug message was also added, but commented out since it contains long dataframe and is noisy therefore...)

This probably closes a couple of old issues as well (related to the deviations found between hyperopt and backtesting results), pls check.
