### PR TITLE
Evaluate current candle during backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -373,7 +373,9 @@ class Backtesting(object):
                         continue
                     trade_count_lock[row.date] = trade_count_lock.get(row.date, 0) + 1
 
-                trade_entry = self._get_sell_trade_entry(pair, row, ticker[pair][indexes[pair]:],
+                # since indexes has been incremented before, we need to go one step back to
+                # also check the buying candle for sell conditions.
+                trade_entry = self._get_sell_trade_entry(pair, row, ticker[pair][indexes[pair]-1:],
                                                          trade_count_lock, stake_amount,
                                                          max_open_trades)
 

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -14,9 +14,8 @@ from freqtrade.tests.optimize import (BTContainer, BTrade,
                                       _get_frame_time_from_offset,
                                       tests_ticker_interval)
 
-# Test 0 Sell signal sell
+# Test 0: Sell with signal sell in candle 3
 # Test with Stop-loss at 1%
-# TC0: Sell signal in candle 3
 tc0 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -29,9 +28,8 @@ tc0 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=4)]
 )
 
-# Test 1 Minus 8% Close
+# Test 1: Stop-Loss Triggered 1% loss
 # Test with Stop-loss at 1%
-# TC1: Stop-Loss Triggered 1% loss
 tc1 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -45,9 +43,8 @@ tc1 = BTContainer(data=[
 )
 
 
-# Test 2 Minus 4% Low, minus 1% close
+# Test 2: Minus 4% Low, minus 1% close
 # Test with Stop-Loss at 3%
-# TC2: Stop-Loss Triggered 3% Loss
 tc2 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -61,12 +58,12 @@ tc2 = BTContainer(data=[
 )
 
 
-# Test 3 Candle drops 4%, Recovers 1%.
-#               Entry Criteria Met
-# 	            Candle drops 20%
-# Test with Stop-Loss at 2%
-# TC3: Trade-A: Stop-Loss Triggered 2% Loss
-#          Trade-B: Stop-Loss Triggered 2% Loss
+# Test 3: Multiple trades.
+#         Candle drops 4%, Recovers 1%.
+#         Entry Criteria Met
+#         Candle drops 20%
+#  Trade-A: Stop-Loss Triggered 2% Loss
+#           Trade-B: Stop-Loss Triggered 2% Loss
 tc3 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -81,10 +78,10 @@ tc3 = BTContainer(data=[
             BTrade(sell_reason=SellType.STOP_LOSS, open_tick=4, close_tick=5)]
 )
 
-# Test 4 Minus 3% / recovery +15%
+# Test 4: Minus 3% / recovery +15%
 # Candle Data for test 3 – Candle drops 3% Closed 15% up
 # Test with Stop-loss at 2% ROI 6%
-# TC4: Stop-Loss Triggered 2% Loss
+# Stop-Loss Triggered 2% Loss
 tc4 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -97,9 +94,8 @@ tc4 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
-# Test 5 / Drops 0.5% Closes +20%
-# Set stop-loss at 1% ROI 3%
-# TC5: ROI triggers 3% Gain
+# Test 5: Drops 0.5% Closes +20%, ROI triggers 3% Gain
+# stop-loss: 1%, ROI: 3%
 tc5 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4980, 4987, 6172, 1, 0],
@@ -112,9 +108,8 @@ tc5 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
-# Test 6 / Drops 3% / Recovers 6% Positive / Closes 1% positve
-# Set stop-loss at 2% ROI at 5%
-# TC6: Stop-Loss triggers 2% Loss
+# Test 6: Drops 3% / Recovers 6% Positive / Closes 1% positve, Stop-Loss triggers 2% Loss
+# stop-loss: 2% ROI: 5%
 tc6 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -127,9 +122,8 @@ tc6 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
-# Test 7 - 6% Positive / 1% Negative / Close 1% Positve
-# Set stop-loss at 2% ROI at 3%
-# TC7: ROI Triggers 3% Gain
+# Test 7: 6% Positive / 1% Negative / Close 1% Positve, ROI Triggers 3% Gain
+# stop-loss: 2% ROI: 3%
 tc7 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -143,9 +137,8 @@ tc7 = BTContainer(data=[
 )
 
 
-# Test 8 - trailing_stop should raise so candle 3 causes a stoploss.
-# Set stop-loss at 10%, ROI at 10% (should not apply)
-# TC8: Trailing stoploss - stoploss should be adjusted candle 2
+# Test 8: trailing_stop should raise so candle 3 causes a stoploss.
+# stop-loss: 10%, ROI: 10% (should not apply), stoploss adjusted in candle 2
 tc8 = BTContainer(data=[
     # D   O     H     L    C     V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -158,10 +151,8 @@ tc8 = BTContainer(data=[
 )
 
 
-# Test 9 - trailing_stop should raise - high and low in same candle.
-# Candle Data for test 9
-# Set stop-loss at 10%, ROI at 10% (should not apply)
-# TC9: Trailing stoploss - stoploss should be adjusted candle 3
+# Test 9: trailing_stop should raise - high and low in same candle.
+# stop-loss: 10%, ROI: 10% (should not apply), stoploss adjusted in candle 3
 tc9 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -173,10 +164,9 @@ tc9 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=3)]
 )
 
-# Test 10 - trailing_stop should raise so candle 3 causes a stoploss
+# Test 10: trailing_stop should raise so candle 3 causes a stoploss
 # without applying trailing_stop_positive since stoploss_offset is at 10%.
-# Set stop-loss at 10%, ROI at 10% (should not apply)
-# TC10: Trailing stoploss - stoploss should be adjusted candle 2
+# stop-loss: 10%, ROI: 10% (should not apply), stoploss adjusted candle 2
 tc10 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -190,10 +180,9 @@ tc10 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=4)]
 )
 
-# Test 11 - trailing_stop should raise so candle 3 causes a stoploss
+# Test 11: trailing_stop should raise so candle 3 causes a stoploss
 # applying a positive trailing stop of 3% since stop_positive_offset is reached.
-# Set stop-loss at 10%, ROI at 10% (should not apply)
-# TC11: Trailing stoploss - stoploss should be adjusted candle 2,
+# stop-loss: 10%, ROI: 10% (should not apply), stoploss adjusted candle 2
 tc11 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -207,10 +196,9 @@ tc11 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=3)]
 )
 
-# Test 12 - trailing_stop should raise in candle 2 and cause a stoploss in the same candle
+# Test 12: trailing_stop should raise in candle 2 and cause a stoploss in the same candle
 # applying a positive trailing stop of 3% since stop_positive_offset is reached.
-# Set stop-loss at 10%, ROI at 10% (should not apply)
-# TC12: Trailing stoploss - stoploss should be adjusted candle 2,
+# stop-loss: 10%, ROI: 10% (should not apply), stoploss adjusted candle 2
 tc12 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -224,8 +212,8 @@ tc12 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
-# Test 13 - Buy and sell ROI on same candle
-# Set stop-loss at 10% (should not apply), ROI at 1%
+# Test 13: Buy and sell ROI on same candle
+# stop-loss: 10% (should not apply), ROI: 1%
 tc13 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -233,14 +221,12 @@ tc13 = BTContainer(data=[
     [2, 5100, 5251, 4850, 5100, 6172, 0, 0],
     [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
     [4, 4750, 4950, 4850, 4750, 6172, 0, 0]],
-    stop_loss=-0.10, roi=0.01, profit_perc=0.01, trailing_stop=False,
-    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
-    trailing_stop_positive=0.03,
+    stop_loss=-0.10, roi=0.01, profit_perc=0.01,
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1)]
 )
 
 # Test 14 - Buy and Stoploss on same candle
-# Set stop-loss at 5%, ROI at 10% (should not apply)
+# stop-loss: 5%, ROI: 10% (should not apply)
 tc14 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -248,15 +234,13 @@ tc14 = BTContainer(data=[
     [2, 5100, 5251, 4850, 5100, 6172, 0, 0],
     [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
-    stop_loss=-0.05, roi=0.10, profit_perc=-0.05, trailing_stop=False,
-    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
-    trailing_stop_positive=0.03,
+    stop_loss=-0.05, roi=0.10, profit_perc=-0.05,
     trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=1)]
 )
 
 
 # Test 15 - Buy and ROI on same candle, followed by buy and Stoploss on next candle
-# Set stop-loss at 5%, ROI at 10% (should not apply)
+# stop-loss: 5%, ROI: 10% (should not apply)
 tc15 = BTContainer(data=[
     # D   O     H     L     C    V    B  S
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -264,9 +248,7 @@ tc15 = BTContainer(data=[
     [2, 5100, 5251, 4650, 5100, 6172, 0, 0],
     [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
-    stop_loss=-0.05, roi=0.01, profit_perc=-0.04, trailing_stop=False,
-    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
-    trailing_stop_positive=0.03,
+    stop_loss=-0.05, roi=0.01, profit_perc=-0.04,
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1),
             BTrade(sell_reason=SellType.STOP_LOSS, open_tick=2, close_tick=2)]
 )

--- a/freqtrade/tests/optimize/test_backtest_detail.py
+++ b/freqtrade/tests/optimize/test_backtest_detail.py
@@ -224,6 +224,53 @@ tc12 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=2)]
 )
 
+# Test 13 - Buy and sell ROI on same candle
+# Set stop-loss at 10% (should not apply), ROI at 1%
+tc13 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5100, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 4850, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4850, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi=0.01, profit_perc=0.01, trailing_stop=False,
+    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1)]
+)
+
+# Test 14 - Buy and Stoploss on same candle
+# Set stop-loss at 5%, ROI at 10% (should not apply)
+tc14 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5100, 4600, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 4850, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.05, roi=0.10, profit_perc=-0.05, trailing_stop=False,
+    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=1)]
+)
+
+
+# Test 15 - Buy and ROI on same candle, followed by buy and Stoploss on next candle
+# Set stop-loss at 5%, ROI at 10% (should not apply)
+tc15 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5100, 4900, 5100, 6172, 1, 0],
+    [2, 5100, 5251, 4650, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4850, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.05, roi=0.01, profit_perc=-0.04, trailing_stop=False,
+    trailing_only_offset_is_reached=False, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1),
+            BTrade(sell_reason=SellType.STOP_LOSS, open_tick=2, close_tick=2)]
+)
+
 TESTS = [
     tc0,
     tc1,
@@ -238,6 +285,9 @@ TESTS = [
     tc10,
     tc11,
     tc12,
+    tc13,
+    tc14,
+    tc15,
 ]
 
 

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -618,8 +618,9 @@ def test_processed(default_conf, mocker) -> None:
 
 
 def test_backtest_pricecontours(default_conf, fee, mocker) -> None:
+    # TODO: Evaluate usefullness of this, the patterns and buy-signls are unrealistic
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
-    tests = [['raise', 19], ['lower', 0], ['sine', 18]]
+    tests = [['raise', 19], ['lower', 0], ['sine', 35]]
     # We need to enable sell-signal - otherwise it sells on ROI!!
     default_conf['experimental'] = {"use_sell_signal": True}
 


### PR DESCRIPTION
## Summary
During backtesting, we use "open" for both timestamp and rate, so realistic backtesting needs to evaluate the current  candle for ROI / stoploss too, which is also happening during live trading.

Closes #1971 

## Quick changelog

- Add 3 new testcases to cover this trading scenario (these 3 fail without the 2nd commit).
- Cleanup of some comments - no need to be that verbose, all information is in the initialization too.
