### PR TITLE
improve stoploss validation

### DIFF
--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -68,6 +68,10 @@ def validate_config_consistency(conf: Dict[str, Any]) -> None:
 
 def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
 
+    if conf.get('stoploss') == 0.0:
+        raise OperationalException(
+            'The config stoploss needs to be different from 0 to avoid problems with sell orders.'
+            )
     # Skip if trailing stoploss is not activated
     if not conf.get('trailing_stop', False):
         return
@@ -79,12 +83,19 @@ def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
     if tsl_only_offset:
         if tsl_positive == 0.0:
             raise OperationalException(
-                f'The config trailing_only_offset_is_reached needs '
+                'The config trailing_only_offset_is_reached needs '
                 'trailing_stop_positive_offset to be more than 0 in your config.')
     if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
         raise OperationalException(
-            f'The config trailing_stop_positive_offset needs '
+            'The config trailing_stop_positive_offset needs '
             'to be greater than trailing_stop_positive_offset in your config.')
+
+    # Fetch again without default
+    if 'trailing_stop_positive' in conf and float(conf['trailing_stop_positive']) == 0.0:
+        raise OperationalException(
+            'The config trailing_stop_positive needs to be different from 0 '
+            'to avoid problems with sell orders.'
+        )
 
 
 def _validate_edge(conf: Dict[str, Any]) -> None:

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -88,7 +88,7 @@ def _validate_trailing_stoploss(conf: Dict[str, Any]) -> None:
     if tsl_positive > 0 and 0 < tsl_offset <= tsl_positive:
         raise OperationalException(
             'The config trailing_stop_positive_offset needs '
-            'to be greater than trailing_stop_positive_offset in your config.')
+            'to be greater than trailing_stop_positive in your config.')
 
     # Fetch again without default
     if 'trailing_stop_positive' in conf and float(conf['trailing_stop_positive']) == 0.0:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -648,6 +648,12 @@ def test_create_userdata_dir_exists_exception(mocker, default_conf, caplog) -> N
 
 
 def test_validate_tsl(default_conf):
+    default_conf['stoploss'] = 0.0
+    with pytest.raises(OperationalException, match='The config stoploss needs to be more '
+                                                   'than 0 to avoid problems with sell orders.'):
+        validate_config_consistency(default_conf)
+    default_conf['stoploss'] = -0.10
+
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0
     default_conf['trailing_stop_positive_offset'] = 0
@@ -668,6 +674,15 @@ def test_validate_tsl(default_conf):
     default_conf['trailing_stop_positive'] = 0.01
     default_conf['trailing_stop_positive_offset'] = 0.015
     validate_config_consistency(default_conf)
+
+    # 0 trailing stop positive - results in "Order would trigger immediately"
+    default_conf['trailing_stop_positive'] = 0
+    default_conf['trailing_stop_positive_offset'] = 0.02
+    default_conf['trailing_only_offset_is_reached'] = False
+    with pytest.raises(OperationalException,
+                       match='The config trailing_stop_positive needs to be more than 0'
+                       'to avoid problems with sell orders'):
+        validate_config_consistency(default_conf)
 
 
 def test_validate_edge(edge_conf):

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -668,7 +668,7 @@ def test_validate_tsl(default_conf):
     default_conf['trailing_stop_positive'] = 0.015
     with pytest.raises(OperationalException,
                        match=r'The config trailing_stop_positive_offset needs '
-                       'to be greater than trailing_stop_positive_offset in your config.'):
+                       'to be greater than trailing_stop_positive in your config.'):
         validate_config_consistency(default_conf)
 
     default_conf['trailing_stop_positive'] = 0.01

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -649,8 +649,8 @@ def test_create_userdata_dir_exists_exception(mocker, default_conf, caplog) -> N
 
 def test_validate_tsl(default_conf):
     default_conf['stoploss'] = 0.0
-    with pytest.raises(OperationalException, match='The config stoploss needs to be more '
-                                                   'than 0 to avoid problems with sell orders.'):
+    with pytest.raises(OperationalException, match='The config stoploss needs to be different '
+                                                   'from 0 to avoid problems with sell orders.'):
         validate_config_consistency(default_conf)
     default_conf['stoploss'] = -0.10
 
@@ -680,7 +680,7 @@ def test_validate_tsl(default_conf):
     default_conf['trailing_stop_positive_offset'] = 0.02
     default_conf['trailing_only_offset_is_reached'] = False
     with pytest.raises(OperationalException,
-                       match='The config trailing_stop_positive needs to be more than 0'
+                       match='The config trailing_stop_positive needs to be different from 0 '
                        'to avoid problems with sell orders'):
         validate_config_consistency(default_conf)
 


### PR DESCRIPTION
# Summary
Stoploss with 0 is problematic, since that would lead to sells immediately.

This should prevent the bog from starting up - otherwise it results in misleading bug reports (as #2171).

Solve the issue: #2171

## Quick changelog

- Validate stoploss_positive !=0 (it can be positive or negative, since we use `-1 * abs()` when applying this).
- validate stoploss != 0 (same `-1 * abs()` logic as before
