### PR TITLE
[minor] Improve hyperopt-loss docs

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -256,12 +256,13 @@ optional arguments:
   --continue            Continue hyperopt from previous runs. By default,
                         temporary files will be removed and hyperopt will
                         start from scratch.
-  --hyperopt-loss       NAME
-                        Specify the class name of the hyperopt loss function
+  --hyperopt-loss NAME  Specify the class name of the hyperopt loss function
                         class (IHyperOptLoss). Different functions can
                         generate completely different results, since the
-                        target for optimization is different. (default:
-                        `DefaultHyperOptLoss`).
+                        target for optimization is different. Built-in
+                        Hyperopt-loss-functions are: DefaultHyperOptLoss,
+                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.
+                        (default: `DefaultHyperOptLoss`).
 ```
 
 ## Edge commands

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -164,7 +164,11 @@ By default, FreqTrade uses a loss function, which has been with freqtrade since 
 A different loss function can be specified by using the `--hyperopt-loss <Class-name>` argument.
 This class should be in its own file within the `user_data/hyperopts/` directory.
 
-Currently, the following loss functions are builtin: `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function), `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns) and `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration).
+Currently, the following loss functions are builtin:
+
+* `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
+* `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
+* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
 
 ### Creating and using a custom loss function
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -226,7 +226,9 @@ AVAILABLE_CLI_OPTIONS = {
         '--hyperopt-loss',
         help='Specify the class name of the hyperopt loss function class (IHyperOptLoss). '
         'Different functions can generate completely different results, '
-        'since the target for optimization is different. (default: `%(default)s`).',
+        'since the target for optimization is different. Built-in Hyperopt-loss-functions are: '
+        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss.'
+        '(default: `%(default)s`).',
         metavar='NAME',
         default=constants.DEFAULT_HYPEROPT_LOSS,
     ),


### PR DESCRIPTION
## Summary
Improve documentation of hyperopt loss (allowing copy/paste of builtin loss-functions from `--help`).
If i know i want Sharpe Loss function, i shouldn't need to go to the documentation to look for the correct name.
