### PR TITLE
allow create_trade() to create multiple trades per iteration

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -258,9 +258,10 @@ class FreqtradeBot(object):
 
     def create_trades(self) -> bool:
         """
-        Checks the implemented trading indicator(s) for a randomly picked pair,
-        if one pair triggers the buy_signal a new trade record gets created
-        :return: True if a trade object has been created and persisted, False otherwise
+        Checks the implemented trading strategy for buy-signals, using the active pair whitelist.
+        If a pair triggers the buy_signal a new trade record gets created.
+        Checks pairs as long as the open trade count is below `max_open_trades`.
+        :return: True if at least one trade has been created.
         """
         interval = self.strategy.ticker_interval
         whitelist = copy.deepcopy(self.active_pair_whitelist)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -256,7 +256,7 @@ class FreqtradeBot(object):
         amount_reserve_percent = max(amount_reserve_percent, 0.5)
         return min(min_stake_amounts) / amount_reserve_percent
 
-    def create_trade(self) -> bool:
+    def create_trades(self) -> bool:
         """
         Checks the implemented trading indicator(s) for a randomly picked pair,
         if one pair triggers the buy_signal a new trade record gets created
@@ -435,7 +435,7 @@ class FreqtradeBot(object):
         """
         try:
             # Create entity and execute trade
-            if not self.create_trade():
+            if not self.create_trades():
                 logger.info('Found no buy signals for whitelisted currencies. Trying again...')
         except DependencyException as exception:
             logger.warning('Unable to create trade: %s', exception)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -299,6 +299,8 @@ class FreqtradeBot(object):
                         (bidstrat_check_depth_of_market.get('bids_to_ask_delta', 0) > 0):
                     if self._check_depth_of_market_buy(_pair, bidstrat_check_depth_of_market):
                         buycount += self.execute_buy(_pair, stake_amount)
+                    else:
+                        continue
 
                 buycount += self.execute_buy(_pair, stake_amount)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -426,21 +426,17 @@ class FreqtradeBot(object):
 
         return True
 
-    def process_maybe_execute_buy(self) -> bool:
+    def process_maybe_execute_buy(self) -> None:
         """
         Tries to execute a buy trade in a safe way
         :return: True if executed
         """
         try:
             # Create entity and execute trade
-            if self.create_trade():
-                return True
-
-            logger.info('Found no buy signals for whitelisted currencies. Trying again..')
-            return False
+            if not self.create_trade():
+                logger.info('Found no buy signals for whitelisted currencies. Trying again...')
         except DependencyException as exception:
             logger.warning('Unable to create trade: %s', exception)
-            return False
 
     def process_maybe_execute_sell(self, trade: Trade) -> bool:
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -105,13 +105,12 @@ class FreqtradeBot(object):
             # Adjust stoploss if it was changed
             Trade.stoploss_reinitialization(self.strategy.stoploss)
 
-    def process(self) -> bool:
+    def process(self) -> None:
         """
         Queries the persistence layer for open trades and handles them,
         otherwise a new trade is created.
         :return: True if one or more trades has been created or closed, False otherwise
         """
-        state_changed = False
 
         # Check whether markets have to be reloaded
         self.exchange._reload_markets()
@@ -138,18 +137,16 @@ class FreqtradeBot(object):
 
         # First process current opened trades
         for trade in trades:
-            state_changed |= self.process_maybe_execute_sell(trade)
+            self.process_maybe_execute_sell(trade)
 
         # Then looking for buy opportunities
         if len(trades) < self.config['max_open_trades']:
-            state_changed = self.process_maybe_execute_buy()
+            self.process_maybe_execute_buy()
 
         if 'unfilledtimeout' in self.config:
             # Check and handle any timed out open orders
             self.check_handle_timedout()
             Trade.session.flush()
-
-        return state_changed
 
     def _extend_whitelist_with_trades(self, whitelist: List[str], trades: List[Any]):
         """

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -44,7 +44,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active trade*'):
         rpc._rpc_trade_status()
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     results = rpc._rpc_trade_status()
     assert {
         'trade_id': 1,
@@ -116,7 +116,7 @@ def test_rpc_status_table(default_conf, ticker, fee, markets, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active order*'):
         rpc._rpc_status_table()
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     result = rpc._rpc_status_table()
     assert 'instantly' in result['Since'].all()
     assert 'ETH/BTC' in result['Pair'].all()
@@ -151,7 +151,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     assert trade
 
@@ -208,7 +208,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
         rpc._rpc_trade_statistics(stake_currency, fiat_display_currency)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -222,7 +222,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     trade.close_date = datetime.utcnow()
     trade.is_open = False
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -292,7 +292,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee, markets,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -536,7 +536,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
@@ -570,7 +570,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     assert cancel_order_mock.call_count == 1
     assert trade.amount == filled_amount
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.filter(Trade.id == '2').first()
     amount = trade.amount
     # make an limit-buy open trade, if there is no 'filled', don't sell it
@@ -589,7 +589,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker, markets) -> None:
     assert cancel_order_mock.call_count == 2
     assert trade.amount == amount
 
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     # make an limit-sell open trade
     mocker.patch(
         'freqtrade.exchange.Exchange.get_order',
@@ -622,7 +622,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     assert trade
 
@@ -660,7 +660,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee, markets) -> None:
     assert counts["current"] == 0
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     counts = rpc._rpc_count()
     assert counts["current"] == 1
 

--- a/freqtrade/tests/rpc/test_rpc_apiserver.py
+++ b/freqtrade/tests/rpc/test_rpc_apiserver.py
@@ -275,7 +275,7 @@ def test_api_count(botclient, mocker, ticker, fee, markets):
     assert rc.json["max"] == 1.0
 
     # Create some test data
-    ftbot.create_trade()
+    ftbot.create_trades()
     rc = client_get(client, f"{BASE_URI}/count")
     assert_response(rc)
     assert rc.json["current"] == 1.0
@@ -329,7 +329,7 @@ def test_api_profit(botclient, mocker, ticker, fee, markets, limit_buy_order, li
     assert len(rc.json) == 1
     assert rc.json == {"error": "Error querying _profit: no closed trade"}
 
-    ftbot.create_trade()
+    ftbot.create_trades()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -418,7 +418,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 502)
     assert rc.json == {'error': 'Error querying _status: no active trade'}
 
-    ftbot.create_trade()
+    ftbot.create_trades()
     rc = client_get(client, f"{BASE_URI}/status")
     assert_response(rc)
     assert len(rc.json) == 1
@@ -548,7 +548,7 @@ def test_api_forcesell(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 502)
     assert rc.json == {"error": "Error querying _forcesell: invalid argument"}
 
-    ftbot.create_trade()
+    ftbot.create_trades()
 
     rc = client_post(client, f"{BASE_URI}/forcesell",
                      data='{"tradeid": "1"}')

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -308,6 +308,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker)
 def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
                       limit_sell_order, markets, mocker) -> None:
     patch_exchange(mocker)
+    default_conf['max_open_trades'] = 1
     mocker.patch(
         'freqtrade.rpc.rpc.CryptoToFiatConverter._find_price',
         return_value=15000.0
@@ -357,8 +358,8 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
 
     # Reset msg_mock
     msg_mock.reset_mock()
+    freqtradebot.config['max_open_trades'] = 2
     # Add two other trades
-    freqtradebot.create_trade()
     freqtradebot.create_trade()
 
     trades = Trade.query.all()
@@ -832,14 +833,13 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, markets, mocker
         markets=PropertyMock(return_value=markets),
         validate_pairs=MagicMock(return_value={})
     )
-
+    default_conf['max_open_trades'] = 4
     freqtradebot = FreqtradeBot(default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    for _ in range(4):
-        freqtradebot.create_trade()
+    freqtradebot.create_trade()
     rpc_mock.reset_mock()
 
     update.message.text = '/forcesell all'

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -192,7 +192,7 @@ def test_status(default_conf, update, mocker, fee, ticker, markets) -> None:
 
     # Create some test data
     for _ in range(3):
-        freqtradebot.create_trade()
+        freqtradebot.create_trades()
 
     telegram._status(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
@@ -240,7 +240,7 @@ def test_status_handle(default_conf, update, ticker, fee, markets, mocker) -> No
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     # Trigger status while we have a fulfilled order for the open trade
     telegram._status(bot=MagicMock(), update=update)
 
@@ -292,7 +292,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker)
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
 
     telegram._status_table(bot=MagicMock(), update=update)
 
@@ -332,7 +332,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     assert trade
 
@@ -360,7 +360,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     msg_mock.reset_mock()
     freqtradebot.config['max_open_trades'] = 2
     # Add two other trades
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
 
     trades = Trade.query.all()
     for trade in trades:
@@ -439,7 +439,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -734,7 +734,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
 
     trade = Trade.query.first()
     assert trade
@@ -785,7 +785,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
 
     # Decrease the price and sell it
     mocker.patch.multiple(
@@ -839,7 +839,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, markets, mocker
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     rpc_mock.reset_mock()
 
     update.message.text = '/forcesell all'
@@ -983,7 +983,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     trade = Trade.query.first()
     assert trade
 
@@ -1028,7 +1028,7 @@ def test_count_handle(default_conf, update, ticker, fee, markets, mocker) -> Non
     freqtradebot.state = State.RUNNING
 
     # Create some test data
-    freqtradebot.create_trade()
+    freqtradebot.create_trades()
     msg_mock.reset_mock()
     telegram._count(bot=MagicMock(), update=update)
 

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -302,6 +302,7 @@ def test_edge_overrides_stoploss(limit_buy_order, fee, markets, caplog, mocker, 
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     patch_edge(mocker)
+    edge_conf['max_open_trades'] = float('inf')
 
     # Strategy stoploss is -0.1 but Edge imposes a stoploss at -0.2
     # Thus, if price falls 21%, stoploss should be triggered
@@ -342,6 +343,7 @@ def test_edge_should_ignore_strategy_stoploss(limit_buy_order, fee, markets,
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     patch_edge(mocker)
+    edge_conf['max_open_trades'] = float('inf')
 
     # Strategy stoploss is -0.1 but Edge imposes a stoploss at -0.2
     # Thus, if price falls 15%, stoploss should not be triggered
@@ -380,6 +382,7 @@ def test_total_open_trades_stakes(mocker, default_conf, ticker,
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     default_conf['stake_amount'] = 0.0000098751
+    default_conf['max_open_trades'] = 2
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
@@ -1284,7 +1287,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     patch_edge(mocker)
-
+    edge_conf['max_open_trades'] = float('inf')
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=MagicMock(return_value={

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1385,14 +1385,12 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
                                                 stop_price=0.00002344 * 0.99)
 
 
-def test_process_maybe_execute_buy(mocker, default_conf) -> None:
+def test_process_maybe_execute_buy(mocker, default_conf, caplog) -> None:
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.create_trade', MagicMock(return_value=True))
-    assert freqtrade.process_maybe_execute_buy()
-
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.create_trade', MagicMock(return_value=False))
-    assert not freqtrade.process_maybe_execute_buy()
+    freqtrade.process_maybe_execute_buy()
+    assert log_has('Found no buy signals for whitelisted currencies. Trying again...', caplog)
 
 
 def test_process_maybe_execute_buy_exception(mocker, default_conf, caplog) -> None:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -711,8 +711,7 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order,
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
     assert not trades
 
-    result = freqtrade.process()
-    assert result is True
+    freqtrade.process()
 
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
     assert len(trades) == 1
@@ -833,11 +832,10 @@ def test_process_trade_no_whitelist_pair(
     ))
 
     assert pair not in freqtrade.active_pair_whitelist
-    result = freqtrade.process()
+    freqtrade.process()
     assert pair in freqtrade.active_pair_whitelist
     # Make sure each pair is only in the list once
     assert len(freqtrade.active_pair_whitelist) == len(set(freqtrade.active_pair_whitelist))
-    assert result is True
 
 
 def test_process_informative_pairs_added(default_conf, ticker, markets, mocker) -> None:

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -697,7 +697,7 @@ def test_create_trade_no_signal(default_conf, fee, mocker) -> None:
     assert not freqtrade.create_trade()
 
 
-@pytest.mark.parametrize("max_open", range(1, 5))
+@pytest.mark.parametrize("max_open", range(0, 5))
 def test_create_trade_multiple_trades(default_conf, ticker,
                                       fee, markets, mocker, max_open) -> None:
     patch_RPCManager(mocker)

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -253,13 +253,14 @@ def test_get_trade_stake_amount_unlimited_amount(default_conf,
     assert result == default_conf['stake_amount'] / conf['max_open_trades']
 
     # create one trade, order amount should be 'balance / (max_open_trades - num_open_trades)'
-    freqtrade.create_trade()
+    # freqtrade.create_trade()
+    freqtrade.execute_buy('ETH/BTC', result)
 
     result = freqtrade._get_trade_stake_amount('LTC/BTC')
     assert result == default_conf['stake_amount'] / (conf['max_open_trades'] - 1)
 
     # create 2 trades, order amount should be None
-    freqtrade.create_trade()
+    freqtrade.execute_buy('LTC/BTC', result)
 
     result = freqtrade._get_trade_stake_amount('XRP/BTC')
     assert result is None

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -744,8 +744,7 @@ def test_process_exchange_failures(default_conf, ticker, markets, mocker) -> Non
     worker = Worker(args=None, config=default_conf)
     patch_get_signal(worker.freqtrade)
 
-    result = worker._process()
-    assert result is False
+    worker._process()
     assert sleep_mock.has_calls()
 
 
@@ -763,8 +762,7 @@ def test_process_operational_exception(default_conf, ticker, markets, mocker) ->
 
     assert worker.state == State.RUNNING
 
-    result = worker._process()
-    assert result is False
+    worker._process()
     assert worker.state == State.STOPPED
     assert 'OperationalException' in msg_mock.call_args_list[-1][0][0]['status']
 
@@ -786,13 +784,14 @@ def test_process_trade_handling(
 
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
     assert not trades
-    result = freqtrade.process()
-    assert result is True
+    freqtrade.process()
+
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
     assert len(trades) == 1
 
-    result = freqtrade.process()
-    assert result is False
+    # Nothing happened ...
+    freqtrade.process()
+    assert len(trades) == 1
 
 
 def test_process_trade_no_whitelist_pair(

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -127,11 +127,10 @@ class Worker(object):
         time.sleep(duration)
         return result
 
-    def _process(self) -> bool:
+    def _process(self) -> None:
         logger.debug("========================================")
-        state_changed = False
         try:
-            state_changed = self.freqtrade.process()
+            self.freqtrade.process()
         except TemporaryError as error:
             logger.warning(f"Error: {error}, retrying in {constants.RETRY_TIMEOUT} seconds...")
             time.sleep(constants.RETRY_TIMEOUT)
@@ -144,10 +143,6 @@ class Worker(object):
             })
             logger.exception('OperationalException. Stopping trader ...')
             self.freqtrade.state = State.STOPPED
-            # TODO: The return value of _process() is not used apart tests
-            # and should (could) be eliminated later. See PR #1689.
-#            state_changed = True
-        return state_changed
 
     def _reconfigure(self) -> None:
         """


### PR DESCRIPTION
## Summary
Returning from the create_trade function does not make sense - if multiple "trade-slots" are open, and we have buy-signals, we should buy immediately to not loose the opportunity.

This will also implicitly fix #1850, since this will run analysis for all whitelisted pairs while checking for trades. In combination with `process_only_new_candles` and #2131, buys only happen right after the new candles appear.

Closes #1850

## Quick changelog

- `process()` functions should not return anything (as identified in TODO in worker.py), since it's only used in tests
- `process_maybe_execute_buy()` should not return anything.
- `create_trade()` should check full whitelist (until `"max_open_trades"` is reached) to create as many trades as allowed (and set by the buy-signal).
- Adapt tests (especially `edge` - which did not set max_open_trades according to it's own definition).
