### PR TITLE
Pass test-data to dockerized backtest

### DIFF
--- a/build_helpers/publish_docker.sh
+++ b/build_helpers/publish_docker.sh
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Run backtest
-docker run --rm -it -v $(pwd)/config.json.example:/freqtrade/config.json:ro freqtrade:${TAG} --datadir freqtrade/tests/testdata backtesting
+docker run --rm -it -v $(pwd)/config.json.example:/freqtrade/config.json:ro -v $(pwd)/tests:/tests freqtrade:${TAG} --datadir /tests/testdata backtesting
 
 if [ $? -ne 0 ]; then
     echo "failed running backtest"


### PR DESCRIPTION
## Summary
Followup to #2236  - forgot that now the docker-image won't have test-data, so the test does not work correctly as visible [here](https://travis-ci.org/freqtrade/freqtrade/jobs/582373246) 

```
No history data for pair: "ETC/BTC", interval: 5m. Use --refresh-pairs-cached option or `freqtrade download-data` script to download the data
```

Small oversight - since this code only runs when a PR is merged to develop.