### PR TITLE
Fix downloadscript pair handling

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -346,10 +346,9 @@ class Configuration(object):
             # or if pairs file is specified explicitely
             if not pairs_file.exists():
                 raise OperationalException(f'No pairs file found with path "{pairs_file}".')
-
-            config['pairs'] = json_load(pairs_file)
-
-            config['pairs'].sort()
+            with pairs_file.open('r') as f:
+                config['pairs'] = json_load(f)
+                config['pairs'].sort()
             return
 
         if "config" in self.args and self.args.config:
@@ -357,7 +356,10 @@ class Configuration(object):
             config['pairs'] = config.get('exchange', {}).get('pair_whitelist')
         else:
             # Fall back to /dl_path/pairs.json
-            pairs_file = Path(config['datadir']) / "pairs.json"
+            pairs_file = Path(config['datadir']) / config['exchange']['name'].lower() / "pairs.json"
+            print(config['datadir'])
             if pairs_file.exists():
-                config['pairs'] = json_load(pairs_file)
-            config['pairs'].sort()
+                with pairs_file.open('r') as f:
+                    config['pairs'] = json_load(f)
+                if 'pairs' in config:
+                    config['pairs'].sort()

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -6,6 +6,7 @@ import logging
 import re
 from datetime import datetime
 from pathlib import Path
+from typing.io import IO
 
 import numpy as np
 import rapidjson
@@ -60,7 +61,7 @@ def file_dump_json(filename: Path, data, is_zip=False) -> None:
     logger.debug(f'done json to "{filename}"')
 
 
-def json_load(datafile):
+def json_load(datafile: IO):
     """
     load data with rapidjson
     Use this to have a consistent experience,

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -770,6 +770,7 @@ def test_pairlist_resolving_with_config_pl(mocker, default_conf):
     load_mock = mocker.patch("freqtrade.configuration.configuration.json_load",
                              MagicMock(return_value=['XRP/BTC', 'ETH/BTC']))
     mocker.patch.object(Path, "exists", MagicMock(return_value=True))
+    mocker.patch.object(Path, "open", MagicMock(return_value=MagicMock()))
 
     arglist = [
         '--config', 'config.json',
@@ -808,6 +809,7 @@ def test_pairlist_resolving_with_config_pl_not_exists(mocker, default_conf):
 
 def test_pairlist_resolving_fallback(mocker):
     mocker.patch.object(Path, "exists", MagicMock(return_value=True))
+    mocker.patch.object(Path, "open", MagicMock(return_value=MagicMock()))
     mocker.patch("freqtrade.configuration.configuration.json_load",
                  MagicMock(return_value=['XRP/BTC', 'ETH/BTC']))
     arglist = [


### PR DESCRIPTION
## Summary

This fixes both bugs (both reported in #2133).

Closes #2133

## Quick changelog

The pairlist part of download-data had 2 bugs
* load_json does expect a file-like object, not a Path
* fallback-path to pairs.json did not include exchange (this was present in the old download-script too)

The 2nd part was not noticed since i accidentally have a `pairs.json` in `user_data/data/` too (while we should load from `user_data/data/<exchange>/pairs.json`.

