### PR TITLE
Deprecate live bt

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -4,31 +4,16 @@ This page contains description of the command line arguments, configuration para
 and the bot features that were declared as DEPRECATED by the bot development team
 and are no longer supported. Please avoid their usage in your configuration.
 
+### the `--live` command line option
+
+`--live` in the context of backtesting allows to download the latest tick data for backtesting.
+Since this only downloads one set of data (by default 500 candles) - this is not really suitable for extendet backtesting, and has therefore been deprecated.
+
+This command was deprecated in `2019.6-dev` and will be removed after the next release.
+
+## Removed features
+
 ### The **--dynamic-whitelist** command line option
 
 This command line option was deprecated in 2018 and removed freqtrade 2019.6-dev (develop branch)
 and in freqtrade 2019.7 (master branch).
-
-Per default `--dynamic-whitelist` will retrieve the 20 currencies based
-on BaseVolume. This value can be changed when you run the script.
-
-**By Default**
-Get the 20 currencies based on BaseVolume.
-
-```bash
-freqtrade --dynamic-whitelist
-```
-
-**Customize the number of currencies to retrieve**
-Get the 30 currencies based on BaseVolume.
-
-```bash
-freqtrade --dynamic-whitelist 30
-```
-
-**Exception**
-`--dynamic-whitelist` must be greater than 0. If you enter 0 or a
-negative value (e.g -2), `--dynamic-whitelist` will use the default
-value (20).
-
-

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -4,6 +4,7 @@ This module contains the configuration class
 import json
 import logging
 import sys
+import warnings
 from argparse import Namespace
 from typing import Any, Callable, Dict, Optional
 
@@ -14,7 +15,6 @@ from freqtrade.configuration.json_schema import validate_config_schema
 from freqtrade.loggers import setup_logging
 from freqtrade.misc import deep_merge_dicts
 from freqtrade.state import RunMode
-
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +187,8 @@ class Configuration(object):
                              'Using ticker_interval: {} ...')
 
         self._args_to_config(config, argname='live',
-                             logstring='Parameter -l/--live detected ...')
+                             logstring='Parameter -l/--live detected ...',
+                             deprecated_msg='--live will be removed soon.')
 
         self._args_to_config(config, argname='position_stacking',
                              logstring='Parameter --enable-position-stacking detected ...')
@@ -323,7 +324,8 @@ class Configuration(object):
                 'to be greater than trailing_stop_positive_offset in your config.')
 
     def _args_to_config(self, config: Dict[str, Any], argname: str,
-                        logstring: str, logfun: Optional[Callable] = None) -> None:
+                        logstring: str, logfun: Optional[Callable] = None,
+                        deprecated_msg: Optional[str] = None) -> None:
         """
         :param config: Configuration dictionary
         :param argname: Argumentname in self.args - will be copied to config dict.
@@ -340,3 +342,5 @@ class Configuration(object):
                 logger.info(logstring.format(logfun(config[argname])))
             else:
                 logger.info(logstring.format(config[argname]))
+            if deprecated_msg:
+                warnings.warn(f"DEPRECATED: {deprecated_msg}", DeprecationWarning)


### PR DESCRIPTION
## Summary
as mentioned in #2052,  `--live` should be deprecated, since it does not provide any value (too short for realistic backtesting).

Closes #2052

## Quick changelog

- Add simple method to deprecate cmdline options
- deprecate `--live`
