### PR TITLE
Improve setup.py to allow "extras" installations

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -12,8 +12,8 @@ Special fields for the documentation (like Note boxes, ...) can be found [here](
 
 ## Developer setup
 
-To configure a development environment, use best use the `setup.sh` script and answer "y" when asked "Do you want to install dependencies for dev [y/N]? ".
-Alternatively (if your system is not supported by the setup.sh script), follow the manual installation process and run `pip3 install -r requirements-dev.txt`.
+To configure a development environment, best use the `setup.sh` script and answer "y" when asked "Do you want to install dependencies for dev [y/N]? ".
+Alternatively (if your system is not supported by the setup.sh script), follow the manual installation process and run `pip3 install -e .[all]`.
 
 This will install all required tools for development, including `pytest`, `flake8`, `mypy`, and `coveralls`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,13 @@
 -r requirements.txt
 -r requirements-plot.txt
 
+coveralls==1.8.1
 flake8==3.7.8
 flake8-type-annotations==0.1.0
 flake8-tidy-imports==2.0.0
+mypy==0.720
 pytest==5.0.1
-pytest-mock==1.10.4
 pytest-asyncio==0.10.0
 pytest-cov==2.7.1
+pytest-mock==1.10.4
 pytest-random-order==1.0.4
-coveralls==1.8.1
-mypy==0.720

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,24 @@ if version_info.major == 3 and version_info.minor < 6 or \
 
 from freqtrade import __version__
 
+# Requirements used for submodules
+api = ['flask']
+plot = ['plotly>=4.0']
+
+develop = [
+    'coveralls',
+    'flake8',
+    'flake8-type-annotations',
+    'flake8-tidy-imports',
+    'mypy',
+    'pytest',
+    'pytest-asyncio',
+    'pytest-cov',
+    'pytest-mock',
+    'pytest-random-order',
+]
+
+all_extra = api + plot + develop
 
 setup(name='freqtrade',
       version=__version__,
@@ -20,26 +38,37 @@ setup(name='freqtrade',
       setup_requires=['pytest-runner', 'numpy'],
       tests_require=['pytest', 'pytest-mock', 'pytest-cov'],
       install_requires=[
-          'ccxt',
+          # from requirements-common.txt
+          'ccxt>=1.18',
           'SQLAlchemy',
           'python-telegram-bot',
           'arrow',
+          'cachetools',
           'requests',
           'urllib3',
           'wrapt',
-          'pandas',
           'scikit-learn',
-          'scipy',
           'joblib',
           'jsonschema',
           'TA-Lib',
           'tabulate',
-          'cachetools',
           'coinmarketcap',
           'scikit-optimize',
+          'filelock',
+          'py_find_1st',
           'python-rapidjson',
-          'py_find_1st'
+          'sdnotify',
+          # from requirements.txt
+          'numpy',
+          'pandas',
+          'scipy',
       ],
+      extras_require={
+          'api': api,
+          'dev': develop,
+          'plot': plot,
+          'all': all_extra,
+      },
       include_package_data=True,
       zip_safe=False,
       entry_points={

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='freqtrade',
       ],
       extras_require={
           'api': api,
-          'dev': develop,
+          'dev': all_extra,
           'plot': plot,
           'all': all_extra,
       },


### PR DESCRIPTION
## Summary
This pr will allow installation via pip using "extras".
basically, to install the bot for a development installation:
`pip install -e .[all]`.

To only install the base bot + plot features: `pip install -e .[plot]`

This will become more power should we be able to sucessfully isntall through pypi - where a command like `pip install freqtrade[all]` will become possible.

## Quick changelog

- add extra-install tools


