### PR TITLE
sending rpc messages should not stop the bot

### DIFF
--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -56,7 +56,10 @@ class RPCManager(object):
         logger.info('Sending rpc message: %s', msg)
         for mod in self.registered_modules:
             logger.debug('Forwarding message to rpc.%s', mod.name)
-            mod.send_msg(msg)
+            try:
+                mod.send_msg(msg)
+            except NotImplementedError:
+                logger.error(f"Message type {msg['type']} not implemented by handler {mod.name}.")
 
     def startup_messages(self, config, pairlist) -> None:
         if config.get('dry_run', False):

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -43,7 +43,9 @@ class Webhook(RPC):
                 valuedict = self._config['webhook'].get('webhookbuy', None)
             elif msg['type'] == RPCMessageType.SELL_NOTIFICATION:
                 valuedict = self._config['webhook'].get('webhooksell', None)
-            elif msg['type'] == RPCMessageType.STATUS_NOTIFICATION:
+            elif msg['type'] in(RPCMessageType.STATUS_NOTIFICATION,
+                                RPCMessageType.CUSTOM_NOTIFICATION,
+                                RPCMessageType.WARNING_NOTIFICATION):
                 valuedict = self._config['webhook'].get('webhookstatus', None)
             else:
                 raise NotImplementedError('Unknown message type: {}'.format(msg['type']))

--- a/freqtrade/tests/rpc/test_rpc_webhook.py
+++ b/freqtrade/tests/rpc/test_rpc_webhook.py
@@ -91,21 +91,24 @@ def test_send_msg(default_conf, mocker):
     assert (msg_mock.call_args[0][0]["value3"] ==
             default_conf["webhook"]["webhooksell"]["value3"].format(**msg))
 
-    # Test notification
-    msg = {
-        'type': RPCMessageType.STATUS_NOTIFICATION,
-        'status': 'Unfilled sell order for BTC cancelled due to timeout'
-    }
-    msg_mock = MagicMock()
-    mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
-    webhook.send_msg(msg)
-    assert msg_mock.call_count == 1
-    assert (msg_mock.call_args[0][0]["value1"] ==
-            default_conf["webhook"]["webhookstatus"]["value1"].format(**msg))
-    assert (msg_mock.call_args[0][0]["value2"] ==
-            default_conf["webhook"]["webhookstatus"]["value2"].format(**msg))
-    assert (msg_mock.call_args[0][0]["value3"] ==
-            default_conf["webhook"]["webhookstatus"]["value3"].format(**msg))
+    for msgtype in [RPCMessageType.STATUS_NOTIFICATION,
+                    RPCMessageType.WARNING_NOTIFICATION,
+                    RPCMessageType.CUSTOM_NOTIFICATION]:
+        # Test notification
+        msg = {
+            'type': msgtype,
+            'status': 'Unfilled sell order for BTC cancelled due to timeout'
+        }
+        msg_mock = MagicMock()
+        mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
+        webhook.send_msg(msg)
+        assert msg_mock.call_count == 1
+        assert (msg_mock.call_args[0][0]["value1"] ==
+                default_conf["webhook"]["webhookstatus"]["value1"].format(**msg))
+        assert (msg_mock.call_args[0][0]["value2"] ==
+                default_conf["webhook"]["webhookstatus"]["value2"].format(**msg))
+        assert (msg_mock.call_args[0][0]["value3"] ==
+                default_conf["webhook"]["webhookstatus"]["value3"].format(**msg))
 
 
 def test_exception_send_msg(default_conf, mocker, caplog):


### PR DESCRIPTION
## Summary
Catch `NotImplementedError` (it can be thrown by any rpc provider).
* Handle new message-types in webhook notifications.

Closes #2200
