### PR TITLE
tests: don't mask numpy errors as warnings in tests

### DIFF
--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import arrow
 import pytest
+import numpy as np
 from telegram import Chat, Message, Update
 
 from freqtrade import constants, persistence
@@ -23,6 +24,10 @@ from freqtrade.worker import Worker
 
 
 logging.getLogger('').setLevel(logging.INFO)
+
+
+# Do not mask numpy errors as warnings that no one read, raise the exсeption
+np.seterr(all='raise')
 
 
 def log_has(line, logs):


### PR DESCRIPTION
...cause these are tests, we need to see all errorneous cases.

This change produces an error in the rpc test -- that's its purpose.

I cannot fix that error because I do not understand why `numpy.mean()` is used in that place in rpc.py...
