### PR TITLE
Allow comments in config files

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -2,7 +2,7 @@
 
 This page explains the different parameters of the bot and how to run it.
 
-!Note:
+!!! Note:
     If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
 
@@ -43,19 +43,22 @@ optional arguments:
   --sd-notify           Notify systemd service manager.
 ```
 
-### How to use a different configuration file?
+### How to specify which configuration file be used?
 
-The bot allows you to select which configuration file you want to use. Per
-default, the bot will load the file `./config.json`
+The bot allows you to select which configuration file you want to use by means of
+the `-c/--config` command line option:
 
 ```bash
 freqtrade -c path/far/far/away/config.json
 ```
 
+Per default, the bot loads the `config.json` configuration file from the current
+working directory.
+
 ### How to use multiple configuration files?
 
 The bot allows you to use multiple configuration files by specifying multiple
-`-c/--config` configuration options in the command line. Configuration parameters
+`-c/--config` options in the command line. Configuration parameters
 defined in the last configuration file override parameters with the same name
 defined in the previous configuration file specified in the command line.
 
@@ -266,7 +269,7 @@ optional arguments:
 
 ## Edge commands
 
-To know your trade expectacny and winrate against historical data, you can use Edge.
+To know your trade expectancy and winrate against historical data, you can use Edge.
 
 ```
 usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,15 +1,24 @@
 # Configure the bot
 
-This page explains how to configure your `config.json` file.
+This page explains how to configure your configuration file.
 
-## Setup config.json
+Per default, the bot loads configuration from the `config.json` file located in the current working directory.
+You can change the configuration file used by the bot with the `-c/--config` option.
 
-We recommend to copy and use the `config.json.example` as a template
+If you used the [Quick start](installation.md/#quick-start) method for installing 
+the bot, the installation script should have already created the default configuration file (`config.json`) for you.
+
+We recommend you to copy and use the `config.json.example` as a template
 for your bot configuration.
 
-The table below will list all configuration parameters.
+The configuration file defines the set of configuration parameters for the bot written in the JSON format.
+Additionally, you may use one-line `// ...` and multi-line `/* ... */` comments.
 
-Mandatory Parameters are marked as **Required**.
+## Configuration parameters
+
+The table below will list all configuration parameters available.
+
+Mandatory parameters are marked as **Required**.
 
 |  Command | Default | Description |
 |----------|---------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,28 @@
 # Configure the bot
 
-This page explains how to configure your configuration file.
+This page explains how to configure the bot.
+
+## The Freqtrade configuration file
+
+The bot uses a set of configuration parameters during its operation that all together conform the bot configuration. It normally reads its configuration from a file (Freqtrade configuration file).
 
 Per default, the bot loads configuration from the `config.json` file located in the current working directory.
-You can change the configuration file used by the bot with the `-c/--config` option.
+
+You can change the name of the configuration file used by the bot with the `-c/--config` command line option.
+
+In some advanced use cases, multiple configuration files can be specified and used by the bot or the bot can read its configuration parameters from the process standard input stream.
 
 If you used the [Quick start](installation.md/#quick-start) method for installing 
 the bot, the installation script should have already created the default configuration file (`config.json`) for you.
 
-We recommend you to copy and use the `config.json.example` as a template
+If default configuration file is not created we recommend you to copy and use the `config.json.example` as a template
 for your bot configuration.
 
-The configuration file defines the set of configuration parameters for the bot written in the JSON format.
-Additionally, you may use one-line `// ...` and multi-line `/* ... */` comments.
+The Freqtrade configuration file is to be written in the JSON format.
+
+Additionally to the standard JSON syntax, you may use one-line `// ...` and multi-line `/* ... */` comments in your configuration files and trailing commas in the lists of parameters.
+
+Do not worry if you are not familiar with JSON format -- simply open the configuration file with an editor of your choice, make some changes to the parameters you need, save your changes and, finally, restart the bot or, if it was previously stopped, run it again with the changes you made to the configuration. The bot validates syntax of the configuration file at startup and will warn you if you made any errors editing it.
 
 ## Configuration parameters
 

--- a/freqtrade/configuration/load_config.py
+++ b/freqtrade/configuration/load_config.py
@@ -1,7 +1,7 @@
 """
 This module contain functions to load the configuration file
 """
-import json
+import rapidjson
 import logging
 import sys
 from typing import Any, Dict
@@ -10,6 +10,9 @@ from freqtrade import OperationalException
 
 
 logger = logging.getLogger(__name__)
+
+
+CONFIG_PARSE_MODE = rapidjson.PM_COMMENTS | rapidjson.PM_TRAILING_COMMAS
 
 
 def load_config_file(path: str) -> Dict[str, Any]:
@@ -21,7 +24,7 @@ def load_config_file(path: str) -> Dict[str, Any]:
     try:
         # Read config from stdin if requested in the options
         with open(path) if path != '-' else sys.stdin as file:
-            config = json.load(file)
+            config = rapidjson.load(file, parse_mode=CONFIG_PARSE_MODE)
     except FileNotFoundError:
         raise OperationalException(
             f'Config file "{path}" not found!'

--- a/freqtrade/tests/config_test_comments.json
+++ b/freqtrade/tests/config_test_comments.json
@@ -1,0 +1,133 @@
+{
+    /* Single-line C-style comment */
+    "max_open_trades": 3,
+    /*
+     * Multi-line C-style comment
+     */
+    "stake_currency": "BTC",
+    "stake_amount": 0.05,
+    "fiat_display_currency": "USD",             // C++-style comment
+    "amount_reserve_percent" : 0.05,		// And more, tabs before this comment
+    "dry_run": false,
+    "ticker_interval": "5m",
+    "trailing_stop": false,
+    "trailing_stop_positive": 0.005,
+    "trailing_stop_positive_offset": 0.0051,
+    "trailing_only_offset_is_reached": false,
+    "minimal_roi": {
+        "40":  0.0,
+        "30":  0.01,
+        "20":  0.02,
+        "0":  0.04
+    },
+    "stoploss": -0.10,
+    "unfilledtimeout": {
+        "buy": 10,
+        "sell": 30,				// Trailing comma should also be accepted now
+    },
+    "bid_strategy": {
+        "use_order_book": false,
+        "ask_last_balance": 0.0,
+        "order_book_top": 1,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+    "ask_strategy":{
+        "use_order_book": false,
+        "order_book_min": 1,
+        "order_book_max": 9
+    },
+    "order_types": {
+        "buy": "limit",
+        "sell": "limit",
+        "stoploss": "market",
+        "stoploss_on_exchange": false,
+        "stoploss_on_exchange_interval": 60
+    },
+    "order_time_in_force": {
+        "buy": "gtc",
+        "sell": "gtc"
+    },
+    "pairlist": {
+        "method": "VolumePairList",
+        "config": {
+            "number_assets": 20,
+            "sort_key": "quoteVolume",
+            "precision_filter": false
+        }
+    },
+    "exchange": {
+        "name": "bittrex",
+        "sandbox": false,
+        "key": "your_exchange_key",
+        "secret": "your_exchange_secret",
+        "password": "",
+        "ccxt_config": {"enableRateLimit": true},
+        "ccxt_async_config": {
+            "enableRateLimit": false,
+            "rateLimit": 500,
+            "aiohttp_trust_env": false
+        },
+        "pair_whitelist": [
+            "ETH/BTC",
+            "LTC/BTC",
+            "ETC/BTC",
+            "DASH/BTC",
+            "ZEC/BTC",
+            "XLM/BTC",
+            "NXT/BTC",
+            "POWR/BTC",
+            "ADA/BTC",
+            "XMR/BTC"
+        ],
+        "pair_blacklist": [
+            "DOGE/BTC"
+        ],
+        "outdated_offset": 5,
+        "markets_refresh_interval": 60
+    },
+    "edge": {
+        "enabled": false,
+        "process_throttle_secs": 3600,
+        "calculate_since_number_of_days": 7,
+        "capital_available_percentage": 0.5,
+        "allowed_risk": 0.01,
+        "stoploss_range_min": -0.01,
+        "stoploss_range_max": -0.1,
+        "stoploss_range_step": -0.01,
+        "minimum_winrate": 0.60,
+        "minimum_expectancy": 0.20,
+        "min_trade_number": 10,
+        "max_trade_duration_minute": 1440,
+        "remove_pumps": false
+    },
+    "experimental": {
+        "use_sell_signal": false,
+        "sell_profit_only": false,
+        "ignore_roi_if_buy_signal": false
+    },
+    "telegram": {
+// We can now comment out some settings
+//        "enabled": true,
+        "enabled": false,
+        "token": "your_telegram_token",
+        "chat_id": "your_telegram_chat_id"
+    },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "username": "freqtrader",
+        "password": "SuperSecurePassword"
+    },
+    "db_url": "sqlite:///tradesv3.sqlite",
+    "initial_state": "running",
+    "forcebuy_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    },
+    "strategy": "DefaultStrategy",
+    "strategy_path": "user_data/strategies/"
+}

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -634,6 +634,17 @@ def test_validate_tsl(default_conf):
     configuration._validate_config_consistency(default_conf)
 
 
+def test_load_config_test_comments() -> None:
+    """
+    Load config with comments
+    """
+    config_file = Path(__file__).parents[0] / "config_test_comments.json"
+    print(config_file)
+    conf = load_config_file(str(config_file))
+
+    assert conf
+
+
 def test_load_config_default_exchange(all_conf) -> None:
     """
     config['exchange'] subtree has required options in it


### PR DESCRIPTION
...and trailing commas.

rapidjson allows this, it has corresponding parse_mode values.

A special test config file (`config_test_comments.json`) was added into the tests dir since I found it inappropriate to add those testing comments into `config_full.example.json` from the main dir.

(btw, `config_full.example.json` is the only file which is really loaded by the tests. Should not we also load in the tests the `config.json.example` after modifying it in the same manner as setup.py does?)

If accepted, TODO:
* [x] describe this in the docs.
