### PR TITLE
[Refactor] Logic for download-data to history

### DIFF
--- a/freqtrade/tests/test_utils.py
+++ b/freqtrade/tests/test_utils.py
@@ -1,5 +1,4 @@
 import re
-from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
@@ -70,74 +69,8 @@ def test_create_datadir(caplog, mocker):
     assert len(caplog.record_tuples) == 0
 
 
-def test_download_data(mocker, markets, caplog):
-    dl_mock = mocker.patch('freqtrade.utils.download_pair_history', MagicMock())
-    patch_exchange(mocker)
-    mocker.patch(
-        'freqtrade.exchange.Exchange.markets', PropertyMock(return_value=markets)
-    )
-    mocker.patch.object(Path, "exists", MagicMock(return_value=True))
-    mocker.patch.object(Path, "unlink", MagicMock())
-
-    args = [
-        "download-data",
-        "--exchange", "binance",
-        "--pairs", "ETH/BTC", "XRP/BTC",
-        "--erase",
-    ]
-    start_download_data(get_args(args))
-
-    assert dl_mock.call_count == 4
-    assert dl_mock.call_args[1]['timerange'].starttype is None
-    assert dl_mock.call_args[1]['timerange'].stoptype is None
-    assert log_has("Deleting existing data for pair ETH/BTC, interval 1m.", caplog)
-    assert log_has("Downloading pair ETH/BTC, interval 1m.", caplog)
-
-
-def test_download_data_days(mocker, markets, caplog):
-    dl_mock = mocker.patch('freqtrade.utils.download_pair_history', MagicMock())
-    patch_exchange(mocker)
-    mocker.patch(
-        'freqtrade.exchange.Exchange.markets', PropertyMock(return_value=markets)
-    )
-    mocker.patch.object(Path, "exists", MagicMock(return_value=True))
-    mocker.patch.object(Path, "unlink", MagicMock())
-
-    args = [
-        "download-data",
-        "--exchange", "binance",
-        "--pairs", "ETH/BTC", "XRP/BTC",
-        "--days", "20",
-    ]
-
-    start_download_data(get_args(args))
-
-    assert dl_mock.call_count == 4
-    assert dl_mock.call_args[1]['timerange'].starttype == 'date'
-
-    assert log_has("Downloading pair ETH/BTC, interval 1m.", caplog)
-
-
-def test_download_data_no_markets(mocker, caplog):
-    dl_mock = mocker.patch('freqtrade.utils.download_pair_history', MagicMock())
-    patch_exchange(mocker)
-    mocker.patch(
-        'freqtrade.exchange.Exchange.markets', PropertyMock(return_value={})
-    )
-    args = [
-        "download-data",
-        "--exchange", "binance",
-        "--pairs", "ETH/BTC", "XRP/BTC",
-    ]
-    start_download_data(get_args(args))
-
-    assert dl_mock.call_count == 0
-    assert log_has("Skipping pair ETH/BTC...", caplog)
-    assert log_has("Pairs [ETH/BTC,XRP/BTC] not available on exchange binance.", caplog)
-
-
 def test_download_data_keyboardInterrupt(mocker, caplog, markets):
-    dl_mock = mocker.patch('freqtrade.utils.download_pair_history',
+    dl_mock = mocker.patch('freqtrade.utils.refresh_backtest_ohlcv_data',
                            MagicMock(side_effect=KeyboardInterrupt))
     patch_exchange(mocker)
     mocker.patch(
@@ -152,3 +85,21 @@ def test_download_data_keyboardInterrupt(mocker, caplog, markets):
         start_download_data(get_args(args))
 
     assert dl_mock.call_count == 1
+
+
+def test_download_data_no_markets(mocker, caplog):
+    dl_mock = mocker.patch('freqtrade.utils.refresh_backtest_ohlcv_data',
+                           MagicMock(return_value=["ETH/BTC", "XRP/BTC"]))
+    patch_exchange(mocker)
+    mocker.patch(
+        'freqtrade.exchange.Exchange.markets', PropertyMock(return_value={})
+    )
+    args = [
+        "download-data",
+        "--exchange", "binance",
+        "--pairs", "ETH/BTC", "XRP/BTC",
+        "--days", "20"
+    ]
+    start_download_data(get_args(args))
+    assert dl_mock.call_args[1]['timerange'].starttype == "date"
+    assert log_has("Pairs [ETH/BTC,XRP/BTC] not available on exchange binance.", caplog)


### PR DESCRIPTION
## Summary
This will simplify the logic in `utils.py`.

Main reason is preparational work for #2134 (trying to keep that PR as small as possible by extracting some needed refactorings).

## Quick changelog

- introduce `refresh_backtest_ohlcv_data()` which is used by download-data
- move tests to test_history.py
