### PR TITLE
Hyperopt: --print-json option

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -22,7 +22,7 @@ ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_pos
 ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "position_stacking", "epochs", "spaces",
                                         "use_max_market_positions", "print_all",
-                                        "print_colorized", "hyperopt_jobs",
+                                        "print_colorized", "print_json", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
                                         "hyperopt_continue", "hyperopt_loss"]
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -198,6 +198,12 @@ AVAILABLE_CLI_OPTIONS = {
         action='store_false',
         default=True,
     ),
+    "print_json": Arg(
+        '--print-json',
+        help='Print best result detailization in JSON format.',
+        action='store_true',
+        default=False,
+    ),
     "hyperopt_jobs": Arg(
         '-j', '--job-workers',
         help='The number of concurrently running jobs for hyperoptimization '

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -242,6 +242,9 @@ class Configuration(object):
         else:
             config.update({'print_colorized': True})
 
+        self._args_to_config(config, argname='print_json',
+                             logstring='Parameter --print-json detected ...')
+
         self._args_to_config(config, argname='hyperopt_jobs',
                              logstring='Parameter -j/--job-workers detected: {}')
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -140,23 +140,23 @@ class Hyperopt(Backtesting):
         print(f"\nBest result:\n\n{log_str}\n")
 
         if self.config.get('print_json'):
-            result_dict = {}
+            result_dict: Dict = {}
             if self.has_space('buy') or self.has_space('sell'):
                 result_dict['params'] = {}
             if self.has_space('buy'):
                 result_dict['params'].update({p.name: params.get(p.name)
-                    for p in self.hyperopt_space('buy')})
+                                             for p in self.hyperopt_space('buy')})
             if self.has_space('sell'):
                 result_dict['params'].update({p.name: params.get(p.name)
-                    for p in self.hyperopt_space('sell')})
+                                             for p in self.hyperopt_space('sell')})
             if self.has_space('roi'):
-                min_roi = self.custom_hyperopt.generate_roi_table(params)
                 # Convert keys in min_roi dict to strings because
                 # rapidjson cannot dump dicts with integer keys...
                 # OrderedDict is used to keep the numeric order of the items
                 # in the dict.
-                min_roi = OrderedDict((str(k),v) for k,v in min_roi.items())
-                result_dict['minimal_roi'] = min_roi
+                result_dict['minimal_roi'] = OrderedDict(
+                    (str(k), v) for k, v in self.custom_hyperopt.generate_roi_table(params).items()
+                )
             if self.has_space('stoploss'):
                 result_dict['stoploss'] = params.get('stoploss')
             print(rapidjson.dumps(result_dict, default=str, number_mode=rapidjson.NM_NATIVE))

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -8,10 +8,13 @@ import logging
 import os
 import sys
 
+from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List, Optional
+
+import rapidjson
 
 from colorama import init as colorama_init
 from colorama import Fore, Style
@@ -133,22 +136,44 @@ class Hyperopt(Backtesting):
         results = sorted(self.trials, key=itemgetter('loss'))
         best_result = results[0]
         params = best_result['params']
-
         log_str = self.format_results_logstring(best_result)
         print(f"\nBest result:\n\n{log_str}\n")
-        if self.has_space('buy'):
-            print('Buy hyperspace params:')
-            pprint({p.name: params.get(p.name) for p in self.hyperopt_space('buy')},
-                   indent=4)
-        if self.has_space('sell'):
-            print('Sell hyperspace params:')
-            pprint({p.name: params.get(p.name) for p in self.hyperopt_space('sell')},
-                   indent=4)
-        if self.has_space('roi'):
-            print("ROI table:")
-            pprint(self.custom_hyperopt.generate_roi_table(params), indent=4)
-        if self.has_space('stoploss'):
-            print(f"Stoploss: {params.get('stoploss')}")
+
+        if self.config.get('print_json'):
+            result_dict = {}
+            if self.has_space('buy') or self.has_space('sell'):
+                result_dict['params'] = {}
+            if self.has_space('buy'):
+                result_dict['params'].update({p.name: params.get(p.name)
+                    for p in self.hyperopt_space('buy')})
+            if self.has_space('sell'):
+                result_dict['params'].update({p.name: params.get(p.name)
+                    for p in self.hyperopt_space('sell')})
+            if self.has_space('roi'):
+                min_roi = self.custom_hyperopt.generate_roi_table(params)
+                # Convert keys in min_roi dict to strings because
+                # rapidjson cannot dump dicts with integer keys...
+                # OrderedDict is used to keep the numeric order of the items
+                # in the dict.
+                min_roi = OrderedDict((str(k),v) for k,v in min_roi.items())
+                result_dict['minimal_roi'] = min_roi
+            if self.has_space('stoploss'):
+                result_dict['stoploss'] = params.get('stoploss')
+            print(rapidjson.dumps(result_dict, default=str, number_mode=rapidjson.NM_NATIVE))
+        else:
+            if self.has_space('buy'):
+                print('Buy hyperspace params:')
+                pprint({p.name: params.get(p.name) for p in self.hyperopt_space('buy')},
+                       indent=4)
+            if self.has_space('sell'):
+                print('Sell hyperspace params:')
+                pprint({p.name: params.get(p.name) for p in self.hyperopt_space('sell')},
+                       indent=4)
+            if self.has_space('roi'):
+                print("ROI table:")
+                pprint(self.custom_hyperopt.generate_roi_table(params), indent=4)
+            if self.has_space('stoploss'):
+                print(f"Stoploss: {params.get('stoploss')}")
 
     def log_results(self, results) -> None:
         """

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -621,6 +621,7 @@ def test_continue_hyperopt(mocker, default_conf, caplog):
 
 
 def test_print_json_spaces_all(mocker, default_conf, caplog, capsys) -> None:
+    dumper = mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock())
     mocker.patch(
         'freqtrade.optimize.hyperopt.get_timeframe',
@@ -651,9 +652,13 @@ def test_print_json_spaces_all(mocker, default_conf, caplog, capsys) -> None:
 
     out, err = capsys.readouterr()
     assert '{"params":{"mfi-value":null,"fastd-value":null,"adx-value":null,"rsi-value":null,"mfi-enabled":null,"fastd-enabled":null,"adx-enabled":null,"rsi-enabled":null,"trigger":null,"sell-mfi-value":null,"sell-fastd-value":null,"sell-adx-value":null,"sell-rsi-value":null,"sell-mfi-enabled":null,"sell-fastd-enabled":null,"sell-adx-enabled":null,"sell-rsi-enabled":null,"sell-trigger":null},"minimal_roi":{},"stoploss":null}' in out  # noqa: E501
+    assert dumper.called
+    # Should be called twice, once for tickerdata, once to save evaluations
+    assert dumper.call_count == 2
 
 
 def test_print_json_spaces_roi_stoploss(mocker, default_conf, caplog, capsys) -> None:
+    dumper = mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.load_data', MagicMock())
     mocker.patch(
         'freqtrade.optimize.hyperopt.get_timeframe',
@@ -684,3 +689,6 @@ def test_print_json_spaces_roi_stoploss(mocker, default_conf, caplog, capsys) ->
 
     out, err = capsys.readouterr()
     assert '{"minimal_roi":{},"stoploss":null}' in out
+    assert dumper.called
+    # Should be called twice, once for tickerdata, once to save evaluations
+    assert dumper.call_count == 2


### PR DESCRIPTION
This PR adds the `--print-json` option which prints best result details in json format, in one line.

This helps automatization of backtesting, since the details in this format are easily greppable (one line, defined format) and can then be easily parsed and transferred into existing strategy or to the options of the freqtrade backtesting or freqtrade dry-run...

Example of output, spaces='all':
```
*    1/10:     15 trades. Avg profit -0.57%. Total profit -0.00429526 BTC (  -8.57Σ%). Avg duration 1287.0 mins. Objective: 2.28322
*    2/10:     60 trades. Avg profit -0.76%. Total profit -0.02279588 BTC ( -45.48Σ%). Avg duration 1638.4 mins. Objective: 2.39411
*    3/10:      0 trades. Avg profit   nan%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration   nan mins. Objective: 100000.00000
*    4/10:      0 trades. Avg profit   nan%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration   nan mins. Objective: 100000.00000
*    5/10:     14 trades. Avg profit -0.13%. Total profit -0.00092800 BTC (  -1.85Σ%). Avg duration 358.2 mins. Objective: 2.26110
*    6/10:     11 trades. Avg profit  0.00%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration 548.6 mins. Objective: 2.25574
*    7/10:      5 trades. Avg profit  0.00%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration 651.0 mins. Objective: 100000.00000
*    8/10:     17 trades. Avg profit  0.00%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration 855.0 mins. Objective: 2.25412
2019-08-15 23:14:45,645 - freqtrade.optimize.hyperopt - INFO - Saving 8 evaluations to 'user_data/hyperopt_results.pickle'

Best result:

*    8/10:     17 trades. Avg profit  0.00%. Total profit  0.00000000 BTC (   0.00Σ%). Avg duration 855.0 mins. Objective: 2.25412

{"params":{"mfi-value":"23","fastd-value":"24","adx-value":"46","rsi-value":"23","mfi-enabled":false,"fastd-enabled":false,"adx-enabled":true,"rsi-enabled":false,"trigger":"sar_reversal","sell-mfi-value":"91","sell-fastd-value":"92","sell-adx-value":"79","sell-rsi-value":"71","sell-mfi-enabled":false,"sell-fastd-enabled":true,"sell-adx-enabled":false,"sell-rsi-enabled":true,"sell-trigger":"sell-sar_reversal"},"minimal_roi":{"0":0.18231284297024036,"31":0.083870261864611,"67":0.0207858410789196,"105":0},"stoploss":-0.40745600020888995}
```

Example of output, spaces='roi stoploss':
```
*    1/10:     15 trades. Avg profit -0.54%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 1962.3 mins. Objective: 2.28178
*    2/10:     15 trades. Avg profit -0.54%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 1962.3 mins. Objective: 2.28178
*    3/10:     18 trades. Avg profit -0.60%. Total profit -0.00540115 BTC ( -10.78Σ%). Avg duration 1273.1 mins. Objective: 2.28977
*    4/10:     17 trades. Avg profit -0.48%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 1335.6 mins. Objective: 2.28125
*    5/10:     15 trades. Avg profit -0.54%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 2003.3 mins. Objective: 2.28178
*    6/10:     18 trades. Avg profit -0.54%. Total profit -0.00489156 BTC (  -9.76Σ%). Avg duration 609.2 mins. Objective: 2.28638
*    7/10:     15 trades. Avg profit -0.54%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 1794.3 mins. Objective: 2.28178
*    8/10:     19 trades. Avg profit -0.70%. Total profit -0.00667074 BTC ( -13.31Σ%). Avg duration 428.4 mins. Objective: 2.29794
2019-08-15 23:16:28,736 - freqtrade.optimize.hyperopt - INFO - Saving 8 evaluations to 'user_data/hyperopt_results.pickle'

Best result:

*    4/10:     17 trades. Avg profit -0.48%. Total profit -0.00407874 BTC (  -8.14Σ%). Avg duration 1335.6 mins. Objective: 2.28125

{"minimal_roi":{"0":0.16187003339696243,"38":0.04901850020517244,"76":0.02871334121790446,"89":0},"stoploss":-0.4529922721868516}
```

The names of the keys in the printed json are chosen to correspond to the name of the params dict in the hyperopts (`'params'`) and the names of the attributes in the strategies (`'minimal_roi'`, `'stoploss'`). This is by intention.

TBD: maybe this option should be named `--print-detail(s)-json` or `--print-best-json`, because it only affects output of the details of the last best epoch.

TODO (if accepted):
* [ ] Add description to the docs.
* [ ] Update hyperopt cli helpstring in the docs.
