### PR TITLE
Telegram fiatconvert with identical currencies

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -104,7 +104,7 @@ class CryptoToFiatConverter(object):
         :return: float, value in fiat of the crypto-currency amount
         """
         if crypto_symbol == fiat_symbol:
-            return crypto_amount
+            return float(crypto_amount)
         price = self.get_price(crypto_symbol=crypto_symbol, fiat_symbol=fiat_symbol)
         return float(crypto_amount) * float(price)
 

--- a/tests/rpc/test_fiat_convert.py
+++ b/tests/rpc/test_fiat_convert.py
@@ -210,3 +210,10 @@ def test_convert_amount(mocker):
         fiat_symbol="BTC"
     )
     assert result == 1.23
+
+    result = fiat_convert.convert_amount(
+        crypto_amount="1.23",
+        crypto_symbol="BTC",
+        fiat_symbol="BTC"
+    )
+    assert result == 1.23


### PR DESCRIPTION
## Summary
Fiatconvert should always return a float (input values can be numeric strings or float).

closes #2239
