### PR TITLE
[minor] Use ccxt methods to round timeframe

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import arrow
 import ccxt
 import ccxt.async_support as ccxt_async
+from ccxt.base.decimal_to_precision import ROUND_UP, ROUND_DOWN
 from pandas import DataFrame
 
 from freqtrade import (DependencyException, InvalidOrderException,
@@ -824,11 +825,9 @@ def timeframe_to_prev_date(timeframe: str, date: datetime = None) -> datetime:
     """
     if not date:
         date = datetime.now(timezone.utc)
-    timeframe_secs = timeframe_to_seconds(timeframe)
-    # Get offset based on timerame_secs
-    offset = date.timestamp() % timeframe_secs
-    # Subtract seconds passed since last offset
-    new_timestamp = date.timestamp() - offset
+
+    new_timestamp = ccxt.Exchange.round_timeframe(timeframe, date.timestamp() * 1000,
+                                                  ROUND_DOWN) // 1000
     return datetime.fromtimestamp(new_timestamp, tz=timezone.utc)
 
 
@@ -839,9 +838,8 @@ def timeframe_to_next_date(timeframe: str, date: datetime = None) -> datetime:
     :param date: date to use. Defaults to utcnow()
     :returns: date of next candle (with utc timezone)
     """
-    prevdate = timeframe_to_prev_date(timeframe, date)
-    timeframe_secs = timeframe_to_seconds(timeframe)
-
-    # Add one interval to previous candle
-    new_timestamp = prevdate.timestamp() + timeframe_secs
+    if not date:
+        date = datetime.now(timezone.utc)
+    new_timestamp = ccxt.Exchange.round_timeframe(timeframe, date.timestamp() * 1000,
+                                                  ROUND_UP) // 1000
     return datetime.fromtimestamp(new_timestamp, tz=timezone.utc)

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1604,7 +1604,7 @@ def test_timeframe_to_prev_date():
         assert timeframe_to_prev_date(interval, date) == result
 
     date = datetime.now(tz=timezone.utc)
-    assert timeframe_to_prev_date("5m", date) < date
+    assert timeframe_to_prev_date("5m") < date
 
 
 def test_timeframe_to_next_date():
@@ -1629,4 +1629,4 @@ def test_timeframe_to_next_date():
         assert timeframe_to_next_date(interval, date) == result
 
     date = datetime.now(tz=timezone.utc)
-    assert timeframe_to_next_date("5m", date) > date
+    assert timeframe_to_next_date("5m") > date

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,6 +1,6 @@
 # requirements without requirements installable via conda
 # mainly used for Raspberry pi installs
-ccxt==1.18.1068
+ccxt==1.18.1084
 SQLAlchemy==1.3.7
 python-telegram-bot==11.1.0
 arrow==0.14.5

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='freqtrade',
       tests_require=['pytest', 'pytest-mock', 'pytest-cov'],
       install_requires=[
           # from requirements-common.txt
-          'ccxt>=1.18',
+          'ccxt>=1.18.1080',
           'SQLAlchemy',
           'python-telegram-bot',
           'arrow',
@@ -76,7 +76,7 @@ setup(name='freqtrade',
           'plot': plot,
           'all': all_extra,
           'jupyter': jupyter,
-          
+
       },
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
## Summary
Since round_timeframe has been added to ccxt, we can rely on that instead of reimplementing the calculation.
