### PR TITLE
load_trades_db should give as many columns as possible

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -81,19 +81,30 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
     """
     trades: pd.DataFrame = pd.DataFrame([], columns=BT_DATA_COLUMNS)
     persistence.init(db_url, clean_open_orders=False)
-    columns = ["pair", "profit", "open_time", "close_time",
-               "open_rate", "close_rate", "duration", "sell_reason",
-               "max_rate", "min_rate"]
 
-    trades = pd.DataFrame([(t.pair, t.calc_profit(),
+    columns = ["pair", "open_time", "close_time", "profit", "profitperc",
+               "open_rate", "close_rate", "amount", "duration", "sell_reason",
+               "fee_open", "fee_close", "open_rate_requested", "close_rate_requested",
+               "stake_amount", "max_rate", "min_rate", "id", "exchange",
+               "stop_loss", "initial_stop_loss", "strategy", "ticker_interval"]
+
+    trades = pd.DataFrame([(t.pair,
                             t.open_date.replace(tzinfo=pytz.UTC),
                             t.close_date.replace(tzinfo=pytz.UTC) if t.close_date else None,
-                            t.open_rate, t.close_rate,
+                            t.calc_profit(), t.calc_profit_percent(),
+                            t.open_rate, t.close_rate, t.amount,
                             t.close_date.timestamp() - t.open_date.timestamp()
                             if t.close_date else None,
                             t.sell_reason,
+                            t.fee_open, t.fee_close,
+                            t.open_rate_requested,
+                            t.close_rate_requested,
+                            t.stake_amount,
                             t.max_rate,
                             t.min_rate,
+                            t.id, t.exchange,
+                            t.stop_loss, t.initial_stop_loss,
+                            t.strategy, t.ticker_interval
                             )
                            for t in Trade.query.all()],
                           columns=columns)

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -93,8 +93,8 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
                             t.close_date.replace(tzinfo=pytz.UTC) if t.close_date else None,
                             t.calc_profit(), t.calc_profit_percent(),
                             t.open_rate, t.close_rate, t.amount,
-                            t.close_date.timestamp() - t.open_date.timestamp()
-                            if t.close_date else None,
+                            (t.close_date.timestamp() - t.open_date.timestamp()
+                                if t.close_date else None),
                             t.sell_reason,
                             t.fee_open, t.fee_close,
                             t.open_rate_requested,

--- a/freqtrade/tests/data/test_btanalysis.py
+++ b/freqtrade/tests/data/test_btanalysis.py
@@ -45,6 +45,11 @@ def test_load_trades_db(default_conf, fee, mocker):
     assert isinstance(trades, DataFrame)
     assert "pair" in trades.columns
     assert "open_time" in trades.columns
+    assert "profitperc" in trades.columns
+
+    for col in BT_DATA_COLUMNS:
+        if col not in ['index', 'open_at_end']:
+            assert col in trades.columns
 
 
 def test_extract_trades_of_period():


### PR DESCRIPTION
## Summary
We were missing one needed column in the load_trades_db function.
 
Solve the issue: #2083

## Quick changelog

- Add multiple columns to have all that backtesting gives, and some more for extendet analysis


