### PR TITLE
Fix pairlist logging

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -5,7 +5,6 @@ bot constants
 """
 DEFAULT_CONFIG = 'config.json'
 DEFAULT_EXCHANGE = 'bittrex'
-DYNAMIC_WHITELIST = 20  # pairs
 PROCESS_THROTTLE_SECS = 5  # sec
 DEFAULT_TICKER_INTERVAL = 5  # min
 HYPEROPT_EPOCH = 100  # epochs

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -55,7 +55,6 @@ class VolumePairList(IPairList):
         # Generate dynamic whitelist
         self._whitelist = self._gen_pair_whitelist(
             self._config['stake_currency'], self._sort_key)[:self._number_pairs]
-        logger.info(f"Searching pairs: {self._whitelist}")
 
     @cached(TTLCache(maxsize=1, ttl=1800))
     def _gen_pair_whitelist(self, base_currency: str, key: str) -> List[str]:
@@ -92,4 +91,6 @@ class VolumePairList(IPairList):
                     valid_tickers.remove(t)
 
         pairs = [s['symbol'] for s in valid_tickers]
+        logger.info(f"Searching pairs: {self._whitelist}")
+
         return pairs

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -29,7 +29,8 @@ class IResolver(object):
         """
 
         # Generate spec based on absolute path
-        spec = importlib.util.spec_from_file_location('unknown', str(module_path))
+        # Pass object_name as first argument to have logging print a reasonable name.
+        spec = importlib.util.spec_from_file_location(object_name, str(module_path))
         module = importlib.util.module_from_spec(spec)
         try:
             spec.loader.exec_module(module)  # type: ignore # importlib does not use typehints


### PR DESCRIPTION
## Summary
VolumePairlist is way too verbose. The whitelist changes once every 1800 seconds, no need to print it with every iteration.

Also, logging did not "know" the volumepairlist's name and used "unknown" since this was passed into the dynamic loader.
Using the class-name seems to make more sense here.

## Quick changelog
logging before:
```
2019-08-18 14:50:09,710 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-08-18 14:50:11,842 - unknown - INFO - Searching pairs: ['BNB/ETH', 'XRP/ETH', 'LINK/ETH', 'ENJ/ETH', 'HC/ETH', 'EOS/ETH', 'LTC/ETH', 'TRX/ETH', 'WAVES/ETH', 'XVG/ETH', 'ADA/ETH', 'MTL/ETH', 'HOT/ETH', 'ICX/ETH', 'THETA/ETH', 'QTUM/ETH', 'NPXS/ETH', 'ZEC/ETH', 'LSK/ETH', 'ZIL/ETH']
2019-08-18 14:50:14,819 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
```

after:
```
2019-08-18 14:50:09,710 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-08-18 14:50:11,842 - VolumePairList - INFO - Searching pairs: ['BNB/ETH', 'XRP/ETH', 'LINK/ETH', 'ENJ/ETH', 'HC/ETH', 'EOS/ETH', 'LTC/ETH', 'TRX/ETH', 'WAVES/ETH', 'XVG/ETH', 'ADA/ETH', 'MTL/ETH', 'HOT/ETH', 'ICX/ETH', 'THETA/ETH', 'QTUM/ETH', 'NPXS/ETH', 'ZEC/ETH', 'LSK/ETH', 'ZIL/ETH']
2019-08-18 14:50:14,819 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
```
