### PR TITLE
get rid of pandas warning in pytest

### DIFF
--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -297,7 +297,7 @@ def test_loss_calculation_prefer_correct_trade_count(default_conf, hyperopt_resu
 
 def test_loss_calculation_prefer_shorter_trades(default_conf, hyperopt_results) -> None:
     resultsb = hyperopt_results.copy()
-    resultsb['trade_duration'][1] = 20
+    resultsb.loc[1, 'trade_duration'] = 20
 
     hl = HyperOptLossResolver(default_conf).hyperoptloss
     longer = hl.hyperopt_loss_function(hyperopt_results, 100)


### PR DESCRIPTION
Eliminates warning;
```
freqtrade/tests/optimize/test_hyperopt.py::test_loss_calculation_prefer_shorter_trades
  /home/user/freqtrade-wrk/github-hroff-1902/freqtrade/freqtrade/tests/optimize/test_hyperopt.py:300: SettingWithCopyWarning:
  
  
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
```