### PR TITLE
datadir should not default to freqtrade/tests/testdata

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -66,8 +66,7 @@ class DataProvider():
         return load_pair_history(pair=pair,
                                  ticker_interval=ticker_interval or self._config['ticker_interval'],
                                  refresh_pairs=False,
-                                 datadir=Path(self._config['datadir']) if self._config.get(
-                                     'datadir') else None
+                                 datadir=Path(self._config['datadir'])
                                  )
 
     def get_pair_dataframe(self, pair: str, ticker_interval: str = None) -> DataFrame:

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -57,7 +57,7 @@ def trim_tickerlist(tickerlist: List[Dict], timerange: TimeRange) -> List[Dict]:
     return tickerlist[start_index:stop_index]
 
 
-def load_tickerdata_file(datadir: Optional[Path], pair: str, ticker_interval: str,
+def load_tickerdata_file(datadir: Path, pair: str, ticker_interval: str,
                          timerange: Optional[TimeRange] = None) -> Optional[list]:
     """
     Load a pair from file, either .json.gz or .json
@@ -73,7 +73,7 @@ def load_tickerdata_file(datadir: Optional[Path], pair: str, ticker_interval: st
     return pairdata
 
 
-def store_tickerdata_file(datadir: Optional[Path], pair: str,
+def store_tickerdata_file(datadir: Path, pair: str,
                           ticker_interval: str, data: list, is_zip: bool = False):
     """
     Stores tickerdata to file
@@ -84,7 +84,7 @@ def store_tickerdata_file(datadir: Optional[Path], pair: str,
 
 def load_pair_history(pair: str,
                       ticker_interval: str,
-                      datadir: Optional[Path],
+                      datadir: Path,
                       timerange: TimeRange = TimeRange(None, None, 0, 0),
                       refresh_pairs: bool = False,
                       exchange: Optional[Exchange] = None,
@@ -135,7 +135,7 @@ def load_pair_history(pair: str,
         return None
 
 
-def load_data(datadir: Optional[Path],
+def load_data(datadir: Path,
               ticker_interval: str,
               pairs: List[str],
               refresh_pairs: bool = False,
@@ -172,19 +172,13 @@ def load_data(datadir: Optional[Path],
     return result
 
 
-def make_testdata_path(datadir: Optional[Path]) -> Path:
-    """Return the path where testdata files are stored"""
-    return datadir or (Path(__file__).parent.parent / "tests" / "testdata").resolve()
-
-
-def pair_data_filename(datadir: Optional[Path], pair: str, ticker_interval: str) -> Path:
-    path = make_testdata_path(datadir)
+def pair_data_filename(datadir: Path, pair: str, ticker_interval: str) -> Path:
     pair_s = pair.replace("/", "_")
-    filename = path.joinpath(f'{pair_s}-{ticker_interval}.json')
+    filename = datadir.joinpath(f'{pair_s}-{ticker_interval}.json')
     return filename
 
 
-def load_cached_data_for_updating(datadir: Optional[Path], pair: str, ticker_interval: str,
+def load_cached_data_for_updating(datadir: Path, pair: str, ticker_interval: str,
                                   timerange: Optional[TimeRange]) -> Tuple[List[Any],
                                                                            Optional[int]]:
     """
@@ -224,7 +218,7 @@ def load_cached_data_for_updating(datadir: Optional[Path], pair: str, ticker_int
     return (data, since_ms)
 
 
-def download_pair_history(datadir: Optional[Path],
+def download_pair_history(datadir: Path,
                           exchange: Optional[Exchange],
                           pair: str,
                           ticker_interval: str = '5m',

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -93,7 +93,7 @@ class Edge():
         logger.info('Using local backtesting data (using whitelist in given config) ...')
 
         data = history.load_data(
-            datadir=Path(self.config['datadir']) if self.config.get('datadir') else None,
+            datadir=Path(self.config['datadir']),
             pairs=pairs,
             ticker_interval=self.strategy.ticker_interval,
             refresh_pairs=self._refresh_pairs,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -407,7 +407,7 @@ class Backtesting(object):
         timerange = TimeRange.parse_timerange(None if self.config.get(
             'timerange') is None else str(self.config.get('timerange')))
         data = history.load_data(
-            datadir=Path(self.config['datadir']) if self.config.get('datadir') else None,
+            datadir=Path(self.config['datadir']),
             pairs=pairs,
             ticker_interval=self.ticker_interval,
             refresh_pairs=self.config.get('refresh_pairs', False),

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -349,7 +349,7 @@ class Hyperopt:
         timerange = TimeRange.parse_timerange(None if self.config.get(
             'timerange') is None else str(self.config.get('timerange')))
         data = load_data(
-            datadir=Path(self.config['datadir']) if self.config.get('datadir') else None,
+            datadir=Path(self.config['datadir']),
             pairs=self.config['exchange']['pair_whitelist'],
             ticker_interval=self.backtesting.ticker_interval,
             refresh_pairs=self.config.get('refresh_pairs', False),

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -1047,3 +1047,8 @@ def rpc_balance():
             'used': 0.0
         },
     }
+
+
+def make_testdata_path(datadir) -> Path:
+    """Return the path where testdata files are stored"""
+    return (Path(__file__).parent / "testdata").resolve()

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -1049,6 +1049,7 @@ def rpc_balance():
     }
 
 
-def make_testdata_path(datadir) -> Path:
+@pytest.fixture
+def testdatadir() -> Path:
     """Return the path where testdata files are stored"""
     return (Path(__file__).parent / "testdata").resolve()

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -182,7 +182,7 @@ def init_persistence(default_conf):
 
 
 @pytest.fixture(scope="function")
-def default_conf():
+def default_conf(testdatadir):
     """ Returns validated configuration suitable for most tests """
     configuration = {
         "max_open_trades": 1,
@@ -237,6 +237,7 @@ def default_conf():
             "token": "token",
             "chat_id": "0"
         },
+        "datadir": str(testdatadir),
         "initial_state": "running",
         "db_url": "sqlite://",
         "user_data_dir": Path("user_data"),

--- a/freqtrade/tests/data/test_btanalysis.py
+++ b/freqtrade/tests/data/test_btanalysis.py
@@ -11,8 +11,8 @@ from freqtrade.data.btanalysis import (BT_DATA_COLUMNS,
                                        extract_trades_of_period,
                                        load_backtest_data, load_trades,
                                        load_trades_from_db)
-from freqtrade.data.history import (load_data, load_pair_history,
-                                    make_testdata_path)
+from freqtrade.data.history import load_data, load_pair_history
+from freqtrade.tests.conftest import make_testdata_path
 from freqtrade.tests.test_persistence import create_mock_trades
 
 

--- a/freqtrade/tests/data/test_btanalysis.py
+++ b/freqtrade/tests/data/test_btanalysis.py
@@ -12,13 +12,12 @@ from freqtrade.data.btanalysis import (BT_DATA_COLUMNS,
                                        load_backtest_data, load_trades,
                                        load_trades_from_db)
 from freqtrade.data.history import load_data, load_pair_history
-from freqtrade.tests.conftest import make_testdata_path
 from freqtrade.tests.test_persistence import create_mock_trades
 
 
-def test_load_backtest_data():
+def test_load_backtest_data(testdatadir):
 
-    filename = make_testdata_path(None) / "backtest-result_test.json"
+    filename = testdatadir / "backtest-result_test.json"
     bt_data = load_backtest_data(filename)
     assert isinstance(bt_data, DataFrame)
     assert list(bt_data.columns) == BT_DATA_COLUMNS + ["profitabs"]
@@ -52,12 +51,12 @@ def test_load_trades_db(default_conf, fee, mocker):
             assert col in trades.columns
 
 
-def test_extract_trades_of_period():
+def test_extract_trades_of_period(testdatadir):
     pair = "UNITTEST/BTC"
     timerange = TimeRange(None, 'line', 0, -1000)
 
     data = load_pair_history(pair=pair, ticker_interval='1m',
-                             datadir=None, timerange=timerange)
+                             datadir=testdatadir, timerange=timerange)
 
     # timerange = 2017-11-14 06:07 - 2017-11-14 22:58:00
     trades = DataFrame(
@@ -108,9 +107,9 @@ def test_load_trades(default_conf, mocker):
     assert bt_mock.call_count == 1
 
 
-def test_combine_tickers_with_mean():
+def test_combine_tickers_with_mean(testdatadir):
     pairs = ["ETH/BTC", "XLM/BTC"]
-    tickers = load_data(datadir=None,
+    tickers = load_data(datadir=testdatadir,
                         pairs=pairs,
                         ticker_interval='5m'
                         )
@@ -121,13 +120,13 @@ def test_combine_tickers_with_mean():
     assert "mean" in df.columns
 
 
-def test_create_cum_profit():
-    filename = make_testdata_path(None) / "backtest-result_test.json"
+def test_create_cum_profit(testdatadir):
+    filename = testdatadir / "backtest-result_test.json"
     bt_data = load_backtest_data(filename)
     timerange = TimeRange.parse_timerange("20180110-20180112")
 
     df = load_pair_history(pair="POWR/BTC", ticker_interval='5m',
-                           datadir=None, timerange=timerange)
+                           datadir=testdatadir, timerange=timerange)
 
     cum_profits = create_cum_profit(df.set_index('date'),
                                     bt_data[bt_data["pair"] == 'POWR/BTC'],

--- a/freqtrade/tests/data/test_converter.py
+++ b/freqtrade/tests/data/test_converter.py
@@ -21,8 +21,8 @@ def test_parse_ticker_dataframe(ticker_history_list, caplog):
     assert log_has('Parsing tickerlist to dataframe', caplog)
 
 
-def test_ohlcv_fill_up_missing_data(caplog):
-    data = load_pair_history(datadir=None,
+def test_ohlcv_fill_up_missing_data(testdatadir, caplog):
+    data = load_pair_history(datadir=testdatadir,
                              ticker_interval='1m',
                              refresh_pairs=False,
                              pair='UNITTEST/BTC',

--- a/freqtrade/tests/data/test_dataprovider.py
+++ b/freqtrade/tests/data/test_dataprovider.py
@@ -45,7 +45,6 @@ def test_historic_ohlcv(mocker, default_conf, ticker_history):
     data = dp.historic_ohlcv("UNITTEST/BTC", "5m")
     assert isinstance(data, DataFrame)
     assert historymock.call_count == 1
-    assert historymock.call_args_list[0][1]["datadir"] is None
     assert historymock.call_args_list[0][1]["refresh_pairs"] is False
     assert historymock.call_args_list[0][1]["ticker_interval"] == "5m"
 

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -16,14 +16,14 @@ from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.history import (download_pair_history,
                                     load_cached_data_for_updating,
-                                    load_tickerdata_file, make_testdata_path,
+                                    load_tickerdata_file,
                                     refresh_backtest_ohlcv_data,
                                     trim_tickerlist)
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.misc import file_dump_json
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.tests.conftest import (get_patched_exchange, log_has,
-                                      patch_exchange)
+                                      patch_exchange, make_testdata_path)
 
 # Change this if modifying UNITTEST/BTC testdatafile
 _BTC_UNITTEST_LENGTH = 13681

--- a/freqtrade/tests/data/test_history.py
+++ b/freqtrade/tests/data/test_history.py
@@ -134,12 +134,12 @@ def test_load_data_with_new_pair_1min(ticker_history_list, mocker, caplog,
     _clean_test_file(file)
 
 
-def test_load_data_live(default_conf, mocker, caplog) -> None:
+def test_load_data_live(default_conf, mocker, caplog, testdatadir) -> None:
     refresh_mock = MagicMock()
     mocker.patch("freqtrade.exchange.Exchange.refresh_latest_ohlcv", refresh_mock)
     exchange = get_patched_exchange(mocker, default_conf)
 
-    history.load_data(datadir=None, ticker_interval='5m',
+    history.load_data(datadir=testdatadir, ticker_interval='5m',
                       pairs=['UNITTEST/BTC', 'UNITTEST2/BTC'],
                       live=True,
                       exchange=exchange)
@@ -148,11 +148,11 @@ def test_load_data_live(default_conf, mocker, caplog) -> None:
     assert log_has('Live: Downloading data for all defined pairs ...', caplog)
 
 
-def test_load_data_live_noexchange(default_conf, mocker, caplog) -> None:
+def test_load_data_live_noexchange(default_conf, mocker, caplog, testdatadir) -> None:
 
     with pytest.raises(OperationalException,
                        match=r'Exchange needs to be initialized when using live data.'):
-        history.load_data(datadir=None, ticker_interval='5m',
+        history.load_data(datadir=testdatadir, ticker_interval='5m',
                           pairs=['UNITTEST/BTC', 'UNITTEST2/BTC'],
                           exchange=None,
                           live=True,

--- a/freqtrade/tests/edge/test_edge.py
+++ b/freqtrade/tests/edge/test_edge.py
@@ -291,7 +291,6 @@ def mocked_load_data(datadir, pairs=[], ticker_interval='0m', refresh_pairs=Fals
 
 
 def test_edge_process_downloaded_data(mocker, edge_conf):
-    edge_conf['datadir'] = None
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.001))
     mocker.patch('freqtrade.data.history.load_data', mocked_load_data)
@@ -303,7 +302,6 @@ def test_edge_process_downloaded_data(mocker, edge_conf):
 
 
 def test_edge_process_no_data(mocker, edge_conf, caplog):
-    edge_conf['datadir'] = None
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.001))
     mocker.patch('freqtrade.data.history.load_data', MagicMock(return_value={}))
@@ -316,7 +314,6 @@ def test_edge_process_no_data(mocker, edge_conf, caplog):
 
 
 def test_edge_process_no_trades(mocker, edge_conf, caplog):
-    edge_conf['datadir'] = None
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
     mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.001))
     mocker.patch('freqtrade.data.history.load_data', mocked_load_data)

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -489,7 +489,7 @@ def test_backtesting_start(default_conf, mocker, testdatadir, caplog) -> None:
         assert log_has(line, caplog)
 
 
-def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
+def test_backtesting_start_no_data(default_conf, mocker, caplog, testdatadir) -> None:
     def get_timeframe(input1):
         return Arrow(2017, 11, 14, 21, 17), Arrow(2017, 11, 14, 22, 59)
 
@@ -505,7 +505,7 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog) -> None:
 
     default_conf['exchange']['pair_whitelist'] = ['UNITTEST/BTC']
     default_conf['ticker_interval'] = "1m"
-    default_conf['datadir'] = None
+    default_conf['datadir'] = testdatadir
     default_conf['export'] = None
     default_conf['timerange'] = '20180101-20180102'
 

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -485,8 +485,8 @@ def test_has_space(hyperopt):
     assert hyperopt.has_space('buy')
 
 
-def test_populate_indicators(hyperopt) -> None:
-    tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m')
+def test_populate_indicators(hyperopt, testdatadir) -> None:
+    tick = load_tickerdata_file(testdatadir, 'UNITTEST/BTC', '1m')
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', pair="UNITTEST/BTC",
                                                          fill_missing=True)}
     dataframes = hyperopt.backtesting.strategy.tickerdata_to_dataframe(tickerlist)
@@ -499,8 +499,8 @@ def test_populate_indicators(hyperopt) -> None:
     assert 'rsi' in dataframe
 
 
-def test_buy_strategy_generator(hyperopt) -> None:
-    tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m')
+def test_buy_strategy_generator(hyperopt, testdatadir) -> None:
+    tick = load_tickerdata_file(testdatadir, 'UNITTEST/BTC', '1m')
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', pair="UNITTEST/BTC",
                                                          fill_missing=True)}
     dataframes = hyperopt.backtesting.strategy.tickerdata_to_dataframe(tickerlist)

--- a/freqtrade/tests/strategy/test_interface.py
+++ b/freqtrade/tests/strategy/test_interface.py
@@ -103,11 +103,11 @@ def test_get_signal_handles_exceptions(mocker, default_conf):
     assert _STRATEGY.get_signal(exchange, 'ETH/BTC', '5m') == (False, False)
 
 
-def test_tickerdata_to_dataframe(default_conf) -> None:
+def test_tickerdata_to_dataframe(default_conf, testdatadir) -> None:
     strategy = DefaultStrategy(default_conf)
 
     timerange = TimeRange(None, 'line', 0, -100)
-    tick = load_tickerdata_file(None, 'UNITTEST/BTC', '1m', timerange=timerange)
+    tick = load_tickerdata_file(testdatadir, 'UNITTEST/BTC', '1m', timerange=timerange)
     tickerlist = {'UNITTEST/BTC': parse_ticker_dataframe(tick, '1m', pair="UNITTEST/BTC",
                                                          fill_missing=True)}
     data = strategy.tickerdata_to_dataframe(tickerlist)

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -45,16 +45,16 @@ def test_file_dump_json(mocker) -> None:
     assert json_dump.call_count == 1
 
 
-def test_file_load_json(mocker) -> None:
+def test_file_load_json(mocker, testdatadir) -> None:
 
     # 7m .json does not exist
-    ret = file_load_json(pair_data_filename(None, 'UNITTEST/BTC', '7m'))
+    ret = file_load_json(pair_data_filename(testdatadir, 'UNITTEST/BTC', '7m'))
     assert not ret
     # 1m json exists (but no .gz exists)
-    ret = file_load_json(pair_data_filename(None, 'UNITTEST/BTC', '1m'))
+    ret = file_load_json(pair_data_filename(testdatadir, 'UNITTEST/BTC', '1m'))
     assert ret
     # 8 .json is empty and will fail if it's loaded. .json.gz is a copy of 1.json
-    ret = file_load_json(pair_data_filename(None, 'UNITTEST/BTC', '8m'))
+    ret = file_load_json(pair_data_filename(testdatadir, 'UNITTEST/BTC', '8m'))
     assert ret
 
 

--- a/freqtrade/tests/test_plotting.py
+++ b/freqtrade/tests/test_plotting.py
@@ -19,8 +19,7 @@ from freqtrade.plot.plotting import (add_indicators, add_profit,
                                      generate_profit_graph, init_plotscript,
                                      plot_profit, plot_trades, store_plot_file)
 from freqtrade.strategy.default_strategy import DefaultStrategy
-from freqtrade.tests.conftest import (get_args, log_has, log_has_re,
-                                      make_testdata_path)
+from freqtrade.tests.conftest import get_args, log_has, log_has_re
 
 
 def fig_generating_mock(fig, *args, **kwargs):
@@ -43,12 +42,12 @@ def generage_empty_figure():
     )
 
 
-def test_init_plotscript(default_conf, mocker):
+def test_init_plotscript(default_conf, mocker, testdatadir):
     default_conf['timerange'] = "20180110-20180112"
     default_conf['trade_source'] = "file"
     default_conf['ticker_interval'] = "5m"
-    default_conf["datadir"] = make_testdata_path(None)
-    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = testdatadir
+    default_conf['exportfilename'] = str(testdatadir / "backtest-result_test.json")
     ret = init_plotscript(default_conf)
     assert "tickers" in ret
     assert "trades" in ret
@@ -61,12 +60,12 @@ def test_init_plotscript(default_conf, mocker):
     assert "XLM/BTC" in ret["tickers"]
 
 
-def test_add_indicators(default_conf, caplog):
+def test_add_indicators(default_conf, testdatadir, caplog):
     pair = "UNITTEST/BTC"
     timerange = TimeRange(None, 'line', 0, -1000)
 
     data = history.load_pair_history(pair=pair, ticker_interval='1m',
-                                     datadir=None, timerange=timerange)
+                                     datadir=testdatadir, timerange=timerange)
     indicators1 = ["ema10"]
     indicators2 = ["macd"]
 
@@ -94,14 +93,14 @@ def test_add_indicators(default_conf, caplog):
     assert log_has_re(r'Indicator "no_indicator" ignored\..*', caplog)
 
 
-def test_plot_trades(caplog):
+def test_plot_trades(testdatadir, caplog):
     fig1 = generage_empty_figure()
     # nothing happens when no trades are available
     fig = plot_trades(fig1, None)
     assert fig == fig1
     assert log_has("No trades found.", caplog)
     pair = "ADA/BTC"
-    filename = make_testdata_path(None) / "backtest-result_test.json"
+    filename = testdatadir / "backtest-result_test.json"
     trades = load_backtest_data(filename)
     trades = trades.loc[trades['pair'] == pair]
 
@@ -122,7 +121,7 @@ def test_plot_trades(caplog):
     assert trade_sell.marker.color == 'red'
 
 
-def test_generate_candlestick_graph_no_signals_no_trades(default_conf, mocker, caplog):
+def test_generate_candlestick_graph_no_signals_no_trades(default_conf, mocker, testdatadir, caplog):
     row_mock = mocker.patch('freqtrade.plot.plotting.add_indicators',
                             MagicMock(side_effect=fig_generating_mock))
     trades_mock = mocker.patch('freqtrade.plot.plotting.plot_trades',
@@ -131,7 +130,7 @@ def test_generate_candlestick_graph_no_signals_no_trades(default_conf, mocker, c
     pair = "UNITTEST/BTC"
     timerange = TimeRange(None, 'line', 0, -1000)
     data = history.load_pair_history(pair=pair, ticker_interval='1m',
-                                     datadir=None, timerange=timerange)
+                                     datadir=testdatadir, timerange=timerange)
     data['buy'] = 0
     data['sell'] = 0
 
@@ -158,7 +157,7 @@ def test_generate_candlestick_graph_no_signals_no_trades(default_conf, mocker, c
     assert log_has("No sell-signals found.", caplog)
 
 
-def test_generate_candlestick_graph_no_trades(default_conf, mocker):
+def test_generate_candlestick_graph_no_trades(default_conf, mocker, testdatadir):
     row_mock = mocker.patch('freqtrade.plot.plotting.add_indicators',
                             MagicMock(side_effect=fig_generating_mock))
     trades_mock = mocker.patch('freqtrade.plot.plotting.plot_trades',
@@ -166,7 +165,7 @@ def test_generate_candlestick_graph_no_trades(default_conf, mocker):
     pair = 'UNITTEST/BTC'
     timerange = TimeRange(None, 'line', 0, -1000)
     data = history.load_pair_history(pair=pair, ticker_interval='1m',
-                                     datadir=None, timerange=timerange)
+                                     datadir=testdatadir, timerange=timerange)
 
     # Generate buy/sell signals and indicators
     strat = DefaultStrategy(default_conf)
@@ -224,13 +223,13 @@ def test_generate_plot_file(mocker, caplog):
                    caplog)
 
 
-def test_add_profit():
-    filename = make_testdata_path(None) / "backtest-result_test.json"
+def test_add_profit(testdatadir):
+    filename = testdatadir / "backtest-result_test.json"
     bt_data = load_backtest_data(filename)
     timerange = TimeRange.parse_timerange("20180110-20180112")
 
     df = history.load_pair_history(pair="POWR/BTC", ticker_interval='5m',
-                                   datadir=None, timerange=timerange)
+                                   datadir=testdatadir, timerange=timerange)
     fig = generage_empty_figure()
 
     cum_profits = create_cum_profit(df.set_index('date'),
@@ -244,13 +243,13 @@ def test_add_profit():
     assert profits.yaxis == "y2"
 
 
-def test_generate_profit_graph():
-    filename = make_testdata_path(None) / "backtest-result_test.json"
+def test_generate_profit_graph(testdatadir):
+    filename = testdatadir / "backtest-result_test.json"
     trades = load_backtest_data(filename)
     timerange = TimeRange.parse_timerange("20180110-20180112")
     pairs = ["POWR/BTC", "XLM/BTC"]
 
-    tickers = history.load_data(datadir=None,
+    tickers = history.load_data(datadir=testdatadir,
                                 pairs=pairs,
                                 ticker_interval='5m',
                                 timerange=timerange
@@ -294,10 +293,10 @@ def test_start_plot_dataframe(mocker):
     assert called_config['pairs'] == ["ETH/BTC"]
 
 
-def test_analyse_and_plot_pairs(default_conf, mocker, caplog):
+def test_analyse_and_plot_pairs(default_conf, mocker, caplog, testdatadir):
     default_conf['trade_source'] = 'file'
-    default_conf["datadir"] = make_testdata_path(None)
-    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = testdatadir
+    default_conf['exportfilename'] = str(testdatadir / "backtest-result_test.json")
     default_conf['indicators1'] = ["sma5", "ema10"]
     default_conf['indicators2'] = ["macd"]
     default_conf['pairs'] = ["ETH/BTC", "LTC/BTC"]
@@ -345,10 +344,10 @@ def test_start_plot_profit_error(mocker):
         start_plot_profit(get_args(args))
 
 
-def test_plot_profit(default_conf, mocker, caplog):
+def test_plot_profit(default_conf, mocker, testdatadir, caplog):
     default_conf['trade_source'] = 'file'
-    default_conf["datadir"] = make_testdata_path(None)
-    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = testdatadir
+    default_conf['exportfilename'] = str(testdatadir / "backtest-result_test.json")
     default_conf['pairs'] = ["ETH/BTC", "LTC/BTC"]
 
     profit_mock = MagicMock()

--- a/freqtrade/tests/test_plotting.py
+++ b/freqtrade/tests/test_plotting.py
@@ -19,7 +19,8 @@ from freqtrade.plot.plotting import (add_indicators, add_profit,
                                      generate_profit_graph, init_plotscript,
                                      plot_profit, plot_trades, store_plot_file)
 from freqtrade.strategy.default_strategy import DefaultStrategy
-from freqtrade.tests.conftest import get_args, log_has, log_has_re
+from freqtrade.tests.conftest import (get_args, log_has, log_has_re,
+                                      make_testdata_path)
 
 
 def fig_generating_mock(fig, *args, **kwargs):
@@ -46,9 +47,8 @@ def test_init_plotscript(default_conf, mocker):
     default_conf['timerange'] = "20180110-20180112"
     default_conf['trade_source'] = "file"
     default_conf['ticker_interval'] = "5m"
-    default_conf["datadir"] = history.make_testdata_path(None)
-    default_conf['exportfilename'] = str(
-        history.make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = make_testdata_path(None)
+    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
     ret = init_plotscript(default_conf)
     assert "tickers" in ret
     assert "trades" in ret
@@ -101,7 +101,7 @@ def test_plot_trades(caplog):
     assert fig == fig1
     assert log_has("No trades found.", caplog)
     pair = "ADA/BTC"
-    filename = history.make_testdata_path(None) / "backtest-result_test.json"
+    filename = make_testdata_path(None) / "backtest-result_test.json"
     trades = load_backtest_data(filename)
     trades = trades.loc[trades['pair'] == pair]
 
@@ -225,7 +225,7 @@ def test_generate_plot_file(mocker, caplog):
 
 
 def test_add_profit():
-    filename = history.make_testdata_path(None) / "backtest-result_test.json"
+    filename = make_testdata_path(None) / "backtest-result_test.json"
     bt_data = load_backtest_data(filename)
     timerange = TimeRange.parse_timerange("20180110-20180112")
 
@@ -245,7 +245,7 @@ def test_add_profit():
 
 
 def test_generate_profit_graph():
-    filename = history.make_testdata_path(None) / "backtest-result_test.json"
+    filename = make_testdata_path(None) / "backtest-result_test.json"
     trades = load_backtest_data(filename)
     timerange = TimeRange.parse_timerange("20180110-20180112")
     pairs = ["POWR/BTC", "XLM/BTC"]
@@ -296,9 +296,8 @@ def test_start_plot_dataframe(mocker):
 
 def test_analyse_and_plot_pairs(default_conf, mocker, caplog):
     default_conf['trade_source'] = 'file'
-    default_conf["datadir"] = history.make_testdata_path(None)
-    default_conf['exportfilename'] = str(
-        history.make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = make_testdata_path(None)
+    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
     default_conf['indicators1'] = ["sma5", "ema10"]
     default_conf['indicators2'] = ["macd"]
     default_conf['pairs'] = ["ETH/BTC", "LTC/BTC"]
@@ -348,9 +347,8 @@ def test_start_plot_profit_error(mocker):
 
 def test_plot_profit(default_conf, mocker, caplog):
     default_conf['trade_source'] = 'file'
-    default_conf["datadir"] = history.make_testdata_path(None)
-    default_conf['exportfilename'] = str(
-        history.make_testdata_path(None) / "backtest-result_test.json")
+    default_conf["datadir"] = make_testdata_path(None)
+    default_conf['exportfilename'] = str(make_testdata_path(None) / "backtest-result_test.json")
     default_conf['pairs'] = ["ETH/BTC", "LTC/BTC"]
 
     profit_mock = MagicMock()


### PR DESCRIPTION
## Summary
Freqtrade should not default to test-data from the tests/datadir.

This data is outdated (early 2018, and not a long timerange) - and is never representative of a realistic backtest used today (which must use more recent data!).

part of #2112 - moving tests out of freqtrade module (which will be the next PR).

## Quick changelog

- datadir is always required (it's also always added to the configuration, so there should not be a problem).
- remove `make_testdata_path()` - and replace it with a fixture returning the correct path
- Adapt all tests to this new way of working.
