### PR TITLE
Since arguments are in milliseconds integer throughout ccxt.

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -725,7 +725,8 @@ class Exchange(object):
             return []
         try:
             # Allow 5s offset to catch slight time offsets (discovered in #1185)
-            my_trades = self._api.fetch_my_trades(pair, since.timestamp() - 5)
+            # since needs to be int in milliseconds
+            my_trades = self._api.fetch_my_trades(pair, int((since.timestamp() - 5) * 1000))
             matched_trades = [trade for trade in my_trades if trade['order'] == order_id]
 
             return matched_trades

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -2,7 +2,7 @@
 # pragma pylint: disable=protected-access
 import copy
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 from unittest.mock import MagicMock, Mock, PropertyMock
 
@@ -11,8 +11,8 @@ import ccxt
 import pytest
 from pandas import DataFrame
 
-from freqtrade import (DependencyException, OperationalException,
-                       TemporaryError, InvalidOrderException)
+from freqtrade import (DependencyException, InvalidOrderException,
+                       OperationalException, TemporaryError)
 from freqtrade.exchange import Binance, Exchange, Kraken
 from freqtrade.exchange.exchange import API_RETRY_COUNT
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
@@ -1361,7 +1361,7 @@ def test_name(default_conf, mocker, exchange_name):
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_get_trades_for_order(default_conf, mocker, exchange_name):
     order_id = 'ABCD-ABCD'
-    since = datetime(2018, 5, 5)
+    since = datetime(2018, 5, 5, tzinfo=timezone.utc)
     default_conf["dry_run"] = False
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
     api_mock = MagicMock()
@@ -1396,7 +1396,7 @@ def test_get_trades_for_order(default_conf, mocker, exchange_name):
     assert isinstance(api_mock.fetch_my_trades.call_args[0][1], int)
     assert api_mock.fetch_my_trades.call_args[0][0] == 'LTC/BTC'
     # Same test twice, hardcoded number and doing the same calculation
-    assert api_mock.fetch_my_trades.call_args[0][1] == 1525471195000
+    assert api_mock.fetch_my_trades.call_args[0][1] == 1525478395000
     assert api_mock.fetch_my_trades.call_args[0][1] == int(since.timestamp() - 5) * 1000
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1391,6 +1391,13 @@ def test_get_trades_for_order(default_conf, mocker, exchange_name):
     orders = exchange.get_trades_for_order(order_id, 'LTC/BTC', since)
     assert len(orders) == 1
     assert orders[0]['price'] == 165
+    assert api_mock.fetch_my_trades.call_count == 1
+    # since argument should be
+    assert isinstance(api_mock.fetch_my_trades.call_args[0][1], int)
+    assert api_mock.fetch_my_trades.call_args[0][0] == 'LTC/BTC'
+    # Same test twice, hardcoded number and doing the same calculation
+    assert api_mock.fetch_my_trades.call_args[0][1] == 1525471195000
+    assert api_mock.fetch_my_trades.call_args[0][1] == int(since.timestamp() - 5) * 1000
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
                            'get_trades_for_order', 'fetch_my_trades',


### PR DESCRIPTION
## Summary
Since arguments are in milliseconds integer throughout ccxt.
apparently this is accidentally working for binance / bittrex, but not for kuocoin (i suspect it did return all trades for that pair from binance, too)...

Explained here: https://github.com/ccxt/ccxt/issues/5636

fixes #2093

## Quick changelog

- Enhanced tests to verify we convert this correctly

