### PR TITLE
Cleanup: Don't inherit from object

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -44,7 +44,7 @@ ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
 NO_CONF_REQURIED = ["download-data", "plot-dataframe", "plot-profit"]
 
 
-class Arguments(object):
+class Arguments:
     """
     Arguments Class. Manage the arguments received by the cli
     """

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -22,7 +22,7 @@ from freqtrade.state import RunMode
 logger = logging.getLogger(__name__)
 
 
-class Configuration(object):
+class Configuration:
     """
     Class to read and init the bot configuration
     Reuse this class for the bot, backtesting, hyperopt and every script that required configuration

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -72,7 +72,7 @@ def retrier(f):
     return wrapper
 
 
-class Exchange(object):
+class Exchange:
 
     _config: Dict = {}
     _params: Dict = {}

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -29,7 +29,7 @@ from freqtrade.wallets import Wallets
 logger = logging.getLogger(__name__)
 
 
-class FreqtradeBot(object):
+class FreqtradeBot:
     """
     Freqtrade is the main class of the bot.
     This is from here the bot start its logic.

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -44,7 +44,7 @@ class BacktestResult(NamedTuple):
     sell_reason: SellType
 
 
-class Backtesting(object):
+class Backtesting:
     """
     Backtesting class, this class contains all the logic to run a backtest
 

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -16,7 +16,7 @@ from freqtrade.resolvers import StrategyResolver
 logger = logging.getLogger(__name__)
 
 
-class EdgeCli(object):
+class EdgeCli:
     """
     EdgeCli class, this class contains all the logic to run edge backtesting
 

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -12,7 +12,7 @@ from typing import Any, List, Optional, Tuple, Type, Union
 logger = logging.getLogger(__name__)
 
 
-class IResolver(object):
+class IResolver:
     """
     This class contains all the logic to load custom classes
     """

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -15,7 +15,7 @@ from freqtrade.constants import SUPPORTED_FIAT
 logger = logging.getLogger(__name__)
 
 
-class CryptoFiat(object):
+class CryptoFiat:
     """
     Object to describe what is the price of Crypto-currency in a FIAT
     """
@@ -60,7 +60,7 @@ class CryptoFiat(object):
         return self._expiration - time.time() <= 0
 
 
-class CryptoToFiatConverter(object):
+class CryptoToFiatConverter:
     """
     Main class to initiate Crypto to FIAT.
     This object contains a list of pair Crypto, FIAT

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -54,7 +54,7 @@ class RPCException(Exception):
         }
 
 
-class RPC(object):
+class RPC:
     """
     RPC class can be used to have extra feature, like bot data, and access to DB data
     """

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -9,7 +9,7 @@ from freqtrade.rpc import RPC, RPCMessageType
 logger = logging.getLogger(__name__)
 
 
-class RPCManager(object):
+class RPCManager:
     """
     Class to manage RPC objects (Telegram, Slack, ...)
     """

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -17,7 +17,7 @@ class Wallet(NamedTuple):
     total: float = 0
 
 
-class Wallets(object):
+class Wallets:
 
     def __init__(self, config: dict, exchange: Exchange) -> None:
         self._config = config

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -19,7 +19,7 @@ from freqtrade.rpc import RPCMessageType
 logger = logging.getLogger(__name__)
 
 
-class Worker(object):
+class Worker:
     """
     Freqtradebot worker class
     """


### PR DESCRIPTION
Minor code cleanup: no need to inherit classes from 'object' in python3.
