### PR TITLE
remove deprecated --dynamic-whitelist option

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -7,8 +7,8 @@ This page explains the different parameters of the bot and how to run it.
 
 ```
 usage: freqtrade [-h] [-v] [--logfile FILE] [--version] [-c PATH] [-d PATH]
-                 [-s NAME] [--strategy-path PATH] [--dynamic-whitelist [INT]]
-                 [--db-url PATH] [--sd-notify]
+                 [-s NAME] [--strategy-path PATH] [--db-url PATH]
+                 [--sd-notify]
                  {backtesting,edge,hyperopt} ...
 
 Free, open source crypto trading bot
@@ -34,9 +34,6 @@ optional arguments:
                         Specify strategy class name (default:
                         DefaultStrategy).
   --strategy-path PATH  Specify additional strategy lookup path.
-  --dynamic-whitelist [INT]
-                        Dynamically generate and update whitelist based on 24h
-                        BaseVolume (default: 20). DEPRECATED.
   --db-url PATH         Override trades database URL, this is useful if
                         dry_run is enabled or in custom deployments (default:
                         None).
@@ -118,17 +115,6 @@ freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
 
 This is very simple. Copy paste your strategy file into the directory
 `user_data/strategies` or use `--strategy-path`. And voila, the bot is ready to use it.
-
-### How to use **--dynamic-whitelist**?
-
-!!! danger "DEPRECATED"
-    This command line option is deprecated. Please move your configurations using it
-to the configurations that utilize the `StaticPairList` or `VolumePairList` methods set
-in the configuration file
-as outlined [here](configuration/#dynamic-pairlists)
-
-Description of this deprecated feature was moved to [here](deprecated.md).
-Please no longer use it.
 
 ### How to use **--db-url**?
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Mandatory Parameters are marked as **Required**.
 | `exchange.sandbox` | false | Use the 'sandbox' version of the exchange, where the exchange provides a sandbox for risk-free integration. See [here](sandbox-testing.md) in more details.
 | `exchange.key` | '' | API key to use for the exchange. Only required when you are in production mode.
 | `exchange.secret` | '' | API secret to use for the exchange. Only required when you are in production mode.
-| `exchange.pair_whitelist` | [] | List of currency to use by the bot. Can be overrided with `--dynamic-whitelist` param.
-| `exchange.pair_blacklist` | [] | List of currency the bot must avoid. Useful when using `--dynamic-whitelist` param.
+| `exchange.pair_whitelist` | [] | List of currency to use by the bot.
+| `exchange.pair_blacklist` | [] | List of currency the bot must avoid.
 | `exchange.ccxt_config` | None | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.markets_refresh_interval` | 60 | The interval in minutes in which markets are reloaded.
@@ -53,8 +53,8 @@ Mandatory Parameters are marked as **Required**.
 | `experimental.use_sell_signal` | false | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.sell_profit_only` | false | Waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.ignore_roi_if_buy_signal` | false | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-the-strategy).
-| `pairlist.method` | StaticPairList | Use Static whitelist. [More information below](#dynamic-pairlists).
-| `pairlist.config` | None | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
+| `pairlist.method` | StaticPairList | Use static or dynamic volume-based pairlist.
+| `pairlist.config` | None | Additional configuration for dynamic pairlists.
 | `telegram.enabled` | true | **Required.** Enable or not the usage of Telegram.
 | `telegram.token` | token | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
 | `telegram.chat_id` | chat_id | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.
@@ -381,7 +381,7 @@ section of the configuration.
   * It uses configuration from `exchange.pair_whitelist` and `exchange.pair_blacklist`.
 * `VolumePairList`
   * Formerly available as `--dynamic-whitelist [<number_assets>]`. This command line
-option is deprecated and should no longer be used.
+option was removed and can no longer be used.
   * It selects `number_assets` top pairs based on `sort_key`, which can be one of
 `askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
   * There is a possibility to filter low-value coins that would not allow setting a stop loss

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,8 +380,6 @@ section of the configuration.
 * `StaticPairList`
   * It uses configuration from `exchange.pair_whitelist` and `exchange.pair_blacklist`.
 * `VolumePairList`
-  * Formerly available as `--dynamic-whitelist [<number_assets>]`. This command line
-option was removed and can no longer be used.
   * It selects `number_assets` top pairs based on `sort_key`, which can be one of
 `askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
   * There is a possibility to filter low-value coins that would not allow setting a stop loss

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Mandatory Parameters are marked as **Required**.
 | `exchange.sandbox` | false | Use the 'sandbox' version of the exchange, where the exchange provides a sandbox for risk-free integration. See [here](sandbox-testing.md) in more details.
 | `exchange.key` | '' | API key to use for the exchange. Only required when you are in production mode.
 | `exchange.secret` | '' | API secret to use for the exchange. Only required when you are in production mode.
-| `exchange.pair_whitelist` | [] | List of currency to use by the bot.
-| `exchange.pair_blacklist` | [] | List of currency the bot must avoid.
+| `exchange.pair_whitelist` | [] | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Can be overriden by dynamic pairlists (see [below](#dynamic-pairlists)).
+| `exchange.pair_blacklist` | [] | List of pairs the bot must absolutely avoid for trading and backtesting. Can be overriden by dynamic pairlists (see [below](#dynamic-pairlists)).
 | `exchange.ccxt_config` | None | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.markets_refresh_interval` | 60 | The interval in minutes in which markets are reloaded.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,8 +53,8 @@ Mandatory Parameters are marked as **Required**.
 | `experimental.use_sell_signal` | false | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.sell_profit_only` | false | Waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.ignore_roi_if_buy_signal` | false | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-the-strategy).
-| `pairlist.method` | StaticPairList | Use static or dynamic volume-based pairlist.
-| `pairlist.config` | None | Additional configuration for dynamic pairlists.
+| `pairlist.method` | StaticPairList | Use static or dynamic volume-based pairlist. [More information below](#dynamic-pairlists).
+| `pairlist.config` | None | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
 | `telegram.enabled` | true | **Required.** Enable or not the usage of Telegram.
 | `telegram.token` | token | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
 | `telegram.chat_id` | chat_id | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -6,6 +6,9 @@ and are no longer supported. Please avoid their usage in your configuration.
 
 ### The **--dynamic-whitelist** command line option
 
+This command line option was deprecated in 2018 and removed freqtrade 2019.6-dev (develop branch)
+and in freqtrade 2019.7 (master branch).
+
 Per default `--dynamic-whitelist` will retrieve the 20 currencies based
 on BaseVolume. This value can be changed when you run the script.
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -3,7 +3,7 @@
 This page explains how to use Edge Positioning module in your bot in order to enter into a trade only if the trade has a reasonable win rate and risk reward ratio, and consequently adjust your position size and stoploss.
 
 !!! Warning
-    Edge positioning is not compatible with dynamic whitelist. If enabled, it overrides the dynamic whitelist option.
+    Edge positioning is not compatible with dynamic (volume-based) whitelist.
 
 !!! Note
     Edge does not consider anything else than buy/sell/stoploss signals. So trailing stoploss, ROI, and everything else are ignored in its calculation.

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -73,16 +73,6 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify additional strategy lookup path.',
         metavar='PATH',
     ),
-    "dynamic_whitelist": Arg(
-        '--dynamic-whitelist',
-        help='Dynamically generate and update whitelist '
-        'based on 24h BaseVolume (default: %(const)s). '
-        'DEPRECATED.',
-        const=constants.DYNAMIC_WHITELIST,
-        type=int,
-        metavar='INT',
-        nargs='?',
-    ),
     "db_url": Arg(
         '--db-url',
         help=f'Override trades database URL, this is useful in custom deployments '
@@ -299,7 +289,7 @@ ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir"]
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 
-ARGS_MAIN = ARGS_COMMON + ARGS_STRATEGY + ["dynamic_whitelist", "db_url", "sd_notify"]
+ARGS_MAIN = ARGS_COMMON + ARGS_STRATEGY + ["db_url", "sd_notify"]
 
 ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange",
                         "max_open_trades", "stake_amount", "refresh_pairs"]

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -137,19 +137,6 @@ class Configuration(object):
         self._process_logging_options(config)
         self._process_strategy_options(config)
 
-        # Add dynamic_whitelist if found
-        if 'dynamic_whitelist' in self.args and self.args.dynamic_whitelist:
-            # Update to volumePairList (the previous default)
-            config['pairlist'] = {'method': 'VolumePairList',
-                                  'config': {'number_assets': self.args.dynamic_whitelist}
-                                  }
-            logger.warning(
-                'Parameter --dynamic-whitelist has been deprecated, '
-                'and will be completely replaced by the whitelist dict in the future. '
-                'For now: using dynamically generated whitelist based on VolumePairList. '
-                '(not applicable with Backtesting and Hyperopt)'
-            )
-
         if ('db_url' in self.args and self.args.db_url and
                 self.args.db_url != constants.DEFAULT_DB_PROD_URL):
             config.update({'db_url': self.args.db_url})

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -86,21 +86,6 @@ def test_parse_args_strategy_path_invalid() -> None:
         Arguments(['--strategy-path'], '').get_parsed_arg()
 
 
-def test_parse_args_dynamic_whitelist() -> None:
-    args = Arguments(['--dynamic-whitelist'], '').get_parsed_arg()
-    assert args.dynamic_whitelist == 20
-
-
-def test_parse_args_dynamic_whitelist_10() -> None:
-    args = Arguments(['--dynamic-whitelist', '10'], '').get_parsed_arg()
-    assert args.dynamic_whitelist == 10
-
-
-def test_parse_args_dynamic_whitelist_invalid_values() -> None:
-    with pytest.raises(SystemExit, match=r'2'):
-        Arguments(['--dynamic-whitelist', 'abc'], '').get_parsed_arg()
-
-
 def test_parse_timerange_incorrect() -> None:
     assert TimeRange(None, 'line', 0, -200) == Arguments.parse_timerange('-200')
     assert TimeRange('line', None, 200, 0) == Arguments.parse_timerange('200-')

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -149,7 +149,6 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
-        '--dynamic-whitelist', '10',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path',
         '--db-url', 'sqlite:///someurl',
@@ -158,8 +157,6 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
-    assert validated_conf.get('pairlist', {}).get('method') == 'VolumePairList'
-    assert validated_conf.get('pairlist', {}).get('config').get('number_assets') == 10
     assert validated_conf.get('strategy') == 'TestStrategy'
     assert validated_conf.get('strategy_path') == '/some/path'
     assert validated_conf.get('db_url') == 'sqlite:///someurl'
@@ -250,7 +247,6 @@ def test_show_info(default_conf, mocker, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
-        '--dynamic-whitelist', '10',
         '--strategy', 'TestStrategy',
         '--db-url', 'sqlite:///tmp/testdb',
     ]
@@ -259,13 +255,6 @@ def test_show_info(default_conf, mocker, caplog) -> None:
     configuration = Configuration(args)
     configuration.get_config()
 
-    assert log_has(
-        'Parameter --dynamic-whitelist has been deprecated, '
-        'and will be completely replaced by the whitelist dict in the future. '
-        'For now: using dynamically generated whitelist based on VolumePairList. '
-        '(not applicable with Backtesting and Hyperopt)',
-        caplog.record_tuples
-    )
     assert log_has('Using DB: "sqlite:///tmp/testdb"', caplog.record_tuples)
     assert log_has('Dry run is enabled', caplog.record_tuples)
 


### PR DESCRIPTION
Removal of the `--dynamic-whitelist` option, which left in the deprecated status for long time.

That was not so easy (many appearances), so verify that I did not forget anything.
