### PR TITLE
Rename testStrategy to sample_strategy

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -79,18 +79,18 @@ freqtrade backtesting --datadir user_data/data/bittrex-20180101
 #### With a (custom) strategy file
 
 ```bash
-freqtrade -s TestStrategy backtesting
+freqtrade -s SampleStrategy backtesting
 ```
 
-Where `-s TestStrategy` refers to the class name within the strategy file `test_strategy.py` found in the `freqtrade/user_data/strategies` directory.
+Where `-s SampleStrategy` refers to the class name within the strategy file `sample_strategy.py` found in the `freqtrade/user_data/strategies` directory.
 
 #### Comparing multiple Strategies
 
 ```bash
-freqtrade backtesting --strategy-list TestStrategy1 AwesomeStrategy --ticker-interval 5m
+freqtrade backtesting --strategy-list SampleStrategy1 AwesomeStrategy --ticker-interval 5m
 ```
 
-Where `TestStrategy1` and `AwesomeStrategy` refer to class names of strategies.
+Where `SampleStrategy1` and `AwesomeStrategy` refer to class names of strategies.
 
 #### Exporting trades to file
 
@@ -103,7 +103,7 @@ The exported trades can be used for [further analysis](#further-backtest-result-
 #### Exporting trades to file specifying a custom filename
 
 ```bash
-freqtrade backtesting --export trades --export-filename=backtest_teststrategy.json
+freqtrade backtesting --export trades --export-filename=backtest_samplestrategy.json
 ```
 
 #### Running backtest with smaller testset

--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -139,7 +139,7 @@ You can override strategy settings as demonstrated below.
 # Define some constants
 ticker_interval = "5m"
 # Name of the strategy class
-strategy_name = 'TestStrategy'
+strategy_name = 'SampleStrategy'
 # Path to user data
 user_data_dir = 'user_data'
 # Location of the strategy

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -24,7 +24,7 @@ strategy file will be updated on Github. Put your custom strategy file
 into the directory `user_data/strategies`.
 
 Best copy the test-strategy and modify this copy to avoid having bot-updates override your changes.
-`cp  user_data/strategies/test_strategy.py user_data/strategies/awesome-strategy.py`
+`cp  user_data/strategies/sample_strategy.py user_data/strategies/awesome-strategy.py`
 
 ### Anatomy of a strategy
 
@@ -36,14 +36,14 @@ A strategy file contains all the information needed to build a good strategy:
 - Minimal ROI recommended
 - Stoploss strongly recommended
 
-The bot also include a sample strategy called `TestStrategy` you can update: `user_data/strategies/test_strategy.py`.
-You can test it with the parameter: `--strategy TestStrategy`
+The bot also include a sample strategy called `SampleStrategy` you can update: `user_data/strategies/sample_strategy.py`.
+You can test it with the parameter: `--strategy SampleStrategy`
 
 ```bash
 freqtrade --strategy AwesomeStrategy
 ```
 
-**For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
+**For the following section we will use the [user_data/strategies/sample_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/sample_strategy.py)
 file as reference.**
 
 !!! Note Strategies and Backtesting
@@ -109,9 +109,8 @@ def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame
     return dataframe
 ```
 
-
 !!! Note "Want more indicator examples?"
-    Look into the [user_data/strategies/test_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/test_strategy.py).<br/>
+    Look into the [user_data/strategies/sample_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/sample_strategy.py).
     Then uncomment indicators you need.
 
 ### Buy signal rules
@@ -122,7 +121,7 @@ It's important to always return the dataframe without removing/modifying the col
 
 This will method will also define a new column, `"buy"`, which needs to contain 1 for buys, and 0 for "no action".
 
-Sample from `user_data/strategies/test_strategy.py`:
+Sample from `user_data/strategies/sample_strategy.py`:
 
 ```python
 def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
@@ -152,7 +151,7 @@ It's important to always return the dataframe without removing/modifying the col
 
 This will method will also define a new column, `"sell"`, which needs to contain 1 for sells, and 0 for "no action".
 
-Sample from `user_data/strategies/test_strategy.py`:
+Sample from `user_data/strategies/sample_strategy.py`:
 
 ```python
 def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -330,7 +330,7 @@ def test_backtesting_init_no_ticker_interval(mocker, default_conf, caplog) -> No
     patch_exchange(mocker)
     del default_conf['ticker_interval']
     default_conf['strategy_list'] = ['DefaultStrategy',
-                                     'TestStrategy']
+                                     'SampleStrategy']
 
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.5))
     with pytest.raises(OperationalException):
@@ -877,7 +877,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
         '--disable-max-market-positions',
         '--strategy-list',
         'DefaultStrategy',
-        'TestStrategy',
+        'SampleStrategy',
     ]
     args = get_args(args)
     start_backtesting(args)
@@ -898,7 +898,7 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog):
         'up to 2017-11-14T22:58:00+00:00 (0 days)..',
         'Parameter --enable-position-stacking detected ...',
         'Running backtesting for Strategy DefaultStrategy',
-        'Running backtesting for Strategy TestStrategy',
+        'Running backtesting for Strategy SampleStrategy',
     ]
 
     for line in exists:

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -254,7 +254,7 @@ def test_start_failure(mocker, default_conf, caplog) -> None:
 
     args = [
         '--config', 'config.json',
-        '--strategy', 'TestStrategy',
+        '--strategy', 'SampleStrategy',
         'hyperopt',
         '--epochs', '5'
     ]

--- a/freqtrade/tests/strategy/legacy_strategy.py
+++ b/freqtrade/tests/strategy/legacy_strategy.py
@@ -15,7 +15,7 @@ class TestStrategyLegacy(IStrategy):
     """
     This is a test strategy using the legacy function headers, which will be
     removed in a future update.
-    Please do not use this as a template, but refer to user_data/strategy/TestStrategy.py
+    Please do not use this as a template, but refer to user_data/strategy/sample_strategy.py
     for a uptodate version of this template.
 
     """

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -61,27 +61,27 @@ def test_search_strategy():
 
 
 def test_load_strategy(default_conf, result):
-    default_conf.update({'strategy': 'TestStrategy'})
+    default_conf.update({'strategy': 'SampleStrategy'})
     resolver = StrategyResolver(default_conf)
     assert 'adx' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 
 
 def test_load_strategy_base64(result, caplog, default_conf):
-    with open("user_data/strategies/test_strategy.py", "rb") as file:
+    with open("user_data/strategies/sample_strategy.py", "rb") as file:
         encoded_string = urlsafe_b64encode(file.read()).decode("utf-8")
-    default_conf.update({'strategy': 'TestStrategy:{}'.format(encoded_string)})
+    default_conf.update({'strategy': 'SampleStrategy:{}'.format(encoded_string)})
 
     resolver = StrategyResolver(default_conf)
     assert 'adx' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
     # Make sure strategy was loaded from base64 (using temp directory)!!
-    assert log_has_re(r"Using resolved strategy TestStrategy from '"
-                      + tempfile.gettempdir() + r"/.*/TestStrategy\.py'\.\.\.", caplog)
+    assert log_has_re(r"Using resolved strategy SampleStrategy from '"
+                      + tempfile.gettempdir() + r"/.*/SampleStrategy\.py'\.\.\.", caplog)
 
 
 def test_load_strategy_invalid_directory(result, caplog, default_conf):
     resolver = StrategyResolver(default_conf)
     extra_dir = Path.cwd() / 'some/path'
-    resolver._load_strategy('TestStrategy', config=default_conf, extra_dir=extra_dir)
+    resolver._load_strategy('SampleStrategy', config=default_conf, extra_dir=extra_dir)
 
     assert log_has_re(r'Path .*' + r'some.*path.*' + r'.* does not exist', caplog)
 

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -102,7 +102,7 @@ def test_parse_args_backtesting_custom() -> None:
         '--refresh-pairs-cached',
         '--strategy-list',
         'DefaultStrategy',
-        'TestStrategy'
+        'SampleStrategy'
         ]
     call_args = Arguments(args, '').get_parsed_arg()
     assert call_args.config == ['test_conf.json']

--- a/user_data/notebooks/strategy_analysis_example.ipynb
+++ b/user_data/notebooks/strategy_analysis_example.ipynb
@@ -52,7 +52,7 @@
     "# Define some constants\n",
     "ticker_interval = \"5m\"\n",
     "# Name of the strategy class\n",
-    "strategy_name = 'TestStrategy'\n",
+    "strategy_name = 'SampleStrategy'\n",
     "# Path to user data\n",
     "user_data_dir = 'user_data'\n",
     "# Location of the strategy\n",

--- a/user_data/strategies/sample_strategy.py
+++ b/user_data/strategies/sample_strategy.py
@@ -13,7 +13,7 @@ import numpy  # noqa
 # This class is a sample. Feel free to customize it.
 class SampleStrategy(IStrategy):
     """
-    This is an example strategy to inspire you.
+    This is a sample strategy to inspire you.
     More information in https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-optimization.md
 
     You can:

--- a/user_data/strategies/sample_strategy.py
+++ b/user_data/strategies/sample_strategy.py
@@ -11,10 +11,9 @@ import numpy  # noqa
 
 
 # This class is a sample. Feel free to customize it.
-class TestStrategy(IStrategy):
-    __test__ = False  # pytest expects to find tests here because of the name
+class SampleStrategy(IStrategy):
     """
-    This is a test strategy to inspire you.
+    This is an example strategy to inspire you.
     More information in https://github.com/freqtrade/freqtrade/blob/develop/docs/bot-optimization.md
 
     You can:
@@ -256,14 +255,14 @@ class TestStrategy(IStrategy):
         # Retrieve best bid and best ask
         # ------------------------------------
         """
-        # first check if dataprovider is available 
+        # first check if dataprovider is available
         if self.dp:
             if self.dp.runmode in ('live', 'dry_run'):
                 ob = self.dp.orderbook(metadata['pair'], 1)
                 dataframe['best_bid'] = ob['bids'][0][0]
                 dataframe['best_ask'] = ob['asks'][0][0]
         """
-        
+
         return dataframe
 
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:


### PR DESCRIPTION
## Summary
Having the name test_strategy can be misleading that this is the strategy which does only test but not use real money.

Also, renaming `TestStrategy` to `SampleStrategy`aligns it with the naming convention used for `Hyperopt`/`HyperoptLoss`.

NB: LInks will fail until merged, since they link to the develop-branch, where the file is not yet renamed.