### PR TITLE
[minor] Improve docstring for some downloading methods

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -252,10 +252,11 @@ def download_pair_history(datadir: Optional[Path],
         logger.debug("Current End: %s", misc.format_ms_time(data[-1][0]) if data else 'None')
 
         # Default since_ms to 30 days if nothing is given
-        new_data = exchange.get_history(pair=pair, ticker_interval=ticker_interval,
-                                        since_ms=since_ms if since_ms
-                                        else
-                                        int(arrow.utcnow().shift(days=-30).float_timestamp) * 1000)
+        new_data = exchange.get_historic_ohlcv(pair=pair, ticker_interval=ticker_interval,
+                                               since_ms=since_ms if since_ms
+                                               else
+                                               int(arrow.utcnow().shift(
+                                                   days=-30).float_timestamp) * 1000)
         data.extend(new_data)
 
         logger.debug("New Start: %s", misc.format_ms_time(data[0][0]))

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -551,6 +551,11 @@ class Exchange(object):
         """
         Gets candle history using asyncio and returns the list of candles.
         Handles all async doing.
+        Async over one pair, assuming we get `_ohlcv_candle_limit` candles per call.
+        :param pair: Pair to download
+        :param ticker_interval: Interval to get
+        :param since_ms: Timestamp in milliseconds to get history from
+        :returns List of tickers
         """
         return asyncio.get_event_loop().run_until_complete(
             self._async_get_history(pair=pair, ticker_interval=ticker_interval,
@@ -585,6 +590,9 @@ class Exchange(object):
     def refresh_latest_ohlcv(self, pair_list: List[Tuple[str, str]]) -> List[Tuple[str, List]]:
         """
         Refresh in-memory ohlcv asyncronously and set `_klines` with the result
+        Loops asyncroneously over pair_list and dowloads all pairs async (semi-parallel).
+        :param pair_list: List of 2 element tuples containing pair,interval to refresh
+        :return: Returns a List of ticker-dataframes.
         """
         logger.debug("Refreshing ohlcv data for %d pairs", len(pair_list))
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -546,8 +546,8 @@ class Exchange(object):
             logger.info("returning cached ticker-data for %s", pair)
             return self._cached_ticker[pair]
 
-    def get_history(self, pair: str, ticker_interval: str,
-                    since_ms: int) -> List:
+    def get_historic_ohlcv(self, pair: str, ticker_interval: str,
+                           since_ms: int) -> List:
         """
         Gets candle history using asyncio and returns the list of candles.
         Handles all async doing.
@@ -558,12 +558,12 @@ class Exchange(object):
         :returns List of tickers
         """
         return asyncio.get_event_loop().run_until_complete(
-            self._async_get_history(pair=pair, ticker_interval=ticker_interval,
-                                    since_ms=since_ms))
+            self._async_get_historic_ohlcv(pair=pair, ticker_interval=ticker_interval,
+                                           since_ms=since_ms))
 
-    async def _async_get_history(self, pair: str,
-                                 ticker_interval: str,
-                                 since_ms: int) -> List:
+    async def _async_get_historic_ohlcv(self, pair: str,
+                                        ticker_interval: str,
+                                        since_ms: int) -> List:
 
         one_call = timeframe_to_msecs(ticker_interval) * self._ohlcv_candle_limit
         logger.debug(

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -589,9 +589,9 @@ class Exchange(object):
 
     def refresh_latest_ohlcv(self, pair_list: List[Tuple[str, str]]) -> List[Tuple[str, List]]:
         """
-        Refresh in-memory ohlcv asyncronously and set `_klines` with the result
-        Loops asyncroneously over pair_list and dowloads all pairs async (semi-parallel).
-        :param pair_list: List of 2 element tuples containing pair,interval to refresh
+        Refresh in-memory ohlcv asynchronously and set `_klines` with the result
+        Loops asynchronously over pair_list and downloads all pairs async (semi-parallel).
+        :param pair_list: List of 2 element tuples containing pair, interval to refresh
         :return: Returns a List of ticker-dataframes.
         """
         logger.debug("Refreshing ohlcv data for %d pairs", len(pair_list))
@@ -640,7 +640,7 @@ class Exchange(object):
     async def _async_get_candle_history(self, pair: str, ticker_interval: str,
                                         since_ms: Optional[int] = None) -> Tuple[str, str, List]:
         """
-        Asyncronously gets candle histories using fetch_ohlcv
+        Asynchronously gets candle histories using fetch_ohlcv
         returns tuple: (pair, ticker_interval, ohlcv_list)
         """
         try:

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -80,7 +80,7 @@ def test_load_data_7min_ticker(mocker, caplog, default_conf) -> None:
 
 
 def test_load_data_1min_ticker(ticker_history, mocker, caplog) -> None:
-    mocker.patch('freqtrade.exchange.Exchange.get_history', return_value=ticker_history)
+    mocker.patch('freqtrade.exchange.Exchange.get_historic_ohlcv', return_value=ticker_history)
     file = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'UNITTEST_BTC-1m.json')
     _backup_file(file, copy_file=True)
     history.load_data(datadir=None, ticker_interval='1m', pairs=['UNITTEST/BTC'])
@@ -96,7 +96,7 @@ def test_load_data_with_new_pair_1min(ticker_history_list, mocker, caplog, defau
     """
     Test load_pair_history() with 1 min ticker
     """
-    mocker.patch('freqtrade.exchange.Exchange.get_history', return_value=ticker_history_list)
+    mocker.patch('freqtrade.exchange.Exchange.get_historic_ohlcv', return_value=ticker_history_list)
     exchange = get_patched_exchange(mocker, default_conf)
     file = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'MEME_BTC-1m.json')
 
@@ -266,7 +266,7 @@ def test_load_cached_data_for_updating(mocker) -> None:
 
 
 def test_download_pair_history(ticker_history_list, mocker, default_conf) -> None:
-    mocker.patch('freqtrade.exchange.Exchange.get_history', return_value=ticker_history_list)
+    mocker.patch('freqtrade.exchange.Exchange.get_historic_ohlcv', return_value=ticker_history_list)
     exchange = get_patched_exchange(mocker, default_conf)
     file1_1 = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'MEME_BTC-1m.json')
     file1_5 = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'MEME_BTC-5m.json')
@@ -319,7 +319,7 @@ def test_download_pair_history2(mocker, default_conf) -> None:
         [1509836580000, 0.00161, 0.00161, 0.00161, 0.00161, 82.390199]
     ]
     json_dump_mock = mocker.patch('freqtrade.misc.file_dump_json', return_value=None)
-    mocker.patch('freqtrade.exchange.Exchange.get_history', return_value=tick)
+    mocker.patch('freqtrade.exchange.Exchange.get_historic_ohlcv', return_value=tick)
     exchange = get_patched_exchange(mocker, default_conf)
     download_pair_history(None, exchange, pair="UNITTEST/BTC", ticker_interval='1m')
     download_pair_history(None, exchange, pair="UNITTEST/BTC", ticker_interval='3m')
@@ -327,7 +327,7 @@ def test_download_pair_history2(mocker, default_conf) -> None:
 
 
 def test_download_backtesting_data_exception(ticker_history, mocker, caplog, default_conf) -> None:
-    mocker.patch('freqtrade.exchange.Exchange.get_history',
+    mocker.patch('freqtrade.exchange.Exchange.get_historic_ohlcv',
                  side_effect=Exception('File Error'))
 
     exchange = get_patched_exchange(mocker, default_conf)

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -996,7 +996,7 @@ def test_get_ticker(default_conf, mocker, exchange_name):
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
-def test_get_history(default_conf, mocker, caplog, exchange_name):
+def test_get_historic_ohlcv(default_conf, mocker, caplog, exchange_name):
     exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
     tick = [
         [
@@ -1017,7 +1017,7 @@ def test_get_history(default_conf, mocker, caplog, exchange_name):
     # one_call calculation * 1.8 should do 2 calls
     since = 5 * 60 * 500 * 1.8
     print(f"since = {since}")
-    ret = exchange.get_history(pair, "5m", int((arrow.utcnow().timestamp - since) * 1000))
+    ret = exchange.get_historic_ohlcv(pair, "5m", int((arrow.utcnow().timestamp - since) * 1000))
 
     assert exchange._async_get_candle_history.call_count == 2
     # Returns twice the above tick


### PR DESCRIPTION
## Summary
Clarify how each method works (async over pair / async over history for one pair)

rename `get_history` to `get_historic_ohlcv` - so it's clear what we're actually downloading.