### PR TITLE
Config consistency checking improvements

### DIFF
--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,3 +1,4 @@
 from freqtrade.configuration.arguments import Arguments  # noqa: F401
 from freqtrade.configuration.timerange import TimeRange  # noqa: F401
 from freqtrade.configuration.configuration import Configuration  # noqa: F401
+from freqtrade.configuration.config_validation import validate_config_consistency  # noqa: F401

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -63,6 +63,7 @@ def validate_config_consistency(conf: Dict[str, Any]) -> None:
     """
     # validating trailing stoploss
     _validate_trailing_stoploss(conf)
+    _validate_edge(conf)
 
 
 def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
@@ -84,3 +85,18 @@ def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
         raise OperationalException(
             f'The config trailing_stop_positive_offset needs '
             'to be greater than trailing_stop_positive_offset in your config.')
+
+
+def _validate_edge(conf: Dict[str, Any]) -> None:
+    """
+    Edge and Dynamic whitelist should not both be enabled, since edge overrides dynamic whitelists.
+    """
+
+    if not conf.get('edge', {}).get('enabled'):
+        return
+
+    if conf.get('pairlist', {}).get('method') == 'VolumePairList':
+        raise OperationalException(
+            "Edge and VolumePairList are incompatible, "
+            "Edge will override whatever pairs VolumePairlist selects."
+        )

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from jsonschema import Draft4Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
 
-from freqtrade import constants
+from freqtrade import constants, OperationalException
 
 
 logger = logging.getLogger(__name__)
@@ -51,3 +51,36 @@ def validate_config_schema(conf: Dict[str, Any]) -> Dict[str, Any]:
         raise ValidationError(
             best_match(Draft4Validator(constants.CONF_SCHEMA).iter_errors(conf)).message
         )
+
+
+def validate_config_consistency(conf: Dict[str, Any]) -> None:
+    """
+    Validate the configuration consistency.
+    Should be ran after loading both configuration and strategy,
+    since strategies can set certain configuration settings too.
+    :param conf: Config in JSON format
+    :return: Returns None if everything is ok, otherwise throw an OperationalException
+    """
+    # validating trailing stoploss
+    _validate_trailing_stoploss(conf)
+
+
+def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
+
+    # Skip if trailing stoploss is not activated
+    if not conf.get('trailing_stop', False):
+        return
+
+    tsl_positive = float(conf.get('trailing_stop_positive', 0))
+    tsl_offset = float(conf.get('trailing_stop_positive_offset', 0))
+    tsl_only_offset = conf.get('trailing_only_offset_is_reached', False)
+
+    if tsl_only_offset:
+        if tsl_positive == 0.0:
+            raise OperationalException(
+                f'The config trailing_only_offset_is_reached needs '
+                'trailing_stop_positive_offset to be more than 0 in your config.')
+    if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
+        raise OperationalException(
+            f'The config trailing_stop_positive_offset needs '
+            'to be greater than trailing_stop_positive_offset in your config.')

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -51,6 +51,8 @@ class FreqtradeBot(object):
         self.config = config
 
         self.strategy: IStrategy = StrategyResolver(self.config).strategy
+
+        # Check config consistency here since strategies can set certain options
         validate_config_consistency(config)
 
         self.rpc: RPCManager = RPCManager(self)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -16,6 +16,7 @@ from freqtrade import (DependencyException, OperationalException, InvalidOrderEx
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
+from freqtrade.configuration import validate_config_consistency
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCManager, RPCMessageType
@@ -50,6 +51,7 @@ class FreqtradeBot(object):
         self.config = config
 
         self.strategy: IStrategy = StrategyResolver(self.config).strategy
+        validate_config_consistency(config)
 
         self.rpc: RPCManager = RPCManager(self)
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -638,6 +638,22 @@ def test_validate_tsl(default_conf):
     validate_config_consistency(default_conf)
 
 
+def test_validate_edge(edge_conf):
+    edge_conf.update({"pairlist": {
+        "method": "VolumePairList",
+    }})
+
+    with pytest.raises(OperationalException,
+                       match="Edge and VolumePairList are incompatible, "
+                       "Edge will override whatever pairs VolumePairlist selects."):
+        validate_config_consistency(edge_conf)
+
+    edge_conf.update({"pairlist": {
+        "method": "StaticPairList",
+    }})
+    validate_config_consistency(edge_conf)
+
+
 def test_load_config_test_comments() -> None:
     """
     Load config with comments

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import warnings
-from argparse import Namespace
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -11,10 +10,10 @@ import pytest
 from jsonschema import Draft4Validator, ValidationError, validate
 
 from freqtrade import OperationalException, constants
-from freqtrade.configuration import Arguments, Configuration
+from freqtrade.configuration import Arguments, Configuration, validate_config_consistency
 from freqtrade.configuration.check_exchange import check_exchange
+from freqtrade.configuration.config_validation import validate_config_schema
 from freqtrade.configuration.create_datadir import create_datadir
-from freqtrade.configuration.json_schema import validate_config_schema
 from freqtrade.configuration.load_config import load_config_file
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
 from freqtrade.loggers import _set_loggers
@@ -625,21 +624,18 @@ def test_validate_tsl(default_conf):
     with pytest.raises(OperationalException,
                        match=r'The config trailing_only_offset_is_reached needs '
                        'trailing_stop_positive_offset to be more than 0 in your config.'):
-        configuration = Configuration(Namespace())
-        configuration._validate_config_consistency(default_conf)
+        validate_config_consistency(default_conf)
 
     default_conf['trailing_stop_positive_offset'] = 0.01
     default_conf['trailing_stop_positive'] = 0.015
     with pytest.raises(OperationalException,
                        match=r'The config trailing_stop_positive_offset needs '
                        'to be greater than trailing_stop_positive_offset in your config.'):
-        configuration = Configuration(Namespace())
-        configuration._validate_config_consistency(default_conf)
+        validate_config_consistency(default_conf)
 
     default_conf['trailing_stop_positive'] = 0.01
     default_conf['trailing_stop_positive_offset'] = 0.015
-    Configuration(Namespace())
-    configuration._validate_config_consistency(default_conf)
+    validate_config_consistency(default_conf)
 
 
 def test_load_config_test_comments() -> None:


### PR DESCRIPTION
## Summary
Validate edge_configuration vs. Volume pairlist - the 2 are incompatible (edge will always override volume pairlist - which will cause unnecessary calls to the exchange from the VolumePairList.

Closes #1196 (5th and last point).

## Quick changelog

- move validation methods out of Configuration
- Check configuration after loading strategy (strategies can set options, especially related trailing stop - so our current approach is inefficient for these cases).
