### PR TITLE
Conda / makefile

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -219,6 +219,17 @@ as the watchdog.
 
 ------
 
+## Using Conda
+
+Freqtrade can also be installed using Anaconda (or Miniconda).
+
+``` bash
+conda env create -f environment.yml
+```
+
+!!! Note:
+    This requires the [ta-lib](#1-install-ta-lib) C-library to be installed first.
+
 ## Windows
 
 We recommend that Windows users use [Docker](docker.md) as this will work much easier and smoother (also more secure).

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,58 @@
+name: freqtrade
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  # Required for app
+  - python>=3.6
+  - pip
+  - wheel
+  - numpy
+  - pandas
+  - scipy
+  - SQLAlchemy
+  - scikit-learn
+  - arrow
+  - requests
+  - urllib3
+  - wrapt
+  - joblib
+  - jsonschema
+  - tabulate
+  - python-rapidjson
+  - filelock
+  - flask
+  - python-dotenv
+  - cachetools
+  - scikit-optimize
+  - python-telegram-bot
+  # Optional for plotting
+  - plotly
+  # Optional for development
+  - flake8
+  - pytest
+  - pytest-mock
+  - pytest-asyncio
+  - pytest-cov
+  - coveralls
+  - mypy
+  # Useful for jupyter
+  - ipykernel
+  - isort
+  - yapf
+  - pip:
+    # Required for app
+    - cython
+    - coinmarketcap
+    - ccxt
+    - TA-Lib
+    - py_find_1st
+    - sdnotify
+    # Optional for develpment
+    - flake8-tidy-imports
+    - flake8-type-annotations
+    - pytest-random-order
+    - -e .
+
+
+


### PR DESCRIPTION
## Summary
Enables building app in a conda environment or Docker container using a Makefile

Solve the issue: #2041 

## Quick changelog

- Added Makefile
- Updated .dockerignore/.gitignore
- Created new logic for generation of startup files
- Added .env file to separate configuration from strategies
- Added support for version control of a repo located at `user_data/user_repo` so users can keep custom strategies, scripts, and jupyter notebooks backed up

## What's new?
This is a proposed alternative to the installation process intended to:

- Streamline the installation options
- Make working with Docker containers less cumbersome and
- Add support for installation in a conda environment. 

The existing `setup.sh` script is untouched and will continue to work as a parallel installation option.

### Configuration

- Overwrite configuration defaults by copying `.env.example` to `~/.freqtrade/.env`, `user_data/.env` or `user_data/user_repo.env`. 
- Execute `make` from the project root to view available commands
- Build conda app with `make conda-app`
- Build docker app with `make docker-app`
