### PR TITLE
Gracefully handle problems with dry-run orders

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -696,8 +696,13 @@ class Exchange(object):
     @retrier
     def get_order(self, order_id: str, pair: str) -> Dict:
         if self._config['dry_run']:
-            order = self._dry_run_open_orders[order_id]
-            return order
+            try:
+                order = self._dry_run_open_orders[order_id]
+                return order
+            except KeyError as e:
+                # Gracefully handle errors with dry-run orders.
+                raise InvalidOrderException(
+                    f'Tried to get an invalid dry-run-order (id: {order_id}). Message: {e}') from e
         try:
             return self._api.fetch_order(order_id, pair)
         except ccxt.InvalidOrder as e:

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1328,6 +1328,9 @@ def test_get_order(default_conf, mocker, exchange_name):
     print(exchange.get_order('X', 'TKN/BTC'))
     assert exchange.get_order('X', 'TKN/BTC').myid == 123
 
+    with pytest.raises(InvalidOrderException, match=r'Tried to get an invalid dry-run-order.*'):
+        exchange.get_order('Y', 'TKN/BTC')
+
     default_conf['dry_run'] = False
     api_mock = MagicMock()
     api_mock.fetch_order = MagicMock(return_value=456)


### PR DESCRIPTION
## Summary
Fixes exceptions with keyerror due to dry-run order handling messing up "something".
We reset dry-run orders on startup so ideally this error should not happen.

If it does, its better to handle it gracefully rather than failing with a keyerror.


## Quick changelog
sample exception
```
2019-08-18 14:50:14,822 - freqtrade - ERROR - Fatal exception!
Traceback (most recent call last):
  File "/freqtrade/freqtrade/main.py", line 49, in main
    worker.run()
  File "/freqtrade/freqtrade/worker.py", line 72, in run
    state = self._worker(old_state=state)
  File "/freqtrade/freqtrade/worker.py", line 110, in _worker
    self._throttle(func=self._process, min_secs=throttle_secs)
  File "/freqtrade/freqtrade/worker.py", line 123, in _throttle
    result = func(*args, **kwargs)
  File "/freqtrade/freqtrade/worker.py", line 133, in _process
    self.freqtrade.process()
  File "/freqtrade/freqtrade/freqtradebot.py", line 148, in process
    self.check_handle_timedout()
  File "/freqtrade/freqtrade/freqtradebot.py", line 763, in check_handle_timedout
    order = self.exchange.get_order(trade.open_order_id, trade.pair)
  File "/freqtrade/freqtrade/exchange/exchange.py", line 57, in wrapper
    return f(*args, **kwargs)
  File "/freqtrade/freqtrade/exchange/exchange.py", line 699, in get_order
    order = self._dry_run_open_orders[order_id]
KeyError: 'dry_run_buy_554825'
```

side note:
in my case, i had 2 docker-containers pointed to the same database file ... 