### PR TITLE
[minor, important] Fix random test failures

### DIFF
--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -1,3 +1,1 @@
 from freqtrade.strategy.interface import IStrategy  # noqa: F401
-# Import Default-Strategy to have hyperopt correctly resolve
-from freqtrade.strategy.default_strategy import DefaultStrategy  # noqa: F401


### PR DESCRIPTION
## Summary
#2235 caused random test-failures (mainly when running `pytest freqtrade/test/test_freqtrade.py` (without randomization).

This is because DefaultStrategy is imported directly, which causes StrategyResolver to reuse the already imported object (importlib seems to do this implicitly).

Since #2235 fixes hyperopt importing however, there is no need for the artificial import causing all this.

Followup to #2235, fixing random test failures