### PR TITLE
Hyperopt print colorized results

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -207,7 +207,7 @@ usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--customhyperopt NAME] [--hyperopt-path PATH]
                           [--eps] [-e INT]
                           [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
-                          [--dmmp] [--print-all] [-j JOBS]
+                          [--dmmp] [--print-all] [--no-color] [-j JOBS]
                           [--random-state INT] [--min-trades INT] [--continue]
                           [--hyperopt-loss NAME]
 
@@ -243,6 +243,8 @@ optional arguments:
                         (same as setting `max_open_trades` to a very high
                         number).
   --print-all           Print all results, not only the best ones.
+  --no-color            Disable colorization of hyperopt results. May be
+                        useful if you are redirecting output to a file.
   -j JOBS, --job-workers JOBS
                         The number of concurrently running jobs for
                         hyperoptimization (hyperopt worker processes). If -1
@@ -256,8 +258,7 @@ optional arguments:
   --continue            Continue hyperopt from previous runs. By default,
                         temporary files will be removed and hyperopt will
                         start from scratch.
-  --hyperopt-loss       NAME
-                        Specify the class name of the hyperopt loss function
+  --hyperopt-loss NAME  Specify the class name of the hyperopt loss function
                         class (IHyperOptLoss). Different functions can
                         generate completely different results, since the
                         target for optimization is different. (default:

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -343,6 +343,10 @@ def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
     return dataframe
 ```
 
+You can use the `--print-all` command line option if you would like to see all results in the hyperopt output, not only the best ones.
+
+When the `--color/--print-colorized` command line option is used, the results are colorized -- bad results (with zero trades or limited by the `--min-trades` option) are red, currest bests -- in green, results with positive total profit are printed in bold.
+
 ### Understand Hyperopt ROI results
 
 If you are optimizing ROI, you're result will look as follows and include a ROI table.

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -343,9 +343,9 @@ def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
     return dataframe
 ```
 
-You can use the `--print-all` command line option if you would like to see all results in the hyperopt output, not only the best ones.
+By default, hyperopt prints colorized results -- epochs with positive profit are printed in the green color. This highlighting helps you find epochs that can be interesting for later analysis. Epochs with zero total profit or with negative profits (losses) are printed in the normal color. If you do not need colorization of results (for instance, when you are redirecting hyperopt output to a file) you can switch colorization off by specifying the `--no-color` option in the command line.
 
-When the `--color/--print-colorized` command line option is used, the results are colorized -- bad results (with zero trades or limited by the `--min-trades` option) are red, current bests -- in green, results with positive total profit are printed in bold.
+You can use the `--print-all` command line option if you would like to see all results in the hyperopt output, not only the best ones. When `--print-all` is used, current best results are also colorized by default -- they are printed in bold (bright) style. This can also be switched off with the `--no-color` command line option.
 
 ### Understand Hyperopt ROI results
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -345,7 +345,7 @@ def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
 
 You can use the `--print-all` command line option if you would like to see all results in the hyperopt output, not only the best ones.
 
-When the `--color/--print-colorized` command line option is used, the results are colorized -- bad results (with zero trades or limited by the `--min-trades` option) are red, currest bests -- in green, results with positive total profit are printed in bold.
+When the `--color/--print-colorized` command line option is used, the results are colorized -- bad results (with zero trades or limited by the `--min-trades` option) are red, current bests -- in green, results with positive total profit are printed in bold.
 
 ### Understand Hyperopt ROI results
 

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -23,7 +23,8 @@ ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_pos
 
 ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "position_stacking", "epochs", "spaces",
-                                        "use_max_market_positions", "print_all", "hyperopt_jobs",
+                                        "use_max_market_positions", "print_all",
+                                        "print_colorized", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
                                         "hyperopt_continue", "hyperopt_loss"]
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -192,10 +192,11 @@ AVAILABLE_CLI_OPTIONS = {
         default=False,
     ),
     "print_colorized": Arg(
-        '--color', '--print-colorized',
-        help='Print colorized hyperopt results.',
-        action='store_true',
-        default=False
+        '--no-color',
+        help='Disable colorization of hyperopt results. May be useful if you are '
+        'redirecting output to a file.',
+        action='store_false',
+        default=True,
     ),
     "hyperopt_jobs": Arg(
         '-j', '--job-workers',

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -191,6 +191,12 @@ AVAILABLE_CLI_OPTIONS = {
         action='store_true',
         default=False,
     ),
+    "print_colorized": Arg(
+        '--color', '--print-colorized',
+        help='Print colorized hyperopt results.',
+        action='store_true',
+        default=False
+    ),
     "hyperopt_jobs": Arg(
         '-j', '--job-workers',
         help='The number of concurrently running jobs for hyperoptimization '

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -256,7 +256,9 @@ class Configuration(object):
 
         if 'print_colorized' in self.args and not self.args.print_colorized:
             logger.info('Parameter --no-color detected ...')
-        config.update({'print_colorized': getattr(self.args, 'print_colorized')})
+            config.update({'print_colorized': False})
+        else:
+            config.update({'print_colorized': True})
 
         self._args_to_config(config, argname='hyperopt_jobs',
                              logstring='Parameter -j/--job-workers detected: {}')

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -254,8 +254,9 @@ class Configuration(object):
         self._args_to_config(config, argname='print_all',
                              logstring='Parameter --print-all detected ...')
 
-        self._args_to_config(config, argname='print_colorized',
-                             logstring='Parameter --color/--print-colorized detected ...')
+        if 'print_colorized' in self.args and not self.args.print_colorized:
+            logger.info('Parameter --no-color detected ...')
+        config.update({'print_colorized': getattr(self.args, 'print_colorized')})
 
         self._args_to_config(config, argname='hyperopt_jobs',
                              logstring='Parameter -j/--job-workers detected: {}')

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -254,6 +254,9 @@ class Configuration(object):
         self._args_to_config(config, argname='print_all',
                              logstring='Parameter --print-all detected ...')
 
+        self._args_to_config(config, argname='print_colorized',
+                             logstring='Parameter --color/--print-colorized detected ...')
+
         self._args_to_config(config, argname='hyperopt_jobs',
                              logstring='Parameter -j/--job-workers detected: {}')
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -113,3 +113,15 @@ def deep_merge_dicts(source, destination):
             destination[key] = value
 
     return destination
+
+
+def green(s):
+    return '\033[92m' + s + '\033[0m'
+
+
+def red(s):
+    return '\033[91m' + s + '\033[0m'
+
+
+def bold(s):
+    return '\033[1m' + s + '\033[0m'

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -113,15 +113,3 @@ def deep_merge_dicts(source, destination):
             destination[key] = value
 
     return destination
-
-
-def green(s):
-    return '\033[92m' + s + '\033[0m'
-
-
-def red(s):
-    return '\033[91m' + s + '\033[0m'
-
-
-def bold(s):
-    return '\033[1m' + s + '\033[0m'

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -13,14 +13,15 @@ from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List, Optional
 
+from colorama import init as colorama_init
 from joblib import Parallel, delayed, dump, load, wrap_non_picklable_objects, cpu_count
 from pandas import DataFrame
 from skopt import Optimizer
 from skopt.space import Dimension
+from termcolor import colored
 
 from freqtrade.configuration import Arguments
 from freqtrade.data.history import load_data, get_timeframe
-from freqtrade.misc import green, red, bold
 from freqtrade.optimize.backtesting import Backtesting
 # Import IHyperOptLoss to allow users import from this file
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F4
@@ -162,11 +163,11 @@ class Hyperopt(Backtesting):
             # Colorize output
             if self.config.get('print_colorized', False):
                 if results['total_profit'] > 0:
-                    log_str = bold(log_str)
+                    log_str = colored(log_str, attrs=['bold'])
                 if results['loss'] >= MAX_LOSS:
-                    log_str = red(log_str)
+                    log_str = colored(log_str, 'red')
                 elif is_best_loss:
-                    log_str = green(log_str)
+                    log_str = colored(log_str, 'green')
             if print_all:
                 print(log_str)
             else:
@@ -353,6 +354,9 @@ class Hyperopt(Backtesting):
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 
         opt = self.get_optimizer(config_jobs)
+
+        colorama_init()
+
         try:
             with Parallel(n_jobs=config_jobs) as parallel:
                 jobs = parallel._effective_n_jobs()

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -163,11 +163,9 @@ class Hyperopt(Backtesting):
             # Colorize output
             if self.config.get('print_colorized', False):
                 if results['total_profit'] > 0:
-                    log_str = Style.BRIGHT + log_str
-                if results['loss'] >= MAX_LOSS:
-                    log_str = Fore.RED + log_str
-                elif is_best_loss:
                     log_str = Fore.GREEN + log_str
+                if print_all and is_best_loss:
+                    log_str = Style.BRIGHT + log_str
             if print_all:
                 print(log_str)
             else:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -14,11 +14,11 @@ from pprint import pprint
 from typing import Any, Dict, List, Optional
 
 from colorama import init as colorama_init
+from colorama import Fore, Style
 from joblib import Parallel, delayed, dump, load, wrap_non_picklable_objects, cpu_count
 from pandas import DataFrame
 from skopt import Optimizer
 from skopt.space import Dimension
-from termcolor import colored
 
 from freqtrade.configuration import Arguments
 from freqtrade.data.history import load_data, get_timeframe
@@ -163,11 +163,11 @@ class Hyperopt(Backtesting):
             # Colorize output
             if self.config.get('print_colorized', False):
                 if results['total_profit'] > 0:
-                    log_str = colored(log_str, attrs=['bold'])
+                    log_str = Style.BRIGHT + log_str
                 if results['loss'] >= MAX_LOSS:
-                    log_str = colored(log_str, 'red')
+                    log_str = Fore.RED + log_str
                 elif is_best_loss:
-                    log_str = colored(log_str, 'green')
+                    log_str = Fore.GREEN + log_str
             if print_all:
                 print(log_str)
             else:
@@ -355,7 +355,8 @@ class Hyperopt(Backtesting):
 
         opt = self.get_optimizer(config_jobs)
 
-        colorama_init()
+        if self.config.get('print_colorized', False):
+            colorama_init(autoreset=True)
 
         try:
             with Parallel(n_jobs=config_jobs) as parallel:

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -605,7 +605,8 @@ def test_generate_optimizer(mocker, default_conf) -> None:
         'loss': 1.9840569076926293,
         'results_explanation': '     1 trades. Avg profit  2.31%. Total profit  0.00023300 BTC '
                                '(   2.31Σ%). Avg duration 100.0 mins.',
-        'params': optimizer_param
+        'params': optimizer_param,
+        'total_profit': 0.00023300
     }
 
     hyperopt = Hyperopt(default_conf)

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -30,3 +30,7 @@ sdnotify==0.3.2
 
 # Api server
 flask==1.1.1
+
+# Support for colorized terminal output
+termcolor==1.1.0
+colorama==0.4.1

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -32,5 +32,4 @@ sdnotify==0.3.2
 flask==1.1.1
 
 # Support for colorized terminal output
-termcolor==1.1.0
 colorama==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='freqtrade',
           'py_find_1st',
           'python-rapidjson',
           'sdnotify',
+          'colorama',
           # from requirements.txt
           'numpy',
           'pandas',


### PR DESCRIPTION
The `--color/--print-colorized` option to print colorized results:
* bad (zero trades or limited by `--min-trades`) are in red;
* current bests -- in green (also when used without `--print-all`)
* epochs with positive total profit -- in bold

This option helps a user recognize visually the performance of hyperopt evaluations, especially when used with `--print-all`.

Brief description added to hyperopt docs (also a description for `--print-all` which was missed).