### PR TITLE
As -sharp_ratio is returned the value should be nagative.

### DIFF
--- a/freqtrade/optimize/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe.py
@@ -39,7 +39,7 @@ class SharpeHyperOptLoss(IHyperOptLoss):
             sharp_ratio = expected_yearly_return / np.std(total_profit) * np.sqrt(365)
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-            sharp_ratio = 20.
+            sharp_ratio = -20.
 
         # print(expected_yearly_return, np.std(total_profit), sharp_ratio)
         return -sharp_ratio


### PR DESCRIPTION
This leads in a high positive result of the loss function, as it is a minimal optimizer
