### PR TITLE
Randomize tests again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
 install:
 - cd build_helpers && ./install_ta-lib.sh; cd ..
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- pip install --upgrade pytest-random-order
 - pip install -r requirements-dev.txt
 - pip install -e .
 jobs:
@@ -27,7 +26,7 @@ jobs:
   include:
     - stage: tests
       script:
-      - pytest --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
+      - pytest --random-order --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
       # Allow failure for coveralls
       - coveralls || true
       name: pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,6 @@ pytest==5.0.0
 pytest-mock==1.10.4
 pytest-asyncio==0.10.0
 pytest-cov==2.7.1
+pytest-random-order==1.0.4
 coveralls==1.8.1
 mypy==0.711


### PR DESCRIPTION
## Summary

Randomized tests used to be enabled, but the plugin changed how it works
> From v1.0.0 onwards, this plugin no longer randomises tests by default.

The intend with this is to capture tests which depend on state left from previous tests.

Since this has been disabled for a while, it'll probably create a few flukes (tests which can be fixed after restarting the testing). Please note the random-seed for these tests so we can have a look at them one by one.