### PR TITLE
Fix documentation for strategy-list

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -57,7 +57,15 @@ freqtrade backtesting --datadir freqtrade/tests/testdata-20180101
 freqtrade -s TestStrategy backtesting
 ```
 
-Where `-s TestStrategy` refers to the class name within the strategy file `test_strategy.py` found in the `freqtrade/user_data/strategies` directory
+Where `-s TestStrategy` refers to the class name within the strategy file `test_strategy.py` found in the `freqtrade/user_data/strategies` directory.
+
+#### Comparing multiple Strategies
+
+```bash
+freqtrade backtesting --strategy-list TestStrategy1 AwesomeStrategy --ticker-interval 5m
+```
+
+Where `TestStrategy1` and `AwesomeStrategy` refer to class names of strategies.
 
 #### Exporting trades to file
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -165,7 +165,7 @@ optional arguments:
                         number).
   -l, --live            Use live data.
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
-                        Provide a commaseparated list of strategies to
+                        Provide a space-separated list of strategies to
                         backtest Please note that ticker-interval needs to be
                         set either in config or via command line. When using
                         this together with --export trades, the strategy-name

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -130,7 +130,7 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "strategy_list": Arg(
         '--strategy-list',
-        help='Provide a comma-separated list of strategies to backtest. '
+        help='Provide a space-separated list of strategies to backtest. '
         'Please note that ticker-interval needs to be set either in config '
         'or via command line. When using this together with `--export trades`, '
         'the strategy-name is injected into the filename '


### PR DESCRIPTION
## Summary
Fix docstring for strategy list (it's space seperated, not comma seperated), add small documentation sample for this option

Closes #2098 
