### PR TITLE
fail for bad exchanges

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ Mandatory Parameters are marked as **Required**.
 | `experimental.use_sell_signal` | false | Use your sell strategy in addition of the `minimal_roi`. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.sell_profit_only` | false | Waits until you have made a positive profit before taking a sell decision. [Strategy Override](#parameters-in-the-strategy).
 | `experimental.ignore_roi_if_buy_signal` | false | Does not sell if the buy-signal is still active. Takes preference over `minimal_roi` and `use_sell_signal`. [Strategy Override](#parameters-in-the-strategy).
+| `experimental.block_bad_exchanges` | true | Block exchanges known to not work with freqtrade. Leave on default unless you want to test if that exchange works now.
 | `pairlist.method` | StaticPairList | Use static or dynamic volume-based pairlist. [More information below](#dynamic-pairlists).
 | `pairlist.config` | None | Additional configuration for dynamic pairlists. [More information below](#dynamic-pairlists).
 | `telegram.enabled` | true | **Required.** Enable or not the usage of Telegram.

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -2,9 +2,9 @@ import logging
 from typing import Any, Dict
 
 from freqtrade import OperationalException
-from freqtrade.exchange import (is_exchange_bad, is_exchange_available,
-                                is_exchange_officially_supported, available_exchanges)
-
+from freqtrade.exchange import (available_exchanges, get_exchange_bad_reason,
+                                is_exchange_available, is_exchange_bad,
+                                is_exchange_officially_supported)
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +31,8 @@ def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
         )
 
     if check_for_bad and is_exchange_bad(exchange):
-        logger.warning(f'Exchange "{exchange}" is known to not work with the bot yet. '
-                       f'Use it only for development and testing purposes.')
-        return False
+        raise OperationalException(f'Exchange "{exchange}" is known to not work with the bot yet. '
+                                   f'Reason: {get_exchange_bad_reason(exchange)}')
 
     if is_exchange_officially_supported(exchange):
         logger.info(f'Exchange "{exchange}" is officially supported '

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -148,7 +148,7 @@ class Configuration(object):
             config['internals'].update({'sd_notify': True})
 
         # Check if the exchange set by the user is supported
-        check_exchange(config)
+        check_exchange(config, config.get('experimental', {}).get('block_bad_exchanges', True))
 
     def _process_datadir_options(self, config: Dict[str, Any]) -> None:
         """

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,5 +1,6 @@
 from freqtrade.exchange.exchange import Exchange  # noqa: F401
-from freqtrade.exchange.exchange import (is_exchange_bad,  # noqa: F401
+from freqtrade.exchange.exchange import (get_exchange_bad_reason,  # noqa: F401
+                                         is_exchange_bad,
                                          is_exchange_available,
                                          is_exchange_officially_supported,
                                          available_exchanges)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 
 API_RETRY_COUNT = 4
+BAD_EXCHANGES = {
+    "bitmex": "Various reasons",
+    "bitstamp": "Does not provide history. Details in https://github.com/freqtrade/freqtrade/issues/1983",
+    }
 
 
 def retrier_async(f):
@@ -755,7 +759,11 @@ class Exchange(object):
 
 
 def is_exchange_bad(exchange: str) -> bool:
-    return exchange in ['bitmex', 'bitstamp']
+    return exchange in BAD_EXCHANGES
+
+
+def get_exchange_bad_reason(exchange: str) -> str:
+    return BAD_EXCHANGES.get(exchange)
 
 
 def is_exchange_available(exchange: str, ccxt_module=None) -> bool:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 API_RETRY_COUNT = 4
 BAD_EXCHANGES = {
     "bitmex": "Various reasons",
-    "bitstamp": "Does not provide history. Details in https://github.com/freqtrade/freqtrade/issues/1983",
+    "bitstamp": "Does not provide history. "
+                "Details in https://github.com/freqtrade/freqtrade/issues/1983",
     }
 
 
@@ -763,7 +764,7 @@ def is_exchange_bad(exchange: str) -> bool:
 
 
 def get_exchange_bad_reason(exchange: str) -> str:
-    return BAD_EXCHANGES.get(exchange)
+    return BAD_EXCHANGES.get(exchange, "")
 
 
 def is_exchange_available(exchange: str, ccxt_module=None) -> bool:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -499,9 +499,9 @@ def test_check_exchange(default_conf, caplog) -> None:
 
     # Test a 'bad' exchange, which known to have serious problems
     default_conf.get('exchange').update({'name': 'bitmex'})
-    assert not check_exchange(default_conf)
-    assert log_has_re(r"Exchange .* is known to not work with the bot yet\. "
-                      r"Use it only for development and testing purposes\.", caplog)
+    with pytest.raises(OperationalException,
+                       match=r"Exchange .* is known to not work with the bot yet.*"):
+        check_exchange(default_conf)
     caplog.clear()
 
     # Test a 'bad' exchange with check_for_bad=False


### PR DESCRIPTION
## Summary
If we know an exchange is not working with freqtrade, freqtrade should not simply warn users, but fail instead (startup-warnings are easily missed ...).
Also adding the "reason" element we discussed in #1992

Closes #1992

## Quick changelog

- Fail for bad exchanges
- show reason why this exchange will not work
- skip-fail in experimental flags (`experimental.block_bad_exchanges=False`)

