### PR TITLE
PoC: Allow hyperopting on strategies

### DIFF
--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -36,6 +36,9 @@ class IHyperOpt(ABC):
     """
     ticker_interval: str
 
+    def __init__(self, config: dict = None) -> None:
+        self.config = config
+
     @staticmethod
     @abstractmethod
     def populate_indicators(dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -65,7 +65,7 @@ class HyperOptResolver(IResolver):
             abs_paths.insert(0, Path(extra_dir).resolve())
 
         hyperopt = self._load_object(paths=abs_paths, object_type=IHyperOpt,
-                                     object_name=hyperopt_name)
+                                     object_name=hyperopt_name, kwargs={'config': config})
         if hyperopt:
             return hyperopt
         raise OperationalException(


### PR DESCRIPTION
Allows to use approach, described in #2231 -- hyperopting using the custom (or even default) strategy,

In user_data/strategies/sample_strategy.py:
```
...
from freqtrade.strategy.interface import IStrategy
from freqtrade.optimize.hyperopt_interface import IHyperOpt
...

class SampleStrategy(IStrategy, IHyperOpt):
...
// The strategy as it is
```
then run hyperopting:
```
$ freqtrade hyperopt --hyperopt-path user_data/strategies/ --customhyperopt SampleStrategy --spaces roi stoploss
```
