### PR TITLE
minor: cleanup in hyperopt

### DIFF
--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -26,6 +26,7 @@ from freqtrade.tests.conftest import (get_args, log_has, log_has_re,
 
 @pytest.fixture(scope='function')
 def hyperopt(default_conf, mocker):
+    default_conf.update({'spaces': ['all']})
     patch_exchange(mocker)
     return Hyperopt(default_conf)
 
@@ -455,6 +456,7 @@ def test_start_calls_optimizer(mocker, default_conf, caplog, capsys) -> None:
 
     hyperopt = Hyperopt(default_conf)
     hyperopt.strategy.tickerdata_to_dataframe = MagicMock()
+    hyperopt.custom_hyperopt.generate_roi_table = MagicMock(return_value={})
 
     hyperopt.start()
 


### PR DESCRIPTION
* modification of the use_sell_signal config setting to True moved to `__init__()` -- it should not be done at every call to `hyperopt_space()`
* minor cleanup in `log_trials_result()` (`params = best_result['params']`)
* detection if roi table should be printed in `log_trials_result()` improved -- this should be done via `has_space()`, because in her custom hyperopt a user may use other names for t1 and other components of the roi table,
* implementation of `has_space()` pythonized
* tests adjusted to not fail with these changes
