### PR TITLE
f the string

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -290,7 +290,7 @@ class Configuration(object):
         if not self.runmode:
             # Handle real mode, infer dry/live from config
             self.runmode = RunMode.DRY_RUN if config.get('dry_run', True) else RunMode.LIVE
-            logger.info("Runmode set to {self.runmode}.")
+            logger.info(f"Runmode set to {self.runmode}.")
 
         config.update({'runmode': self.runmode})
 


### PR DESCRIPTION
## Summary
Someone wrote an fstring without the f

## Quick changelog

- add f to the fstring to make logging print the variable

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 

Output will print the actual runmode now instead of this:
```
2019-08-15 16:12:19,640 - freqtrade.configuration.configuration - INFO - Runmode set to {self.runmode}.
```