### PR TITLE
[minor] Don't escape ticks where it's not needed

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -216,7 +216,7 @@ class FreqtradeBot(object):
         if stake_amount == constants.UNLIMITED_STAKE_AMOUNT:
             open_trades = len(Trade.get_open_trades())
             if open_trades >= self.config['max_open_trades']:
-                logger.warning('Can\'t open a new trade: max number of trades is reached')
+                logger.warning("Can't open a new trade: max number of trades is reached")
                 return None
             return available_amount / (self.config['max_open_trades'] - open_trades)
 
@@ -351,8 +351,8 @@ class FreqtradeBot(object):
         min_stake_amount = self._get_min_pair_stake_amount(pair_s, buy_limit_requested)
         if min_stake_amount is not None and min_stake_amount > stake_amount:
             logger.warning(
-                f'Can\'t open a new trade for {pair_s}: stake amount '
-                f'is too small ({stake_amount} < {min_stake_amount})'
+                f"Can't open a new trade for {pair_s}: stake amount "
+                f"is too small ({stake_amount} < {min_stake_amount})"
             )
             return False
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -124,14 +124,14 @@ class Hyperopt:
         Save hyperopt trials to file
         """
         if self.trials:
-            logger.info('Saving %d evaluations to \'%s\'', len(self.trials), self.trials_file)
+            logger.info("Saving %d evaluations to '%s'", len(self.trials), self.trials_file)
             dump(self.trials, self.trials_file)
 
     def read_trials(self) -> List:
         """
         Read hyperopt trials file
         """
-        logger.info('Reading Trials from \'%s\'', self.trials_file)
+        logger.info("Reading Trials from '%s'", self.trials_file)
         trials = load(self.trials_file)
         self.trials_file.unlink()
         return trials
@@ -379,7 +379,7 @@ class Hyperopt:
         self.load_previous_results()
 
         cpus = cpu_count()
-        logger.info(f'Found {cpus} CPU cores. Let\'s make them scream!')
+        logger.info(f"Found {cpus} CPU cores. Let's make them scream!")
         config_jobs = self.config.get('hyperopt_jobs', -1)
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -48,8 +48,8 @@ def init(db_url: str, clean_open_orders: bool = False) -> None:
     try:
         engine = create_engine(db_url, **kwargs)
     except NoSuchModuleError:
-        raise OperationalException(f'Given value for db_url: \'{db_url}\' '
-                                   f'is no valid database URL! (See {_SQL_DOCS_URL})')
+        raise OperationalException(f"Given value for db_url: '{db_url}' "
+                                   f"is no valid database URL! (See {_SQL_DOCS_URL})")
 
     session = scoped_session(sessionmaker(bind=engine, autoflush=True, autocommit=True))
     Trade.session = session()

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -381,7 +381,7 @@ def test_save_trials_saves_trials(mocker, hyperopt, caplog) -> None:
     hyperopt.save_trials()
 
     trials_file = os.path.join('freqtrade', 'tests', 'optimize', 'ut_trials.pickle')
-    assert log_has('Saving 1 evaluations to \'{}\''.format(trials_file), caplog)
+    assert log_has("Saving 1 evaluations to '{}'".format(trials_file), caplog)
     mock_dump.assert_called_once()
 
 
@@ -390,7 +390,7 @@ def test_read_trials_returns_trials_file(mocker, hyperopt, caplog) -> None:
     mock_load = mocker.patch('freqtrade.optimize.hyperopt.load', return_value=trials)
     hyperopt_trial = hyperopt.read_trials()
     trials_file = os.path.join('freqtrade', 'tests', 'optimize', 'ut_trials.pickle')
-    assert log_has('Reading Trials from \'{}\''.format(trials_file), caplog)
+    assert log_has("Reading Trials from '{}'".format(trials_file), caplog)
     assert hyperopt_trial == trials
     mock_load.assert_called_once()
 

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -41,14 +41,14 @@ def test_load_config_invalid_pair(default_conf) -> None:
 def test_load_config_missing_attributes(default_conf) -> None:
     default_conf.pop('exchange')
 
-    with pytest.raises(ValidationError, match=r'.*\'exchange\' is a required property.*'):
+    with pytest.raises(ValidationError, match=r".*'exchange' is a required property.*"):
         validate_config_schema(default_conf)
 
 
 def test_load_config_incorrect_stake_amount(default_conf) -> None:
     default_conf['stake_amount'] = 'fake'
 
-    with pytest.raises(ValidationError, match=r'.*\'fake\' does not match \'unlimited\'.*'):
+    with pytest.raises(ValidationError, match=r".*'fake' does not match 'unlimited'.*"):
         validate_config_schema(default_conf)
 
 
@@ -472,7 +472,7 @@ def test_hyperopt_with_arguments(mocker, default_conf, caplog) -> None:
 
     assert 'spaces' in config
     assert config['spaces'] == ['all']
-    assert log_has('Parameter -s/--spaces detected: [\'all\']', caplog)
+    assert log_has("Parameter -s/--spaces detected: ['all']", caplog)
     assert "runmode" in config
     assert config['runmode'] == RunMode.HYPEROPT
 
@@ -722,7 +722,7 @@ def test_load_config_default_exchange(all_conf) -> None:
     assert 'exchange' not in all_conf
 
     with pytest.raises(ValidationError,
-                       match=r'\'exchange\' is a required property'):
+                       match=r"'exchange' is a required property"):
         validate_config_schema(all_conf)
 
 
@@ -736,7 +736,7 @@ def test_load_config_default_exchange_name(all_conf) -> None:
     assert 'name' not in all_conf['exchange']
 
     with pytest.raises(ValidationError,
-                       match=r'\'name\' is a required property'):
+                       match=r"'name' is a required property"):
         validate_config_schema(all_conf)
 
 


### PR DESCRIPTION
## Summary
We shouldn't escape `'` in strings if we can use double-quotes as string-delimiters

