### PR TITLE
WiP: refactor exchange

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -6,12 +6,12 @@ Common Interface for bot and strategy to access data.
 """
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from pandas import DataFrame
 
 from freqtrade.data.history import load_pair_history
-from freqtrade.exchange import Exchange
+from freqtrade.exchange import Exchange, get_exchange
 from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
@@ -19,9 +19,9 @@ logger = logging.getLogger(__name__)
 
 class DataProvider():
 
-    def __init__(self, config: dict, exchange: Exchange) -> None:
+    def __init__(self, config: dict, exchange_name: Optional[str] = None) -> None:
         self._config = config
-        self._exchange = exchange
+        self._exchange: Exchange = get_exchange(config, exchange_name)
 
     def refresh(self,
                 pairlist: List[Tuple[str, str]],

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,4 +1,6 @@
 from freqtrade.exchange.exchange import Exchange  # noqa: F401
+from freqtrade.exchange.exchange import (get_exchange,  # noqa: F401
+                                         delete_exchange)
 from freqtrade.exchange.exchange import (get_exchange_bad_reason,  # noqa: F401
                                          is_exchange_bad,
                                          is_exchange_available,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -17,10 +17,10 @@ from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
 from freqtrade.configuration import validate_config_consistency
-from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
+from freqtrade.exchange import Exchange, get_exchange, timeframe_to_minutes, timeframe_to_next_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCManager, RPCMessageType
-from freqtrade.resolvers import ExchangeResolver, StrategyResolver, PairListResolver
+from freqtrade.resolvers import StrategyResolver, PairListResolver
 from freqtrade.state import State, RunMode
 from freqtrade.strategy.interface import SellType, IStrategy
 from freqtrade.wallets import Wallets
@@ -57,10 +57,10 @@ class FreqtradeBot(object):
 
         self.rpc: RPCManager = RPCManager(self)
 
-        self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
+        self.exchange: Exchange = get_exchange(self.config)
 
-        self.wallets = Wallets(self.config, self.exchange)
-        self.dataprovider = DataProvider(self.config, self.exchange)
+        self.wallets = Wallets(self.config)
+        self.dataprovider = DataProvider(self.config)
 
         # Attach Dataprovider to Strategy baseclass
         IStrategy.dp = self.dataprovider

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -10,7 +10,7 @@ from freqtrade import constants
 from freqtrade.edge import Edge
 
 from freqtrade.configuration import TimeRange
-from freqtrade.exchange import Exchange
+from freqtrade.exchange import Exchange, get_exchange
 from freqtrade.resolvers import StrategyResolver
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class EdgeCli(object):
         self.config['exchange']['uid'] = ''
         self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
         self.config['dry_run'] = True
-        self.exchange = Exchange(self.config)
+        self.exchange: Exchange = get_exchange(self.config)
         self.strategy = StrategyResolver(self.config).strategy
 
         self.edge = Edge(config, self.exchange, self.strategy)

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import pandas as pd
 
@@ -8,8 +8,9 @@ from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import (combine_tickers_with_mean,
                                        create_cum_profit, load_trades)
-from freqtrade.exchange import Exchange
-from freqtrade.resolvers import ExchangeResolver, StrategyResolver
+from freqtrade.exchange import Exchange, get_exchange
+from freqtrade.resolvers import StrategyResolver
+
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ try:
     from plotly.offline import plot
     import plotly.graph_objects as go
 except ImportError:
-    logger.exception("Module plotly not found \n Please install using `pip install plotly`")
+    logger.exception("Module plotly not found.\nPlease install using `pip install plotly`.")
     exit(1)
 
 
@@ -28,12 +29,11 @@ def init_plotscript(config):
     Initialize objects needed for plotting
     :return: Dict with tickers, trades, pairs and strategy
     """
-    exchange: Optional[Exchange] = None
+    exchange: Exchange = None
 
     # Exchange is only needed when downloading data!
     if config.get("refresh_pairs", False):
-        exchange = ExchangeResolver(config.get('exchange', {}).get('name'),
-                                    config).exchange
+        exchange = get_exchange(config)
 
     strategy = StrategyResolver(config).strategy
     if "pairs" in config:

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -3,7 +3,6 @@ This module loads custom exchanges
 """
 import logging
 
-from freqtrade.exchange import Exchange
 import freqtrade.exchange as exchanges
 from freqtrade.resolvers import IResolver
 
@@ -29,10 +28,10 @@ class ExchangeResolver(IResolver):
             logger.info(
                 f"No {exchange_name} specific subclass found. Using the generic class instead.")
         if not hasattr(self, "exchange"):
-            self.exchange = Exchange(config)
+            self.exchange = exchanges.Exchange(config)
 
     def _load_exchange(
-            self, exchange_name: str, kwargs: dict) -> Exchange:
+            self, exchange_name: str, kwargs: dict) -> exchanges.Exchange:
         """
         Loads the specified exchange.
         Only checks for exchanges exported in freqtrade.exchanges

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -14,7 +14,7 @@ def test_ohlcv(mocker, default_conf, ticker_history):
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
 
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.DRY_RUN
     assert ticker_history.equals(dp.ohlcv("UNITTEST/BTC", ticker_interval))
     assert isinstance(dp.ohlcv("UNITTEST/BTC", ticker_interval), DataFrame)
@@ -27,12 +27,12 @@ def test_ohlcv(mocker, default_conf, ticker_history):
     assert dp.ohlcv("UNITTEST/BTC", ticker_interval).equals(dp.ohlcv("UNITTEST/BTC"))
 
     default_conf["runmode"] = RunMode.LIVE
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.LIVE
     assert isinstance(dp.ohlcv("UNITTEST/BTC", ticker_interval), DataFrame)
 
     default_conf["runmode"] = RunMode.BACKTEST
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.BACKTEST
     assert dp.ohlcv("UNITTEST/BTC", ticker_interval).empty
 
@@ -41,7 +41,7 @@ def test_historic_ohlcv(mocker, default_conf, ticker_history):
     historymock = MagicMock(return_value=ticker_history)
     mocker.patch("freqtrade.data.dataprovider.load_pair_history", historymock)
 
-    dp = DataProvider(default_conf, None)
+    dp = DataProvider(default_conf)
     data = dp.historic_ohlcv("UNITTEST/BTC", "5m")
     assert isinstance(data, DataFrame)
     assert historymock.call_count == 1
@@ -57,7 +57,7 @@ def test_get_pair_dataframe(mocker, default_conf, ticker_history):
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
 
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.DRY_RUN
     assert ticker_history.equals(dp.get_pair_dataframe("UNITTEST/BTC", ticker_interval))
     assert isinstance(dp.get_pair_dataframe("UNITTEST/BTC", ticker_interval), DataFrame)
@@ -70,7 +70,7 @@ def test_get_pair_dataframe(mocker, default_conf, ticker_history):
                                  ticker_interval).equals(dp.get_pair_dataframe("UNITTEST/BTC"))
 
     default_conf["runmode"] = RunMode.LIVE
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.LIVE
     assert isinstance(dp.get_pair_dataframe("UNITTEST/BTC", ticker_interval), DataFrame)
     assert dp.get_pair_dataframe("NONESENSE/AAA", ticker_interval).empty
@@ -78,7 +78,7 @@ def test_get_pair_dataframe(mocker, default_conf, ticker_history):
     historymock = MagicMock(return_value=ticker_history)
     mocker.patch("freqtrade.data.dataprovider.load_pair_history", historymock)
     default_conf["runmode"] = RunMode.BACKTEST
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert dp.runmode == RunMode.BACKTEST
     assert isinstance(dp.get_pair_dataframe("UNITTEST/BTC", ticker_interval), DataFrame)
     # assert dp.get_pair_dataframe("NONESENSE/AAA", ticker_interval).empty
@@ -90,7 +90,7 @@ def test_available_pairs(mocker, default_conf, ticker_history):
     exchange._klines[("XRP/BTC", ticker_interval)] = ticker_history
     exchange._klines[("UNITTEST/BTC", ticker_interval)] = ticker_history
 
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     assert len(dp.available_pairs) == 2
     assert dp.available_pairs == [
         ("XRP/BTC", ticker_interval),
@@ -108,7 +108,7 @@ def test_refresh(mocker, default_conf, ticker_history):
 
     pairs_non_trad = [("ETH/USDT", ticker_interval), ("BTC/TUSD", "1h")]
 
-    dp = DataProvider(default_conf, exchange)
+    dp = DataProvider(default_conf)
     dp.refresh(pairs)
 
     assert refresh_mock.call_count == 1

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -9,8 +9,7 @@ import arrow
 from freqtrade.configuration import Configuration, TimeRange
 from freqtrade.configuration.directory_operations import create_userdata_dir
 from freqtrade.data.history import download_pair_history
-from freqtrade.exchange import available_exchanges
-from freqtrade.resolvers import ExchangeResolver
+from freqtrade.exchange import Exchange, get_exchange, available_exchanges
 from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
@@ -79,7 +78,7 @@ def start_download_data(args: Namespace) -> None:
 
     try:
         # Init exchange
-        exchange = ExchangeResolver(config['exchange']['name'], config).exchange
+        exchange: Exchange = get_exchange(config)
 
         for pair in config["pairs"]:
             if pair not in exchange.markets:

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -2,8 +2,8 @@
 """ Wallet """
 
 import logging
-from typing import Dict, NamedTuple
-from freqtrade.exchange import Exchange
+from typing import Dict, NamedTuple, Optional
+from freqtrade.exchange import Exchange, get_exchange
 from freqtrade import constants
 
 logger = logging.getLogger(__name__)
@@ -19,9 +19,9 @@ class Wallet(NamedTuple):
 
 class Wallets(object):
 
-    def __init__(self, config: dict, exchange: Exchange) -> None:
+    def __init__(self, config: dict, exchange_name: Optional[str] = None) -> None:
         self._config = config
-        self._exchange = exchange
+        self._exchange_name = exchange_name
         self._wallets: Dict[str, Wallet] = {}
 
         self.update()
@@ -61,7 +61,8 @@ class Wallets(object):
 
     def update(self) -> None:
 
-        balances = self._exchange.get_balances()
+        exchange: Exchange = get_exchange(self._config, self._exchange_name)
+        balances = exchange.get_balances()
 
         for currency in balances:
             self._wallets[currency] = Wallet(


### PR DESCRIPTION
This PR moves created exchange instances to a kind of singleton (python's modules are singletons) or a factory, with an easy way to fetch the exchange where it's needed:

```
exchange: Exchange = get_exchange(config, exchange_name)
```
or even
```
exchange: Exchange = get_exchange(config)
```
(the exchange name will be taken from the config)

* Exchange objects are created on-demand.
* Simplifies interfaces (see DataProvider and Wallet). There is not need to keep the `self.exchanges` attribute at all (Wallet) or pass exchange to the init (DataProvider).
* Hides ExchangeResolver, no need to call it or create exchange explicitly as `Exchange()`
* Resolves pickling problems in hyperopt (no need to delete the exchange before start of the workers processes). It probably would allow using dataprovider under hyperopt (need to check).
* exchanges are kept in a dict, this is a provisionary solution. It will allow in the future create Exchange objects for other exchanges (for informative pairs from other exchanges, with syntax like `OTHEREXCHANGE:XXX/YYY`), allowing inter-exchange arbitrage strategies...
* in the previous version I tried to implement it in a sep. `class Exchanges` in a sep. `exchanges.py` module under exchange dir, but python circular dependencies are awful...

Huh? (You may not like it since 'explicit is better than implicit' but...)
