### PR TITLE
Always use config.json if it's available

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -3,6 +3,7 @@ This module contains the argument manager class
 """
 import argparse
 from typing import List, Optional
+from pathlib import Path
 
 from freqtrade.configuration.cli_options import AVAILABLE_CLI_OPTIONS
 from freqtrade import constants
@@ -73,11 +74,13 @@ class Arguments(object):
         """
         parsed_arg = self.parser.parse_args(self.args)
 
+        # When no config is provided, but a config exists, use that configuration!
+
         # Workaround issue in argparse with action='append' and default value
         # (see https://bugs.python.org/issue16399)
         # Allow no-config for certain commands (like downloading / plotting)
-        if (parsed_arg.config is None
-                and not ('subparser' in parsed_arg and parsed_arg.subparser in NO_CONF_REQURIED)):
+        if (parsed_arg.config is None and ((Path.cwd() / constants.DEFAULT_CONFIG).is_file() or
+           not ('subparser' in parsed_arg and parsed_arg.subparser in NO_CONF_REQURIED))):
             parsed_arg.config = [constants.DEFAULT_CONFIG]
 
         return parsed_arg

--- a/freqtrade/plot/plot_utils.py
+++ b/freqtrade/plot/plot_utils.py
@@ -1,7 +1,15 @@
 from argparse import Namespace
-
+from freqtrade import OperationalException
 from freqtrade.state import RunMode
 from freqtrade.utils import setup_utils_configuration
+
+
+def validate_plot_args(args: Namespace):
+    args_tmp = vars(args)
+    if not args_tmp.get('datadir') and not args_tmp.get('config'):
+        raise OperationalException(
+            "You need to specify either `--datadir` or `--config` "
+            "for plot-profit and plot-dataframe.")
 
 
 def start_plot_dataframe(args: Namespace) -> None:
@@ -10,6 +18,7 @@ def start_plot_dataframe(args: Namespace) -> None:
     """
     # Import here to avoid errors if plot-dependencies are not installed.
     from freqtrade.plot.plotting import analyse_and_plot_pairs
+    validate_plot_args(args)
     config = setup_utils_configuration(args, RunMode.PLOT)
 
     analyse_and_plot_pairs(config)
@@ -21,6 +30,7 @@ def start_plot_profit(args: Namespace) -> None:
     """
     # Import here to avoid errors if plot-dependencies are not installed.
     from freqtrade.plot.plotting import plot_profit
+    validate_plot_args(args)
     config = setup_utils_configuration(args, RunMode.PLOT)
 
     plot_profit(config)

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -871,6 +871,8 @@ def test_pairlist_resolving_fallback(mocker):
     ]
 
     args = Arguments(arglist).get_parsed_arg()
+    # Fix flaky tests if config.json exists
+    args.config = None
 
     configuration = Configuration(args)
     config = configuration.get_config()

--- a/freqtrade/tests/test_plotting.py
+++ b/freqtrade/tests/test_plotting.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import plotly.graph_objects as go
+import pytest
 from plotly.subplots import make_subplots
 
+from freqtrade import OperationalException
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import create_cum_profit, load_backtest_data
@@ -333,6 +335,15 @@ def test_start_plot_profit(mocker):
     called_config = aup.call_args_list[0][0][0]
     assert "pairs" in called_config
     assert called_config['pairs'] == ["ETH/BTC"]
+
+
+def test_start_plot_profit_error(mocker):
+    args = [
+        "plot-profit",
+        "--pairs", "ETH/BTC"
+    ]
+    with pytest.raises(OperationalException):
+        start_plot_profit(get_args(args))
 
 
 def test_plot_profit(default_conf, mocker, caplog):


### PR DESCRIPTION
## Summary
We should always default to config.json if it exists (also for plot-scripts).

Closes #2215

## Quick changelog

- Use `config.json` if it exists
- use None only if it really doesn't exist and for allowed subcommands
- Validate that either --config or --datadir is specified for plot commands (download-data requires exchange, so validation for this is different).
