### PR TITLE
Fix #2013

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -288,9 +288,8 @@ class Hyperopt(Backtesting):
             (max_date - min_date).days
         )
 
-        if self.has_space('buy') or self.has_space('sell'):
-            self.strategy.advise_indicators = \
-                self.custom_hyperopt.populate_indicators  # type: ignore
+        self.strategy.advise_indicators = \
+            self.custom_hyperopt.populate_indicators  # type: ignore
 
         preprocessed = self.strategy.tickerdata_to_dataframe(data)
 


### PR DESCRIPTION
We need our indicators defined in the hyperopt even if static populate_buy/sell_trend() are used (i.e. when spaces contain neither buy nor sell).

Resolves #2013 
