### PR TITLE
Resolve issue #2042

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -2,7 +2,8 @@
 
 This page explains the different parameters of the bot and how to run it.
 
-Note: You can now use the bot by executing `source .env/bin/activate; freqtrade`.
+!Note:
+    If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
 
 ## Bot commands

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -2,6 +2,8 @@
 
 This page explains the different parameters of the bot and how to run it.
 
+Note: You can now use the bot by executing `source .env/bin/activate; freqtrade`.
+
 
 ## Bot commands
 


### PR DESCRIPTION
Issue #2042 noted that the terminal output from `setup.sh` regarding an option use the bot was missing from the documentation. This has been added.

## Summary
Add note to docs from `setup.sh`.

Solve the issue: #2042

## Quick changelog

- Added second paragraph to Start the Bot page of documentation.

## What's new?
Just a new line in `docs/bot_usage.md`
