### PR TITLE
hyperopt loss function based on calmar ratio - not merge - WIP - POC

### DIFF
--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -59,8 +59,8 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         abs_mediam_simulated_drawdowns = Series(simulated_drawdowns).median()
         calmar_ratio = return_avg_per_year/abs_mediam_simulated_drawdowns
 
-        # Normalize loss value to be float between (0, 1)
-        calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 100))
+        # Normalize loss value to be float between (0, 1) :  0.5 value mean no profit
+        calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 10))
 
         # feel free to add other criterias (e.g avg expected time duration)
         loss = (calmar_loss * CALMAR_LOSS_WEIGHT)

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -70,12 +70,15 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         0 mean no profit
         """
         calmar_loss = 0.5 - (norm.cdf(calmar_ratio, 0, 1.5/CALMAR_LOSS_WEIGHT))
+        normalized_expected_trade_loss = norm.cdf(trade_count-NB_EXPECTED_TRADES,
+                                                  -NB_EXPECTED_TRADES,
+                                                  (NB_EXPECTED_TRADES*(2/3))*EXPECTED_TRADES_WEIGHT)
 
         """
         Normalize loss value to be float between (0, 0.5) :
         Closed to 0 mean trade_count = NB_EXPECTED_TRADES
         """
-        expected_trade_loss_penalty = 1 - norm.cdf(trade_count-NB_EXPECTED_TRADES,-NB_EXPECTED_TRADES,(NB_EXPECTED_TRADES*(2/3))*EXPECTED_TRADES_WEIGHT)
+        expected_trade_loss_penalty = 1 - normalized_expected_trade_loss
 
         # want to see the loss -> shorturl.at/DHX34
         loss = calmar_loss + expected_trade_loss_penalty

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -7,10 +7,11 @@ from freqtrade.optimize.hyperopt import IHyperOptLoss, MAX_LOSS
 
 NB_SIMULATIONS = 1000
 SIMULATION_YEAR_DURATION = 3
-CALMAR_LOSS_WEIGHT = 1
 
 SLIPPAGE_PERCENT = 0.000
 NB_EXPECTED_TRADES = 600
+
+CALMAR_LOSS_WEIGHT = 0.5
 EXPECTED_TRADES_WEIGHT = 0.5
 
 
@@ -64,8 +65,12 @@ class CalmarHyperOptLoss(IHyperOptLoss):
 
         calmar_ratio = mediam_simulated_annualized_returns/abs_mediam_simulated_drawdowns
 
-        # Normalize loss value to be float between (0, 1) :  0.5 value mean no profit
-        calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 10))
+        """
+        Normalize loss value to be float between (-0.5, 0.5)
+        0 mean no profit
+        """
+        calmar_loss = 0.5 - (norm.cdf(calmar_ratio, 0, 1.5/CALMAR_LOSS_WEIGHT))
+
         """
         Normalize loss value to be float between (0, 0.5) :
         Closed to 0 mean trade_count = NB_EXPECTED_TRADES

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -17,7 +17,7 @@ EXPECTED_TRADES_WEIGHT = 0.5
 class CalmarHyperOptLoss(IHyperOptLoss):
     """
     Defines the calmar loss function for hyperopt (you maybe need to add other criterias
-    like the number of trades expected and the max duration expected).
+    as the max duration expected).
     Calmar ratio is based on  average annual rate of return for the last 36 months divided by the
     maximum drawdown for the last 36 months.
     But you maybe don't have running hyperopt with 36 months of data so we will simulate 36 months

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -55,7 +55,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         abs_mediam_simulated_drawdowns = Series(simulated_drawdowns).median()
         calmar_ratio = return_avg_simulation_duration/abs_mediam_simulated_drawdowns
 
-        # float between ]0,1[
+        # Normalize loss value to be float between (0, 1)
         calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 100))
 
         # feel free to add other criterias (e.g avg expected time duration)

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from pandas import DataFrame, Series
-from freqtrade.optimize.hyperopt import IHyperOptLoss
 import numpy as np
 from scipy.stats import norm
 
+from freqtrade.optimize.hyperopt import IHyperOptLoss, MAX_LOSS
+
 NB_SIMULATIONS = 1000
 SIMULATION_YEAR_DURATION = 3
-HIGH_NUMBER = 100000
 CALMAR_LOSS_WEIGHT = 1
 SLIPPAGE_PERCENT = 0.001
 
@@ -42,7 +42,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
 
         # exclude the case when no trade was lost
         if(results.profit_percent.min() >= 0):
-            return HIGH_NUMBER
+            return MAX_LOSS
 
         # simulate n years of run to define a median max drawdown
         for i in range(0, NB_SIMULATIONS):

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -77,8 +77,8 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         """
         expected_trade_loss_penalty = 1 - norm.cdf(trade_count-NB_EXPECTED_TRADES,-NB_EXPECTED_TRADES,(NB_EXPECTED_TRADES*(2/3))*EXPECTED_TRADES_WEIGHT)
 
-        # feel free to add other criterias (e.g avg expected time duration)
-        loss = (calmar_loss * CALMAR_LOSS_WEIGHT)
+        # want to see the loss -> shorturl.at/DHX34
+        loss = calmar_loss + expected_trade_loss_penalty
 
         # print('calmar_ratio {}'.format(calmar_ratio))
 

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -46,7 +46,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         backtest_duration_years = ((max_date-min_date).days/365)
         trade_count_average_per_year = trade_count/backtest_duration_years
 
-        # add slipage to be closed to live
+        # add extra slipage to be closed to live?
         results['profit_percent'] -= SLIPPAGE_PERCENT
 
         sample_size = round(trade_count_average_per_year * SIMULATION_YEAR_DURATION)

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -32,6 +32,10 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         Objective function, returns smaller number for better results
         """
 
+        # exclude the case when no trade was lost
+        if(results.profit_percent.min() >= 0):
+            return MAX_LOSS
+
         simulated_drawdowns = []
 
         backtest_duration_years = ((max_date-min_date).days/365.2425)
@@ -43,10 +47,6 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         return_avg_per_year = (results.profit_percent.sum() / backtest_duration_years)
 
         sample_size = round(trade_count_average_per_year * SIMULATION_YEAR_DURATION)
-
-        # exclude the case when no trade was lost
-        if(results.profit_percent.min() >= 0):
-            return MAX_LOSS
 
         # simulate n years of run to define a median max drawdown
         for i in range(0, NB_SIMULATIONS):

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -8,7 +8,8 @@ from freqtrade.optimize.hyperopt import IHyperOptLoss, MAX_LOSS
 NB_SIMULATIONS = 1000
 SIMULATION_YEAR_DURATION = 3
 CALMAR_LOSS_WEIGHT = 1
-SLIPPAGE_PERCENT = 0.001
+
+SLIPPAGE_PERCENT = 0.000
 
 
 class CalmarHyperOptLoss(IHyperOptLoss):

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -33,7 +33,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         """
 
         # exclude the case when no trade was lost
-        if(results.profit_percent.min() >= 0):
+        if results.profit_percent.min() >= 0:
             return MAX_LOSS
 
         simulated_drawdowns = []

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -8,9 +8,9 @@ from freqtrade.optimize.hyperopt import IHyperOptLoss, MAX_LOSS
 NB_SIMULATIONS = 1000
 SIMULATION_YEAR_DURATION = 3
 
+# Configure according to your needs
 SLIPPAGE_PERCENT = 0.000
 NB_EXPECTED_TRADES = 600
-
 CALMAR_LOSS_WEIGHT = 0.5
 EXPECTED_TRADES_WEIGHT = 0.5
 

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -18,8 +18,8 @@ class CalmarHyperOptLoss(IHyperOptLoss):
     Calmar ratio is based on  average annual rate of return for the last 36 months divided by the
     maximum drawdown for the last 36 months.
     But you maybe don't have running hyperopt with 36 months of data so we will simulate 36 months
-    of trading with a montecarlo simulation and find the median drawdown (what's happenned if the trades
-    orders changes, the max drawdown change ?)
+    of trading with a montecarlo simulation and find the median drawdown (what's happenned if the
+    trades orders changes, the max drawdown change ?)
     shorturl.at/ioAK2
     """
 

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -10,6 +10,8 @@ SIMULATION_YEAR_DURATION = 3
 CALMAR_LOSS_WEIGHT = 1
 
 SLIPPAGE_PERCENT = 0.000
+NB_EXPECTED_TRADES = 600
+EXPECTED_TRADES_WEIGHT = 0.5
 
 
 class CalmarHyperOptLoss(IHyperOptLoss):
@@ -64,6 +66,11 @@ class CalmarHyperOptLoss(IHyperOptLoss):
 
         # Normalize loss value to be float between (0, 1) :  0.5 value mean no profit
         calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 10))
+        """
+        Normalize loss value to be float between (0, 0.5) :
+        Closed to 0 mean trade_count = NB_EXPECTED_TRADES
+        """
+        expected_trade_loss_penalty = 1 - norm.cdf(trade_count-NB_EXPECTED_TRADES,-NB_EXPECTED_TRADES,(NB_EXPECTED_TRADES*(2/3))*EXPECTED_TRADES_WEIGHT)
 
         # feel free to add other criterias (e.g avg expected time duration)
         loss = (calmar_loss * CALMAR_LOSS_WEIGHT)

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -41,7 +41,6 @@ class CalmarHyperOptLoss(IHyperOptLoss):
         results['profit_percent'] -= SLIPPAGE_PERCENT
 
         return_avg_per_year = (results.profit_percent.sum() / backtest_duration_years)
-        return_avg_simulation_duration = return_avg_per_year * SIMULATION_YEAR_DURATION
 
         sample_size = round(trade_count_average_per_year * SIMULATION_YEAR_DURATION)
 
@@ -58,7 +57,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
             simulated_drawdowns.append(simulated_drawdown)
 
         abs_mediam_simulated_drawdowns = Series(simulated_drawdowns).median()
-        calmar_ratio = return_avg_simulation_duration/abs_mediam_simulated_drawdowns
+        calmar_ratio = return_avg_per_year/abs_mediam_simulated_drawdowns
 
         # Normalize loss value to be float between (0, 1)
         calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 100))

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from pandas import DataFrame, Series
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+import numpy as np
+from scipy.stats import norm
+
+NB_SIMULATIONS = 1000
+SIMULATION_YEAR_DURATION = 3
+HIGH_NUMBER = 100000
+CALMAR_LOSS_WEIGHT = 1
+SLIPPAGE_PERCENT = 0.001
+
+
+class CalmarHyperOptLoss(IHyperOptLoss):
+    """
+    Defines the default loss function for hyperopt
+    This is intended to give you some inspiration for your own loss function.
+    The Function needs to return a number (float) - which becomes for better backtest results.
+    """
+
+    @classmethod
+    def hyperopt_loss_function(cls, results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               *args, **kwargs) -> float:
+
+        """
+        Objective function, returns smaller number for better results
+        """
+
+        simulated_drawdowns = []
+
+        backtest_duration_years = ((max_date-min_date).days/365.2425)
+        trade_count_average_per_year = trade_count/backtest_duration_years
+
+        # add slipage to be closed to live
+        results['profit_percent'] -= SLIPPAGE_PERCENT
+
+        return_avg_per_year = (results.profit_percent.sum() / backtest_duration_years)
+        return_avg_simulation_duration = return_avg_per_year * SIMULATION_YEAR_DURATION
+
+        sample_size = round(trade_count_average_per_year * SIMULATION_YEAR_DURATION)
+
+        # exclude the case when no trade was lost
+        if(results.profit_percent.min() >= 0):
+            return HIGH_NUMBER
+
+        # simulate n years of run to define a median max drawdown
+        for i in range(0, NB_SIMULATIONS):
+            randomized_result = results.profit_percent.sample(n=sample_size,
+                                                              random_state=np.random.RandomState(),
+                                                              replace=True)
+            simulated_drawdown = cls.abs_max_drawdown(randomized_result)
+            simulated_drawdowns.append(simulated_drawdown)
+
+        abs_mediam_simulated_drawdowns = Series(simulated_drawdowns).median()
+        calmar_ratio = return_avg_simulation_duration/abs_mediam_simulated_drawdowns
+
+        # float between ]0,1[
+        calmar_loss = 1 - (norm.cdf(calmar_ratio, 0, 100))
+
+        # feel free to add other criterias (e.g avg expected time duration)
+        loss = (calmar_loss * CALMAR_LOSS_WEIGHT)
+
+        # print('calmar_ratio {}'.format(calmar_ratio))
+
+        return loss
+
+    @staticmethod
+    def abs_max_drawdown(profit_percent_results: Series) -> float:
+
+        max_drawdown_df = DataFrame()
+        max_drawdown_df['cumulative'] = profit_percent_results.cumsum()
+        max_drawdown_df['high_value'] = max_drawdown_df['cumulative'].cummax()
+        max_drawdown_df['drawdown'] = max_drawdown_df['cumulative'] - max_drawdown_df['high_value']
+
+        return abs(max_drawdown_df['drawdown'].min())

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -38,7 +38,7 @@ class CalmarHyperOptLoss(IHyperOptLoss):
 
         simulated_drawdowns = []
 
-        backtest_duration_years = ((max_date-min_date).days/365.2425)
+        backtest_duration_years = ((max_date-min_date).days/365)
         trade_count_average_per_year = trade_count/backtest_duration_years
 
         # add slipage to be closed to live

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -13,9 +13,13 @@ SLIPPAGE_PERCENT = 0.001
 
 class CalmarHyperOptLoss(IHyperOptLoss):
     """
-    Defines the default loss function for hyperopt
-    This is intended to give you some inspiration for your own loss function.
-    The Function needs to return a number (float) - which becomes for better backtest results.
+    Defines the calmar loss function for hyperopt.
+    Calmar ratio is based on  average annual rate of return for the last 36 months divided by the
+    maximum drawdown for the last 36 months.
+    But you maybe don't have running hyperopt with 36 months of data so we will simulate 36 months
+    of trading with a montecarlo simulation and find the median drawdown (what's happenned if the trades
+    orders changes, the max drawdown change ?)
+    shorturl.at/ioAK2
     """
 
     @classmethod

--- a/freqtrade/optimize/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss_calmar.py
@@ -13,7 +13,8 @@ SLIPPAGE_PERCENT = 0.001
 
 class CalmarHyperOptLoss(IHyperOptLoss):
     """
-    Defines the calmar loss function for hyperopt.
+    Defines the calmar loss function for hyperopt (you maybe need to add other criterias
+    like the number of trades expected and the max duration expected).
     Calmar ratio is based on  average annual rate of return for the last 36 months divided by the
     maximum drawdown for the last 36 months.
     But you maybe don't have running hyperopt with 36 months of data so we will simulate 36 months

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -328,6 +328,21 @@ def test_sharpe_loss_prefers_higher_profits(default_conf, hyperopt_results) -> N
     assert over < correct
     assert under > correct
 
+# When the profit a two backtests are the same i prefer to take the one that minimise the median drawdown
+def test_calmar_loss_prefers_higher_profits(default_conf,
+                                            hyperopt_results_min_median_drawdown,
+                                            hyperopt_results_max_median_drawdown) -> None:
+
+    default_conf.update({'hyperopt_loss': 'CalmarHyperOptLoss'})
+    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    min_median_drawdown_loss = hl.hyperopt_loss_function(hyperopt_results_min_median_drawdown,
+                                                        len(hyperopt_results_min_median_drawdown),
+                                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    max_median_drawdown_loss = hl.hyperopt_loss_function(hyperopt_results_max_median_drawdown,
+                                                        len(hyperopt_results_max_median_drawdown),
+                                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    assert min_median_drawdown_loss < max_median_drawdown_loss
+
 
 def test_onlyprofit_loss_prefers_higher_profits(default_conf, hyperopt_results) -> None:
     results_over = hyperopt_results.copy()

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -44,6 +44,29 @@ def hyperopt_results():
         }
     )
 
+@pytest.fixture(scope='function')
+def hyperopt_results_min_median_drawdown():
+    return pd.DataFrame(
+        {
+            'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
+            'profit_percent': [0.1, 0.1, -0.1, 0.1, 0.1],
+            'profit_abs': [0.2, 0.2, -0.2, 0.2, 0.2],
+            'trade_duration': [10, 30, 10, 30, 10],
+            'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS,SellType.ROI, SellType.ROI]
+        }
+    )
+
+@pytest.fixture(scope='function')
+def hyperopt_results_max_median_drawdown():
+    return pd.DataFrame(
+        {
+            'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
+            'profit_percent': [0.3, -0.1, -0.1, -0.1, 0.3],
+            'profit_abs': [0.6, -0.2, -0.2, -0.2, 0.6],
+            'trade_duration': [10, 30, 10, 30, 10],
+            'sell_reason': [SellType.ROI, SellType.STOP_LOSS, SellType.STOP_LOSS,SellType.STOP_LOSS, SellType.ROI]
+        }
+    )
 
 # Functions for recurrent object patching
 def create_trials(mocker, hyperopt, testdatadir) -> None:

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -44,6 +44,7 @@ def hyperopt_results():
         }
     )
 
+
 @pytest.fixture(scope='function')
 def hyperopt_results_min_median_drawdown():
     return pd.DataFrame(
@@ -52,9 +53,11 @@ def hyperopt_results_min_median_drawdown():
             'profit_percent': [0.1, 0.1, -0.1, 0.1, 0.1],
             'profit_abs': [0.2, 0.2, -0.2, 0.2, 0.2],
             'trade_duration': [10, 30, 10, 30, 10],
-            'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS,SellType.ROI, SellType.ROI]
+            'sell_reason':
+            [SellType.ROI, SellType.ROI, SellType.STOP_LOSS, SellType.ROI, SellType.ROI]
         }
     )
+
 
 @pytest.fixture(scope='function')
 def hyperopt_results_max_median_drawdown():
@@ -64,9 +67,11 @@ def hyperopt_results_max_median_drawdown():
             'profit_percent': [0.3, -0.1, -0.1, -0.1, 0.3],
             'profit_abs': [0.6, -0.2, -0.2, -0.2, 0.6],
             'trade_duration': [10, 30, 10, 30, 10],
-            'sell_reason': [SellType.ROI, SellType.STOP_LOSS, SellType.STOP_LOSS,SellType.STOP_LOSS, SellType.ROI]
+            'sell_reason':
+            [SellType.ROI, SellType.STOP_LOSS, SellType.STOP_LOSS, SellType.STOP_LOSS, SellType.ROI]
         }
     )
+
 
 # Functions for recurrent object patching
 def create_trials(mocker, hyperopt, testdatadir) -> None:
@@ -328,7 +333,13 @@ def test_sharpe_loss_prefers_higher_profits(default_conf, hyperopt_results) -> N
     assert over < correct
     assert under > correct
 
-# When the profit a two backtests are the same i prefer to take the one that minimise the median drawdown
+
+"""
+When the profit a two backtests are the same i prefer to take
+the one that minimise the median drawdown
+"""
+
+
 def test_calmar_loss_prefers_higher_profits(default_conf,
                                             hyperopt_results_min_median_drawdown,
                                             hyperopt_results_max_median_drawdown) -> None:
@@ -336,11 +347,11 @@ def test_calmar_loss_prefers_higher_profits(default_conf,
     default_conf.update({'hyperopt_loss': 'CalmarHyperOptLoss'})
     hl = HyperOptLossResolver(default_conf).hyperoptloss
     min_median_drawdown_loss = hl.hyperopt_loss_function(hyperopt_results_min_median_drawdown,
-                                                        len(hyperopt_results_min_median_drawdown),
-                                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+                                                         len(hyperopt_results_min_median_drawdown),
+                                                         datetime(2019, 1, 1), datetime(2019, 5, 1))
     max_median_drawdown_loss = hl.hyperopt_loss_function(hyperopt_results_max_median_drawdown,
-                                                        len(hyperopt_results_max_median_drawdown),
-                                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+                                                         len(hyperopt_results_max_median_drawdown),
+                                                         datetime(2019, 1, 1), datetime(2019, 5, 1))
     assert min_median_drawdown_loss < max_median_drawdown_loss
 
 


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? 

unit test -> no i will but think i need to use the fixtures from
https://github.com/freqtrade/freqtrade/blob/f987e6e0f9bdcae6f0cec3a273e270a3a35a3c12/tests/optimize/test_hyperopt.py#L33 but the last trade in the dataframe is SellType.STOP_LOSS and profitperc positive ? i missed something for sure. 

PE8 conformant -> yes

## Summary

Provide to freqrade hyperopt a loss function based on calmar ratio (max drawdown)

## Quick changelog

- add an extra hyperopt loss function

## What's new?
- Based on the simulation of the median max drawdown (montecarlo simulation) calculate the calmar ratio. (https://www.seeitmarket.com/3-of-many-uses-for-monte-carlo-simulations-in-trading-18266/ kind of the second part based on randomization)

## Questions
1/ Don't know the road map and the fact that you don't want to include a lot of dependencies is there a way to include a risk library (e.g https://github.com/quantopian/empyrical) -> it can be useful for loss function and backtest (in my case i create a max_drawdown function but a library could be better) ?
2/ i see that all params for loss are hardcoded (eg :  MAX_ACCEPTED_TRADE_DURATION = 300
) but it couls be usefull to be able to overwrite defaults in the hyperopt class ?

This pull request is for now only to have a feedback (feel free to tell me this is not in the road map or useless :-) ) (if you think it useful i spend some times create tests, update doc...)

Have a nice day and many tks for this beautiful project.
