### PR TITLE
Fix RPC /balance failure

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -30,6 +30,9 @@ BAD_EXCHANGES = {
     "bitmex": "Various reasons",
     "bitstamp": "Does not provide history. "
                 "Details in https://github.com/freqtrade/freqtrade/issues/1983",
+    "kraken": "TEMPORARY: Balance does not report free balance, so freqtrade will not know "
+              "if enough balance is available."
+              "Details in https://github.com/freqtrade/freqtrade/issues/1687#issuecomment-528509266"
     }
 
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -294,9 +294,9 @@ class RPC(object):
             total = total + est_btc
             output.append({
                 'currency': coin,
-                'free': balance['free'],
-                'balance': balance['total'],
-                'used': balance['used'],
+                'free': balance['free'] if balance['free'] is not None else 0,
+                'balance': balance['total'] if balance['total'] is not None else 0,
+                'used': balance['used'] if balance['used'] is not None else 0,
                 'est_btc': est_btc,
             })
         if total == 0.0:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -294,9 +294,9 @@ class RPC(object):
             total = total + est_btc
             output.append({
                 'currency': coin,
-                'available': balance['free'],
+                'free': balance['free'],
                 'balance': balance['total'],
-                'pending': balance['used'],
+                'used': balance['used'],
                 'est_btc': est_btc,
             })
         if total == 0.0:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -328,9 +328,9 @@ class Telegram(RPC):
             for currency in result['currencies']:
                 if currency['est_btc'] > 0.0001:
                     curr_output = "*{currency}:*\n" \
-                            "\t`Available: {available: .8f}`\n" \
+                            "\t`Available: {free: .8f}`\n" \
                             "\t`Balance: {balance: .8f}`\n" \
-                            "\t`Pending: {pending: .8f}`\n" \
+                            "\t`Pending: {used: .8f}`\n" \
                             "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
                 else:
                     curr_output = "*{currency}:* not showing <1$ amount \n".format(**currency)

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -363,9 +363,9 @@ def test_rpc_balance_handle_error(default_conf, mocker):
     assert 'USD' == result['symbol']
     assert result['currencies'] == [{
         'currency': 'BTC',
-        'available': 10.0,
+        'free': 10.0,
         'balance': 12.0,
-        'pending': 2.0,
+        'used': 2.0,
         'est_btc': 12.0,
     }]
     assert result['total'] == 12.0
@@ -417,22 +417,22 @@ def test_rpc_balance_handle(default_conf, mocker):
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',
-            'available': 10.0,
+            'free': 10.0,
             'balance': 12.0,
-            'pending': 2.0,
+            'used': 2.0,
             'est_btc': 12.0,
          },
-        {'available': 1.0,
+        {'free': 1.0,
          'balance': 5.0,
          'currency': 'ETH',
          'est_btc': 0.05,
-         'pending': 4.0
+         'used': 4.0
          },
-        {'available': 5.0,
+        {'free': 5.0,
          'balance': 10.0,
          'currency': 'PAX',
          'est_btc': 0.1,
-         'pending': 5.0}
+         'used': 5.0}
     ]
     assert result['total'] == 12.15
 

--- a/freqtrade/tests/rpc/test_rpc_apiserver.py
+++ b/freqtrade/tests/rpc/test_rpc_apiserver.py
@@ -251,9 +251,9 @@ def test_api_balance(botclient, mocker, rpc_balance):
     assert len(rc.json["currencies"]) == 5
     assert rc.json['currencies'][0] == {
         'currency': 'BTC',
-        'available': 12.0,
+        'free': 12.0,
         'balance': 12.0,
-        'pending': 0.0,
+        'used': 0.0,
         'est_btc': 12.0,
     }
 

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -577,8 +577,8 @@ def test_balance_handle_too_large_response(default_conf, update, mocker) -> None
         curr = choice(ascii_uppercase) + choice(ascii_uppercase) + choice(ascii_uppercase)
         balances.append({
             'currency': curr,
-            'available': 1.0,
-            'pending': 0.5,
+            'free': 1.0,
+            'used': 0.5,
             'balance': i,
             'est_btc': 1
         })

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -494,7 +494,7 @@ def test_check_exchange(default_conf, caplog) -> None:
     caplog.clear()
 
     # Test an available exchange, supported by ccxt
-    default_conf.get('exchange').update({'name': 'kraken'})
+    default_conf.get('exchange').update({'name': 'huobipro'})
     assert check_exchange(default_conf)
     assert log_has_re(r"Exchange .* is supported by ccxt and .* not officially supported "
                       r"by the Freqtrade development team\. .*", caplog)


### PR DESCRIPTION
## Summary
`/balance`  should not fail if None is reported by ccxt, since this is a valid return value according to their documentation.

In addition to that i discovered that Kraken does not correctly report "free" balances, making detecting of available balances impossible.
Details and a possible fix are documented in the Kraken issue https://github.com/freqtrade/freqtrade/issues/1687#issuecomment-528509266
.
Until we have that fix implemented / developed, we will need to block kraken, since trading on it will not be possible.

Close #2225

## Quick changelog:

* fix /balance failure
* block Kraken trading since it's not working due to wrong return values for `get_balance()` calls