### PR TITLE
Eliminate asyncio warnings in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def patch_freqtradebot(mocker, config) -> None:
     """
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     persistence.init(config['db_url'])
-    patch_exchange(mocker, None)
+    patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -69,8 +69,7 @@ def test_init(default_conf, mocker, caplog):
     assert log_has('Instance is running with dry_run enabled', caplog)
 
 
-@pytest.mark.asyncio
-async def test_init_ccxt_kwargs(default_conf, mocker, caplog):
+def test_init_ccxt_kwargs(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     caplog.set_level(logging.INFO)
     conf = copy.deepcopy(default_conf)
@@ -1363,11 +1362,8 @@ def test_get_order(default_conf, mocker, exchange_name):
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
-@pytest.mark.asyncio
-async def test_name(default_conf, mocker, exchange_name):
-    mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
-    default_conf['exchange']['name'] = exchange_name
-    exchange = Exchange(default_conf)
+def test_name(default_conf, mocker, exchange_name):
+    exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
 
     assert exchange.name == exchange_name.title()
     assert exchange.id == exchange_name

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -69,7 +69,8 @@ def test_init(default_conf, mocker, caplog):
     assert log_has('Instance is running with dry_run enabled', caplog)
 
 
-def test_init_ccxt_kwargs(default_conf, mocker, caplog):
+@pytest.mark.asyncio
+async def test_init_ccxt_kwargs(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     caplog.set_level(logging.INFO)
     conf = copy.deepcopy(default_conf)
@@ -1362,7 +1363,8 @@ def test_get_order(default_conf, mocker, exchange_name):
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
-def test_name(default_conf, mocker, exchange_name):
+@pytest.mark.asyncio
+async def test_name(default_conf, mocker, exchange_name):
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     default_conf['exchange']['name'] = exchange_name
     exchange = Exchange(default_conf)

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -26,7 +26,8 @@ def prec_satoshi(a, b) -> float:
 
 
 # Unit tests
-def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -26,12 +26,11 @@ def prec_satoshi(a, b) -> float:
 
 
 # Unit tests
-@pytest.mark.asyncio
-async def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
+def test_rpc_trade_status(default_conf, ticker, fee, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -723,8 +723,9 @@ def test_reload_conf_handle(default_conf, update, mocker) -> None:
     assert 'reloading config' in msg_mock.call_args_list[0][0][0]
 
 
-def test_forcesell_handle(default_conf, update, ticker, fee,
-                          ticker_sell_up, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_forcesell_handle(default_conf, update, ticker, fee,
+                                ticker_sell_up, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
@@ -775,8 +776,9 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     } == last_msg
 
 
-def test_forcesell_down_handle(default_conf, update, ticker, fee,
-                               ticker_sell_down, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_forcesell_down_handle(default_conf, update, ticker, fee,
+                                     ticker_sell_down, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.fiat_convert.CryptoToFiatConverter._find_price',
                  return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
@@ -923,7 +925,8 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
     assert 'invalid argument' in msg_mock.call_args_list[0][0][0]
 
 
-def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
@@ -963,7 +966,8 @@ def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
     assert fbuy_mock.call_args_list[0][0][1] == 0.055
 
 
-def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -90,7 +90,7 @@ def test_cleanup(default_conf, mocker) -> None:
 
 
 def test_authorized_only(default_conf, mocker, caplog) -> None:
-    patch_exchange(mocker, None)
+    patch_exchange(mocker)
 
     chat = Chat(0, 0)
     update = Update(randint(1, 100))
@@ -108,7 +108,7 @@ def test_authorized_only(default_conf, mocker, caplog) -> None:
 
 
 def test_authorized_only_unauthorized(default_conf, mocker, caplog) -> None:
-    patch_exchange(mocker, None)
+    patch_exchange(mocker)
     chat = Chat(0xdeadbeef, 0)
     update = Update(randint(1, 100))
     update.message = Message(randint(1, 100), 0, datetime.utcnow(), chat)

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -723,19 +723,17 @@ def test_reload_conf_handle(default_conf, update, mocker) -> None:
     assert 'reloading config' in msg_mock.call_args_list[0][0][0]
 
 
-@pytest.mark.asyncio
-async def test_forcesell_handle(default_conf, update, ticker, fee,
-                                ticker_sell_up, markets, mocker) -> None:
+def test_forcesell_handle(default_conf, update, ticker, fee,
+                          ticker_sell_up, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets),
-        validate_pairs=MagicMock(return_value={})
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -776,20 +774,18 @@ async def test_forcesell_handle(default_conf, update, ticker, fee,
     } == last_msg
 
 
-@pytest.mark.asyncio
-async def test_forcesell_down_handle(default_conf, update, ticker, fee,
-                                     ticker_sell_down, markets, mocker) -> None:
+def test_forcesell_down_handle(default_conf, update, ticker, fee,
+                               ticker_sell_down, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.fiat_convert.CryptoToFiatConverter._find_price',
                  return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets),
-        validate_pairs=MagicMock(return_value={})
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -845,7 +841,6 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, markets, mocker
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets),
-        validate_pairs=MagicMock(return_value={})
     )
     default_conf['max_open_trades'] = 4
     freqtradebot = FreqtradeBot(default_conf)
@@ -925,16 +920,14 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
     assert 'invalid argument' in msg_mock.call_args_list[0][0][0]
 
 
-@pytest.mark.asyncio
-async def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
+def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         markets=PropertyMock(markets),
-        validate_pairs=MagicMock(return_value={})
         )
     fbuy_mock = MagicMock(return_value=None)
     mocker.patch('freqtrade.rpc.RPC._rpc_forcebuy', fbuy_mock)
@@ -966,16 +959,14 @@ async def test_forcebuy_handle(default_conf, update, markets, mocker) -> None:
     assert fbuy_mock.call_args_list[0][0][1] == 0.055
 
 
-@pytest.mark.asyncio
-async def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> None:
+def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram._send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         markets=PropertyMock(markets),
-        validate_pairs=MagicMock(return_value={})
     )
     freqtradebot = FreqtradeBot(default_conf)
     patch_get_signal(freqtradebot, (True, False))
@@ -1002,7 +993,6 @@ def test_performance_handle(default_conf, update, ticker, fee,
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(markets),
-        validate_pairs=MagicMock(return_value={})
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     freqtradebot = FreqtradeBot(default_conf)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2198,7 +2198,8 @@ def test_handle_timedout_limit_sell(mocker, default_conf) -> None:
     assert cancel_order_mock.call_count == 1
 
 
-def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -2244,7 +2245,9 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, moc
     } == last_msg
 
 
-def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down,
+                                 markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -2291,9 +2294,10 @@ def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, markets,
     } == last_msg
 
 
-def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fee,
-                                                        ticker_sell_down,
-                                                        markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fee,
+                                                              ticker_sell_down,
+                                                              markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -2377,9 +2381,10 @@ def test_execute_sell_sloe_cancel_exception(mocker, default_conf, ticker, fee,
     assert log_has('Could not cancel stoploss order abcd', caplog)
 
 
-def test_execute_sell_with_stoploss_on_exchange(default_conf,
-                                                ticker, fee, ticker_sell_up,
-                                                markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_execute_sell_with_stoploss_on_exchange(default_conf,
+                                                      ticker, fee, ticker_sell_up,
+                                                      markets, mocker) -> None:
 
     default_conf['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
@@ -2432,10 +2437,11 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf,
     assert rpc_mock.call_count == 2
 
 
-def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
-                                                         ticker, fee,
-                                                         limit_buy_order,
-                                                         markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
+                                                               ticker, fee,
+                                                               limit_buy_order,
+                                                               markets, mocker) -> None:
     default_conf['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
     mocker.patch.multiple(
@@ -2499,8 +2505,9 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
     assert rpc_mock.call_count == 2
 
 
-def test_execute_sell_market_order(default_conf, ticker, fee,
-                                   ticker_sell_up, markets, mocker) -> None:
+@pytest.mark.asyncio
+async def test_execute_sell_market_order(default_conf, ticker, fee,
+                                         ticker_sell_up, markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -2676,7 +2683,9 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, fee, marke
     assert trade.sell_reason == SellType.SELL_SIGNAL.value
 
 
-def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, markets, mocker, caplog) -> None:
+@pytest.mark.asyncio
+async def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down,
+                            markets, mocker, caplog) -> None:
     patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2198,12 +2198,11 @@ def test_handle_timedout_limit_sell(mocker, default_conf) -> None:
     assert cancel_order_mock.call_count == 1
 
 
-@pytest.mark.asyncio
-async def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, mocker) -> None:
+def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2245,13 +2244,11 @@ async def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, market
     } == last_msg
 
 
-@pytest.mark.asyncio
-async def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down,
-                                 markets, mocker) -> None:
+def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2294,14 +2291,13 @@ async def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down,
     } == last_msg
 
 
-@pytest.mark.asyncio
-async def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fee,
-                                                              ticker_sell_down,
-                                                              markets, mocker) -> None:
+def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fee,
+                                                        ticker_sell_down,
+                                                        markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2356,9 +2352,9 @@ def test_execute_sell_sloe_cancel_exception(mocker, default_conf, ticker, fee,
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
     mocker.patch('freqtrade.exchange.Exchange.cancel_order', side_effect=InvalidOrderException())
     sellmock = MagicMock()
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets),
@@ -2381,16 +2377,15 @@ def test_execute_sell_sloe_cancel_exception(mocker, default_conf, ticker, fee,
     assert log_has('Could not cancel stoploss order abcd', caplog)
 
 
-@pytest.mark.asyncio
-async def test_execute_sell_with_stoploss_on_exchange(default_conf,
-                                                      ticker, fee, ticker_sell_up,
-                                                      markets, mocker) -> None:
+def test_execute_sell_with_stoploss_on_exchange(default_conf,
+                                                ticker, fee, ticker_sell_up,
+                                                markets, mocker) -> None:
 
     default_conf['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2437,16 +2432,15 @@ async def test_execute_sell_with_stoploss_on_exchange(default_conf,
     assert rpc_mock.call_count == 2
 
 
-@pytest.mark.asyncio
-async def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
-                                                               ticker, fee,
-                                                               limit_buy_order,
-                                                               markets, mocker) -> None:
+def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
+                                                         ticker, fee,
+                                                         limit_buy_order,
+                                                         markets, mocker) -> None:
     default_conf['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2505,13 +2499,12 @@ async def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
     assert rpc_mock.call_count == 2
 
 
-@pytest.mark.asyncio
-async def test_execute_sell_market_order(default_conf, ticker, fee,
-                                         ticker_sell_up, markets, mocker) -> None:
+def test_execute_sell_market_order(default_conf, ticker, fee,
+                                   ticker_sell_up, markets, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
@@ -2683,13 +2676,11 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, fee, marke
     assert trade.sell_reason == SellType.SELL_SIGNAL.value
 
 
-@pytest.mark.asyncio
-async def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down,
-                            markets, mocker, caplog) -> None:
+def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, markets, mocker, caplog) -> None:
     patch_RPCManager(mocker)
+    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        _load_markets=MagicMock(return_value={}),
         get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)


### PR DESCRIPTION
This PR eliminates asyncio and aiohttp DeprecationWarnings while testing with pytest.

I also found the aiohttp-pytest plugin, but seems it's not needed...

I found this recipe, but I actually don't completely understand in all details what I'm doing by introducing this change and how it can influence testing of other functionality in the affected tests. Especially, I do not understand while other tests in those modules, just below and above the changed tests, do not require it...
