### PR TITLE
don't allow resolving object if there are more than one module containing it

### DIFF
--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -14,6 +14,7 @@ class ExchangeResolver(IResolver):
     """
     This class contains all the logic to load a custom exchange class
     """
+    type_name = "Exchange"
 
     __slots__ = ['exchange']
 

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -19,6 +19,7 @@ class HyperOptResolver(IResolver):
     """
     This class contains all the logic to load custom hyperopt class
     """
+    type_name = "Hyperopt"
 
     __slots__ = ['hyperopt']
 

--- a/freqtrade/resolvers/pairlist_resolver.py
+++ b/freqtrade/resolvers/pairlist_resolver.py
@@ -17,6 +17,7 @@ class PairListResolver(IResolver):
     """
     This class contains all the logic to load custom hyperopt class
     """
+    type_name = "PairList"
 
     __slots__ = ['pairlist']
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -23,6 +23,7 @@ class StrategyResolver(IResolver):
     """
     This class contains all the logic to load custom strategy class
     """
+    type_name = "Strategy"
 
     __slots__ = ['strategy']
 

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -2,9 +2,8 @@ import logging
 import sys
 from copy import deepcopy
 
+from freqtrade import constants
 from freqtrade.strategy.interface import IStrategy
-# Import Default-Strategy to have hyperopt correctly resolve
-from freqtrade.strategy.default_strategy import DefaultStrategy  # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +27,10 @@ def import_strategy(strategy: IStrategy, config: dict) -> IStrategy:
     attr = deepcopy(comb)
 
     # Adjust module name
-    attr['__module__'] = 'freqtrade.strategy'
+    attr['__module__'] = (
+            'freqtrade.strategy.default_strategy'
+            if config.get('strategy') == constants.DEFAULT_STRATEGY
+            else 'freqtrade.strategy')
 
     name = strategy.__class__.__name__
     clazz = type(name, (IStrategy,), attr)

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -44,7 +44,8 @@ def test_import_strategy(caplog):
 
 def test_search_strategy():
     default_config = {}
-    default_location = Path(__file__).parent.parent.joinpath('strategy').resolve()
+    # Use default strategy from freqtrade/strategy, not from freqtrade/tests/strategy
+    default_location = Path(__file__).parent.parent.parent.joinpath('strategy').resolve()
 
     s, _ = StrategyResolver._search_object(
         directory=default_location,


### PR DESCRIPTION
Inspired by the results of digging to a user's problem remotely via chat (#2036).

This PR prevents resolver from resolving and loading an object (strategy, hyperopt, etc) if resolver finds more than one object with the same requested name in the modules in the search path. 

This would allow to avoid errors when a user copies a strategy and hyperopt, modifies it, but forget to change the name of the class. Everyone does it. Even me. So a wrong object from another module can be resolved in this case.

* @xmatthias pls review wording of the new exception and change it if you wish.
* the type_name class attribute should also be added to the new HyperOptLoss class (as "HyperOpt Loss Function", for example. It's printed in the exception).
