### PR TITLE
Disable stoploss on exchange during dry-runs

### DIFF
--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -81,7 +81,7 @@ class StrategyResolver(IResolver):
             key=lambda t: t[0]))
         self.strategy.stoploss = float(self.strategy.stoploss)
 
-        self._strategy_sanity_validations(config)
+        self._strategy_sanity_validations()
 
     def _override_attribute_helper(self, config, attribute: str, default):
         """
@@ -102,7 +102,7 @@ class StrategyResolver(IResolver):
             setattr(self.strategy, attribute, default)
             config[attribute] = default
 
-    def _strategy_sanity_validations(self, config):
+    def _strategy_sanity_validations(self):
         if not all(k in self.strategy.order_types for k in constants.REQUIRED_ORDERTYPES):
             raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
                               f"Order-types mapping is incomplete.")
@@ -110,12 +110,6 @@ class StrategyResolver(IResolver):
         if not all(k in self.strategy.order_time_in_force for k in constants.REQUIRED_ORDERTIF):
             raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
                               f"Order-time-in-force mapping is incomplete.")
-
-        # Stoploss on exchange does not make sense, therefore we need to disable that.
-        if config.get('dry_run'):
-            logger.info("Disabling stoploss_on_exchange during dry-run.")
-            self.strategy.order_types['stoploss_on_exchange'] = False
-            config['order_types']['stoploss_on_exchange'] = False
 
     def _load_strategy(
             self, strategy_name: str, config: dict, extra_dir: Optional[str] = None) -> IStrategy:

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -81,7 +81,7 @@ class StrategyResolver(IResolver):
             key=lambda t: t[0]))
         self.strategy.stoploss = float(self.strategy.stoploss)
 
-        self._strategy_sanity_validations()
+        self._strategy_sanity_validations(config)
 
     def _override_attribute_helper(self, config, attribute: str, default):
         """
@@ -102,7 +102,7 @@ class StrategyResolver(IResolver):
             setattr(self.strategy, attribute, default)
             config[attribute] = default
 
-    def _strategy_sanity_validations(self):
+    def _strategy_sanity_validations(self, config):
         if not all(k in self.strategy.order_types for k in constants.REQUIRED_ORDERTYPES):
             raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
                               f"Order-types mapping is incomplete.")
@@ -110,6 +110,12 @@ class StrategyResolver(IResolver):
         if not all(k in self.strategy.order_time_in_force for k in constants.REQUIRED_ORDERTIF):
             raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
                               f"Order-time-in-force mapping is incomplete.")
+
+        # Stoploss on exchange does not make sense, therefore we need to disable that.
+        if config.get('dry_run'):
+            logger.info("Disabling stoploss_on_exchange during dry-run.")
+            self.strategy.order_types['stoploss_on_exchange'] = False
+            config['order_types']['stoploss_on_exchange'] = False
 
     def _load_strategy(
             self, strategy_name: str, config: dict, extra_dir: Optional[str] = None) -> IStrategy:

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -15,7 +15,7 @@ from freqtrade.resolvers import StrategyResolver
 from freqtrade.strategy import import_strategy
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import IStrategy
-from freqtrade.tests.conftest import log_has_re
+from freqtrade.tests.conftest import log_has_re, log_has
 
 
 def test_import_strategy(caplog):
@@ -257,12 +257,9 @@ def test_strategy_override_order_types(caplog):
     for method in ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']:
         assert resolver.strategy.order_types[method] == order_types[method]
 
-    assert ('freqtrade.resolvers.strategy_resolver',
-            logging.INFO,
-            "Override strategy 'order_types' with value in config file:"
-            " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit',"
-            " 'stoploss_on_exchange': True}."
-            ) in caplog.record_tuples
+    assert log_has("Override strategy 'order_types' with value in config file:"
+                   " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit',"
+                   " 'stoploss_on_exchange': True}.", caplog.record_tuples)
 
     config = {
         'strategy': 'DefaultStrategy',
@@ -273,6 +270,34 @@ def test_strategy_override_order_types(caplog):
                        match=r"Impossible to load Strategy 'DefaultStrategy'. "
                              r"Order-types mapping is incomplete."):
         StrategyResolver(config)
+
+
+def test_strategy_override_order_types_dryrun(caplog):
+    caplog.set_level(logging.INFO)
+
+    order_types = {
+        'buy': 'market',
+        'sell': 'limit',
+        'stoploss': 'limit',
+        'stoploss_on_exchange': True,
+    }
+
+    config = {
+        'strategy': 'DefaultStrategy',
+        'order_types': order_types,
+        'dry_run': True,
+    }
+    resolver = StrategyResolver(config)
+
+    assert resolver.strategy.order_types
+    for method in ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']:
+        assert resolver.strategy.order_types[method] == order_types[method]
+
+    assert log_has("Disabling stoploss_on_exchange during dry-run.", caplog.record_tuples)
+
+    assert log_has("Override strategy 'order_types' with value in config file:"
+                   " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit',"
+                   " 'stoploss_on_exchange': False}.", caplog.record_tuples)
 
 
 def test_strategy_override_order_tif(caplog):

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -272,34 +272,6 @@ def test_strategy_override_order_types(caplog):
         StrategyResolver(config)
 
 
-def test_strategy_override_order_types_dryrun(caplog):
-    caplog.set_level(logging.INFO)
-
-    order_types = {
-        'buy': 'market',
-        'sell': 'limit',
-        'stoploss': 'limit',
-        'stoploss_on_exchange': True,
-    }
-
-    config = {
-        'strategy': 'DefaultStrategy',
-        'order_types': order_types,
-        'dry_run': True,
-    }
-    resolver = StrategyResolver(config)
-
-    assert resolver.strategy.order_types
-    for method in ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']:
-        assert resolver.strategy.order_types[method] == order_types[method]
-
-    assert log_has("Disabling stoploss_on_exchange during dry-run.", caplog.record_tuples)
-
-    assert log_has("Override strategy 'order_types' with value in config file:"
-                   " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit',"
-                   " 'stoploss_on_exchange': False}.", caplog.record_tuples)
-
-
 def test_strategy_override_order_tif(caplog):
     caplog.set_level(logging.INFO)
 


### PR DESCRIPTION
## Summary
Stoploss on exchange does not make sense for dry-run scenarios - so we need to disable this option similar to how we handle this for backtesting.

Closes #2106

Using stoploss on exchange with dry-runs causes errors, and will provide no benefit since there is no exchange executing dry orders.