### PR TITLE
Reenable stoploss_on_exchange for dry-run

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -367,7 +367,7 @@ class Exchange(object):
     def dry_run_order(self, pair: str, ordertype: str, side: str, amount: float,
                       rate: float, params: Dict = {}) -> Dict[str, Any]:
         order_id = f'dry_run_{side}_{randint(0, 10**6)}'
-        dry_order = {  # TODO: additional entry should be added for stoploss limit
+        dry_order = {
             "id": order_id,
             'pair': pair,
             'price': rate,
@@ -382,6 +382,7 @@ class Exchange(object):
             "info": {}
         }
         self._store_dry_order(dry_order)
+        # Copy order and close it - so the returned order is open unless it's a market order
         return dry_order
 
     def _store_dry_order(self, dry_order: Dict) -> None:
@@ -392,6 +393,8 @@ class Exchange(object):
                 "filled": closed_order["amount"],
                 "remaining": 0
                 })
+        if closed_order["type"] in ["stop_loss_limit"]:
+            closed_order["info"].update({"stopPrice": closed_order["price"]})
         self._dry_run_open_orders[closed_order["id"]] = closed_order
 
     def create_order(self, pair: str, ordertype: str, side: str, amount: float,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -21,7 +21,7 @@ from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCManager, RPCMessageType
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver, PairListResolver
-from freqtrade.state import State, RunMode
+from freqtrade.state import State
 from freqtrade.strategy.interface import SellType, IStrategy
 from freqtrade.wallets import Wallets
 
@@ -79,12 +79,6 @@ class FreqtradeBot(object):
         persistence.init(self.config.get('db_url', None),
                          clean_open_orders=self.config.get('dry_run', False))
 
-        # Stoploss on exchange does not make sense, therefore we need to disable that.
-        if (self.dataprovider.runmode == RunMode.DRY_RUN and
-           self.strategy.order_types.get('stoploss_on_exchange', False)):
-            logger.info("Disabling stoploss_on_exchange during dry-run.")
-            self.strategy.order_types['stoploss_on_exchange'] = False
-            config['order_types']['stoploss_on_exchange'] = False
         # Set initial bot state from config
         initial_state = self.config.get('initial_state')
         self.state = State[initial_state.upper()] if initial_state else State.STOPPED

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -147,8 +147,7 @@ def test_order_dict_dry_run(default_conf, mocker, caplog) -> None:
     }
 
     freqtrade = FreqtradeBot(conf)
-    assert log_has("Disabling stoploss_on_exchange during dry-run.", caplog)
-    assert not freqtrade.strategy.order_types['stoploss_on_exchange']
+    assert freqtrade.strategy.order_types['stoploss_on_exchange']
 
     caplog.clear()
     # is left untouched


### PR DESCRIPTION
## Summary
Stoploss on exchange does make (limited) sense in dry-run (and it was also implemented, but had a bug for trailing stoplosses).

stoploss on exchange during dry-run assumes to always sell at stop_price - while regular operations can have a stoploss at 5%, and sell at -7% because there was a sharp drop (so it makes sense to leave this setting on during dry-run).

Solve the issue: #2106, revert #2119

## Quick changelog

- Add missing attribute for dry-run stoploss orders
- remove setting `stoploss_on_exchange` to false during dry-run operations.