### PR TITLE
Fix/missintfstring

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -30,7 +30,7 @@ def load_backtest_data(filename) -> pd.DataFrame:
         filename = Path(filename)
 
     if not filename.is_file():
-        raise ValueError("File {filename} does not exist.")
+        raise ValueError(f"File {filename} does not exist.")
 
     with filename.open() as file:
         data = json_load(file)


### PR DESCRIPTION
## Summary
we should show the used filename, not a empty "{filename}" - which is caused by a wrongly used fstring.

Closes #2081 
