### PR TITLE
Make configuration a module

### DIFF
--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,8 +1,2 @@
 from freqtrade.configuration.arguments import Arguments, TimeRange  # noqa: F401
-
-from freqtrade.configuration.arguments import (  # noqa: F401
-        ARGS_DOWNLOADER,
-        ARGS_PLOT_DATAFRAME,
-        ARGS_PLOT_PROFIT)
-
 from freqtrade.configuration.configuration import Configuration  # noqa: F401

--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,0 +1,8 @@
+from freqtrade.configuration.arguments import Arguments, TimeRange  # noqa: F401
+
+from freqtrade.configuration.arguments import (  # noqa: F401
+        ARGS_DOWNLOADER,
+        ARGS_PLOT_DATAFRAME,
+        ARGS_PLOT_PROFIT)
+
+from freqtrade.configuration.configuration import Configuration  # noqa: F401

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import re
 from typing import List, NamedTuple, Optional
+
 import arrow
 from freqtrade import __version__, constants
 

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Any, Dict
+
+from freqtrade import OperationalException
+from freqtrade.exchange import (is_exchange_bad, is_exchange_available,
+                                is_exchange_officially_supported, available_exchanges)
+
+
+logger = logging.getLogger(__name__)
+
+
+def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
+    """
+    Check if the exchange name in the config file is supported by Freqtrade
+    :param check_for_bad: if True, check the exchange against the list of known 'bad'
+                          exchanges
+    :return: False if exchange is 'bad', i.e. is known to work with the bot with
+             critical issues or does not work at all, crashes, etc. True otherwise.
+             raises an exception if the exchange if not supported by ccxt
+             and thus is not known for the Freqtrade at all.
+    """
+    logger.info("Checking exchange...")
+
+    exchange = config.get('exchange', {}).get('name').lower()
+    if not is_exchange_available(exchange):
+        raise OperationalException(
+                f'Exchange "{exchange}" is not supported by ccxt '
+                f'and therefore not available for the bot.\n'
+                f'The following exchanges are supported by ccxt: '
+                f'{", ".join(available_exchanges())}'
+        )
+
+    if check_for_bad and is_exchange_bad(exchange):
+        logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
+                       f'Use it only for development and testing purposes.')
+        return False
+
+    if is_exchange_officially_supported(exchange):
+        logger.info(f'Exchange "{exchange}" is officially supported '
+                    f'by the Freqtrade development team.')
+    else:
+        logger.warning(f'Exchange "{exchange}" is supported by ccxt '
+                       f'and therefore available for the bot but not officially supported '
+                       f'by the Freqtrade development team. '
+                       f'It may work flawlessly (please report back) or have serious issues. '
+                       f'Use it at your own discretion.')
+
+    return True

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -3,13 +3,13 @@ This module contains the configuration class
 """
 import json
 import logging
-import os
 import sys
 from argparse import Namespace
 from typing import Any, Callable, Dict, Optional
 
 from freqtrade import OperationalException, constants
 from freqtrade.configuration.check_exchange import check_exchange
+from freqtrade.configuration.create_datadir import create_datadir
 from freqtrade.configuration.json_schema import validate_config_schema
 from freqtrade.loggers import setup_logging
 from freqtrade.misc import deep_merge_dicts
@@ -171,17 +171,6 @@ class Configuration(object):
 
         return config
 
-    def _create_datadir(self, config: Dict[str, Any], datadir: Optional[str] = None) -> str:
-        if not datadir:
-            # set datadir
-            exchange_name = config.get('exchange', {}).get('name').lower()
-            datadir = os.path.join('user_data', 'data', exchange_name)
-
-        if not os.path.isdir(datadir):
-            os.makedirs(datadir)
-            logger.info(f'Created data directory: {datadir}')
-        return datadir
-
     def _args_to_config(self, config: Dict[str, Any], argname: str,
                         logstring: str, logfun: Optional[Callable] = None) -> None:
         """
@@ -207,9 +196,9 @@ class Configuration(object):
         the --datadir option
         """
         if 'datadir' in self.args and self.args.datadir:
-            config.update({'datadir': self._create_datadir(config, self.args.datadir)})
+            config.update({'datadir': create_datadir(config, self.args.datadir)})
         else:
-            config.update({'datadir': self._create_datadir(config, None)})
+            config.update({'datadir': create_datadir(config, None)})
         logger.info('Using data directory: %s ...', config.get('datadir'))
 
     def _load_optimize_config(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -8,43 +8,15 @@ import sys
 from argparse import Namespace
 from typing import Any, Callable, Dict, Optional
 
-from jsonschema import Draft4Validator, validators
-from jsonschema.exceptions import ValidationError, best_match
-
 from freqtrade import OperationalException, constants
-from freqtrade.exchange import (is_exchange_bad, is_exchange_available,
-                                is_exchange_officially_supported, available_exchanges)
+from freqtrade.configuration.check_exchange import check_exchange
+from freqtrade.configuration.json_schema import validate_config_schema
 from freqtrade.loggers import setup_logging
 from freqtrade.misc import deep_merge_dicts
 from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)
-
-
-def _extend_validator(validator_class):
-    """
-    Extended validator for the Freqtrade configuration JSON Schema.
-    Currently it only handles defaults for subschemas.
-    """
-    validate_properties = validator_class.VALIDATORS['properties']
-
-    def set_defaults(validator, properties, instance, schema):
-        for prop, subschema in properties.items():
-            if 'default' in subschema:
-                instance.setdefault(prop, subschema['default'])
-
-        for error in validate_properties(
-            validator, properties, instance, schema,
-        ):
-            yield error
-
-    return validators.extend(
-        validator_class, {'properties': set_defaults}
-    )
-
-
-FreqtradeValidator = _extend_validator(Draft4Validator)
 
 
 class Configuration(object):
@@ -57,6 +29,16 @@ class Configuration(object):
         self.args = args
         self.config: Optional[Dict[str, Any]] = None
         self.runmode = runmode
+
+    def get_config(self) -> Dict[str, Any]:
+        """
+        Return the config. Use this method to get the bot config
+        :return: Dict: Bot config
+        """
+        if self.config is None:
+            self.config = self.load_config()
+
+        return self.config
 
     def load_config(self) -> Dict[str, Any]:
         """
@@ -75,7 +57,7 @@ class Configuration(object):
             config['internals'] = {}
 
         logger.info('Validating configuration ...')
-        self._validate_config_schema(config)
+        validate_config_schema(config)
         self._validate_config_consistency(config)
 
         # Set strategy if not specified in config and or if it's non default
@@ -185,7 +167,7 @@ class Configuration(object):
         logger.info(f'Using DB: "{config["db_url"]}"')
 
         # Check if the exchange set by the user is supported
-        self.check_exchange(config)
+        check_exchange(config)
 
         return config
 
@@ -337,24 +319,6 @@ class Configuration(object):
                              logstring='Using trades from: {}')
         return config
 
-    def _validate_config_schema(self, conf: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Validate the configuration follow the Config Schema
-        :param conf: Config in JSON format
-        :return: Returns the config if valid, otherwise throw an exception
-        """
-        try:
-            FreqtradeValidator(constants.CONF_SCHEMA).validate(conf)
-            return conf
-        except ValidationError as exception:
-            logger.critical(
-                'Invalid configuration. See config.json.example. Reason: %s',
-                exception
-            )
-            raise ValidationError(
-                best_match(Draft4Validator(constants.CONF_SCHEMA).iter_errors(conf)).message
-            )
-
     def _validate_config_consistency(self, conf: Dict[str, Any]) -> None:
         """
         Validate the configuration consistency
@@ -383,51 +347,3 @@ class Configuration(object):
             raise OperationalException(
                 f'The config trailing_stop_positive_offset needs '
                 'to be greater than trailing_stop_positive_offset in your config.')
-
-    def get_config(self) -> Dict[str, Any]:
-        """
-        Return the config. Use this method to get the bot config
-        :return: Dict: Bot config
-        """
-        if self.config is None:
-            self.config = self.load_config()
-
-        return self.config
-
-    def check_exchange(self, config: Dict[str, Any], check_for_bad: bool = True) -> bool:
-        """
-        Check if the exchange name in the config file is supported by Freqtrade
-        :param check_for_bad: if True, check the exchange against the list of known 'bad'
-                              exchanges
-        :return: False if exchange is 'bad', i.e. is known to work with the bot with
-                 critical issues or does not work at all, crashes, etc. True otherwise.
-                 raises an exception if the exchange if not supported by ccxt
-                 and thus is not known for the Freqtrade at all.
-        """
-        logger.info("Checking exchange...")
-
-        exchange = config.get('exchange', {}).get('name').lower()
-        if not is_exchange_available(exchange):
-            raise OperationalException(
-                    f'Exchange "{exchange}" is not supported by ccxt '
-                    f'and therefore not available for the bot.\n'
-                    f'The following exchanges are supported by ccxt: '
-                    f'{", ".join(available_exchanges())}'
-            )
-
-        if check_for_bad and is_exchange_bad(exchange):
-            logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
-                           f'Use it only for development and testing purposes.')
-            return False
-
-        if is_exchange_officially_supported(exchange):
-            logger.info(f'Exchange "{exchange}" is officially supported '
-                        f'by the Freqtrade development team.')
-        else:
-            logger.warning(f'Exchange "{exchange}" is supported by ccxt '
-                           f'and therefore available for the bot but not officially supported '
-                           f'by the Freqtrade development team. '
-                           f'It may work flawlessly (please report back) or have serious issues. '
-                           f'Use it at your own discretion.')
-
-        return True

--- a/freqtrade/configuration/create_datadir.py
+++ b/freqtrade/configuration/create_datadir.py
@@ -1,0 +1,18 @@
+import logging
+import os
+from typing import Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> str:
+    if not datadir:
+        # set datadir
+        exchange_name = config.get('exchange', {}).get('name').lower()
+        datadir = os.path.join('user_data', 'data', exchange_name)
+
+    if not os.path.isdir(datadir):
+        os.makedirs(datadir)
+        logger.info(f'Created data directory: {datadir}')
+    return datadir

--- a/freqtrade/configuration/json_schema.py
+++ b/freqtrade/configuration/json_schema.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Any, Dict
+
+from jsonschema import Draft4Validator, validators
+from jsonschema.exceptions import ValidationError, best_match
+
+from freqtrade import constants
+
+
+logger = logging.getLogger(__name__)
+
+
+def _extend_validator(validator_class):
+    """
+    Extended validator for the Freqtrade configuration JSON Schema.
+    Currently it only handles defaults for subschemas.
+    """
+    validate_properties = validator_class.VALIDATORS['properties']
+
+    def set_defaults(validator, properties, instance, schema):
+        for prop, subschema in properties.items():
+            if 'default' in subschema:
+                instance.setdefault(prop, subschema['default'])
+
+        for error in validate_properties(
+            validator, properties, instance, schema,
+        ):
+            yield error
+
+    return validators.extend(
+        validator_class, {'properties': set_defaults}
+    )
+
+
+FreqtradeValidator = _extend_validator(Draft4Validator)
+
+
+def validate_config_schema(conf: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Validate the configuration follow the Config Schema
+    :param conf: Config in JSON format
+    :return: Returns the config if valid, otherwise throw an exception
+    """
+    try:
+        FreqtradeValidator(constants.CONF_SCHEMA).validate(conf)
+        return conf
+    except ValidationError as e:
+        logger.critical(
+            f"Invalid configuration. See config.json.example. Reason: {e}"
+        )
+        raise ValidationError(
+            best_match(Draft4Validator(constants.CONF_SCHEMA).iter_errors(conf)).message
+        )

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -16,7 +16,7 @@ import arrow
 from pandas import DataFrame
 
 from freqtrade import OperationalException, misc
-from freqtrade.arguments import TimeRange
+from freqtrade.configuration import TimeRange
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.exchange import Exchange, timeframe_to_minutes
 

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -10,8 +10,7 @@ import utils_find_1st as utf1st
 from pandas import DataFrame
 
 from freqtrade import constants, OperationalException
-from freqtrade.arguments import Arguments
-from freqtrade.arguments import TimeRange
+from freqtrade.configuration import Arguments, TimeRange
 from freqtrade.data import history
 from freqtrade.strategy.interface import SellType
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -15,7 +15,7 @@ from argparse import Namespace
 from typing import Any, List
 
 from freqtrade import OperationalException
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.worker import Worker
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from pandas import DataFrame
 from tabulate import tabulate
 
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.data import history
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.exchange import timeframe_to_minutes

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -9,7 +9,7 @@ from tabulate import tabulate
 from freqtrade import constants
 from freqtrade.edge import Edge
 
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.exchange import Exchange
 from freqtrade.resolvers import StrategyResolver
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -18,7 +18,7 @@ from pandas import DataFrame
 from skopt import Optimizer
 from skopt.space import Dimension
 
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.data.history import load_data, get_timeframe
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.data import history
 from freqtrade.data.btanalysis import (combine_tickers_with_mean,
                                        create_cum_profit, load_trades)

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -44,6 +44,20 @@ def get_args(args):
     return Arguments(args, '').get_parsed_arg()
 
 
+def patched_configuration_open(mocker, config):
+    file_mock = mocker.patch('freqtrade.configuration.configuration.open', mocker.mock_open(
+        read_data=json.dumps(config)
+    ))
+    return file_mock
+
+
+def patched_configuration_load_config_file(mocker, config) -> None:
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._load_config_file',
+        lambda *args, **kwargs: config
+    )
+
+
 def patch_exchange(mocker, api_mock=None, id='bittrex') -> None:
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -43,13 +43,6 @@ def get_args(args):
     return Arguments(args, '').get_parsed_arg()
 
 
-def patched_configuration_open(mocker, config):
-    file_mock = mocker.patch('freqtrade.configuration.configuration.open', mocker.mock_open(
-        read_data=json.dumps(config)
-    ))
-    return file_mock
-
-
 def patched_configuration_load_config_file(mocker, config) -> None:
     mocker.patch(
         'freqtrade.configuration.configuration.Configuration._load_config_file',

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -14,13 +14,14 @@ import pytest
 from telegram import Chat, Message, Update
 
 from freqtrade import constants, persistence
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.edge import Edge, PairInfo
 from freqtrade.exchange import Exchange
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.resolvers import ExchangeResolver
 from freqtrade.worker import Worker
+
 
 logging.getLogger('').setLevel(logging.INFO)
 
@@ -39,7 +40,7 @@ def log_has_re(line, logs):
                   False)
 
 
-def get_args(args) -> List[str]:
+def get_args(args):
     return Arguments(args, '').get_parsed_arg()
 
 

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from datetime import datetime
 from functools import reduce
 from pathlib import Path
-from typing import List
 from unittest.mock import MagicMock, PropertyMock
 
 import arrow

--- a/freqtrade/tests/data/test_btanalysis.py
+++ b/freqtrade/tests/data/test_btanalysis.py
@@ -4,7 +4,7 @@ import pytest
 from arrow import Arrow
 from pandas import DataFrame, to_datetime
 
-from freqtrade.arguments import Arguments, TimeRange
+from freqtrade.configuration import Arguments, TimeRange
 from freqtrade.data.btanalysis import (BT_DATA_COLUMNS,
                                        combine_tickers_with_mean,
                                        create_cum_profit,

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -12,7 +12,7 @@ import pytest
 from pandas import DataFrame
 
 from freqtrade import OperationalException
-from freqtrade.arguments import TimeRange
+from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.history import (download_pair_history,
                                     load_cached_data_for_updating,

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -1,6 +1,5 @@
 # pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103, unused-argument
 
-import json
 import math
 import random
 from unittest.mock import MagicMock
@@ -23,7 +22,7 @@ from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-        patched_configuration_open)
+                                      patched_configuration_open)
 
 
 def trim_dictlist(dict_list, num):
@@ -205,7 +204,10 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
-    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._create_datadir',
+        lambda s, c, x: x
+    )
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -22,7 +22,7 @@ from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-                                      patched_configuration_open)
+                                      patched_configuration_load_config_file)
 
 
 def trim_dictlist(dict_list, num):
@@ -165,7 +165,7 @@ def _trend_alternate(dataframe=None, metadata=None):
 
 # Unit tests
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -203,7 +203,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(
         'freqtrade.configuration.configuration.create_datadir',
         lambda c, x: x
@@ -275,7 +275,7 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
 def test_setup_configuration_unlimited_stake_amount(mocker, default_conf, caplog) -> None:
     default_conf['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
 
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -292,7 +292,7 @@ def test_start(mocker, fee, default_conf, caplog) -> None:
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     patch_exchange(mocker)
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.start', start_mock)
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -824,7 +824,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
     patch_exchange(mocker, api_mock)
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', MagicMock())
     mocker.patch('freqtrade.optimize.backtesting.Backtesting._generate_text_table', MagicMock())
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -874,7 +874,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     gen_strattable_mock = MagicMock()
     mocker.patch('freqtrade.optimize.backtesting.Backtesting._generate_text_table_strategy',
                  gen_strattable_mock)
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -11,7 +11,7 @@ import pytest
 from arrow import Arrow
 
 from freqtrade import DependencyException, constants
-from freqtrade.arguments import TimeRange
+from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import evaluate_result_multi
 from freqtrade.data.converter import parse_ticker_dataframe

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -22,7 +22,8 @@ from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
-from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
+        patched_configuration_open)
 
 
 def trim_dictlist(dict_list, num):
@@ -165,9 +166,7 @@ def _trend_alternate(dataframe=None, metadata=None):
 
 # Unit tests
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -205,10 +204,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
-    mocker.patch('freqtrade.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    patched_configuration_open(mocker, default_conf)
+    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
 
     args = [
         '--config', 'config.json',
@@ -276,9 +273,7 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
 def test_setup_configuration_unlimited_stake_amount(mocker, default_conf, caplog) -> None:
     default_conf['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
 
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -295,9 +290,8 @@ def test_start(mocker, fee, default_conf, caplog) -> None:
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     patch_exchange(mocker)
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.start', start_mock)
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
+
     args = [
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
@@ -828,9 +822,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
     patch_exchange(mocker, api_mock)
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', MagicMock())
     mocker.patch('freqtrade.optimize.backtesting.Backtesting._generate_text_table', MagicMock())
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -880,9 +872,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     gen_strattable_mock = MagicMock()
     mocker.patch('freqtrade.optimize.backtesting.Backtesting._generate_text_table_strategy',
                  gen_strattable_mock)
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -205,8 +205,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
     mocker.patch(
-        'freqtrade.configuration.configuration.Configuration._create_datadir',
-        lambda s, c, x: x
+        'freqtrade.configuration.configuration.create_datadir',
+        lambda c, x: x
     )
 
     args = [

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -46,8 +46,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> None:
     patched_configuration_open(mocker, edge_conf)
     mocker.patch(
-        'freqtrade.configuration.configuration.Configuration._create_datadir',
-        lambda s, c, x: x
+        'freqtrade.configuration.configuration.create_datadir',
+        lambda c, x: x
     )
 
     args = [

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -8,11 +8,11 @@ from freqtrade.optimize import setup_configuration, start_edge
 from freqtrade.optimize.edge_cli import EdgeCli
 from freqtrade.state import RunMode
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-                                      patched_configuration_open)
+                                      patched_configuration_load_config_file)
 
 
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -44,7 +44,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 
 def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> None:
-    patched_configuration_open(mocker, edge_conf)
+    patched_configuration_load_config_file(mocker, edge_conf)
     mocker.patch(
         'freqtrade.configuration.configuration.create_datadir',
         lambda c, x: x
@@ -91,7 +91,7 @@ def test_start(mocker, fee, edge_conf, caplog) -> None:
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     patch_exchange(mocker)
     mocker.patch('freqtrade.optimize.edge_cli.EdgeCli.start', start_mock)
-    patched_configuration_open(mocker, edge_conf)
+    patched_configuration_load_config_file(mocker, edge_conf)
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -8,13 +8,12 @@ from freqtrade.edge import PairInfo
 from freqtrade.optimize import setup_configuration, start_edge
 from freqtrade.optimize.edge_cli import EdgeCli
 from freqtrade.state import RunMode
-from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
+        patched_configuration_open)
 
 
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -46,10 +45,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 
 def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(edge_conf)
-    ))
-    mocker.patch('freqtrade.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    patched_configuration_open(mocker, edge_conf)
+    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
 
     args = [
         '--config', 'config.json',
@@ -92,9 +89,8 @@ def test_start(mocker, fee, edge_conf, caplog) -> None:
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     patch_exchange(mocker)
     mocker.patch('freqtrade.optimize.edge_cli.EdgeCli.start', start_mock)
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(edge_conf)
-    ))
+    patched_configuration_open(mocker, edge_conf)
+
     args = [
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -1,7 +1,6 @@
 # pragma pylint: disable=missing-docstring, C0103, C0330
 # pragma pylint: disable=protected-access, too-many-lines, invalid-name, too-many-arguments
 
-import json
 from unittest.mock import MagicMock
 
 from freqtrade.edge import PairInfo
@@ -9,7 +8,7 @@ from freqtrade.optimize import setup_configuration, start_edge
 from freqtrade.optimize.edge_cli import EdgeCli
 from freqtrade.state import RunMode
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-        patched_configuration_open)
+                                      patched_configuration_open)
 
 
 def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> None:
@@ -46,7 +45,10 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> None:
     patched_configuration_open(mocker, edge_conf)
-    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._create_datadir',
+        lambda s, c, x: x
+    )
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -83,8 +83,8 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
 def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
     mocker.patch(
-        'freqtrade.configuration.configuration.Configuration._create_datadir',
-        lambda s, c, x: x
+        'freqtrade.configuration.configuration.create_datadir',
+        lambda c, x: x
     )
 
     args = [

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -1,5 +1,4 @@
 # pragma pylint: disable=missing-docstring,W0212,C0103
-import json
 import os
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -17,7 +16,8 @@ from freqtrade.optimize import setup_configuration, start_hyperopt
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
 from freqtrade.state import RunMode
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-        patched_configuration_load_config_file, patched_configuration_open)
+                                      patched_configuration_load_config_file,
+                                      patched_configuration_open)
 
 
 @pytest.fixture(scope='function')
@@ -82,7 +82,10 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
 
 def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
-    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._create_datadir',
+        lambda s, c, x: x
+    )
 
     args = [
         '--config', 'config.json',

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -16,8 +16,7 @@ from freqtrade.optimize import setup_configuration, start_hyperopt
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
 from freqtrade.state import RunMode
 from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
-                                      patched_configuration_load_config_file,
-                                      patched_configuration_open)
+                                      patched_configuration_load_config_file)
 
 
 @pytest.fixture(scope='function')
@@ -45,7 +44,7 @@ def create_trials(mocker, hyperopt) -> None:
 
 
 def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -81,7 +80,7 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
 
 
 def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
-    patched_configuration_open(mocker, default_conf)
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(
         'freqtrade.configuration.configuration.create_datadir',
         lambda c, x: x

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -16,7 +16,8 @@ from freqtrade.optimize.hyperopt import Hyperopt, HYPEROPT_LOCKFILE
 from freqtrade.optimize import setup_configuration, start_hyperopt
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
 from freqtrade.state import RunMode
-from freqtrade.tests.conftest import get_args, log_has, log_has_re, patch_exchange
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
+        patched_configuration_load_config_file, patched_configuration_open)
 
 
 @pytest.fixture(scope='function')
@@ -44,9 +45,7 @@ def create_trials(mocker, hyperopt) -> None:
 
 
 def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
+    patched_configuration_open(mocker, default_conf)
 
     args = [
         '--config', 'config.json',
@@ -82,10 +81,8 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
 
 
 def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
-    mocker.patch('freqtrade.configuration.open', mocker.mock_open(
-        read_data=json.dumps(default_conf)
-    ))
-    mocker.patch('freqtrade.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    patched_configuration_open(mocker, default_conf)
+    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
 
     args = [
         '--config', 'config.json',
@@ -148,11 +145,8 @@ def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplo
 
 
 def test_hyperoptresolver(mocker, default_conf, caplog) -> None:
+    patched_configuration_load_config_file(mocker, default_conf)
 
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
     hyperopts = DefaultHyperOpts
     delattr(hyperopts, 'populate_buy_trend')
     delattr(hyperopts, 'populate_sell_trend')
@@ -172,10 +166,7 @@ def test_hyperoptresolver(mocker, default_conf, caplog) -> None:
 
 def test_start(mocker, default_conf, caplog) -> None:
     start_mock = MagicMock()
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.optimize.hyperopt.Hyperopt.start', start_mock)
     patch_exchange(mocker)
 
@@ -198,10 +189,7 @@ def test_start(mocker, default_conf, caplog) -> None:
 
 
 def test_start_no_data(mocker, default_conf, caplog) -> None:
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock(return_value={}))
     mocker.patch(
         'freqtrade.optimize.hyperopt.get_timeframe',
@@ -226,10 +214,7 @@ def test_start_no_data(mocker, default_conf, caplog) -> None:
 
 def test_start_failure(mocker, default_conf, caplog) -> None:
     start_mock = MagicMock()
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.optimize.hyperopt.Hyperopt.start', start_mock)
     patch_exchange(mocker)
 
@@ -250,10 +235,7 @@ def test_start_failure(mocker, default_conf, caplog) -> None:
 
 def test_start_filelock(mocker, default_conf, caplog) -> None:
     start_mock = MagicMock(side_effect=Timeout(HYPEROPT_LOCKFILE))
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.optimize.hyperopt.Hyperopt.start', start_mock)
     patch_exchange(mocker)
 

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import arrow
 from pandas import DataFrame
 
-from freqtrade.arguments import TimeRange
+from freqtrade.configuration import TimeRange
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.data.history import load_tickerdata_file
 from freqtrade.persistence import Trade

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -4,7 +4,7 @@ import argparse
 import pytest
 
 from freqtrade.configuration import Arguments, TimeRange
-from freqtrade.configuration import ARGS_DOWNLOADER, ARGS_PLOT_DATAFRAME
+from freqtrade.configuration.arguments import ARGS_DOWNLOADER, ARGS_PLOT_DATAFRAME
 from freqtrade.configuration.arguments import check_int_positive
 
 

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -3,8 +3,9 @@ import argparse
 
 import pytest
 
-from freqtrade.arguments import (ARGS_DOWNLOADER, ARGS_PLOT_DATAFRAME,
-                                 Arguments, TimeRange, check_int_positive)
+from freqtrade.configuration import Arguments, TimeRange
+from freqtrade.configuration import ARGS_DOWNLOADER, ARGS_PLOT_DATAFRAME
+from freqtrade.configuration.arguments import check_int_positive
 
 
 # Parse common command-line-arguments. Used for all tools

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -1,6 +1,5 @@
 # pragma pylint: disable=missing-docstring, protected-access, invalid-name
 
-import json
 import logging
 from argparse import Namespace
 from copy import deepcopy
@@ -83,7 +82,10 @@ def test_load_config_combine_dicts(default_conf, mocker, caplog) -> None:
     config_files = [conf1, conf2]
 
     configsmock = MagicMock(side_effect=config_files)
-    mocker.patch('freqtrade.configuration.configuration.Configuration._load_config_file', configsmock)
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._load_config_file',
+        configsmock
+    )
 
     arg_list = ['-c', 'test_conf.json', '--config', 'test2_conf.json', ]
     args = Arguments(arg_list, '').get_parsed_arg()
@@ -305,7 +307,10 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 
 def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
-    mocker.patch('freqtrade.configuration.configuration.Configuration._create_datadir', lambda s, c, x: x)
+    mocker.patch(
+        'freqtrade.configuration.configuration.Configuration._create_datadir',
+        lambda s, c, x: x
+    )
 
     arglist = [
         '--config', 'config.json',

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -12,6 +12,7 @@ from jsonschema import Draft4Validator, ValidationError, validate
 from freqtrade import OperationalException, constants
 from freqtrade.configuration import Arguments, Configuration
 from freqtrade.configuration.check_exchange import check_exchange
+from freqtrade.configuration.create_datadir import create_datadir
 from freqtrade.configuration.json_schema import validate_config_schema
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
 from freqtrade.loggers import _set_loggers
@@ -308,8 +309,8 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
 def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_open(mocker, default_conf)
     mocker.patch(
-        'freqtrade.configuration.configuration.Configuration._create_datadir',
-        lambda s, c, x: x
+        'freqtrade.configuration.configuration.create_datadir',
+        lambda c, x: x
     )
 
     arglist = [
@@ -580,12 +581,11 @@ def test_validate_default_conf(default_conf) -> None:
     validate(default_conf, constants.CONF_SCHEMA, Draft4Validator)
 
 
-def test__create_datadir(mocker, default_conf, caplog) -> None:
+def test_create_datadir(mocker, default_conf, caplog) -> None:
     mocker.patch('os.path.isdir', MagicMock(return_value=False))
     md = MagicMock()
     mocker.patch('os.makedirs', md)
-    cfg = Configuration(Namespace())
-    cfg._create_datadir(default_conf, '/foo/bar')
+    create_datadir(default_conf, '/foo/bar')
     assert md.call_args[0][0] == "/foo/bar"
     assert log_has('Created data directory: /foo/bar', caplog.record_tuples)
 

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -10,7 +10,8 @@ from freqtrade.configuration import Arguments
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State
-from freqtrade.tests.conftest import log_has, patch_exchange
+from freqtrade.tests.conftest import (log_has, patch_exchange,
+        patched_configuration_load_config_file)
 from freqtrade.worker import Worker
 
 
@@ -50,10 +51,7 @@ def test_main_fatal_exception(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.cleanup', MagicMock())
     mocker.patch('freqtrade.worker.Worker._worker', MagicMock(side_effect=Exception))
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
@@ -70,10 +68,7 @@ def test_main_keyboard_interrupt(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.cleanup', MagicMock())
     mocker.patch('freqtrade.worker.Worker._worker', MagicMock(side_effect=KeyboardInterrupt))
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
@@ -93,10 +88,7 @@ def test_main_operational_exception(mocker, default_conf, caplog) -> None:
         'freqtrade.worker.Worker._worker',
         MagicMock(side_effect=OperationalException('Oh snap!'))
     )
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
@@ -118,10 +110,7 @@ def test_main_reload_conf(mocker, default_conf, caplog) -> None:
                                          State.RUNNING,
                                          OperationalException("Oh snap!")])
     mocker.patch('freqtrade.worker.Worker._worker', worker_mock)
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     reconfigure_mock = mocker.patch('freqtrade.main.Worker._reconfigure', MagicMock())
 
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
@@ -145,10 +134,7 @@ def test_reconfigure(mocker, default_conf) -> None:
         'freqtrade.worker.Worker._worker',
         MagicMock(side_effect=OperationalException('Oh snap!'))
     )
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: default_conf
-    )
+    patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
@@ -159,10 +145,7 @@ def test_reconfigure(mocker, default_conf) -> None:
     # Renew mock to return modified data
     conf = deepcopy(default_conf)
     conf['stake_amount'] += 1
-    mocker.patch(
-        'freqtrade.configuration.Configuration._load_config_file',
-        lambda *args, **kwargs: conf
-    )
+    patched_configuration_load_config_file(mocker, conf)
 
     worker._config = conf
     # reconfigure should return a new instance

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from freqtrade import OperationalException
-from freqtrade.arguments import Arguments
+from freqtrade.configuration import Arguments
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -11,7 +11,7 @@ from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State
 from freqtrade.tests.conftest import (log_has, patch_exchange,
-        patched_configuration_load_config_file)
+                                      patched_configuration_load_config_file)
 from freqtrade.worker import Worker
 
 

--- a/freqtrade/tests/test_plotting.py
+++ b/freqtrade/tests/test_plotting.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import plotly.graph_objs as go
 from plotly import tools
 
-from freqtrade.arguments import Arguments, TimeRange
+from freqtrade.configuration import Arguments, TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import create_cum_profit, load_backtest_data
 from freqtrade.plot.plotting import (add_indicators, add_profit,

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from freqtrade.configuration import Arguments, TimeRange
-from freqtrade.configuration import ARGS_DOWNLOADER
 from freqtrade.configuration import Configuration
+from freqtrade.configuration.arguments import ARGS_DOWNLOADER
 from freqtrade.configuration.check_exchange import check_exchange
 from freqtrade.data.history import download_pair_history
 from freqtrade.exchange import Exchange

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -8,8 +8,10 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
-from freqtrade.arguments import Arguments, TimeRange, ARGS_DOWNLOADER
+from freqtrade.configuration import Arguments, TimeRange
+from freqtrade.configuration import ARGS_DOWNLOADER
 from freqtrade.configuration import Configuration
+from freqtrade.configuration.check_exchange import check_exchange
 from freqtrade.data.history import download_pair_history
 from freqtrade.exchange import Exchange
 from freqtrade.misc import deep_merge_dicts
@@ -79,7 +81,7 @@ if args.config and args.exchange:
                    "using exchange settings from the configuration file.")
 
 # Check if the exchange set by the user is supported
-configuration.check_exchange(config)
+check_exchange(config)
 
 configuration._load_datadir_config(config)
 

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -18,7 +18,8 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from freqtrade.configuration import Arguments, ARGS_PLOT_DATAFRAME
+from freqtrade.configuration import Arguments
+from freqtrade.configuration.arguments import ARGS_PLOT_DATAFRAME
 from freqtrade.data.btanalysis import extract_trades_of_period
 from freqtrade.optimize import setup_configuration
 from freqtrade.plot.plotting import (init_plotscript, generate_candlestick_graph,

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from freqtrade.arguments import ARGS_PLOT_DATAFRAME, Arguments
+from freqtrade.configuration import Arguments, ARGS_PLOT_DATAFRAME
 from freqtrade.data.btanalysis import extract_trades_of_period
 from freqtrade.optimize import setup_configuration
 from freqtrade.plot.plotting import (init_plotscript, generate_candlestick_graph,

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from typing import Any, Dict, List
 
-from freqtrade.arguments import ARGS_PLOT_PROFIT, Arguments
+from freqtrade.configuration import Arguments, ARGS_PLOT_PROFIT
 from freqtrade.optimize import setup_configuration
 from freqtrade.plot.plotting import init_plotscript, generate_profit_graph, store_plot_file
 from freqtrade.state import RunMode

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -8,7 +8,8 @@ import logging
 import sys
 from typing import Any, Dict, List
 
-from freqtrade.configuration import Arguments, ARGS_PLOT_PROFIT
+from freqtrade.configuration import Arguments
+from freqtrade.configuration.arguments import ARGS_PLOT_PROFIT
 from freqtrade.optimize import setup_configuration
 from freqtrade.plot.plotting import init_plotscript, generate_profit_graph, store_plot_file
 from freqtrade.state import RunMode


### PR DESCRIPTION
The patch is wider than I expected but this mostly is due to the tests.

* configuration is made a sep. module in a sep. directory
* arguments moved also to the new configuration module. Because arguments are also a part of configuration.
* validation of json schema separated from configuration.py
* check_exchange() separated from configuration.py
* tests adjusted and improved (2 common functions made in conftest)
* create_datadir() moved to its own separate file