### PR TITLE
Fix random failure if config.json exists

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -336,12 +336,17 @@ def test_start_plot_profit(mocker):
 
 
 def test_start_plot_profit_error(mocker):
+
     args = [
         "plot-profit",
         "--pairs", "ETH/BTC"
     ]
+    argsp = get_args(args)
+    # Make sure we use no config. Details: #2241
+    # not resetting config causes random failures if config.json exists
+    argsp.config = []
     with pytest.raises(OperationalException):
-        start_plot_profit(get_args(args))
+        start_plot_profit(argsp)
 
 
 def test_plot_profit(default_conf, mocker, testdatadir, caplog):


### PR DESCRIPTION
## Summary
This test fails if `config.json` exists, since we add `config.json` to the passed arguments whenever we find it in CWD().

Closes #2241

