### PR TITLE
Update install-script to use parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,11 @@ services:
 env:
   global:
     - IMAGE_NAME=freqtradeorg/freqtrade
-addons:
-  apt:
-    packages:
-    - libelf-dev
-    - libdw-dev
-    - binutils-dev
 install:
-- cd build_helpers && ./install_ta-lib.sh; cd ..
-- export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+- cd build_helpers && ./install_ta-lib.sh ${HOME}/dependencies/; cd ..
+- export LD_LIBRARY_PATH=${HOME}/dependencies/lib:$LD_LIBRARY_PATH
+- export TA_LIBRARY_PATH=${HOME}/dependencies/lib
+- export TA_INCLUDE_PATH=${HOME}/dependencies/lib/include
 - pip install -r requirements-dev.txt
 - pip install -e .
 jobs:
@@ -55,4 +51,4 @@ notifications:
 cache:
   pip: True
   directories:
-    - /usr/local/lib/
+    - $HOME/dependencies

--- a/build_helpers/install_ta-lib.sh
+++ b/build_helpers/install_ta-lib.sh
@@ -1,8 +1,14 @@
-if [ ! -f "/usr/local/lib/libta_lib.a" ]; then
+if [ -z "$1" ]; then
+  INSTALL_LOC=/usr/local
+else
+  INSTALL_LOC=${1}
+fi
+echo "Installing to ${INSTALL_LOC}"
+if [ ! -f "${INSTALL_LOC}/lib/libta_lib.a" ]; then
   tar zxvf ta-lib-0.4.0-src.tar.gz
   cd ta-lib \
   && sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h \
-  && ./configure \
+  && ./configure --prefix=${INSTALL_LOC}/ \
   && make \
   && which sudo && sudo make install || make install \
   && cd ..


### PR DESCRIPTION
## Summary
Installing ta-lib on travis takes some time (80+ seconds usually).
Since it's running once per job, it accounts for the most part of our CI cycle.

Travis does support caching, which we had in place for ta-lib, but since it's a system-folder (non-empty) - caching does not work correctly.

This PR will reenable travis to cache ta-lib, improving performance as can be seen here:
https://travis-ci.org/freqtrade/freqtrade/builds/568019204

To see this problem, extend one of the tasks and go to the step `install.1` (on a current and new build).

## Quick changelog

- Use --prefix /usr/local for install-script too
- improve travis performance greatly
- Cleanup some unused apt installs from `.travis.yml`

## What's new?
before:
![](https://user-images.githubusercontent.com/5024695/62512435-376b1000-b818-11e9-808b-6ee332bac3f5.png)


after / with caching
![](https://user-images.githubusercontent.com/5024695/62512381-0c80bc00-b818-11e9-8553-7a766f97e848.png)

