### PR TITLE
Update urllib to latest version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -6,7 +6,7 @@ python-telegram-bot==11.1.0
 arrow==0.14.3
 cachetools==3.1.1
 requests==2.22.0
-urllib3==1.24.2  # pyup: ignore
+urllib3==1.25.3
 wrapt==1.11.2
 scikit-learn==0.21.2
 joblib==0.13.2


### PR DESCRIPTION
## Summary
As pointed out in #2077, requests has been updated to support the latest urllib3 version too, so there is no reason to pin urllib3 to an older version.

closes #2077

## Quick changelog

- update urllib3 to latest version
