### PR TITLE
Improve logging: output divider in logs between throttles

### DIFF
--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -128,6 +128,7 @@ class Worker(object):
         return result
 
     def _process(self) -> bool:
+        logger.debug("========================================")
         state_changed = False
         try:
             state_changed = self.freqtrade.process()


### PR DESCRIPTION
This was the FIRST change I made into freqtrade when I fetched it...

Without this the logs are too blind -- it helps to navigate in the sheets of logs, especially with verbosity increased.

Now printed at debug level, can also be printed as info.
