### PR TITLE
Backtest ticker interval unset

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional
 
 from pandas import DataFrame
-from tabulate import tabulate
 
+from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
 from freqtrade.data import history
 from freqtrade.data.dataprovider import DataProvider
@@ -21,6 +21,7 @@ from freqtrade.persistence import Trade
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.state import RunMode
 from freqtrade.strategy.interface import IStrategy, SellType
+from tabulate import tabulate
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,9 @@ class Backtesting(object):
         Load strategy into backtesting
         """
         self.strategy = strategy
+        if "ticker_interval" not in self.config:
+            raise OperationalException("Ticker-interval needs to be set in either configuration "
+                                       "or as cli argument `--ticker-interval 5m`")
 
         self.ticker_interval = self.config.get('ticker_interval')
         self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 from arrow import Arrow
 
-from freqtrade import DependencyException, constants
+from freqtrade import DependencyException, OperationalException, constants
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import evaluate_result_multi
@@ -21,7 +21,8 @@ from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.state import RunMode
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
-from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re,
+                                      patch_exchange,
                                       patched_configuration_load_config_file)
 
 
@@ -343,6 +344,23 @@ def test_backtesting_init(mocker, default_conf, order_types) -> None:
     get_fee.assert_called()
     assert backtesting.fee == 0.5
     assert not backtesting.strategy.order_types["stoploss_on_exchange"]
+
+
+def test_backtesting_init_no_ticker_interval(mocker, default_conf, caplog) -> None:
+    """
+    Check that stoploss_on_exchange is set to False while backtesting
+    since backtesting assumes a perfect stoploss anyway.
+    """
+    patch_exchange(mocker)
+    del default_conf['ticker_interval']
+    default_conf['strategy_list'] = ['DefaultStrategy',
+                                     'TestStrategy']
+
+    mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.5))
+    with pytest.raises(OperationalException):
+        Backtesting(default_conf)
+    log_has("Ticker-interval needs to be set in either configuration "
+            "or as cli argument `--ticker-interval 5m`", caplog.record_tuples)
 
 
 def test_tickerdata_to_dataframe_bt(default_conf, mocker) -> None:


### PR DESCRIPTION
## Summary
ticker-interval needs to be set for backtesting to work.
In case of strategy-list, it needs to be defined on either config or cli level, since each strategy could define it's own interval.

Solves #2099

## Quick changelog

- Fix uncought error
- add test for this behaviour
