### PR TITLE
minor: add OnlyProfitHyperOptLoss

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -156,10 +156,10 @@ Each hyperparameter tuning requires a target. This is usually defined as a loss 
 
 By default, FreqTrade uses a loss function, which has been with freqtrade since the beginning and optimizes mostly for short trade duration and avoiding losses.
 
-A different version this can be used by using the `--hyperopt-loss <Class-name>` argument.
-This class should be in it's own file within the `user_data/hyperopts/` directory.
+A different loss function can be specified by using the `--hyperopt-loss <Class-name>` argument.
+This class should be in its own file within the `user_data/hyperopts/` directory.
 
-Currently, the following loss functions are builtin: `SharpeHyperOptLoss` and `DefaultHyperOptLoss`.
+Currently, the following loss functions are builtin: `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function), `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns) and `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration).
 
 ### Creating and using a custom loss function
 

--- a/freqtrade/optimize/default_hyperopt_loss.py
+++ b/freqtrade/optimize/default_hyperopt_loss.py
@@ -3,27 +3,26 @@ DefaultHyperOptLoss
 This module defines the default HyperoptLoss class which is being used for
 Hyperoptimization.
 """
-
 from math import exp
 
 from pandas import DataFrame
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
-# Define some constants:
 
-# set TARGET_TRADES to suit your number concurrent trades so its realistic
+# Set TARGET_TRADES to suit your number concurrent trades so its realistic
 # to the number of days
 TARGET_TRADES = 600
+
 # This is assumed to be expected avg profit * expected trade count.
 # For example, for 0.35% avg per trade (or 0.0035 as ratio) and 1100 trades,
-# self.expected_max_profit = 3.85
+# expected max profit = 3.85
 # Check that the reported Σ% values do not exceed this!
 # Note, this is ratio. 3.85 stated above means 385Σ%.
 EXPECTED_MAX_PROFIT = 3.0
 
-# max average trade duration in minutes
-# if eval ends with higher value, we consider it a failed eval
+# Max average trade duration in minutes.
+# If eval ends with higher value, we consider it a failed eval.
 MAX_ACCEPTED_TRADE_DURATION = 300
 
 

--- a/freqtrade/optimize/hyperopt_loss_onlyprofit.py
+++ b/freqtrade/optimize/hyperopt_loss_onlyprofit.py
@@ -12,8 +12,12 @@ from freqtrade.optimize.hyperopt import IHyperOptLoss
 # This is assumed to be expected avg profit * expected trade count.
 # For example, for 0.35% avg per trade (or 0.0035 as ratio) and 1100 trades,
 # expected max profit = 3.85
-# Check that the reported Σ% values do not exceed this!
-# Note, this is ratio. 3.85 stated above means 385Σ%.
+#
+# Note, this is ratio. 3.85 stated above means 385Σ%, 3.0 means 300Σ%.
+#
+# In this implementation it's only used in calculation of the resulting value
+# of the objective function as a normalization coefficient and does not
+# represent any limit for profits as in the Freqtrade legacy default loss function.
 EXPECTED_MAX_PROFIT = 3.0
 
 
@@ -31,4 +35,4 @@ class OnlyProfitHyperOptLoss(IHyperOptLoss):
         Objective function, returns smaller number for better results.
         """
         total_profit = results.profit_percent.sum()
-        return max(0, 1 - total_profit / EXPECTED_MAX_PROFIT)
+        return 1 - total_profit / EXPECTED_MAX_PROFIT

--- a/freqtrade/optimize/hyperopt_loss_onlyprofit.py
+++ b/freqtrade/optimize/hyperopt_loss_onlyprofit.py
@@ -1,0 +1,34 @@
+"""
+OnlyProfitHyperOptLoss
+
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
+from pandas import DataFrame
+
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+# This is assumed to be expected avg profit * expected trade count.
+# For example, for 0.35% avg per trade (or 0.0035 as ratio) and 1100 trades,
+# expected max profit = 3.85
+# Check that the reported Σ% values do not exceed this!
+# Note, this is ratio. 3.85 stated above means 385Σ%.
+EXPECTED_MAX_PROFIT = 3.0
+
+
+class OnlyProfitHyperOptLoss(IHyperOptLoss):
+    """
+    Defines the loss function for hyperopt.
+
+    This implementation takes only profit into account.
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               *args, **kwargs) -> float:
+        """
+        Objective function, returns smaller number for better results.
+        """
+        total_profit = results.profit_percent.sum()
+        return max(0, 1 - total_profit / EXPECTED_MAX_PROFIT)

--- a/freqtrade/optimize/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe.py
@@ -1,8 +1,9 @@
 """
-IHyperOptLoss interface
-This module defines the interface for the loss-function for hyperopts
-"""
+SharpeHyperOptLoss
 
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
 from datetime import datetime
 
 from pandas import DataFrame
@@ -13,8 +14,9 @@ from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 class SharpeHyperOptLoss(IHyperOptLoss):
     """
-    Defines the a loss function for hyperopt.
-    This implementation uses the sharpe ratio calculation.
+    Defines the loss function for hyperopt.
+
+    This implementation uses the Sharpe Ratio calculation.
     """
 
     @staticmethod
@@ -22,8 +24,9 @@ class SharpeHyperOptLoss(IHyperOptLoss):
                                min_date: datetime, max_date: datetime,
                                *args, **kwargs) -> float:
         """
-        Objective function, returns smaller number for more optimal results
-        Using sharpe ratio calculation
+        Objective function, returns smaller number for more optimal results.
+
+        Uses Sharpe Ratio calculation.
         """
         total_profit = results.profit_percent
         days_period = (max_date - min_date).days

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -337,6 +337,24 @@ def test_sharpe_loss_prefers_higher_profits(default_conf, hyperopt_results) -> N
     assert under > correct
 
 
+def test_onlyprofit_loss_prefers_higher_profits(default_conf, hyperopt_results) -> None:
+    results_over = hyperopt_results.copy()
+    results_over['profit_percent'] = hyperopt_results['profit_percent'] * 2
+    results_under = hyperopt_results.copy()
+    results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
+
+    default_conf.update({'hyperopt_loss': 'OnlyProfitHyperOptLoss'})
+    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
+                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),
+                                     datetime(2019, 1, 1), datetime(2019, 5, 1))
+    under = hl.hyperopt_loss_function(results_under, len(hyperopt_results),
+                                      datetime(2019, 1, 1), datetime(2019, 5, 1))
+    assert over < correct
+    assert under > correct
+
+
 def test_log_results_if_loss_improves(hyperopt, capsys) -> None:
     hyperopt.current_best_loss = 2
     hyperopt.log_results(


### PR DESCRIPTION
Minor changes:

* Adds Hyperopt Loss Function that takes only profit into account.
May be useful for users , I use it in practice.

If `freqtrade/optimize` is not a proper place for it, I could move it into `user_data/hyperopts` dir or to the `freqtrade/freqtrade-strategies` project.

* Improves wording in comments in DefaultHyperOptLoss and SharpeHyperOptLoss
