### PR TITLE
Apply dynamic versioning to develop

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -5,8 +5,9 @@ if __version__ == 'develop':
 
     try:
         import subprocess
-        __version__ = str(subprocess.check_output(
-            ["git", "describe"], stderr=subprocess.DEVNULL).rstrip())
+        __version__ = 'develop-' + subprocess.check_output(
+            ['git', 'log', '--format="%h"', '-n 1'],
+            stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
     except Exception:
         # git not available, ignore
         pass

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,5 +1,15 @@
 """ FreqTrade bot """
-__version__ = '2019.7-dev'
+__version__ = 'develop'
+
+if __version__ == 'develop':
+
+    try:
+        import subprocess
+        __version__ = str(subprocess.check_output(
+            ["git", "describe"], stderr=subprocess.DEVNULL).rstrip())
+    except Exception:
+        # git not available, ignore
+        pass
 
 
 class DependencyException(Exception):


### PR DESCRIPTION
## Summary
We should use git commits as version for develop. This ensures that it's always uptodate, and we don't need to adjust the version in develop when we do a new relese.

closes #2166 

## Quick changelog

- use `git describe` to print version if we're on develop (`__version__` is develop
