### PR TITLE
Fix datadir init to always include exchange

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -160,6 +160,11 @@ class Configuration(object):
         Extract information for sys.argv and load directory configurations
         --user-data, --datadir
         """
+        # Check exchange parameter here - otherwise `datadir` might be wrong.
+        if "exchange" in self.args and self.args.exchange:
+            config['exchange']['name'] = self.args.exchange
+            logger.info(f"Using exchange {config['exchange']['name']}")
+
         if 'user_data_dir' in self.args and self.args.user_data_dir:
             config.update({'user_data_dir': self.args.user_data_dir})
         elif 'user_data_dir' not in config:
@@ -297,10 +302,6 @@ class Configuration(object):
         self._args_to_config(config, argname='days',
                              logstring='Detected --days: {}')
 
-        if "exchange" in self.args and self.args.exchange:
-            config['exchange']['name'] = self.args.exchange
-            logger.info(f"Using exchange {config['exchange']['name']}")
-
     def _process_runmode(self, config: Dict[str, Any]) -> None:
 
         if not self.runmode:
@@ -361,7 +362,7 @@ class Configuration(object):
             config['pairs'] = config.get('exchange', {}).get('pair_whitelist')
         else:
             # Fall back to /dl_path/pairs.json
-            pairs_file = Path(config['datadir']) / config['exchange']['name'].lower() / "pairs.json"
+            pairs_file = Path(config['datadir']) / "pairs.json"
             if pairs_file.exists():
                 with pairs_file.open('r') as f:
                     config['pairs'] = json_load(f)

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -4,6 +4,7 @@ This module contains the configuration class
 import logging
 import warnings
 from argparse import Namespace
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -56,7 +57,7 @@ class Configuration(object):
         config: Dict[str, Any] = {}
 
         if not files:
-            return constants.MINIMAL_CONFIG.copy()
+            return deepcopy(constants.MINIMAL_CONFIG)
 
         # We expect here a list of config filenames
         for path in files:

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -871,3 +871,4 @@ def test_pairlist_resolving_fallback(mocker):
 
     assert config['pairs'] == ['ETH/BTC', 'XRP/BTC']
     assert config['exchange']['name'] == 'binance'
+    assert config['datadir'] == str(Path.cwd() / "user_data/data/binance")


### PR DESCRIPTION
## Summary
When running `freqtrade download-data --exchange binance ` - the path needs to point to the final folder (incl. exchange). To accomplish this, `--exchange` needs to be parsed before setting datadir.
This also simplifies detecting the pair-list (wrongly fixed in #2168).

## Quick changelog

- Change argument resolution sequence to have exchange name available earlier
- test that running the bot with `--exchange binance` sets the correct path.
- Fix test-leakage (MINCONFIG was changed...) by not copying a dict properly.
