### PR TITLE
Remove deprecated option live  - deprecate -r

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -69,6 +69,9 @@ freqtrade backtesting --ticker-interval 1m
 
 #### Using a different on-disk ticker-data source
 
+Assume you downloaded the history data from the Bittrex exchange and kept it in the `user_data/data/bittrex-20180101` directory. 
+You can then use this data for backtesting as follows:
+
 ```bash
 freqtrade backtesting --datadir user_data/data/bittrex-20180101
 ```

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -67,22 +67,10 @@ freqtrade backtesting
 freqtrade backtesting --ticker-interval 1m
 ```
 
-#### Update cached pairs with the latest data
-
-```bash
-freqtrade backtesting --refresh-pairs-cached
-```
-
-#### With live data (do not alter your testdata files)
-
-```bash
-freqtrade backtesting --live
-```
-
 #### Using a different on-disk ticker-data source
 
 ```bash
-freqtrade backtesting --datadir freqtrade/tests/testdata-20180101
+freqtrade backtesting --datadir user_data/data/bittrex-20180101
 ```
 
 #### With a (custom) strategy file

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -166,7 +166,6 @@ optional arguments:
                         Disable applying `max_open_trades` during backtest
                         (same as setting `max_open_trades` to a very high
                         number).
-  -l, --live            Use live data.
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
                         Provide a space-separated list of strategies to
                         backtest Please note that ticker-interval needs to be

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -23,4 +23,4 @@ and in freqtrade 2019.7 (master branch).
 
 `--live` in the context of backtesting allowed to download the latest tick data for backtesting.
 Did only download the latest 500 candles, so was ineffective in getting good backtest data.
-Removed in `2019-7-dev` (develop branch) and in freqtrade 2019-8 (master branch)
+Removed in 2019-7-dev (develop branch) and in freqtrade 2019-8 (master branch)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -6,11 +6,11 @@ and are no longer supported. Please avoid their usage in your configuration.
 
 ### the `--refresh-pairs-cached` command line option
 
-`--refresh-pairs-cached` in the context of backtesting, hyperopt and edge allowes to refresh candle data for backtesting.
-Since this leads to much confusion, and slows down backtesting (while not beeing part of backtesting) this has been singled out 
+`--refresh-pairs-cached` in the context of backtesting, hyperopt and edge allows to refresh candle data for backtesting.
+Since this leads to much confusion, and slows down backtesting (while not being part of backtesting) this has been singled out 
 as a seperate freqtrade subcommand `freqtrade download-data`.
 
-This command was deprecated in `2019.7-dev` and will be removed after the next release.
+This command line option was deprecated in `2019.7-dev` and will be removed after the next release.
 
 ## Removed features
 
@@ -18,3 +18,9 @@ This command was deprecated in `2019.7-dev` and will be removed after the next r
 
 This command line option was deprecated in 2018 and removed freqtrade 2019.6-dev (develop branch)
 and in freqtrade 2019.7 (master branch).
+
+### the `--live` command line option
+
+`--live` in the context of backtesting allowed to download the latest tick data for backtesting.
+Did only download the latest 500 candles, so was ineffective in getting good backtest data.
+Removed in `2019-7-dev` (develop branch) and in freqtrade 2019-8 (master branch)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -4,12 +4,13 @@ This page contains description of the command line arguments, configuration para
 and the bot features that were declared as DEPRECATED by the bot development team
 and are no longer supported. Please avoid their usage in your configuration.
 
-### the `--live` command line option
+### the `--refresh-pairs-cached` command line option
 
-`--live` in the context of backtesting allows to download the latest tick data for backtesting.
-Since this only downloads one set of data (by default 500 candles) - this is not really suitable for extendet backtesting, and has therefore been deprecated.
+`--refresh-pairs-cached` in the context of backtesting, hyperopt and edge allowes to refresh candle data for backtesting.
+Since this leads to much confusion, and slows down backtesting (while not beeing part of backtesting) this has been singled out 
+as a seperate freqtrade subcommand `freqtrade download-data`.
 
-This command was deprecated in `2019.6-dev` and will be removed after the next release.
+This command was deprecated in `2019.7-dev` and will be removed after the next release.
 
 ## Removed features
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -4,6 +4,8 @@ This page contains description of the command line arguments, configuration para
 and the bot features that were declared as DEPRECATED by the bot development team
 and are no longer supported. Please avoid their usage in your configuration.
 
+## Deprecated
+
 ### the `--refresh-pairs-cached` command line option
 
 `--refresh-pairs-cached` in the context of backtesting, hyperopt and edge allows to refresh candle data for backtesting.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -234,9 +234,8 @@ An example of its output:
 
 ### Update cached pairs with the latest data
 
-```bash
-freqtrade edge --refresh-pairs-cached
-```
+Edge requires historic data the same way than backtesting does.
+Please refer to the [download section](backtesting.md#Getting-data-for-backtesting-and-hyperopt) of the documentation for details.
 
 ### Precising stoploss range
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -234,7 +234,7 @@ An example of its output:
 
 ### Update cached pairs with the latest data
 
-Edge requires historic data the same way than backtesting does.
+Edge requires historic data the same way as backtesting does.
 Please refer to the [download section](backtesting.md#Getting-data-for-backtesting-and-hyperopt) of the documentation for details.
 
 ### Precising stoploss range

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -44,10 +44,8 @@ python3 scripts/plot_dataframe.py -p BTC/ETH,XRP/ETH
 To plot a timerange (to zoom in):
 
 ``` bash
-python3 scripts/plot_dataframe.py -p BTC/ETH --timerange=100-200
+python3 scripts/plot_dataframe.py -p BTC/ETH --timerange=20180801-20180805
 ```
-
-Timerange doesn't work with live data.
 
 To plot trades stored in a database use `--db-url` argument:
 

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -15,7 +15,7 @@ pip install -U -r requirements-plot.txt
 Usage for the price plotter:
 
 ``` bash
-python3 script/plot_dataframe.py [-h] [-p pairs] [--live]
+python3 script/plot_dataframe.py [-h] [-p pairs]
 ```
 
 Example
@@ -39,12 +39,6 @@ To plot multiple pairs, separate them with a comma:
 
 ``` bash
 python3 scripts/plot_dataframe.py -p BTC/ETH,XRP/ETH
-```
-
-To plot the current live price use the `--live` flag:
-
-``` bash
-python3 scripts/plot_dataframe.py -p BTC/ETH --live
 ```
 
 To plot a timerange (to zoom in):

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -319,7 +319,6 @@ if self.dp:
         print(f"available {pair}, {ticker}")
 ```
 
-
 #### Get data for non-tradeable pairs
 
 Data for additional, informative pairs (reference pairs) can be beneficial for some strategies.

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -17,7 +17,7 @@ ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange",
                         "max_open_trades", "stake_amount", "refresh_pairs"]
 
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
-                                        "live", "strategy_list", "export", "exportfilename"]
+                                        "strategy_list", "export", "exportfilename"]
 
 ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "position_stacking", "epochs", "spaces",
@@ -35,7 +35,7 @@ ARGS_DOWNLOAD_DATA = ["pairs", "pairs_file", "days", "exchange", "timeframes", "
 ARGS_PLOT_DATAFRAME = (ARGS_COMMON + ARGS_STRATEGY +
                        ["pairs", "indicators1", "indicators2", "plot_limit", "db_url",
                         "trade_source", "export", "exportfilename", "timerange",
-                        "refresh_pairs", "live"])
+                        "refresh_pairs"])
 
 ARGS_PLOT_PROFIT = (ARGS_COMMON + ARGS_STRATEGY +
                     ["pairs", "timerange", "export", "exportfilename", "db_url", "trade_source"])

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -123,11 +123,6 @@ AVAILABLE_CLI_OPTIONS = {
         action='store_false',
         default=True,
     ),
-    "live": Arg(
-        '-l', '--live',
-        help='Use live data.',
-        action='store_true',
-    ),
     "strategy_list": Arg(
         '--strategy-list',
         help='Provide a space-separated list of strategies to backtest. '

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -199,7 +199,8 @@ class Configuration(object):
         self._process_datadir_options(config)
 
         self._args_to_config(config, argname='refresh_pairs',
-                             logstring='Parameter -r/--refresh-pairs-cached detected ...')
+                             logstring='Parameter -r/--refresh-pairs-cached detected ...',
+                             deprecated_msg='-r/--refresh-pairs-cached will be removed soon.')
 
         self._args_to_config(config, argname='strategy_list',
                              logstring='Using strategy list of {} Strategies', logfun=len)

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -175,10 +175,6 @@ class Configuration(object):
                              logstring='Parameter -i/--ticker-interval detected ... '
                              'Using ticker_interval: {} ...')
 
-        self._args_to_config(config, argname='live',
-                             logstring='Parameter -l/--live detected ...',
-                             deprecated_msg='--live will be removed soon.')
-
         self._args_to_config(config, argname='position_stacking',
                              logstring='Parameter --enable-position-stacking detected ...')
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -413,7 +413,6 @@ class Backtesting(object):
             refresh_pairs=self.config.get('refresh_pairs', False),
             exchange=self.exchange,
             timerange=timerange,
-            live=self.config.get('live', False)
         )
 
         if not data:

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -31,7 +31,7 @@ def init_plotscript(config):
     exchange: Optional[Exchange] = None
 
     # Exchange is only needed when downloading data!
-    if config.get("live", False) or config.get("refresh_pairs", False):
+    if config.get("refresh_pairs", False):
         exchange = ExchangeResolver(config.get('exchange', {}).get('name'),
                                     config).exchange
 
@@ -51,7 +51,6 @@ def init_plotscript(config):
         refresh_pairs=config.get('refresh_pairs', False),
         timerange=timerange,
         exchange=exchange,
-        live=config.get("live", False),
     )
 
     trades = load_trades(config)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -186,9 +186,6 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'ticker_interval' in config
     assert not log_has_re('Parameter -i/--ticker-interval detected .*', caplog)
 
-    assert 'live' not in config
-    assert not log_has('Parameter -l/--live detected ...', caplog)
-
     assert 'position_stacking' not in config
     assert not log_has('Parameter --enable-position-stacking detected ...', caplog)
 
@@ -201,7 +198,6 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert config['runmode'] == RunMode.BACKTEST
 
 
-@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(
@@ -215,7 +211,6 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
         '--datadir', '/foo/bar',
         'backtesting',
         '--ticker-interval', '1m',
-        '--live',
         '--enable-position-stacking',
         '--disable-max-market-positions',
         '--refresh-pairs-cached',
@@ -237,9 +232,6 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
     assert 'ticker_interval' in config
     assert log_has('Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
                    caplog)
-
-    assert 'live' in config
-    assert log_has('Parameter -l/--live detected ...', caplog)
 
     assert 'position_stacking' in config
     assert log_has('Parameter --enable-position-stacking detected ...', caplog)
@@ -815,8 +807,7 @@ def test_backtest_record(default_conf, fee, mocker):
         assert dur > 0
 
 
-@pytest.mark.filterwarnings("ignore:DEPRECATED")
-def test_backtest_start_live(default_conf, mocker, caplog):
+def test_backtest_start_timerange(default_conf, mocker, caplog):
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
 
     async def load_pairs(pair, timeframe, since):
@@ -836,7 +827,6 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         '--datadir', 'freqtrade/tests/testdata',
         'backtesting',
         '--ticker-interval', '1m',
-        '--live',
         '--timerange', '-100',
         '--enable-position-stacking',
         '--disable-max-market-positions'
@@ -846,14 +836,12 @@ def test_backtest_start_live(default_conf, mocker, caplog):
     # check the logs, that will contain the backtest result
     exists = [
         'Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
-        'Parameter -l/--live detected ...',
         'Ignoring max_open_trades (--disable-max-market-positions was used) ...',
         'Parameter --timerange detected: -100 ...',
         'Using data directory: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
-        'Live: Downloading data for all defined pairs ...',
-        'Backtesting with data from 2017-11-14T19:31:00+00:00 '
+        'Backtesting with data from 2017-11-14T21:17:00+00:00 '
         'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...'
     ]
@@ -862,7 +850,6 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         assert log_has(line, caplog)
 
 
-@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
 
@@ -886,7 +873,6 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
         '--datadir', 'freqtrade/tests/testdata',
         'backtesting',
         '--ticker-interval', '1m',
-        '--live',
         '--timerange', '-100',
         '--enable-position-stacking',
         '--disable-max-market-positions',
@@ -904,14 +890,12 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
     # check the logs, that will contain the backtest result
     exists = [
         'Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
-        'Parameter -l/--live detected ...',
         'Ignoring max_open_trades (--disable-max-market-positions was used) ...',
         'Parameter --timerange detected: -100 ...',
         'Using data directory: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
-        'Live: Downloading data for all defined pairs ...',
-        'Backtesting with data from 2017-11-14T19:31:00+00:00 '
+        'Backtesting with data from 2017-11-14T21:17:00+00:00 '
         'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...',
         'Running backtesting for Strategy DefaultStrategy',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -471,7 +471,6 @@ def test_backtesting_start(default_conf, mocker, caplog) -> None:
 
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
     default_conf['ticker_interval'] = '1m'
-    default_conf['live'] = False
     default_conf['datadir'] = None
     default_conf['export'] = None
     default_conf['timerange'] = '-100'
@@ -505,7 +504,6 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
 
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
     default_conf['ticker_interval'] = "1m"
-    default_conf['live'] = False
     default_conf['datadir'] = None
     default_conf['export'] = None
     default_conf['timerange'] = '20180101-20180102'

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -198,6 +198,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert config['runmode'] == RunMode.BACKTEST
 
 
+@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(

--- a/freqtrade/tests/optimize/test_edge_cli.py
+++ b/freqtrade/tests/optimize/test_edge_cli.py
@@ -3,11 +3,14 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from freqtrade.edge import PairInfo
 from freqtrade.optimize import setup_configuration, start_edge
 from freqtrade.optimize.edge_cli import EdgeCli
 from freqtrade.state import RunMode
-from freqtrade.tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re,
+                                      patch_exchange,
                                       patched_configuration_load_config_file)
 
 
@@ -40,6 +43,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'stoploss_range' not in config
 
 
+@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, edge_conf)
     mocker.patch(

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -94,6 +94,7 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
     assert config['runmode'] == RunMode.HYPEROPT
 
 
+@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -83,9 +83,6 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
     assert 'ticker_interval' in config
     assert not log_has_re('Parameter -i/--ticker-interval detected .*', caplog)
 
-    assert 'live' not in config
-    assert not log_has('Parameter -l/--live detected ...', caplog)
-
     assert 'position_stacking' not in config
     assert not log_has('Parameter --enable-position-stacking detected ...', caplog)
 

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -98,7 +98,6 @@ def test_parse_args_backtesting_custom() -> None:
     args = [
         '-c', 'test_conf.json',
         'backtesting',
-        '--live',
         '--ticker-interval', '1m',
         '--refresh-pairs-cached',
         '--strategy-list',
@@ -107,7 +106,6 @@ def test_parse_args_backtesting_custom() -> None:
         ]
     call_args = Arguments(args, '').get_parsed_arg()
     assert call_args.config == ['test_conf.json']
-    assert call_args.live is True
     assert call_args.verbosity == 0
     assert call_args.subparser == 'backtesting'
     assert call_args.func is not None

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -335,9 +335,6 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'ticker_interval' in config
     assert not log_has('Parameter -i/--ticker-interval detected ...', caplog)
 
-    assert 'live' not in config
-    assert not log_has('Parameter -l/--live detected ...', caplog)
-
     assert 'position_stacking' not in config
     assert not log_has('Parameter --enable-position-stacking detected ...', caplog)
 
@@ -348,7 +345,6 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'export' not in config
 
 
-@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(
@@ -362,7 +358,6 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         '--datadir', '/foo/bar',
         'backtesting',
         '--ticker-interval', '1m',
-        '--live',
         '--enable-position-stacking',
         '--disable-max-market-positions',
         '--refresh-pairs-cached',
@@ -384,9 +379,6 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'ticker_interval' in config
     assert log_has('Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
                    caplog)
-
-    assert 'live' in config
-    assert log_has('Parameter -l/--live detected ...', caplog)
 
     assert 'position_stacking'in config
     assert log_has('Parameter --enable-position-stacking detected ...', caplog)

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -345,6 +345,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'export' not in config
 
 
+@pytest.mark.filterwarnings("ignore:DEPRECATED")
 def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch(

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -28,7 +28,6 @@ def test_parse_args_backtesting(mocker) -> None:
     assert backtesting_mock.call_count == 1
     call_args = backtesting_mock.call_args[0][0]
     assert call_args.config == ['config.json']
-    assert call_args.live is False
     assert call_args.verbosity == 0
     assert call_args.subparser == 'backtesting'
     assert call_args.func is not None


### PR DESCRIPTION
## Summary
We have --live deprecated now in one release version, so we can remove it as agreed.
This pr will also deprecate -r as discussed in #2148.

This PR shall be merged after  #2146 - and rebased onto develop first (carefully go through the ocs after that).

closes #2148 

## todo:
* [x] rebase to develop after #2146 is merged
* [x] review documentation for contextual errors
* [x]  fix link in edge.md (search for `xxxx`)