### PR TITLE
[minor] Convert create_datadir to Pathlib

### DIFF
--- a/freqtrade/configuration/create_datadir.py
+++ b/freqtrade/configuration/create_datadir.py
@@ -1,18 +1,20 @@
 import logging
-import os
 from typing import Any, Dict, Optional
+from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
 
 
 def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> str:
+
+    folder = Path(datadir) if datadir else Path('user_data/data')
     if not datadir:
         # set datadir
         exchange_name = config.get('exchange', {}).get('name').lower()
-        datadir = os.path.join('user_data', 'data', exchange_name)
+        folder = folder.joinpath(exchange_name)
 
-    if not os.path.isdir(datadir):
-        os.makedirs(datadir)
+    if not folder.is_dir():
+        folder.mkdir(parents=True)
         logger.info(f'Created data directory: {datadir}')
-    return datadir
+    return str(folder)

--- a/freqtrade/resolvers/pairlist_resolver.py
+++ b/freqtrade/resolvers/pairlist_resolver.py
@@ -39,7 +39,7 @@ class PairListResolver(IResolver):
         current_path = Path(__file__).parent.parent.joinpath('pairlist').resolve()
 
         abs_paths = [
-            current_path.parent.parent.joinpath('user_data/pairlist'),
+            Path.cwd().joinpath('user_data/pairlist'),
             current_path,
         ]
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -585,11 +585,11 @@ def test_validate_default_conf(default_conf) -> None:
 
 
 def test_create_datadir(mocker, default_conf, caplog) -> None:
-    mocker.patch('os.path.isdir', MagicMock(return_value=False))
-    md = MagicMock()
-    mocker.patch('os.makedirs', md)
+    mocker.patch.object(Path, "is_dir", MagicMock(return_value=False))
+    md = mocker.patch.object(Path, 'mkdir', MagicMock())
+
     create_datadir(default_conf, '/foo/bar')
-    assert md.call_args[0][0] == "/foo/bar"
+    assert md.call_args[1]['parents'] is True
     assert log_has('Created data directory: /foo/bar', caplog.record_tuples)
 
 


### PR DESCRIPTION
## Summary
* Using the more modern pathlib instead of os.path.
* we should also not assume user_data is in parent.parent.parent but use cwd() instead (this is not fully implemented yet - will need followup pr's for other sections of the code)

