### PR TITLE
minor: cleanup Arguments

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -342,14 +342,15 @@ class Arguments(object):
     """
     Arguments Class. Manage the arguments received by the cli
     """
-    def __init__(self, args: Optional[List[str]], description: str) -> None:
+    def __init__(self, args: Optional[List[str]], description: str,
+                 no_default_config: bool = False) -> None:
         self.args = args
-        self.parsed_arg: Optional[argparse.Namespace] = None
+        self._parsed_arg: Optional[argparse.Namespace] = None
         self.parser = argparse.ArgumentParser(description=description)
+        self._no_default_config = no_default_config
 
     def _load_args(self) -> None:
-        self.build_args(optionlist=ARGS_MAIN)
-
+        self._build_args(optionlist=ARGS_MAIN)
         self._build_subcommands()
 
     def get_parsed_arg(self) -> argparse.Namespace:
@@ -357,13 +358,13 @@ class Arguments(object):
         Return the list of arguments
         :return: List[str] List of arguments
         """
-        if self.parsed_arg is None:
+        if self._parsed_arg is None:
             self._load_args()
-            self.parsed_arg = self.parse_args()
+            self._parsed_arg = self._parse_args()
 
-        return self.parsed_arg
+        return self._parsed_arg
 
-    def parse_args(self, no_default_config: bool = False) -> argparse.Namespace:
+    def _parse_args(self) -> argparse.Namespace:
         """
         Parses given arguments and returns an argparse Namespace instance.
         """
@@ -371,12 +372,12 @@ class Arguments(object):
 
         # Workaround issue in argparse with action='append' and default value
         # (see https://bugs.python.org/issue16399)
-        if not no_default_config and parsed_arg.config is None:
+        if not self._no_default_config and parsed_arg.config is None:
             parsed_arg.config = [constants.DEFAULT_CONFIG]
 
         return parsed_arg
 
-    def build_args(self, optionlist, parser=None):
+    def _build_args(self, optionlist, parser=None):
         parser = parser or self.parser
 
         for val in optionlist:
@@ -396,17 +397,17 @@ class Arguments(object):
         # Add backtesting subcommand
         backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.')
         backtesting_cmd.set_defaults(func=start_backtesting)
-        self.build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
+        self._build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
 
         # Add edge subcommand
         edge_cmd = subparsers.add_parser('edge', help='Edge module.')
         edge_cmd.set_defaults(func=start_edge)
-        self.build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
+        self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
 
         # Add hyperopt subcommand
         hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.')
         hyperopt_cmd.set_defaults(func=start_hyperopt)
-        self.build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
+        self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
 
         # Add list-exchanges subcommand
         list_exchanges_cmd = subparsers.add_parser(
@@ -414,7 +415,7 @@ class Arguments(object):
             help='Print available exchanges.'
         )
         list_exchanges_cmd.set_defaults(func=start_list_exchanges)
-        self.build_args(optionlist=ARGS_LIST_EXCHANGES, parser=list_exchanges_cmd)
+        self._build_args(optionlist=ARGS_LIST_EXCHANGES, parser=list_exchanges_cmd)
 
     @staticmethod
     def parse_timerange(text: Optional[str]) -> TimeRange:

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -51,8 +51,8 @@ def test_parse_args_verbose() -> None:
 
 def test_common_scripts_options() -> None:
     arguments = Arguments(['-p', 'ETH/BTC'], '')
-    arguments.build_args(ARGS_DOWNLOADER)
-    args = arguments.parse_args()
+    arguments._build_args(ARGS_DOWNLOADER)
+    args = arguments._parse_args()
     assert args.pairs == 'ETH/BTC'
 
 
@@ -180,9 +180,8 @@ def test_download_data_options() -> None:
         '--exchange', 'binance'
     ]
     arguments = Arguments(args, '')
-    arguments.build_args(ARGS_DOWNLOADER)
-
-    args = arguments.parse_args()
+    arguments._build_args(ARGS_DOWNLOADER)
+    args = arguments._parse_args()
     assert args.pairs_file == 'file_with_pairs'
     assert args.datadir == 'datadir/directory'
     assert args.days == 30
@@ -197,8 +196,8 @@ def test_plot_dataframe_options() -> None:
         '-p', 'UNITTEST/BTC',
     ]
     arguments = Arguments(args, '')
-    arguments.build_args(ARGS_PLOT_DATAFRAME)
-    pargs = arguments.parse_args(True)
+    arguments._build_args(ARGS_PLOT_DATAFRAME)
+    pargs = arguments._parse_args()
     assert pargs.indicators1 == "sma10,sma100"
     assert pargs.indicators2 == "macd,fastd,fastk"
     assert pargs.plot_limit == 30
@@ -206,7 +205,6 @@ def test_plot_dataframe_options() -> None:
 
 
 def test_check_int_positive() -> None:
-
     assert check_int_positive("3") == 3
     assert check_int_positive("1") == 1
     assert check_int_positive("100") == 100

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -22,12 +22,12 @@ logger = logging.getLogger('download_backtest_data')
 
 DEFAULT_DL_PATH = 'user_data/data'
 
-arguments = Arguments(sys.argv[1:], 'Download backtest data')
-arguments.build_args(ARGS_DOWNLOADER)
-
 # Do not read the default config if config is not specified
 # in the command line options explicitely
-args = arguments.parse_args(no_default_config=True)
+arguments = Arguments(sys.argv[1:], 'Download backtest data',
+                      no_default_config=True)
+arguments._build_args(optionlist=ARGS_DOWNLOADER)
+args = arguments._parse_args()
 
 # Use bittrex as default exchange
 exchange_name = args.exchange or 'bittrex'

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -89,9 +89,8 @@ def plot_parse_args(args: List[str]) -> Dict[str, Any]:
     :return: args: Array with all arguments
     """
     arguments = Arguments(args, 'Graph dataframe')
-    arguments.build_args(optionlist=ARGS_PLOT_DATAFRAME)
-
-    parsed_args = arguments.parse_args()
+    arguments._build_args(optionlist=ARGS_PLOT_DATAFRAME)
+    parsed_args = arguments._parse_args()
 
     # Load the configuration
     config = setup_configuration(parsed_args, RunMode.OTHER)

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -42,9 +42,8 @@ def plot_parse_args(args: List[str]) -> Dict[str, Any]:
     :return: args: Array with all arguments
     """
     arguments = Arguments(args, 'Graph profits')
-    arguments.build_args(optionlist=ARGS_PLOT_PROFIT)
-
-    parsed_args = arguments.parse_args()
+    arguments._build_args(optionlist=ARGS_PLOT_PROFIT)
+    parsed_args = arguments._parse_args()
 
     # Load the configuration
     config = setup_configuration(parsed_args, RunMode.OTHER)


### PR DESCRIPTION
name non-public class attributes and methods with leading underscore.

Currently, `_parse_args()` is also used in the scripts, but this is only temporary till they moved to the subcommands.
