### PR TITLE
minor: cleanup in strategy interface

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -154,7 +154,7 @@ class IStrategy(ABC):
         """
         return self.__class__.__name__
 
-    def analyze_ticker(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def _analyze_ticker(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Parses the given ticker history and returns a populated DataFrame
         add several TA indicators and buy signal to it
@@ -198,7 +198,7 @@ class IStrategy(ABC):
             return False, False
 
         try:
-            dataframe = self.analyze_ticker(dataframe, {'pair': pair})
+            dataframe = self._analyze_ticker(dataframe, {'pair': pair})
         except ValueError as error:
             logger.warning(
                 'Unable to analyze ticker for pair %s: %s',

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -19,13 +19,13 @@ _STRATEGY = DefaultStrategy(config={})
 
 def test_returns_latest_buy_signal(mocker, default_conf, ticker_history):
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame([{'buy': 1, 'sell': 0, 'date': arrow.utcnow()}])
     )
     assert _STRATEGY.get_signal('ETH/BTC', '5m', ticker_history) == (True, False)
 
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame([{'buy': 0, 'sell': 1, 'date': arrow.utcnow()}])
     )
     assert _STRATEGY.get_signal('ETH/BTC', '5m', ticker_history) == (False, True)
@@ -33,14 +33,14 @@ def test_returns_latest_buy_signal(mocker, default_conf, ticker_history):
 
 def test_returns_latest_sell_signal(mocker, default_conf, ticker_history):
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame([{'sell': 1, 'buy': 0, 'date': arrow.utcnow()}])
     )
 
     assert _STRATEGY.get_signal('ETH/BTC', '5m', ticker_history) == (False, True)
 
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame([{'sell': 0, 'buy': 1, 'date': arrow.utcnow()}])
     )
     assert _STRATEGY.get_signal('ETH/BTC', '5m', ticker_history) == (True, False)
@@ -60,7 +60,7 @@ def test_get_signal_empty(default_conf, mocker, caplog):
 def test_get_signal_exception_valueerror(default_conf, mocker, caplog, ticker_history):
     caplog.set_level(logging.INFO)
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         side_effect=ValueError('xyz')
     )
     assert (False, False) == _STRATEGY.get_signal('foo', default_conf['ticker_interval'],
@@ -71,7 +71,7 @@ def test_get_signal_exception_valueerror(default_conf, mocker, caplog, ticker_hi
 def test_get_signal_empty_dataframe(default_conf, mocker, caplog, ticker_history):
     caplog.set_level(logging.INFO)
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame([])
     )
     assert (False, False) == _STRATEGY.get_signal('xyz', default_conf['ticker_interval'],
@@ -86,7 +86,7 @@ def test_get_signal_old_dataframe(default_conf, mocker, caplog, ticker_history):
     oldtime = arrow.utcnow().shift(minutes=-16)
     ticks = DataFrame([{'buy': 1, 'date': oldtime}])
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         return_value=DataFrame(ticks)
     )
     assert (False, False) == _STRATEGY.get_signal('xyz', default_conf['ticker_interval'],
@@ -100,7 +100,7 @@ def test_get_signal_old_dataframe(default_conf, mocker, caplog, ticker_history):
 def test_get_signal_handles_exceptions(mocker, default_conf):
     exchange = get_patched_exchange(mocker, default_conf)
     mocker.patch.object(
-        _STRATEGY, 'analyze_ticker',
+        _STRATEGY, '_analyze_ticker',
         side_effect=Exception('invalid ticker history ')
     )
     assert _STRATEGY.get_signal(exchange, 'ETH/BTC', '5m') == (False, False)
@@ -232,7 +232,7 @@ def test_analyze_ticker_default(ticker_history, mocker, caplog) -> None:
 
     )
     strategy = DefaultStrategy({})
-    strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
+    strategy._analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
     assert ind_mock.call_count == 1
     assert buy_mock.call_count == 1
     assert buy_mock.call_count == 1
@@ -242,7 +242,7 @@ def test_analyze_ticker_default(ticker_history, mocker, caplog) -> None:
                        caplog.record_tuples)
     caplog.clear()
 
-    strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
+    strategy._analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
     # No analysis happens as process_only_new_candles is true
     assert ind_mock.call_count == 2
     assert buy_mock.call_count == 2
@@ -267,7 +267,7 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
     strategy = DefaultStrategy({})
     strategy.process_only_new_candles = True
 
-    ret = strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
+    ret = strategy._analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
     assert 'high' in ret.columns
     assert 'low' in ret.columns
     assert 'close' in ret.columns
@@ -280,7 +280,7 @@ def test_analyze_ticker_skip_analyze(ticker_history, mocker, caplog) -> None:
                        caplog.record_tuples)
     caplog.clear()
 
-    ret = strategy.analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
+    ret = strategy._analyze_ticker(ticker_history, {'pair': 'ETH/BTC'})
     # No analysis happens as process_only_new_candles is true
     assert ind_mock.call_count == 1
     assert buy_mock.call_count == 1

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -366,6 +366,7 @@ def test_strategy_override_use_sell_profit_only(caplog):
             ) in caplog.record_tuples
 
 
+@pytest.mark.filterwarnings("ignore:deprecated")
 def test_deprecate_populate_indicators(result):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     resolver = StrategyResolver({'strategy': 'TestStrategyLegacy',
@@ -398,6 +399,7 @@ def test_deprecate_populate_indicators(result):
             in str(w[-1].message)
 
 
+@pytest.mark.filterwarnings("ignore:deprecated")
 def test_call_deprecated_function(result, monkeypatch):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     resolver = StrategyResolver({'strategy': 'TestStrategyLegacy',

--- a/freqtrade/tests/test_plotting.py
+++ b/freqtrade/tests/test_plotting.py
@@ -68,7 +68,7 @@ def test_add_indicators(default_conf, caplog):
 
     # Generate buy/sell signals and indicators
     strat = DefaultStrategy(default_conf)
-    data = strat.analyze_ticker(data, {'pair': pair})
+    data = strat._analyze_ticker(data, {'pair': pair})
     fig = generage_empty_figure()
 
     # Row 1
@@ -166,7 +166,7 @@ def test_generate_candlestick_graph_no_trades(default_conf, mocker):
 
     # Generate buy/sell signals and indicators
     strat = DefaultStrategy(default_conf)
-    data = strat.analyze_ticker(data, {'pair': pair})
+    data = strat._analyze_ticker(data, {'pair': pair})
 
     indicators1 = []
     indicators2 = []


### PR DESCRIPTION
* underscore added to the name of `analyze_ticker()` since it's not a public method.

* eliminate warnings in pytest when testing deprecated strategy interfaces.
