### PR TITLE
minor: improvements to resolvers

### DIFF
--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -45,13 +45,13 @@ class ExchangeResolver(IResolver):
 
             exchange = ex_class(kwargs['config'])
             if exchange:
-                logger.info("Using resolved exchange %s", exchange_name)
+                logger.info(f"Using resolved exchange '{exchange_name}'...")
                 return exchange
         except AttributeError:
-            # Pass and raise ImportError instead
+            # Pass and raise OperationalException instead
             pass
 
         raise ImportError(
-            "Impossible to load Exchange '{}'. This class does not exist"
-            " or contains Python code errors".format(exchange_name)
+            f"Impossible to load Exchange '{exchange_name}'. This class does not exist "
+            "or contains Python code errors."
         )

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -48,7 +48,7 @@ class ExchangeResolver(IResolver):
                 logger.info(f"Using resolved exchange '{exchange_name}'...")
                 return exchange
         except AttributeError:
-            # Pass and raise OperationalException instead
+            # Pass and raise ImportError instead
             pass
 
         raise ImportError(

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Dict
 
+from freqtrade import OperationalException
 from freqtrade.constants import DEFAULT_HYPEROPT
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
 from freqtrade.resolvers import IResolver
@@ -63,15 +64,16 @@ class HyperOptResolver(IResolver):
 
         for _path in abs_paths:
             try:
-                hyperopt = self._search_object(directory=_path, object_type=IHyperOpt,
-                                               object_name=hyperopt_name)
+                (hyperopt, module_path) = self._search_object(directory=_path,
+                                                              object_type=IHyperOpt,
+                                                              object_name=hyperopt_name)
                 if hyperopt:
-                    logger.info("Using resolved hyperopt %s from '%s'", hyperopt_name, _path)
+                    logger.info(f"Using resolved hyperopt {hyperopt_name} from '{module_path}'...")
                     return hyperopt
             except FileNotFoundError:
-                logger.warning('Path "%s" does not exist', _path.relative_to(Path.cwd()))
+                logger.warning('Path "%s" does not exist.', _path.relative_to(Path.cwd()))
 
-        raise ImportError(
-            "Impossible to load Hyperopt '{}'. This class does not exist"
-            " or contains Python code errors".format(hyperopt_name)
+        raise OperationalException(
+            f"Impossible to load Hyperopt '{hyperopt_name}'. This class does not exist "
+            "or contains Python code errors."
         )

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -7,7 +7,7 @@ import importlib.util
 import inspect
 import logging
 from pathlib import Path
-from typing import Optional, Type, Any
+from typing import Any, Optional, Tuple, Type, Union
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class IResolver(object):
 
     @staticmethod
     def _search_object(directory: Path, object_type, object_name: str,
-                       kwargs: dict = {}) -> Optional[Any]:
+                       kwargs: dict = {}) -> Union[Tuple[Any, Path], Tuple[None, None]]:
         """
         Search for the objectname in the given directory
         :param directory: relative or absolute directory path
@@ -57,9 +57,10 @@ class IResolver(object):
             if not str(entry).endswith('.py'):
                 logger.debug('Ignoring %s', entry)
                 continue
+            module_path = Path.resolve(directory.joinpath(entry))
             obj = IResolver._get_valid_object(
-                object_type, Path.resolve(directory.joinpath(entry)), object_name
+                object_type, module_path, object_name
             )
             if obj:
-                return obj(**kwargs)
-        return None
+                return (obj(**kwargs), module_path)
+        return (None, None)

--- a/freqtrade/resolvers/pairlist_resolver.py
+++ b/freqtrade/resolvers/pairlist_resolver.py
@@ -6,6 +6,7 @@ This module load custom hyperopts
 import logging
 from pathlib import Path
 
+from freqtrade import OperationalException
 from freqtrade.pairlist.IPairList import IPairList
 from freqtrade.resolvers import IResolver
 
@@ -44,16 +45,17 @@ class PairListResolver(IResolver):
 
         for _path in abs_paths:
             try:
-                pairlist = self._search_object(directory=_path, object_type=IPairList,
-                                               object_name=pairlist_name,
-                                               kwargs=kwargs)
+                (pairlist, module_path) = self._search_object(directory=_path,
+                                                              object_type=IPairList,
+                                                              object_name=pairlist_name,
+                                                              kwargs=kwargs)
                 if pairlist:
-                    logger.info("Using resolved pairlist %s from '%s'", pairlist_name, _path)
+                    logger.info(f"Using resolved pairlist {pairlist_name} from '{module_path}'...")
                     return pairlist
             except FileNotFoundError:
-                logger.warning('Path "%s" does not exist', _path.relative_to(Path.cwd()))
+                logger.warning('Path "%s" does not exist.', _path.relative_to(Path.cwd()))
 
-        raise ImportError(
-            "Impossible to load Pairlist '{}'. This class does not exist"
-            " or contains Python code errors".format(pairlist_name)
+        raise OperationalException(
+            f"Impossible to load Pairlist '{pairlist_name}'. This class does not exist "
+            "or contains Python code errors."
         )

--- a/freqtrade/tests/pairlist/test_pairlist.py
+++ b/freqtrade/tests/pairlist/test_pairlist.py
@@ -34,9 +34,9 @@ def whitelist_conf(default_conf):
 def test_load_pairlist_noexist(mocker, markets, default_conf):
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(return_value=markets))
-    with pytest.raises(ImportError,
-                       match=r"Impossible to load Pairlist 'NonexistingPairList'."
-                             r" This class does not exist or contains Python code errors"):
+    with pytest.raises(OperationalException,
+                       match=r"Impossible to load Pairlist 'NonexistingPairList'. "
+                             r"This class does not exist or contains Python code errors."):
         PairListResolver('NonexistingPairList', freqtradebot, default_conf).pairlist
 
 


### PR DESCRIPTION
Inspired by https://github.com/freqtrade/freqtrade-strategies/issues/37.

* Improvements to logging.

In the meantime in the logs I can see which non-py files were skipped by freqtrade while resolving strategy or hyperopt, but I cannot see what particular .py file the strategy was loaded from.

People (and me) often copy the strategy and hyperopt files just in order to test new variations and forget to change the name of the class. This change allows to see (at least) what's the filename of the .py file the object was loaded from.

The module_path of the module where the object was found is now returned from the `_search_object()` along with the object and then printed by resolvers in the logging messages.

* ImportError changed to OperationalException in order to avoid printing traceback in case the object could not be loaded -- since it's not an unexpected exception somewhere in the middle, we don't need traceback in this case.

* Logging messages cleaned up a bit.

* Tests adjusted to reflect the changes.

TBD (sep. PR):
* allow `--strategy-path` be a single filename, where the strategy will be loaded from, not only a catalog... Same for Hyperopts.
