### PR TITLE
Restricted pairs warning

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,7 +48,7 @@ You can use the `/forcesell all` command from Telegram.
 ### I get the message "RESTRICTED_MARKET"
 
 Currently known to happen for US Bittrex users.  
-Bittrex split it's exchange into US and International versions.
+Bittrex split its exchange into US and International versions.
 The International version has more pairs available, however the API always returns all pairs, so there is currently no automated way to detect if you're affected by the restriction.
 
 If you have restricted pairs in your whitelist, you'll get a warning message in the log on FreqTrade startup for each restricted pair.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,11 +48,11 @@ You can use the `/forcesell all` command from Telegram.
 ### I get the message "RESTRICTED_MARKET"
 
 Currently known to happen for US Bittrex users.  
-Bittrex split it's exchange into an US and an International verssion.
+Bittrex split it's exchange into US and International versions.
 The International version has more pairs available, however the API always returns all pairs, so there is currently no automated way to detect if you're affected by the restriction.
 
-If you have restricted pairs in your whitelist, you'll get a Warning-message on startup for each restricted pair.
-If you're an "International" Customer on the Bittrex exchange, then this warning will not impact you.
+If you have restricted pairs in your whitelist, you'll get a warning message in the log on FreqTrade startup for each restricted pair.
+If you're an "International" Customer on the Bittrex exchange, then this warning will probably not impact you.
 If you're a US customer, the bot will fail to create orders for these pairs, and you should remove them from your Whitelist.
 
 ## Hyperopt module

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,6 +45,16 @@ the tutorial [here|Testing-new-strategies-with-Hyperopt](bot-usage.md#hyperopt-c
 
 You can use the `/forcesell all` command from Telegram.
 
+### I get the message "RESTRICTED_MARKET"
+
+Currently known to happen for US Bittrex users.  
+Bittrex split it's exchange into an US and an International verssion.
+The International version has more pairs available, however the API always returns all pairs, so there is currently no automated way to detect if you're affected by the restriction.
+
+If you have restricted pairs in your whitelist, you'll get a Warning-message on startup for each restricted pair.
+If you're an "International" Customer on the Bittrex exchange, then this warning will not impact you.
+If you're a US customer, the bot will fail to create orders for these pairs, and you should remove them from your Whitelist.
+
 ## Hyperopt module
 
 ### How many epoch do I need to get a good Hyperopt result?

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -260,7 +260,7 @@ class Exchange(object):
 
         if not self.markets:
             logger.warning('Unable to validate pairs (assuming they are correct).')
-        #     return
+            return
 
         for pair in pairs:
             # Note: ccxt has BaseCurrency/QuoteCurrency format for pairs
@@ -269,6 +269,12 @@ class Exchange(object):
                 raise OperationalException(
                     f'Pair {pair} is not available on {self.name}. '
                     f'Please remove {pair} from your whitelist.')
+            elif self.markets[pair].get('info', {}).get('IsRestricted', False):
+                # Warn users about restricted pairs in whitelist.
+                # We cannot determine reliably if Users are affected.
+                logger.warning(f"Pair {pair} is restricted for some users on this exchange."
+                               f"Please check if you are impacted by this restriction "
+                               f"on the exchange and eventually remove {pair} from your whitelist.")
 
     def get_valid_pair_combination(self, curr_1, curr_2) -> str:
         """

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -304,7 +304,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'TKN/BTC': {
             'id': 'tknbtc',
@@ -329,7 +329,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'BLK/BTC': {
             'id': 'blkbtc',
@@ -354,7 +354,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'LTC/BTC': {
             'id': 'ltcbtc',
@@ -379,7 +379,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'XRP/BTC': {
             'id': 'xrpbtc',
@@ -404,7 +404,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'NEO/BTC': {
             'id': 'neobtc',
@@ -429,7 +429,7 @@ def markets():
                     'max': 500000,
                 },
             },
-            'info': '',
+            'info': {},
         },
         'BTT/BTC': {
             'id': 'BTTBTC',
@@ -457,7 +457,7 @@ def markets():
                     'max': None
                 }
             },
-            'info': "",
+            'info': {},
         },
         'ETH/USDT': {
             'id': 'USDT-ETH',
@@ -479,7 +479,7 @@ def markets():
                 }
             },
             'active': True,
-            'info': ""
+            'info': {},
         },
         'LTC/USDT': {
             'id': 'USDT-LTC',
@@ -501,7 +501,7 @@ def markets():
                     'max': None
                 }
             },
-            'info': ""
+            'info': {},
         }
     }
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -332,7 +332,7 @@ def test_validate_pairs(default_conf, mocker):  # test exchange.validate_pairs d
 def test_validate_pairs_not_available(default_conf, mocker):
     api_mock = MagicMock()
     type(api_mock).markets = PropertyMock(return_value={
-        'XRP/BTC': {'inactive'}
+        'XRP/BTC': {'inactive': True}
     })
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())


### PR DESCRIPTION
## Summary
Freqtrade should warn users if they have restricted pairs in their whitelist.

As noted in https://github.com/ccxt/ccxt/issues/5624, there is currently
no way to detect if a user is impacted by the restriction or not prior to creating (and eventually failing to create) an order.

Closes #2074, 
Closes #1690

## Quick changelog

- Warn on startup
- document in FAQ about this problem