### PR TITLE
minor: Backtesting cleanup

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -64,6 +64,12 @@ class Backtesting(object):
         self.config['dry_run'] = True
         self.strategylist: List[IStrategy] = []
 
+        if "ticker_interval" not in self.config:
+            raise OperationalException("Ticker-interval needs to be set in either configuration "
+                                       "or as cli argument `--ticker-interval 5m`")
+        self.ticker_interval = str(self.config.get('ticker_interval'))
+        self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)
+
         self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
         self.fee = self.exchange.get_fee()
 
@@ -89,12 +95,6 @@ class Backtesting(object):
         Load strategy into backtesting
         """
         self.strategy = strategy
-        if "ticker_interval" not in self.config:
-            raise OperationalException("Ticker-interval needs to be set in either configuration "
-                                       "or as cli argument `--ticker-interval 5m`")
-
-        self.ticker_interval = self.config.get('ticker_interval')
-        self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)
         self.advise_buy = strategy.advise_buy
         self.advise_sell = strategy.advise_sell
         # Set stoploss_on_exchange to false for backtesting,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -64,12 +64,6 @@ class Backtesting(object):
         self.config['dry_run'] = True
         self.strategylist: List[IStrategy] = []
 
-        if "ticker_interval" not in self.config:
-            raise OperationalException("Ticker-interval needs to be set in either configuration "
-                                       "or as cli argument `--ticker-interval 5m`")
-        self.ticker_interval = str(self.config.get('ticker_interval'))
-        self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)
-
         self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
         self.fee = self.exchange.get_fee()
 
@@ -86,6 +80,12 @@ class Backtesting(object):
         else:
             # No strategy list specified, only one strategy
             self.strategylist.append(StrategyResolver(self.config).strategy)
+
+        if "ticker_interval" not in self.config:
+            raise OperationalException("Ticker-interval needs to be set in either configuration "
+                                       "or as cli argument `--ticker-interval 5m`")
+        self.ticker_interval = str(self.config.get('ticker_interval'))
+        self.ticker_interval_mins = timeframe_to_minutes(self.ticker_interval)
 
         # Load one (first) strategy
         self._set_strategy(self.strategylist[0])


### PR DESCRIPTION
Small optimization in Backtesting: move initialization of `self.ticker_interval` from `_set_strategy` method to `__init__()`. It's not taken from the strategy attribute and required to be set in the config/options.
