### PR TITLE
Dataprovider: get_pair_dataframe() helper method, cleanup

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -85,7 +85,7 @@ class DataProvider():
             # Get historic ohlcv data (cached on disk).
             data = self.historic_ohlcv(pair=pair, ticker_interval=ticker_interval)
         if len(data) == 0:
-            logger.warning(f"No data found for pair {pair}")
+            logger.warning(f"No data found for ({pair}, {ticker_interval}).")
         return data
 
     def ticker(self, pair: str):

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -52,11 +52,10 @@ class DataProvider():
                      Use False only for read-only operations (where the dataframe is not modified)
         """
         if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE):
-            pairtick = (pair, ticker_interval or self._config['ticker_interval'])
-            if pairtick in self.available_pairs:
-                return self._exchange.klines(pairtick, copy=copy)
-
-        return DataFrame()
+            return self._exchange.klines((pair, ticker_interval or self._config['ticker_interval']),
+                                         copy=copy)
+        else:
+            return DataFrame()
 
     def historic_ohlcv(self, pair: str, ticker_interval: str = None) -> DataFrame:
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -45,7 +45,7 @@ class DataProvider():
     def ohlcv(self, pair: str, ticker_interval: str = None, copy: bool = True) -> DataFrame:
         """
         Get ohlcv data for the given pair as DataFrame
-        Please check `self.available_pairs` to verify which pairs are currently cached.
+        Please use the `available_pairs` method to verify which pairs are currently cached.
         :param pair: pair to get the data for
         :param ticker_interval: ticker interval to get data for
         :param copy: copy dataframe before returning if True.

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -13,6 +13,7 @@ def test_ohlcv(mocker, default_conf, ticker_history):
     exchange = get_patched_exchange(mocker, default_conf)
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
+
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.DRY_RUN
     assert ticker_history.equals(dp.ohlcv("UNITTEST/BTC", ticker_interval))
@@ -37,11 +38,9 @@ def test_ohlcv(mocker, default_conf, ticker_history):
 
 
 def test_historic_ohlcv(mocker, default_conf, ticker_history):
-
     historymock = MagicMock(return_value=ticker_history)
     mocker.patch("freqtrade.data.dataprovider.load_pair_history", historymock)
 
-    # exchange = get_patched_exchange(mocker, default_conf)
     dp = DataProvider(default_conf, None)
     data = dp.historic_ohlcv("UNITTEST/BTC", "5m")
     assert isinstance(data, DataFrame)
@@ -57,6 +56,7 @@ def test_get_pair_dataframe(mocker, default_conf, ticker_history):
     exchange = get_patched_exchange(mocker, default_conf)
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
+
     dp = DataProvider(default_conf, exchange)
     assert dp.runmode == RunMode.DRY_RUN
     assert ticker_history.equals(dp.get_pair_dataframe("UNITTEST/BTC", ticker_interval))
@@ -86,12 +86,11 @@ def test_get_pair_dataframe(mocker, default_conf, ticker_history):
 
 def test_available_pairs(mocker, default_conf, ticker_history):
     exchange = get_patched_exchange(mocker, default_conf)
-
     ticker_interval = default_conf["ticker_interval"]
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
-    dp = DataProvider(default_conf, exchange)
 
+    dp = DataProvider(default_conf, exchange)
     assert len(dp.available_pairs) == 2
     assert dp.available_pairs == [
         ("XRP/BTC", ticker_interval),


### PR DESCRIPTION
* The `get_pair_dataframe()` method added. This can help dealing with informative pairs in the custom strategies. For example, the `InformativeSample.populate_indicators()` can be simplified to be as easy as:

```
    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        dataframe['ema20'] = ta.EMA(dataframe, timeperiod=20)
        dataframe['ema50'] = ta.EMA(dataframe, timeperiod=50)
        dataframe['ema100'] = ta.EMA(dataframe, timeperiod=100)

        if self.dp:
            data = self.dp.get_pair_dataframe(pair=f"{self.stake_currency}/USDT", ticker_interval=self.ticker_interval)

            # Combine the 2 dataframes using close
            # this will result in a column named 'closeETH' or 'closeBTC' - depending on stake_currency.
            dataframe = dataframe.merge(data[["date", "close"]], on="date", how="left", suffixes=("", self.config['stake_currency']))

            # Calculate SMA20 on 'close' data for stake_currency/USDT. Resulting column is named as 'smaETH20' (if stake_currency is ETH)
            dataframe[f"sma{self.config['stake_currency']}20"] = dataframe[f'close{self.stake_currency}'].rolling(20).mean()

        return dataframe
```

* Tests for new `get_pair_dataframe()` added

* The `ohlcv()` method pythonized
* Prototype of the `historic_ohlcv()` method adjusted to be closer to `ohlcv()` (optional ticker_interval)
* Various minor cleanup in comments: wording etc.
