### PR TITLE
Remove wrong import in legacy startup sript

### DIFF
--- a/bin/freqtrade
+++ b/bin/freqtrade
@@ -3,9 +3,7 @@
 import sys
 import warnings
 
-from freqtrade.main import main, set_loggers
-
-set_loggers()
+from freqtrade.main import main
 
 warnings.warn(
     "Deprecated - To continue to run the bot like this, please run `pip install -e .` again.",


### PR DESCRIPTION
## Summary
As raised in #2020, the legacy script uses a wrong import.

If the bot was installed / reinstalled recently, this can be tested by running `./bin/freqtrade -c config.json`.
For new installations, this will have no impact (`which freqtrade` links to a automatically generated file).

I guess we should also consider removing this file (or removing the call to main() - so it doesn't crash but force you to reinstall)?

Closes #2020
