### PR TITLE
minor: add -V alias for --version

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -23,7 +23,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
   --logfile FILE        Log to the file specified
-  --version             show program's version number and exit
+  -V, --version         show program's version number and exit
   -c PATH, --config PATH
                         Specify configuration file (default: None). Multiple
                         --config options may be used. Can be set to '-' to

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -44,7 +44,7 @@ AVAILABLE_CLI_OPTIONS = {
         metavar='FILE',
     ),
     "version": Arg(
-        '--version',
+        '-V', '--version',
         action='version',
         version=f'%(prog)s {__version__}',
     ),


### PR DESCRIPTION
`-V` is frequently used for apps as a shortcut for `--version`.

* bot-usage docs also updated with this change
