### PR TITLE
[refactor] Move stoploss on exchange implementation to binance

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -11,7 +11,7 @@ class DependencyException(Exception):
 
 class OperationalException(Exception):
     """
-    Requires manual intervention.
+    Requires manual intervention and will usually stop the bot.
     This happens when an exchange returns an unexpected error during runtime
     or given configuration is invalid.
     """

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -2,6 +2,9 @@
 import logging
 from typing import Dict
 
+import ccxt
+
+from freqtrade import DependencyException, OperationalException, TemporaryError
 from freqtrade.exchange import Exchange
 
 logger = logging.getLogger(__name__)
@@ -25,3 +28,52 @@ class Binance(Exchange):
         limit = min(list(filter(lambda x: limit <= x, limit_range)))
 
         return super().get_order_book(pair, limit)
+
+    def stoploss_limit(self, pair: str, amount: float, stop_price: float, rate: float) -> Dict:
+        """
+        creates a stoploss limit order.
+        this stoploss-limit is binance-specific.
+        It may work with a limited number of other exchanges, but this has not been tested yet.
+
+        """
+        ordertype = "stop_loss_limit"
+
+        stop_price = self.symbol_price_prec(pair, stop_price)
+
+        # Ensure rate is less than stop price
+        if stop_price <= rate:
+            raise OperationalException(
+                'In stoploss limit order, stop price should be more than limit price')
+
+        if self._config['dry_run']:
+            dry_order = self.dry_run_order(
+                pair, ordertype, "sell", amount, stop_price)
+            return dry_order
+
+        params = self._params.copy()
+        params.update({'stopPrice': stop_price})
+        try:
+            amount = self.symbol_amount_prec(pair, amount)
+
+            rate = self.symbol_price_prec(pair, rate)
+
+            order = self._api.create_order(pair, ordertype, 'sell',
+                                           amount, rate, params)
+            logger.info('stoploss limit order added for %s. '
+                        'stop price: %s. limit: %s', pair, stop_price, rate)
+            return order
+        except ccxt.InsufficientFunds as e:
+            raise DependencyException(
+                f'Insufficient funds to create {ordertype} sell order on market {pair}.'
+                f'Tried to sell amount {amount} at rate {rate}.'
+                f'Message: {e}') from e
+        except ccxt.InvalidOrder as e:
+            raise DependencyException(
+                f'Could not create {ordertype} sell order on market {pair}. '
+                f'Tried to sell amount {amount} at rate {rate}.'
+                f'Message: {e}') from e
+        except (ccxt.NetworkError, ccxt.ExchangeError) as e:
+            raise TemporaryError(
+                f'Could not place sell order due to {e.__class__.__name__}. Message: {e}') from e
+        except ccxt.BaseError as e:
+            raise OperationalException(e) from e

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -50,9 +50,10 @@ class Binance(Exchange):
                 pair, ordertype, "sell", amount, stop_price)
             return dry_order
 
-        params = self._params.copy()
-        params.update({'stopPrice': stop_price})
         try:
+            params = self._params.copy()
+            params.update({'stopPrice': stop_price})
+
             amount = self.symbol_amount_prec(pair, amount)
 
             rate = self.symbol_price_prec(pair, rate)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -470,7 +470,12 @@ class Exchange(object):
         params = self._params.copy()
         params.update({'stopPrice': stop_price})
         try:
-            order = self.create_order(pair, ordertype, 'sell', amount, rate, params)
+            amount = self.symbol_amount_prec(pair, amount)
+
+            rate = self.symbol_price_prec(pair, rate)
+
+            order = self._api.create_order(pair, ordertype, 'sell',
+                                           amount, rate, params)
             logger.info('stoploss limit order added for %s. '
                         'stop price: %s. limit: %s', pair, stop_price, rate)
             return order

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -457,7 +457,7 @@ class Exchange(object):
         Note: Changes to this interface need to be applied to all sub-classes too.
         """
 
-        raise OperationalException(f"stoploss_limit not implemented for {self.name}.")
+        raise OperationalException(f"stoploss_limit is not implemented for {self.name}.")
 
     @retrier
     def get_balance(self, currency: str) -> float:

--- a/freqtrade/tests/exchange/test_binance.py
+++ b/freqtrade/tests/exchange/test_binance.py
@@ -1,0 +1,90 @@
+from random import randint
+from unittest.mock import MagicMock
+
+import ccxt
+import pytest
+
+from freqtrade import DependencyException, OperationalException, TemporaryError
+from freqtrade.tests.conftest import get_patched_exchange
+
+
+def test_stoploss_limit_order(default_conf, mocker):
+    api_mock = MagicMock()
+    order_id = 'test_prod_buy_{}'.format(randint(0, 10 ** 6))
+    order_type = 'stop_loss_limit'
+
+    api_mock.create_order = MagicMock(return_value={
+        'id': order_id,
+        'info': {
+            'foo': 'bar'
+        }
+    })
+
+    default_conf['dry_run'] = False
+    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+
+    with pytest.raises(OperationalException):
+        order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=190, rate=200)
+
+    api_mock.create_order.reset_mock()
+
+    order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+    assert 'id' in order
+    assert 'info' in order
+    assert order['id'] == order_id
+    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
+    assert api_mock.create_order.call_args[0][1] == order_type
+    assert api_mock.create_order.call_args[0][2] == 'sell'
+    assert api_mock.create_order.call_args[0][3] == 1
+    assert api_mock.create_order.call_args[0][4] == 200
+    assert api_mock.create_order.call_args[0][5] == {'stopPrice': 220}
+
+    # test exception handling
+    with pytest.raises(DependencyException):
+        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds("0 balance"))
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+    with pytest.raises(DependencyException):
+        api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder("Order not found"))
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+    with pytest.raises(TemporaryError):
+        api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError("No connection"))
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+    with pytest.raises(OperationalException, match=r".*DeadBeef.*"):
+        api_mock.create_order = MagicMock(side_effect=ccxt.BaseError("DeadBeef"))
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+
+def test_stoploss_limit_order_dry_run(default_conf, mocker):
+    api_mock = MagicMock()
+    order_type = 'stop_loss_limit'
+    default_conf['dry_run'] = True
+    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+
+    with pytest.raises(OperationalException):
+        order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=190, rate=200)
+
+    api_mock.create_order.reset_mock()
+
+    order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+    assert 'id' in order
+    assert 'info' in order
+    assert 'type' in order
+
+    assert order['type'] == order_type
+    assert order['price'] == 220
+    assert order['amount'] == 1

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1436,62 +1436,6 @@ def test_get_fee(default_conf, mocker, exchange_name):
                            'get_fee', 'calculate_fee')
 
 
-def test_stoploss_limit_order(default_conf, mocker):
-    api_mock = MagicMock()
-    order_id = 'test_prod_buy_{}'.format(randint(0, 10 ** 6))
-    order_type = 'stop_loss_limit'
-
-    api_mock.create_order = MagicMock(return_value={
-        'id': order_id,
-        'info': {
-            'foo': 'bar'
-        }
-    })
-
-    default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
-
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
-
-    with pytest.raises(OperationalException):
-        order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=190, rate=200)
-
-    api_mock.create_order.reset_mock()
-
-    order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-    assert 'id' in order
-    assert 'info' in order
-    assert order['id'] == order_id
-    assert api_mock.create_order.call_args[0][0] == 'ETH/BTC'
-    assert api_mock.create_order.call_args[0][1] == order_type
-    assert api_mock.create_order.call_args[0][2] == 'sell'
-    assert api_mock.create_order.call_args[0][3] == 1
-    assert api_mock.create_order.call_args[0][4] == 200
-    assert api_mock.create_order.call_args[0][5] == {'stopPrice': 220}
-
-    # test exception handling
-    with pytest.raises(DependencyException):
-        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds("0 balance"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
-        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-    with pytest.raises(DependencyException):
-        api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder("Order not found"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
-        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-    with pytest.raises(TemporaryError):
-        api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError("No connection"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
-        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-    with pytest.raises(OperationalException):
-        api_mock.create_order = MagicMock(side_effect=ccxt.BaseError("DeadBeef"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock)
-        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
 
 def test_stoploss_limit_order_unsupported_exchange(default_conf, mocker):
     exchange = get_patched_exchange(mocker, default_conf, 'bittrex')
@@ -1499,29 +1443,7 @@ def test_stoploss_limit_order_unsupported_exchange(default_conf, mocker):
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
 
 
-def test_stoploss_limit_order_dry_run(default_conf, mocker):
-    api_mock = MagicMock()
-    order_type = 'stop_loss_limit'
-    default_conf['dry_run'] = True
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
 
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
-
-    with pytest.raises(OperationalException):
-        order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=190, rate=200)
-
-    api_mock.create_order.reset_mock()
-
-    order = exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-    assert 'id' in order
-    assert 'info' in order
-    assert 'type' in order
-
-    assert order['type'] == order_type
-    assert order['price'] == 220
-    assert order['amount'] == 1
 
 
 def test_merge_ft_has_dict(default_conf, mocker):

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1474,22 +1474,28 @@ def test_stoploss_limit_order(default_conf, mocker):
     # test exception handling
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds("0 balance"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock)
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
 
     with pytest.raises(DependencyException):
         api_mock.create_order = MagicMock(side_effect=ccxt.InvalidOrder("Order not found"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock)
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
 
     with pytest.raises(TemporaryError):
         api_mock.create_order = MagicMock(side_effect=ccxt.NetworkError("No connection"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock)
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
 
     with pytest.raises(OperationalException):
         api_mock.create_order = MagicMock(side_effect=ccxt.BaseError("DeadBeef"))
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
+        exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
+
+
+def test_stoploss_limit_order_unsupported_exchange(default_conf, mocker):
+    exchange = get_patched_exchange(mocker, default_conf, 'bittrex')
+    with pytest.raises(OperationalException, match=r"stoploss_limit is not implemented .*"):
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
 
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -101,16 +101,19 @@ def test_destroy(default_conf, mocker, caplog):
 def test_init_exception(default_conf, mocker):
     default_conf['exchange']['name'] = 'wrong_exchange_name'
 
-    with pytest.raises(
-            OperationalException,
-            match='Exchange {} is not supported'.format(default_conf['exchange']['name'])):
+    with pytest.raises(OperationalException,
+                       match=f"Exchange {default_conf['exchange']['name']} is not supported"):
         Exchange(default_conf)
 
     default_conf['exchange']['name'] = 'binance'
-    with pytest.raises(
-            OperationalException,
-            match='Exchange {} is not supported'.format(default_conf['exchange']['name'])):
+    with pytest.raises(OperationalException,
+                       match=f"Exchange {default_conf['exchange']['name']} is not supported"):
         mocker.patch("ccxt.binance", MagicMock(side_effect=AttributeError))
+        Exchange(default_conf)
+
+    with pytest.raises(OperationalException,
+                       match=r"Initialization of ccxt failed. Reason: DeadBeef"):
+        mocker.patch("ccxt.binance", MagicMock(side_effect=ccxt.BaseError("DeadBeef")))
         Exchange(default_conf)
 
 
@@ -1436,14 +1439,10 @@ def test_get_fee(default_conf, mocker, exchange_name):
                            'get_fee', 'calculate_fee')
 
 
-
 def test_stoploss_limit_order_unsupported_exchange(default_conf, mocker):
     exchange = get_patched_exchange(mocker, default_conf, 'bittrex')
     with pytest.raises(OperationalException, match=r"stoploss_limit is not implemented .*"):
         exchange.stoploss_limit(pair='ETH/BTC', amount=1, stop_price=220, rate=200)
-
-
-
 
 
 def test_merge_ft_has_dict(default_conf, mocker):

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -2414,7 +2414,7 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
 
     mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
     mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.stoploss_limit', stoploss_limit)
+    mocker.patch('freqtrade.exchange.Binance.stoploss_limit', stoploss_limit)
 
     freqtrade = FreqtradeBot(default_conf)
     freqtrade.strategy.order_types['stoploss_on_exchange'] = True
@@ -2454,7 +2454,6 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
     freqtrade.process_maybe_execute_sell(trade)
     assert trade.stoploss_order_id is None
     assert trade.is_open is False
-    print(trade.sell_reason)
     assert trade.sell_reason == SellType.STOPLOSS_ON_EXCHANGE.value
     assert rpc_mock.call_count == 2
 


### PR DESCRIPTION
## Summary
Stoploss on exchange is currently only supported by binance, and the code is binance-specific, therefore we should move the implementation to the binance subclass.

We also should not use `self.create_order()` for this case, since we need to handle `InvalidOrder` exceptions differently (in a future PR) - probably by force-selling the pair.

Note: There is no functional change in this PR, so nothing will improve for users, but it enables #1557

## Quick changelog

- Move implementation to binance subclass
- some minor maintenance in exchange class
- Improve docstring for OperationalException 
- move corresponding tests to newly created `test_binance.py` 
