### PR TITLE
add --hyperopt-path option

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -201,7 +201,7 @@ to find optimal parameter values for your stategy.
 usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--max_open_trades INT]
                           [--stake_amount STAKE_AMOUNT] [-r]
-			  [--customhyperopt NAME] [--hyperopt-path PATH]
+                          [--customhyperopt NAME] [--hyperopt-path PATH]
                           [--eps] [-e INT]
                           [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
                           [--dmmp] [--print-all] [-j JOBS]

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -201,7 +201,8 @@ to find optimal parameter values for your stategy.
 usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--max_open_trades INT]
                           [--stake_amount STAKE_AMOUNT] [-r]
-                          [--customhyperopt NAME] [--eps] [-e INT]
+			  [--customhyperopt NAME] [--hyperopt-path PATH]
+                          [--eps] [-e INT]
                           [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
                           [--dmmp] [--print-all] [-j JOBS]
                           [--random-state INT] [--min-trades INT] [--continue]
@@ -225,6 +226,8 @@ optional arguments:
   --customhyperopt NAME
                         Specify hyperopt class name (default:
                         `DefaultHyperOpts`).
+  --hyperopt-path PATH  Specify additional lookup path for Hyperopts and
+                        Hyperopt Loss functions.
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
                         stacking).

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -168,6 +168,11 @@ AVAILABLE_CLI_OPTIONS = {
         metavar='NAME',
         default=constants.DEFAULT_HYPEROPT,
     ),
+    "hyperopt_path": Arg(
+        '--hyperopt-path',
+        help='Specify additional lookup path for Hyperopts and Hyperopt Loss functions.',
+        metavar='PATH',
+    ),
     "epochs": Arg(
         '-e', '--epochs',
         help='Specify number of epochs (default: %(default)d).',
@@ -312,7 +317,8 @@ ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange",
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
                                         "live", "strategy_list", "export", "exportfilename"]
 
-ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "position_stacking", "epochs", "spaces",
+ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
+                                        "position_stacking", "epochs", "spaces",
                                         "use_max_market_positions", "print_all", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
                                         "hyperopt_continue", "hyperopt_loss"]

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -129,8 +129,8 @@ class Configuration(object):
         if self.args.strategy != constants.DEFAULT_STRATEGY or not config.get('strategy'):
             config.update({'strategy': self.args.strategy})
 
-        if self.args.strategy_path:
-            config.update({'strategy_path': self.args.strategy_path})
+        self._args_to_config(config, argname='strategy_path',
+                             logstring='Using additional Strategy lookup path: {}')
 
     def _process_common_options(self, config: Dict[str, Any]) -> None:
 
@@ -238,6 +238,9 @@ class Configuration(object):
         # Hyperopt section
         self._args_to_config(config, argname='hyperopt',
                              logstring='Using Hyperopt file {}')
+
+        self._args_to_config(config, argname='hyperopt_path',
+                             logstring='Using additional Hyperopt lookup path: {}')
 
         self._args_to_config(config, argname='epochs',
                              logstring='Parameter --epochs detected ... '

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -60,7 +60,7 @@ class HyperOptResolver(IResolver):
 
         if extra_dir:
             # Add extra hyperopt directory on top of search paths
-            abs_paths.insert(0, Path(extra_dir))
+            abs_paths.insert(0, Path(extra_dir).resolve())
 
         hyperopt = self._load_object(paths=abs_paths, object_type=IHyperOpt,
                                      object_name=hyperopt_name)
@@ -115,7 +115,7 @@ class HyperOptLossResolver(IResolver):
 
         if extra_dir:
             # Add extra hyperopt directory on top of search paths
-            abs_paths.insert(0, Path(extra_dir))
+            abs_paths.insert(0, Path(extra_dir).resolve())
 
         hyperoptloss = self._load_object(paths=abs_paths, object_type=IHyperOptLoss,
                                          object_name=hyper_loss_name)


### PR DESCRIPTION
* The option similar to `--strategy-path`.
* Anything was already ready in `hyperopt_resolver.py`.
* Option works for both `HyperOptResolver` and `HyperOptLossResolver`.
* Docs adjusted.
* Handling of `strategy_path` in `configuration.py` improved (moved to the use of 'standard' `_arg_to_config()` method)
