### PR TITLE
Allow all arguments after subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       name: backtest
     - script:
       - cp config.json.example config.json
-      - freqtrade hyperopt --datadir tests/testdata -e 5 --strategy DefaultStrategy
+      - freqtrade hyperopt --datadir tests/testdata -e 5 --strategy DefaultStrategy --customhyperopt DefaultHyperOpts
       name: hyperopt
     - script: flake8
       name: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ jobs:
       name: pytest
     - script:
       - cp config.json.example config.json
-      - freqtrade backtesting --datadir tests/testdata
+      - freqtrade backtesting --datadir tests/testdata --strategy DefaultStrategy
       name: backtest
     - script:
       - cp config.json.example config.json
-      - freqtrade hyperopt --datadir tests/testdata -e 5
+      - freqtrade hyperopt --datadir tests/testdata -e 5 --strategy DefaultStrategy
       name: hyperopt
     - script: flake8
       name: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       name: backtest
     - script:
       - cp config.json.example config.json
-      - freqtrade hyperopt --datadir tests/testdata -e 5 --strategy DefaultStrategy --customhyperopt DefaultHyperOpts
+      - freqtrade hyperopt --datadir tests/testdata -e 5 --strategy DefaultStrategy --hyperopt DefaultHyperOpts
       name: hyperopt
     - script: flake8
       name: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ jobs:
       name: pytest
     - script:
       - cp config.json.example config.json
-      - freqtrade --datadir tests/testdata backtesting
+      - freqtrade backtesting --datadir tests/testdata
       name: backtest
     - script:
       - cp config.json.example config.json
-      - freqtrade --datadir tests/testdata hyperopt -e 5
+      - freqtrade hyperopt --datadir tests/testdata -e 5
       name: hyperopt
     - script: flake8
       name: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,5 @@ RUN pip install numpy --no-cache-dir \
 COPY . /freqtrade/
 RUN pip install -e . --no-cache-dir
 ENTRYPOINT ["freqtrade"]
+# Default to trade mode
+CMD [ "trade" ]

--- a/build_helpers/publish_docker.sh
+++ b/build_helpers/publish_docker.sh
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Run backtest
-docker run --rm -it -v $(pwd)/config.json.example:/freqtrade/config.json:ro -v $(pwd)/tests:/tests freqtrade:${TAG} --datadir /tests/testdata backtesting
+docker run --rm -it -v $(pwd)/config.json.example:/freqtrade/config.json:ro -v $(pwd)/tests:/tests freqtrade:${TAG} backtesting --datadir /tests/testdata --strategy DefaultStrategy
 
 if [ $? -ne 0 ]; then
     echo "failed running backtest"

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -45,7 +45,7 @@ freqtrade backtesting --datadir user_data/data/bittrex-20180101
 #### With a (custom) strategy file
 
 ```bash
-freqtrade -s SampleStrategy backtesting
+freqtrade backtesting -s SampleStrategy
 ```
 
 Where `-s SampleStrategy` refers to the class name within the strategy file `sample_strategy.py` found in the `freqtrade/user_data/strategies` directory.

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -5,27 +5,47 @@ This page explains the different parameters of the bot and how to run it.
 !!! Note
     If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
-
 ## Bot commands
 
 ```
-usage: freqtrade [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
-                 [--userdir PATH] [-s NAME] [--strategy-path PATH]
-                 [--db-url PATH] [--sd-notify]
-                 {backtesting,edge,hyperopt,create-userdir,list-exchanges} ...
+usage: freqtrade [-h] [-V]
+                 {trade,backtesting,edge,hyperopt,create-userdir,list-exchanges,download-data,plot-dataframe,plot-profit}
+                 ...
 
 Free, open source crypto trading bot
 
 positional arguments:
-  {backtesting,edge,hyperopt,create-userdir,list-exchanges}
+  {trade,backtesting,edge,hyperopt,create-userdir,list-exchanges,download-data,plot-dataframe,plot-profit}
+    trade               Trade module.
     backtesting         Backtesting module.
     edge                Edge module.
     hyperopt            Hyperopt module.
     create-userdir      Create user-data directory.
     list-exchanges      Print available exchanges.
+    download-data       Download backtesting data.
+    plot-dataframe      Plot candles with indicators.
+    plot-profit         Generate plot showing profits.
 
 optional arguments:
   -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
+```
+
+### Bot trading commands
+
+```
+usage: freqtrade trade [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
+                       [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                       [--db-url PATH] [--sd-notify]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --db-url PATH         Override trades database URL, this is useful in custom
+                        deployments (default: `sqlite:///tradesv3.sqlite` for
+                        Live Run mode, `sqlite://` for Dry Run).
+  --sd-notify           Notify systemd service manager.
+
+Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
   --logfile FILE        Log to the file specified.
   -V, --version         show program's version number and exit
@@ -37,14 +57,12 @@ optional arguments:
                         Path to directory with historical backtesting data.
   --userdir PATH, --user-data-dir PATH
                         Path to userdata directory.
+
+Strategy arguments:
   -s NAME, --strategy NAME
                         Specify strategy class name (default:
                         `DefaultStrategy`).
   --strategy-path PATH  Specify additional strategy lookup path.
-  --db-url PATH         Override trades database URL, this is useful in custom
-                        deployments (default: `sqlite:///tradesv3.sqlite` for
-                        Live Run mode, `sqlite://` for Dry Run).
-  --sd-notify           Notify systemd service manager.
 
 ```
 
@@ -128,7 +146,7 @@ In `user_data/strategies` you have a file `my_awesome_strategy.py` which has
 a strategy class called `AwesomeStrategy` to load it:
 
 ```bash
-freqtrade --strategy AwesomeStrategy
+freqtrade trade --strategy AwesomeStrategy
 ```
 
 If the bot does not find your strategy file, it will display in an error
@@ -143,7 +161,7 @@ This parameter allows you to add an additional strategy lookup path, which gets
 checked before the default locations (The passed path must be a directory!):
 
 ```bash
-freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
+freqtrade trade --strategy AwesomeStrategy --strategy-path /some/directory
 ```
 
 #### How to install a strategy?
@@ -167,20 +185,22 @@ freqtrade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 Backtesting also uses the config specified via `-c/--config`.
 
 ```
-usage: freqtrade backtesting [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                           [--max_open_trades MAX_OPEN_TRADES]
-                           [--stake_amount STAKE_AMOUNT] [-r] [--eps] [--dmmp]
-                           [-l]
-                           [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
-                           [--export EXPORT] [--export-filename PATH]
+usage: freqtrade backtesting [-h] [-v] [--logfile FILE] [-V] [-c PATH]
+                             [-d PATH] [--userdir PATH] [-s NAME]
+                             [--strategy-path PATH] [-i TICKER_INTERVAL]
+                             [--timerange TIMERANGE] [--max_open_trades INT]
+                             [--stake_amount STAKE_AMOUNT] [--eps] [--dmmp]
+                             [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
+                             [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades MAX_OPEN_TRADES
+  --max_open_trades INT
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
@@ -193,26 +213,47 @@ optional arguments:
                         number).
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
                         Provide a space-separated list of strategies to
-                        backtest Please note that ticker-interval needs to be
+                        backtest. Please note that ticker-interval needs to be
                         set either in config or via command line. When using
-                        this together with --export trades, the strategy-name
-                        is injected into the filename (so backtest-data.json
-                        becomes backtest-data-DefaultStrategy.json
-  --export EXPORT       Export backtest results, argument are: trades. Example
-                        --export=trades
+                        this together with `--export trades`, the strategy-
+                        name is injected into the filename (so `backtest-
+                        data.json` becomes `backtest-data-
+                        DefaultStrategy.json`
+  --export EXPORT       Export backtest results, argument are: trades.
+                        Example: `--export=trades`
   --export-filename PATH
-                        Save backtest results to this filename requires
-                        --export to be set as well Example --export-
-                        filename=user_data/backtest_results/backtest_today.json
-                        (default: user_data/backtest_results/backtest-
-                        result.json)
+                        Save backtest results to the file with this filename
+                        (default: `user_data/backtest_results/backtest-
+                        result.json`). Requires `--export` to be set as well.
+                        Example: `--export-filename=user_data/backtest_results
+                        /backtest_today.json`
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
+
+Strategy arguments:
+  -s NAME, --strategy NAME
+                        Specify strategy class name (default:
+                        `DefaultStrategy`).
+  --strategy-path PATH  Specify additional strategy lookup path.
+
 ```
 
 ### Getting historic data for backtesting
 
 The first time your run Backtesting, you will need to download some historic data first.
 This can be accomplished by using `freqtrade download-data`.  
-Check the corresponding [help page section](backtesting.md#Getting-data-for-backtesting-and-hyperopt) for more details
+Check the corresponding [Data Downloading](data-download.md) section for more details
 
 ## Hyperopt commands
 
@@ -220,15 +261,17 @@ To optimize your strategy, you can use hyperopt parameter hyperoptimization
 to find optimal parameter values for your stategy.
 
 ```
-usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
+usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
+                          [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                          [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--max_open_trades INT]
-                          [--stake_amount STAKE_AMOUNT] [-r]
+                          [--stake_amount STAKE_AMOUNT]
                           [--customhyperopt NAME] [--hyperopt-path PATH]
                           [--eps] [-e INT]
-                          [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
-                          [--dmmp] [--print-all] [--no-color] [-j JOBS]
-                          [--random-state INT] [--min-trades INT] [--continue]
-                          [--hyperopt-loss NAME]
+                          [--spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
+                          [--dmmp] [--print-all] [--no-color] [--print-json]
+                          [-j JOBS] [--random-state INT] [--min-trades INT]
+                          [--continue] [--hyperopt-loss NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -250,7 +293,7 @@ optional arguments:
                         Allow buying the same pair multiple times (position
                         stacking).
   -e INT, --epochs INT  Specify number of epochs (default: 100).
-  -s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...], --spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]
+  --spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]
                         Specify which parameters to hyperopt. Space-separated
                         list. Default: `all`.
   --dmmp, --disable-max-market-positions
@@ -260,6 +303,7 @@ optional arguments:
   --print-all           Print all results, not only the best ones.
   --no-color            Disable colorization of hyperopt results. May be
                         useful if you are redirecting output to a file.
+  --print-json          Print best result detailization in JSON format.
   -j JOBS, --job-workers JOBS
                         The number of concurrently running jobs for
                         hyperoptimization (hyperopt worker processes). If -1
@@ -278,8 +322,28 @@ optional arguments:
                         generate completely different results, since the
                         target for optimization is different. Built-in
                         Hyperopt-loss-functions are: DefaultHyperOptLoss,
-                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.
-                        (default: `DefaultHyperOptLoss`).
+                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.(default:
+                        `DefaultHyperOptLoss`).
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
+
+Strategy arguments:
+  -s NAME, --strategy NAME
+                        Specify strategy class name (default:
+                        `DefaultStrategy`).
+  --strategy-path PATH  Specify additional strategy lookup path.
+
 ```
 
 ## Edge commands
@@ -287,26 +351,48 @@ optional arguments:
 To know your trade expectancy and winrate against historical data, you can use Edge.
 
 ```
-usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                    [--max_open_trades MAX_OPEN_TRADES]
-                    [--stake_amount STAKE_AMOUNT] [-r]
-                    [--stoplosses STOPLOSS_RANGE]
+usage: freqtrade edge [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
+                      [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                      [-i TICKER_INTERVAL] [--timerange TIMERANGE]
+                      [--max_open_trades INT] [--stake_amount STAKE_AMOUNT]
+                      [--stoplosses STOPLOSS_RANGE]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades MAX_OPEN_TRADES
+  --max_open_trades INT
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
   --stoplosses STOPLOSS_RANGE
-                        Defines a range of stoploss against which edge will
-                        assess the strategy the format is "min,max,step"
-                        (without any space).example:
-                        --stoplosses=-0.01,-0.1,-0.001
+                        Defines a range of stoploss values against which edge
+                        will assess the strategy. The format is "min,max,step"
+                        (without any space). Example:
+                        `--stoplosses=-0.01,-0.1,-0.001`
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
+
+Strategy arguments:
+  -s NAME, --strategy NAME
+                        Specify strategy class name (default:
+                        `DefaultStrategy`).
+  --strategy-path PATH  Specify additional strategy lookup path.
+
 ```
 
 To understand edge and how to read the results, please read the [edge documentation](edge.md).

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -72,7 +72,7 @@ The bot allows you to select which configuration file you want to use by means o
 the `-c/--config` command line option:
 
 ```bash
-freqtrade -c path/far/far/away/config.json
+freqtrade trade -c path/far/far/away/config.json
 ```
 
 Per default, the bot loads the `config.json` configuration file from the current
@@ -91,13 +91,13 @@ empty key and secrete values while running in the Dry Mode (which does not actua
 require them):
 
 ```bash
-freqtrade -c ./config.json
+freqtrade trade -c ./config.json
 ```
 
 and specify both configuration files when running in the normal Live Trade Mode:
 
 ```bash
-freqtrade -c ./config.json -c path/to/secrets/keys.config.json
+freqtrade trade -c ./config.json -c path/to/secrets/keys.config.json
 ```
 
 This could help you hide your private Exchange key and Exchange secrete on you local machine
@@ -177,7 +177,7 @@ using `--db-url`. This can also be used to specify a custom database
 in production mode. Example command:
 
 ```bash
-freqtrade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
+freqtrade trade -c config.json --db-url sqlite:///tradesv3.dry_run.sqlite
 ```
 
 ## Backtesting commands

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -36,7 +36,7 @@ optional arguments:
 ```
 usage: freqtrade trade [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                        [--userdir PATH] [-s NAME] [--strategy-path PATH]
-                       [--db-url PATH] [--sd-notify]
+                       [--db-url PATH] [--sd-notify] [--dry-run]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -44,6 +44,8 @@ optional arguments:
                         deployments (default: `sqlite:///tradesv3.sqlite` for
                         Live Run mode, `sqlite://` for Dry Run).
   --sd-notify           Notify systemd service manager.
+  --dry-run             Enforce dry-run for trading (removes Exchange secrets
+                        and simulates trades).
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
@@ -63,7 +65,6 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
-
 ```
 
 ### How to specify which configuration file be used?

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -267,7 +267,7 @@ usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                           [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--max_open_trades INT]
                           [--stake_amount STAKE_AMOUNT]
-                          [--customhyperopt NAME] [--hyperopt-path PATH]
+                          [--hyperopt NAME] [--hyperopt-path PATH]
                           [--eps] [-e INT]
                           [--spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
                           [--dmmp] [--print-all] [--no-color] [--print-json]
@@ -285,7 +285,7 @@ optional arguments:
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
-  --customhyperopt NAME
+  --hyperopt NAME
                         Specify hyperopt class name which will be used by the
                         bot.
   --hyperopt-path PATH  Specify additional lookup path for Hyperopts and

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -60,8 +60,8 @@ Common arguments:
 
 Strategy arguments:
   -s NAME, --strategy NAME
-                        Specify strategy class name (default:
-                        `DefaultStrategy`).
+                        Specify strategy class name which will be used by the
+                        bot.
   --strategy-path PATH  Specify additional strategy lookup path.
 
 ```

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -285,8 +285,8 @@ optional arguments:
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
   --customhyperopt NAME
-                        Specify hyperopt class name (default:
-                        `DefaultHyperOpts`).
+                        Specify hyperopt class name which will be used by the
+                        bot.
   --hyperopt-path PATH  Specify additional lookup path for Hyperopts and
                         Hyperopt Loss functions.
   --eps, --enable-position-stacking
@@ -322,8 +322,9 @@ optional arguments:
                         generate completely different results, since the
                         target for optimization is different. Built-in
                         Hyperopt-loss-functions are: DefaultHyperOptLoss,
-                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.(default:
+                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss (default:
                         `DefaultHyperOptLoss`).
+
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `db_url` | `sqlite:///tradesv3.sqlite`| Declares database URL to use. NOTE: This defaults to `sqlite://` if `dry_run` is `True`.
 | `initial_state` | running | Defines the initial application state. More information below.
 | `forcebuy_enable` | false | Enables the RPC Commands to force a buy. More information below.
-| `strategy` | DefaultStrategy | Defines Strategy class to use.
+| `strategy` | None | **Required** Defines Strategy class to use. Recommended to set via `--strategy NAME`. 
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a directory).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
 | `internals.sd_notify` | false | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -160,7 +160,7 @@ docker run -d \
   -v ~/.freqtrade/config.json:/freqtrade/config.json \
   -v ~/.freqtrade/user_data/:/freqtrade/user_data \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
-  freqtrade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
+  freqtrade trade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
 ```
 
 !!! Note
@@ -199,7 +199,7 @@ docker run -d \
   -v ~/.freqtrade/config.json:/freqtrade/config.json \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
   -v ~/.freqtrade/user_data/:/freqtrade/user_data/ \
-  freqtrade --strategy AwsomelyProfitableStrategy backtesting
+  freqtrade backtesting --strategy AwsomelyProfitableStrategy
 ```
 
 Head over to the [Backtesting Documentation](backtesting.md) for more details.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -235,7 +235,7 @@ An example of its output:
 ### Update cached pairs with the latest data
 
 Edge requires historic data the same way as backtesting does.
-Please refer to the [download section](backtesting.md#Getting-data-for-backtesting-and-hyperopt) of the documentation for details.
+Please refer to the [Data Downloading](data-download.md) section of the documentation for details.
 
 ### Precising stoploss range
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@
 
 ### The bot does not start
 
-Running the bot with `freqtrade --config config.json` does show the output `freqtrade: command not found`.
+Running the bot with `freqtrade trade --config config.json` does show the output `freqtrade: command not found`.
 
 This could have the following reasons:
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -239,7 +239,7 @@ Because hyperopt tries a lot of combinations to find the best parameters it will
 We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 
 ```bash
-freqtrade -c config.json hyperopt --customhyperopt <hyperoptname> -e 5000 --spaces all
+freqtrade hyperopt --config config.json --customhyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
 Use  `<hyperoptname>` as the name of the custom hyperopt used.

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -239,7 +239,7 @@ Because hyperopt tries a lot of combinations to find the best parameters it will
 We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 
 ```bash
-freqtrade hyperopt --config config.json --customhyperopt <hyperoptname> -e 5000 --spaces all
+freqtrade hyperopt --config config.json --hyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
 Use  `<hyperoptname>` as the name of the custom hyperopt used.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -187,7 +187,7 @@ python3 -m pip install -e .
 If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
 
 ```bash
-freqtrade -c config.json
+freqtrade trade -c config.json
 ```
 
 *Note*: If you run the bot on a server, you should consider using [Docker](docker.md) or a terminal multiplexer like `screen` or [`tmux`](https://en.wikipedia.org/wiki/Tmux) to avoid that the bot is stopped on logout.

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -23,13 +23,15 @@ The `freqtrade plot-dataframe` subcommand shows an interactive graph with three 
 Possible arguments:
 
 ```
-usage: freqtrade plot-dataframe [-h] [-p PAIRS [PAIRS ...]]
+usage: freqtrade plot-dataframe [-h] [-v] [--logfile FILE] [-V] [-c PATH]
+                                [-d PATH] [--userdir PATH] [-s NAME]
+                                [--strategy-path PATH] [-p PAIRS [PAIRS ...]]
                                 [--indicators1 INDICATORS1 [INDICATORS1 ...]]
                                 [--indicators2 INDICATORS2 [INDICATORS2 ...]]
                                 [--plot-limit INT] [--db-url PATH]
                                 [--trade-source {DB,file}] [--export EXPORT]
                                 [--export-filename PATH]
-                                [--timerange TIMERANGE]
+                                [--timerange TIMERANGE] [-i TICKER_INTERVAL]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -62,6 +64,28 @@ optional arguments:
                         /backtest_today.json`
   --timerange TIMERANGE
                         Specify what timerange of data to use.
+  -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
+
+Strategy arguments:
+  -s NAME, --strategy NAME
+                        Specify strategy class name (default:
+                        `DefaultStrategy`).
+  --strategy-path PATH  Specify additional strategy lookup path.
 
 ```
 
@@ -83,7 +107,7 @@ Use `--indicators1` for the main plot and `--indicators2` for the subplot below 
     You will almost certainly want to specify a custom strategy! This can be done by adding `-s Classname` / `--strategy ClassName` to the command.
 
 ``` bash
-freqtrade --strategy AwesomeStrategy plot-dataframe -p BTC/ETH --indicators1 sma ema --indicators2 macd
+freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH --indicators1 sma ema --indicators2 macd
 ```
 
 ### Further usage examples
@@ -91,25 +115,25 @@ freqtrade --strategy AwesomeStrategy plot-dataframe -p BTC/ETH --indicators1 sma
 To plot multiple pairs, separate them with a space:
 
 ``` bash
-freqtrade --strategy AwesomeStrategy plot-dataframe -p BTC/ETH XRP/ETH
+freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH XRP/ETH
 ```
 
 To plot a timerange (to zoom in)
 
 ``` bash
-freqtrade --strategy AwesomeStrategy plot-dataframe -p BTC/ETH --timerange=20180801-20180805
+freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH --timerange=20180801-20180805
 ```
 
 To plot trades stored in a database use `--db-url` in combination with `--trade-source DB`:
 
 ``` bash
-freqtrade --strategy AwesomeStrategy plot-dataframe --db-url sqlite:///tradesv3.dry_run.sqlite -p BTC/ETH --trade-source DB
+freqtrade plot-dataframe --strategy AwesomeStrategy --db-url sqlite:///tradesv3.dry_run.sqlite -p BTC/ETH --trade-source DB
 ```
 
 To plot trades from a backtesting result, use `--export-filename <filename>`
 
 ``` bash
-freqtrade --strategy AwesomeStrategy plot-dataframe --export-filename user_data/backtest_results/backtest-result.json -p BTC/ETH
+freqtrade plot-dataframe --strategy AwesomeStrategy --export-filename user_data/backtest_results/backtest-result.json -p BTC/ETH
 ```
 
 ## Plot profit
@@ -133,10 +157,11 @@ The third graph can be useful to spot outliers, events in pairs that cause profi
 Possible options for the `freqtrade plot-profit` subcommand:
 
 ```
-usage: freqtrade plot-profit [-h] [-p PAIRS [PAIRS ...]]
+usage: freqtrade plot-profit [-h] [-v] [--logfile FILE] [-V] [-c PATH]
+                             [-d PATH] [--userdir PATH] [-p PAIRS [PAIRS ...]]
                              [--timerange TIMERANGE] [--export EXPORT]
                              [--export-filename PATH] [--db-url PATH]
-                             [--trade-source {DB,file}]
+                             [--trade-source {DB,file}] [-i TICKER_INTERVAL]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -159,6 +184,22 @@ optional arguments:
   --trade-source {DB,file}
                         Specify the source for trades (Can be DB or file
                         (backtest file)) Default: file
+  -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
 
 ```
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -58,7 +58,7 @@ docker run -d \
   -v ~/.freqtrade/user_data/:/freqtrade/user_data \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
   -p 127.0.0.1:8080:8080 \
-  freqtrade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
+  freqtrade trade --db-url sqlite:///tradesv3.sqlite --strategy MyAwesomeStrategy
 ```
 
 !!! Danger "Security warning"

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -13,7 +13,7 @@ Let assume you have a class called `AwesomeStrategy` in the file `awesome-strate
 2. Start the bot with the param `--strategy AwesomeStrategy` (the parameter is the class name)
 
 ```bash
-freqtrade --strategy AwesomeStrategy
+freqtrade trade --strategy AwesomeStrategy
 ```
 
 ## Change your strategy
@@ -45,7 +45,7 @@ The current version is 2 - which is also the default when it's not set explicitl
 Future versions will require this to be set.
 
 ```bash
-freqtrade --strategy AwesomeStrategy
+freqtrade trade --strategy AwesomeStrategy
 ```
 
 **For the following section we will use the [user_data/strategies/sample_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/sample_strategy.py)
@@ -402,7 +402,7 @@ The default buy strategy is located in the file
 If you want to use a strategy from a different directory you can pass `--strategy-path`
 
 ```bash
-freqtrade --strategy AwesomeStrategy --strategy-path /some/directory
+freqtrade trade --strategy AwesomeStrategy --strategy-path /some/directory
 ```
 
 ### Further strategy ideas

--- a/freqtrade.service
+++ b/freqtrade.service
@@ -6,7 +6,7 @@ After=network.target
 # Set WorkingDirectory and ExecStart to your file paths accordingly
 # NOTE: %h will be resolved to /home/<username>
 WorkingDirectory=%h/freqtrade
-ExecStart=/usr/bin/freqtrade
+ExecStart=/usr/bin/freqtrade trade
 Restart=on-failure
 
 [Install]

--- a/freqtrade.service.watchdog
+++ b/freqtrade.service.watchdog
@@ -6,7 +6,7 @@ After=network.target
 # Set WorkingDirectory and ExecStart to your file paths accordingly
 # NOTE: %h will be resolved to /home/<username>
 WorkingDirectory=%h/freqtrade
-ExecStart=/usr/bin/freqtrade --sd-notify
+ExecStart=/usr/bin/freqtrade trade --sd-notify
 
 Restart=always
 #Restart=on-failure

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -12,10 +12,9 @@ ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_dat
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 
-ARGS_MAIN = ARGS_STRATEGY + ["db_url", "sd_notify"]
+ARGS_TRADE = ["db_url", "sd_notify"]
 
-ARGS_COMMON_OPTIMIZE = ARGS_STRATEGY + ["ticker_interval", "timerange",
-                                        "max_open_trades", "stake_amount"]
+ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange", "max_open_trades", "stake_amount"]
 
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
                                         "strategy_list", "export", "exportfilename"]
@@ -35,8 +34,9 @@ ARGS_CREATE_USERDIR = ["user_data_dir"]
 
 ARGS_DOWNLOAD_DATA = ["pairs", "pairs_file", "days", "exchange", "timeframes", "erase"]
 
-ARGS_PLOT_DATAFRAME = ["pairs", "indicators1", "indicators2", "plot_limit", "db_url",
-                       "trade_source", "export", "exportfilename", "timerange", "ticker_interval"]
+ARGS_PLOT_DATAFRAME = ["pairs", "indicators1", "indicators2", "plot_limit",
+                       "db_url", "trade_source", "export", "exportfilename",
+                       "timerange", "ticker_interval"]
 
 ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
                     "trade_source", "ticker_interval"]
@@ -94,8 +94,12 @@ class Arguments:
         """
         # Build shared arguments (as group Common Options)
         _common_parser = argparse.ArgumentParser(add_help=False)
-        group = _common_parser.add_argument_group("Common Options")
+        group = _common_parser.add_argument_group("Common arguments")
         self._build_args(optionlist=ARGS_COMMON, parser=group)
+
+        _strategy_parser = argparse.ArgumentParser(add_help=False)
+        strategy_group = _common_parser.add_argument_group("Strategy arguments")
+        self._build_args(optionlist=ARGS_STRATEGY, parser=strategy_group)
 
         # Build main command
         self.parser = argparse.ArgumentParser(description='Free, open source crypto trading bot')
@@ -114,25 +118,25 @@ class Arguments:
 
         # Add trade subcommand
         trade_cmd = subparsers.add_parser('trade', help='Trade module.',
-                                          parents=[_common_parser])
+                                          parents=[_common_parser, _strategy_parser])
         trade_cmd.set_defaults(func=start_trading)
-        self._build_args(optionlist=ARGS_MAIN, parser=trade_cmd)
+        self._build_args(optionlist=ARGS_TRADE, parser=trade_cmd)
 
         # Add backtesting subcommand
         backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.',
-                                                parents=[_common_parser])
+                                                parents=[_common_parser, _strategy_parser])
         backtesting_cmd.set_defaults(func=start_backtesting)
         self._build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
 
         # Add edge subcommand
         edge_cmd = subparsers.add_parser('edge', help='Edge module.',
-                                         parents=[_common_parser])
+                                         parents=[_common_parser, _strategy_parser])
         edge_cmd.set_defaults(func=start_edge)
         self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
 
         # Add hyperopt subcommand
         hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.',
-                                             parents=[_common_parser],
+                                             parents=[_common_parser, _strategy_parser],
                                              )
         hyperopt_cmd.set_defaults(func=start_hyperopt)
         self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
@@ -140,7 +144,6 @@ class Arguments:
         # add create-userdir subcommand
         create_userdir_cmd = subparsers.add_parser('create-userdir',
                                                    help="Create user-data directory.",
-
                                                    )
         create_userdir_cmd.set_defaults(func=start_create_userdir)
         self._build_args(optionlist=ARGS_CREATE_USERDIR, parser=create_userdir_cmd)
@@ -164,7 +167,7 @@ class Arguments:
         # Add Plotting subcommand
         plot_dataframe_cmd = subparsers.add_parser('plot-dataframe',
                                                    help='Plot candles with indicators.',
-                                                   parents=[_common_parser],
+                                                   parents=[_common_parser, _strategy_parser],
                                                    )
         plot_dataframe_cmd.set_defaults(func=start_plot_dataframe)
         self._build_args(optionlist=ARGS_PLOT_DATAFRAME, parser=plot_dataframe_cmd)

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -12,7 +12,7 @@ ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_dat
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 
-ARGS_TRADE = ["db_url", "sd_notify"]
+ARGS_TRADE = ["db_url", "sd_notify", "dry_run"]
 
 ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange", "max_open_trades", "stake_amount"]
 

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -14,8 +14,8 @@ ARGS_STRATEGY = ["strategy", "strategy_path"]
 
 ARGS_MAIN = ARGS_STRATEGY + ["db_url", "sd_notify"]
 
-ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange",
-                        "max_open_trades", "stake_amount"]
+ARGS_COMMON_OPTIMIZE = ARGS_STRATEGY + ["ticker_interval", "timerange",
+                                        "max_open_trades", "stake_amount"]
 
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
                                         "strategy_list", "export", "exportfilename"]
@@ -75,7 +75,7 @@ class Arguments:
         # (see https://bugs.python.org/issue16399)
         # Allow no-config for certain commands (like downloading / plotting)
         if (parsed_arg.config is None and ((Path.cwd() / constants.DEFAULT_CONFIG).is_file() or
-           not ('subparser' in parsed_arg and parsed_arg.subparser in NO_CONF_REQURIED))):
+           not ('command' in parsed_arg and parsed_arg.command in NO_CONF_REQURIED))):
             parsed_arg.config = [constants.DEFAULT_CONFIG]
 
         return parsed_arg
@@ -120,7 +120,8 @@ class Arguments:
         self._build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
 
         # Add edge subcommand
-        edge_cmd = subparsers.add_parser('edge', help='Edge module.', parents=[_common_parser])
+        edge_cmd = subparsers.add_parser('edge', help='Edge module.',
+                                         parents=[_common_parser])
         edge_cmd.set_defaults(func=start_edge)
         self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
 

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -105,7 +105,7 @@ class Arguments:
                                      start_list_exchanges, start_trading)
         from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
 
-        subparsers = self.parser.add_subparsers(dest='subparser', required=True)
+        subparsers = self.parser.add_subparsers(dest='command', required=True)
 
         # Add trade subcommand
         trade_cmd = subparsers.add_parser('trade', help='Trade module.',

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -98,7 +98,7 @@ class Arguments:
         self._build_args(optionlist=ARGS_COMMON, parser=group)
 
         _strategy_parser = argparse.ArgumentParser(add_help=False)
-        strategy_group = _common_parser.add_argument_group("Strategy arguments")
+        strategy_group = _strategy_parser.add_argument_group("Strategy arguments")
         self._build_args(optionlist=ARGS_STRATEGY, parser=strategy_group)
 
         # Build main command

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -99,6 +99,7 @@ class Arguments:
 
         # Build main command
         self.parser = argparse.ArgumentParser(description='Free, open source crypto trading bot')
+        self._build_args(optionlist=['version'], parser=self.parser)
 
         from freqtrade.optimize import start_backtesting, start_hyperopt, start_edge
         from freqtrade.utils import (start_create_userdir, start_download_data,

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -80,7 +80,7 @@ class Arguments:
 
         return parsed_arg
 
-    def _build_args(self, optionlist, parser=None):
+    def _build_args(self, optionlist, parser):
 
         for val in optionlist:
             opt = AVAILABLE_CLI_OPTIONS[val]

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -99,12 +99,19 @@ class Arguments:
         # Build main command
         self.parser = argparse.ArgumentParser(description='Free, open source crypto trading bot',
                                               parents=[_common_parser])
-        self._build_args(optionlist=ARGS_MAIN, parser=self.parser)
 
         from freqtrade.optimize import start_backtesting, start_hyperopt, start_edge
-        from freqtrade.utils import start_create_userdir, start_download_data, start_list_exchanges
+        from freqtrade.utils import (start_create_userdir, start_download_data,
+                                     start_list_exchanges, start_trading)
+        from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
 
-        subparsers = self.parser.add_subparsers(dest='subparser')
+        subparsers = self.parser.add_subparsers(dest='subparser', required=True)
+
+        # Add trade subcommand
+        trade_cmd = subparsers.add_parser('trade', help='Trade module.',
+                                          parents=[_common_parser])
+        trade_cmd.set_defaults(func=start_trading)
+        self._build_args(optionlist=ARGS_MAIN, parser=trade_cmd)
 
         # Add backtesting subcommand
         backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.',
@@ -149,7 +156,6 @@ class Arguments:
         self._build_args(optionlist=ARGS_DOWNLOAD_DATA, parser=download_data_cmd)
 
         # Add Plotting subcommand
-        from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
         plot_dataframe_cmd = subparsers.add_parser('plot-dataframe',
                                                    help='Plot candles with indicators.',
                                                    parents=[_common_parser],

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -74,8 +74,9 @@ class Arguments:
         # Workaround issue in argparse with action='append' and default value
         # (see https://bugs.python.org/issue16399)
         # Allow no-config for certain commands (like downloading / plotting)
-        if (parsed_arg.config is None and ((Path.cwd() / constants.DEFAULT_CONFIG).is_file() or
-           not ('command' in parsed_arg and parsed_arg.command in NO_CONF_REQURIED))):
+        if ('config' in parsed_arg and parsed_arg.config is None and
+            ((Path.cwd() / constants.DEFAULT_CONFIG).is_file() or
+             not ('command' in parsed_arg and parsed_arg.command in NO_CONF_REQURIED))):
             parsed_arg.config = [constants.DEFAULT_CONFIG]
 
         return parsed_arg
@@ -97,15 +98,18 @@ class Arguments:
         self._build_args(optionlist=ARGS_COMMON, parser=group)
 
         # Build main command
-        self.parser = argparse.ArgumentParser(description='Free, open source crypto trading bot',
-                                              parents=[_common_parser])
+        self.parser = argparse.ArgumentParser(description='Free, open source crypto trading bot')
 
         from freqtrade.optimize import start_backtesting, start_hyperopt, start_edge
         from freqtrade.utils import (start_create_userdir, start_download_data,
                                      start_list_exchanges, start_trading)
         from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
 
-        subparsers = self.parser.add_subparsers(dest='command', required=True)
+        subparsers = self.parser.add_subparsers(dest='command',
+                                                # Use custom message when no subhandler is added
+                                                # shown from `main.py`
+                                                # required=True
+                                                )
 
         # Add trade subcommand
         trade_cmd = subparsers.add_parser('trade', help='Trade module.',

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -157,7 +157,7 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     # Hyperopt
     "hyperopt": Arg(
-        '--customhyperopt',
+        '--hyperopt',
         help='Specify hyperopt class name which will be used by the bot.',
         metavar='NAME',
     ),

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -66,9 +66,8 @@ AVAILABLE_CLI_OPTIONS = {
     # Main options
     "strategy": Arg(
         '-s', '--strategy',
-        help='Specify strategy class name (default: `%(default)s`).',
+        help='Specify strategy class name which will be used by the bot.',
         metavar='NAME',
-        default='DefaultStrategy',
     ),
     "strategy_path": Arg(
         '--strategy-path',

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -171,7 +171,7 @@ AVAILABLE_CLI_OPTIONS = {
         default=constants.HYPEROPT_EPOCH,
     ),
     "spaces": Arg(
-        '-s', '--spaces',
+        '--spaces',
         help='Specify which parameters to hyperopt. Space-separated list. '
         'Default: `%(default)s`.',
         choices=['all', 'buy', 'sell', 'roi', 'stoploss'],

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -153,9 +153,8 @@ AVAILABLE_CLI_OPTIONS = {
     # Hyperopt
     "hyperopt": Arg(
         '--customhyperopt',
-        help='Specify hyperopt class name (default: `%(default)s`).',
+        help='Specify hyperopt class name which will be used by the bot.',
         metavar='NAME',
-        default=constants.DEFAULT_HYPEROPT,
     ),
     "hyperopt_path": Arg(
         '--hyperopt-path',
@@ -232,7 +231,7 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify the class name of the hyperopt loss function class (IHyperOptLoss). '
         'Different functions can generate completely different results, '
         'since the target for optimization is different. Built-in Hyperopt-loss-functions are: '
-        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss.'
+        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss '
         '(default: `%(default)s`).',
         metavar='NAME',
         default=constants.DEFAULT_HYPEROPT_LOSS,

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -86,6 +86,11 @@ AVAILABLE_CLI_OPTIONS = {
         help='Notify systemd service manager.',
         action='store_true',
     ),
+    "dry_run": Arg(
+        '--dry-run',
+        help='Enforce dry-run for trading (removes Exchange secrets and simulates trades).',
+        action='store_true',
+    ),
     # Optimize common
     "ticker_interval": Arg(
         '-i', '--ticker-interval',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -162,6 +162,10 @@ class Configuration:
         if 'sd_notify' in self.args and self.args["sd_notify"]:
             config['internals'].update({'sd_notify': True})
 
+        self._args_to_config(config, argname='dry_run',
+                             logstring='Parameter --dry-run detected, '
+                             'overriding dry_run to: {} ...')
+
     def _process_datadir_options(self, config: Dict[str, Any]) -> None:
         """
         Extract information for sys.argv and load directory configurations

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -128,7 +128,7 @@ class Configuration:
         self._process_logging_options(config)
 
         # Set strategy if not specified in config and or if it's non default
-        if self.args.get("strategy") != constants.DEFAULT_STRATEGY or not config.get('strategy'):
+        if self.args.get("strategy") or not config.get('strategy'):
             config.update({'strategy': self.args.get("strategy")})
 
         self._args_to_config(config, argname='strategy_path',

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -9,7 +9,6 @@ PROCESS_THROTTLE_SECS = 5  # sec
 DEFAULT_TICKER_INTERVAL = 5  # min
 HYPEROPT_EPOCH = 100  # epochs
 RETRY_TIMEOUT = 30  # sec
-DEFAULT_STRATEGY = 'DefaultStrategy'
 DEFAULT_HYPEROPT = 'DefaultHyperOpts'
 DEFAULT_HYPEROPT_LOSS = 'DefaultHyperOptLoss'
 DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -9,7 +9,6 @@ PROCESS_THROTTLE_SECS = 5  # sec
 DEFAULT_TICKER_INTERVAL = 5  # min
 HYPEROPT_EPOCH = 100  # epochs
 RETRY_TIMEOUT = 30  # sec
-DEFAULT_HYPEROPT = 'DefaultHyperOpts'
 DEFAULT_HYPEROPT_LOSS = 'DefaultHyperOptLoss'
 DEFAULT_DB_PROD_URL = 'sqlite:///tradesv3.sqlite'
 DEFAULT_DB_DRYRUN_URL = 'sqlite://'

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -35,6 +35,13 @@ def main(sysargv: List[str] = None) -> None:
         # Call subcommand.
         if 'func' in args:
             return_code = args['func'](args)
+        else:
+            # No subcommand was issued.
+            raise OperationalException(
+                "Usage of freqtrade requires a subcommand.\n"
+                "To use the previous behaviour, run freqtrade with `freqtrade trade [...]`.\n"
+                "To see a full list of options, please use `freqtrade --help`"
+                )
 
     except SystemExit as e:
         return_code = e

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -15,7 +15,6 @@ from typing import Any, List
 
 from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
-from freqtrade.worker import Worker
 
 
 logger = logging.getLogger('freqtrade')
@@ -33,16 +32,9 @@ def main(sysargv: List[str] = None) -> None:
         arguments = Arguments(sysargv)
         args = arguments.get_parsed_arg()
 
-        # A subcommand has been issued.
-        # Means if Backtesting or Hyperopt have been called we exit the bot
+        # Call subcommand.
         if 'func' in args:
-            args['func'](args)
-            # TODO: fetch return_code as returned by the command function here
-            return_code = 0
-        else:
-            # Load and run worker
-            worker = Worker(args)
-            worker.run()
+            return_code = args['func'](args)
 
     except SystemExit as e:
         return_code = e

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -28,7 +28,7 @@ class HyperOptResolver(IResolver):
         :param config: configuration dictionary
         """
         if not config.get('hyperopt'):
-            raise OperationalException("No Hyperopt set. Please use `--customhyperopt` to specify "
+            raise OperationalException("No Hyperopt set. Please use `--hyperopt` to specify "
                                        "the Hyperopt class to use.")
 
         hyperopt_name = config['hyperopt']

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional, Dict
 
 from freqtrade import OperationalException
-from freqtrade.constants import DEFAULT_HYPEROPT, DEFAULT_HYPEROPT_LOSS
+from freqtrade.constants import DEFAULT_HYPEROPT_LOSS
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss
 from freqtrade.resolvers import IResolver
@@ -20,7 +20,6 @@ class HyperOptResolver(IResolver):
     """
     This class contains all the logic to load custom hyperopt class
     """
-
     __slots__ = ['hyperopt']
 
     def __init__(self, config: Dict) -> None:
@@ -28,9 +27,12 @@ class HyperOptResolver(IResolver):
         Load the custom class from config parameter
         :param config: configuration dictionary
         """
+        if not config.get('hyperopt'):
+            raise OperationalException("No Hyperopt set. Please use `--customhyperopt` to specify "
+                                       "the Hyperopt class to use.")
 
-        # Verify the hyperopt is in the configuration, otherwise fallback to the default hyperopt
-        hyperopt_name = config.get('hyperopt') or DEFAULT_HYPEROPT
+        hyperopt_name = config['hyperopt']
+
         self.hyperopt = self._load_hyperopt(hyperopt_name, config,
                                             extra_dir=config.get('hyperopt_path'))
 
@@ -75,27 +77,28 @@ class HyperOptLossResolver(IResolver):
     """
     This class contains all the logic to load custom hyperopt loss class
     """
-
     __slots__ = ['hyperoptloss']
 
-    def __init__(self, config: Dict = None) -> None:
+    def __init__(self, config: Dict) -> None:
         """
         Load the custom class from config parameter
-        :param config: configuration dictionary or None
+        :param config: configuration dictionary
         """
-        config = config or {}
 
-        # Verify the hyperopt is in the configuration, otherwise fallback to the default hyperopt
-        hyperopt_name = config.get('hyperopt_loss') or DEFAULT_HYPEROPT_LOSS
+        # Verify the hyperopt_loss is in the configuration, otherwise fallback to the
+        # default hyperopt loss
+        hyperoptloss_name = config.get('hyperopt_loss') or DEFAULT_HYPEROPT_LOSS
+
         self.hyperoptloss = self._load_hyperoptloss(
-            hyperopt_name, config, extra_dir=config.get('hyperopt_path'))
+            hyperoptloss_name, config, extra_dir=config.get('hyperopt_path'))
 
         # Assign ticker_interval to be used in hyperopt
         self.hyperoptloss.__class__.ticker_interval = str(config['ticker_interval'])
 
         if not hasattr(self.hyperoptloss, 'hyperopt_loss_function'):
             raise OperationalException(
-                f"Found hyperopt {hyperopt_name} does not implement `hyperopt_loss_function`.")
+                f"Found HyperoptLoss class {hyperoptloss_name} does not "
+                "implement `hyperopt_loss_function`.")
 
     def _load_hyperoptloss(
             self, hyper_loss_name: str, config: Dict,

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -32,8 +32,11 @@ class StrategyResolver(IResolver):
         """
         config = config or {}
 
-        # Verify the strategy is in the configuration, otherwise fallback to the default strategy
-        strategy_name = config.get('strategy') or constants.DEFAULT_STRATEGY
+        if not config.get('strategy'):
+            raise OperationalException("No strategy set. Please use `--strategy` to specify "
+                                       "the strategy class to use.")
+
+        strategy_name = config['strategy']
         self.strategy: IStrategy = self._load_strategy(strategy_name,
                                                        config=config,
                                                        extra_dir=config.get('strategy_path'))

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -58,7 +58,7 @@ def start_list_exchanges(args: Dict[str, Any]) -> None:
               f"{', '.join(available_exchanges())}")
 
 
-def start_create_userdir(args: Dict[str, Any]) -> int:
+def start_create_userdir(args: Dict[str, Any]) -> None:
     """
     Create "user_data" directory to contain user data strategies, hyperopts, ...)
     :param args: Cli args from Arguments()

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -33,6 +33,17 @@ def setup_utils_configuration(args: Dict[str, Any], method: RunMode) -> Dict[str
     return config
 
 
+def start_trading(args: Dict[str, Any]) -> int:
+    """
+    Main entry point for trading mode
+    """
+    from freqtrade.worker import Worker
+    # Load and run worker
+    worker = Worker(args)
+    worker.run()
+    return 0
+
+
 def start_list_exchanges(args: Dict[str, Any]) -> None:
     """
     Print available exchanges
@@ -47,7 +58,7 @@ def start_list_exchanges(args: Dict[str, Any]) -> None:
               f"{', '.join(available_exchanges())}")
 
 
-def start_create_userdir(args: Dict[str, Any]) -> None:
+def start_create_userdir(args: Dict[str, Any]) -> int:
     """
     Create "user_data" directory to contain user data strategies, hyperopts, ...)
     :param args: Cli args from Arguments()
@@ -57,7 +68,7 @@ def start_create_userdir(args: Dict[str, Any]) -> None:
         create_userdata_dir(args["user_data_dir"], create_dir=True)
     else:
         logger.warning("`create-userdir` requires --userdir to be set.")
-        sys.exit(1)
+        return 1
 
 
 def start_download_data(args: Dict[str, Any]) -> None:

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -68,7 +68,7 @@ def start_create_userdir(args: Dict[str, Any]) -> int:
         create_userdata_dir(args["user_data_dir"], create_dir=True)
     else:
         logger.warning("`create-userdir` requires --userdir to be set.")
-        return 1
+        sys.exit(1)
 
 
 def start_download_data(args: Dict[str, Any]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,7 @@ def default_conf(testdatadir):
         "db_url": "sqlite://",
         "user_data_dir": Path("user_data"),
         "verbosity": 3,
+        "strategy": "DefaultStrategy"
     }
     return configuration
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -169,9 +169,9 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'backtesting'
     ]
 
     config = setup_configuration(get_args(args), RunMode.BACKTEST)
@@ -202,10 +202,10 @@ def test_setup_bt_configuration_with_arguments(mocker, default_conf, caplog) -> 
     )
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
         '--datadir', '/foo/bar',
-        'backtesting',
         '--ticker-interval', '1m',
         '--enable-position-stacking',
         '--disable-max-market-positions',
@@ -250,9 +250,9 @@ def test_setup_configuration_unlimited_stake_amount(mocker, default_conf, caplog
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'backtesting'
     ]
 
     with pytest.raises(DependencyException, match=r'.*stake amount.*'):
@@ -267,9 +267,9 @@ def test_start(mocker, fee, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'backtesting'
     ]
     args = get_args(args)
     start_backtesting(args)
@@ -812,10 +812,10 @@ def test_backtest_start_timerange(default_conf, mocker, caplog, testdatadir):
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
         '--datadir', str(testdatadir),
-        'backtesting',
         '--ticker-interval', '1m',
         '--timerange', '-100',
         '--enable-position-stacking',
@@ -859,9 +859,9 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'backtesting',
         '--config', 'config.json',
         '--datadir', str(testdatadir),
-        'backtesting',
         '--ticker-interval', '1m',
         '--timerange', '-100',
         '--enable-position-stacking',

--- a/tests/optimize/test_edge_cli.py
+++ b/tests/optimize/test_edge_cli.py
@@ -15,9 +15,9 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'edge',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'edge'
     ]
 
     config = setup_configuration(get_args(args), RunMode.EDGE)
@@ -45,10 +45,10 @@ def test_setup_edge_configuration_with_arguments(mocker, edge_conf, caplog) -> N
     )
 
     args = [
+        'edge',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
         '--datadir', '/foo/bar',
-        'edge',
         '--ticker-interval', '1m',
         '--timerange', ':100',
         '--stoplosses=-0.01,-0.10,-0.001'
@@ -79,9 +79,9 @@ def test_start(mocker, fee, edge_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, edge_conf)
 
     args = [
+        'edge',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'edge'
     ]
     args = get_args(args)
     start_edge(args)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -73,7 +73,7 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
     ]
 
     config = setup_configuration(get_args(args), RunMode.HYPEROPT)
@@ -105,7 +105,7 @@ def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplo
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
         '--datadir', '/foo/bar',
         '--ticker-interval', '1m',
         '--timerange', ':100',
@@ -181,7 +181,7 @@ def test_hyperoptresolver_wrongname(mocker, default_conf, caplog) -> None:
 def test_hyperoptresolver_noname(default_conf):
     default_conf['hyperopt'] = ''
     with pytest.raises(OperationalException,
-                       match="No Hyperopt set. Please use `--customhyperopt` to specify "
+                       match="No Hyperopt set. Please use `--hyperopt` to specify "
                              "the Hyperopt class to use."):
         HyperOptResolver(default_conf)
 
@@ -214,7 +214,7 @@ def test_start_not_installed(mocker, default_conf, caplog, import_fails) -> None
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
         '--epochs', '5'
     ]
     args = get_args(args)
@@ -232,7 +232,7 @@ def test_start(mocker, default_conf, caplog) -> None:
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
         '--epochs', '5'
     ]
     args = get_args(args)
@@ -255,7 +255,7 @@ def test_start_no_data(mocker, default_conf, caplog) -> None:
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
         '--epochs', '5'
     ]
     args = get_args(args)
@@ -273,7 +273,7 @@ def test_start_filelock(mocker, default_conf, caplog) -> None:
     args = [
         'hyperopt',
         '--config', 'config.json',
-        '--customhyperopt', 'DefaultHyperOpts',
+        '--hyperopt', 'DefaultHyperOpts',
         '--epochs', '5'
     ]
     args = get_args(args)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -68,8 +68,8 @@ def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, ca
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
+        'hyperopt',
         '--config', 'config.json',
-        'hyperopt'
     ]
 
     config = setup_configuration(get_args(args), RunMode.HYPEROPT)
@@ -99,9 +99,9 @@ def test_setup_hyperopt_configuration_with_arguments(mocker, default_conf, caplo
     )
 
     args = [
+        'hyperopt',
         '--config', 'config.json',
         '--datadir', '/foo/bar',
-        'hyperopt',
         '--ticker-interval', '1m',
         '--timerange', ':100',
         '--enable-position-stacking',
@@ -215,8 +215,8 @@ def test_start(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
 
     args = [
-        '--config', 'config.json',
         'hyperopt',
+        '--config', 'config.json',
         '--epochs', '5'
     ]
     args = get_args(args)
@@ -237,8 +237,8 @@ def test_start_no_data(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
 
     args = [
-        '--config', 'config.json',
         'hyperopt',
+        '--config', 'config.json',
         '--epochs', '5'
     ]
     args = get_args(args)
@@ -254,8 +254,8 @@ def test_start_filelock(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
 
     args = [
-        '--config', 'config.json',
         'hyperopt',
+        '--config', 'config.json',
         '--epochs', '5'
     ]
     args = get_args(args)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -198,8 +198,8 @@ def test_start_not_installed(mocker, default_conf, caplog, import_fails) -> None
     patch_exchange(mocker)
 
     args = [
-        '--config', 'config.json',
         'hyperopt',
+        '--config', 'config.json',
         '--epochs', '5'
     ]
     args = get_args(args)

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -70,8 +70,7 @@ def test_load_not_found_strategy(default_conf):
     with pytest.raises(OperationalException,
                        match=r"Impossible to load Strategy 'NotFoundStrategy'. "
                              r"This class does not exist or contains Python code errors."):
-        strategy = StrategyResolver(default_conf)
-        strategy._load_strategy(strategy_name='NotFoundStrategy', config=default_conf)
+        StrategyResolver(default_conf)
 
 
 def test_load_strategy_noname(default_conf):

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -55,6 +55,7 @@ def test_load_strategy_base64(result, caplog, default_conf):
 
 
 def test_load_strategy_invalid_directory(result, caplog, default_conf):
+    default_conf['strategy'] = 'SampleStrategy'
     resolver = StrategyResolver(default_conf)
     extra_dir = Path.cwd() / 'some/path'
     resolver._load_strategy('SampleStrategy', config=default_conf, extra_dir=extra_dir)
@@ -65,11 +66,20 @@ def test_load_strategy_invalid_directory(result, caplog, default_conf):
 
 
 def test_load_not_found_strategy(default_conf):
-    strategy = StrategyResolver(default_conf)
+    default_conf['strategy'] = 'NotFoundStrategy'
     with pytest.raises(OperationalException,
                        match=r"Impossible to load Strategy 'NotFoundStrategy'. "
                              r"This class does not exist or contains Python code errors."):
+        strategy = StrategyResolver(default_conf)
         strategy._load_strategy(strategy_name='NotFoundStrategy', config=default_conf)
+
+
+def test_load_strategy_noname(default_conf):
+    default_conf['strategy'] = ''
+    with pytest.raises(OperationalException,
+                       match="No strategy set. Please use `--strategy` to specify "
+                             "the strategy class to use."):
+        StrategyResolver(default_conf)
 
 
 def test_strategy(result, default_conf):

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -25,27 +25,27 @@ def test_parse_args_defaults() -> None:
 
 
 def test_parse_args_config() -> None:
-    args = Arguments(['-c', '/dev/null']).get_parsed_arg()
+    args = Arguments(['trade', '-c', '/dev/null']).get_parsed_arg()
     assert args["config"] == ['/dev/null']
 
-    args = Arguments(['--config', '/dev/null']).get_parsed_arg()
+    args = Arguments(['trade', '--config', '/dev/null']).get_parsed_arg()
     assert args["config"] == ['/dev/null']
 
-    args = Arguments(['--config', '/dev/null',
+    args = Arguments(['trade', '--config', '/dev/null',
                       '--config', '/dev/zero'],).get_parsed_arg()
     assert args["config"] == ['/dev/null', '/dev/zero']
 
 
 def test_parse_args_db_url() -> None:
-    args = Arguments(['--db-url', 'sqlite:///test.sqlite']).get_parsed_arg()
+    args = Arguments(['trade', '--db-url', 'sqlite:///test.sqlite']).get_parsed_arg()
     assert args["db_url"] == 'sqlite:///test.sqlite'
 
 
 def test_parse_args_verbose() -> None:
-    args = Arguments(['-v']).get_parsed_arg()
+    args = Arguments(['trade', '-v']).get_parsed_arg()
     assert args["verbosity"] == 1
 
-    args = Arguments(['--verbose']).get_parsed_arg()
+    args = Arguments(['trade', '--verbose']).get_parsed_arg()
     assert args["verbosity"] == 1
 
 
@@ -67,7 +67,7 @@ def test_parse_args_invalid() -> None:
 
 
 def test_parse_args_strategy() -> None:
-    args = Arguments(['--strategy', 'SomeStrategy']).get_parsed_arg()
+    args = Arguments(['trade', '--strategy', 'SomeStrategy']).get_parsed_arg()
     assert args["strategy"] == 'SomeStrategy'
 
 
@@ -77,7 +77,7 @@ def test_parse_args_strategy_invalid() -> None:
 
 
 def test_parse_args_strategy_path() -> None:
-    args = Arguments(['--strategy-path', '/some/path']).get_parsed_arg()
+    args = Arguments(['trade', '--strategy-path', '/some/path']).get_parsed_arg()
     assert args["strategy_path"] == '/some/path'
 
 
@@ -96,8 +96,8 @@ def test_parse_args_backtesting_invalid() -> None:
 
 def test_parse_args_backtesting_custom() -> None:
     args = [
-        '-c', 'test_conf.json',
         'backtesting',
+        '-c', 'test_conf.json',
         '--ticker-interval', '1m',
         '--strategy-list',
         'DefaultStrategy',
@@ -115,8 +115,8 @@ def test_parse_args_backtesting_custom() -> None:
 
 def test_parse_args_hyperopt_custom() -> None:
     args = [
-        '-c', 'test_conf.json',
         'hyperopt',
+        '-c', 'test_conf.json',
         '--epochs', '20',
         '--spaces', 'buy'
     ]
@@ -132,8 +132,8 @@ def test_parse_args_hyperopt_custom() -> None:
 
 def test_download_data_options() -> None:
     args = [
-        '--datadir', 'datadir/directory',
         'download-data',
+        '--datadir', 'datadir/directory',
         '--pairs-file', 'file_with_pairs',
         '--days', '30',
         '--exchange', 'binance'

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,5 +1,6 @@
 # pragma pylint: disable=missing-docstring, C0103
 import argparse
+import re
 
 import pytest
 
@@ -8,8 +9,16 @@ from freqtrade.configuration.cli_options import check_int_positive
 
 
 # Parse common command-line-arguments. Used for all tools
-def test_parse_args_none() -> None:
+def test_parse_args_error(capsys) -> None:
     arguments = Arguments([])
+    with pytest.raises(SystemExit):
+        arguments.get_parsed_arg()
+    captured = capsys.readouterr()
+    assert re.search(r".*the following arguments are required.*", captured.err)
+
+
+def test_parse_args_none() -> None:
+    arguments = Arguments(['trade'])
     assert isinstance(arguments, Arguments)
     x = arguments.get_parsed_arg()
     assert isinstance(x, dict)
@@ -17,7 +26,7 @@ def test_parse_args_none() -> None:
 
 
 def test_parse_args_defaults() -> None:
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     assert args["config"] == ['config.json']
     assert args["strategy_path"] is None
     assert args["datadir"] is None

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -106,7 +106,7 @@ def test_parse_args_backtesting_custom() -> None:
     call_args = Arguments(args).get_parsed_arg()
     assert call_args["config"] == ['test_conf.json']
     assert call_args["verbosity"] == 0
-    assert call_args["subparser"] == 'backtesting'
+    assert call_args["command"] == 'backtesting'
     assert call_args["func"] is not None
     assert call_args["ticker_interval"] == '1m'
     assert type(call_args["strategy_list"]) is list
@@ -124,7 +124,7 @@ def test_parse_args_hyperopt_custom() -> None:
     assert call_args["config"] == ['test_conf.json']
     assert call_args["epochs"] == 20
     assert call_args["verbosity"] == 0
-    assert call_args["subparser"] == 'hyperopt'
+    assert call_args["command"] == 'hyperopt'
     assert call_args["spaces"] == ['buy']
     assert call_args["func"] is not None
     assert callable(call_args["func"])

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -4,19 +4,12 @@ import re
 
 import pytest
 
+from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
 from freqtrade.configuration.cli_options import check_int_positive
 
 
 # Parse common command-line-arguments. Used for all tools
-def test_parse_args_error(capsys) -> None:
-    arguments = Arguments([])
-    with pytest.raises(SystemExit):
-        arguments.get_parsed_arg()
-    captured = capsys.readouterr()
-    assert re.search(r".*the following arguments are required.*", captured.err)
-
-
 def test_parse_args_none() -> None:
     arguments = Arguments(['trade'])
     assert isinstance(arguments, Arguments)
@@ -157,8 +150,8 @@ def test_download_data_options() -> None:
 
 def test_plot_dataframe_options() -> None:
     args = [
-        '-c', 'config.json.example',
         'plot-dataframe',
+        '-c', 'config.json.example',
         '--indicators1', 'sma10', 'sma100',
         '--indicators2', 'macd', 'fastd', 'fastk',
         '--plot-limit', '30',

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,10 +1,8 @@
 # pragma pylint: disable=missing-docstring, C0103
 import argparse
-import re
 
 import pytest
 
-from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
 from freqtrade.configuration.cli_options import check_int_positive
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -806,8 +806,8 @@ def test_pairlist_resolving():
 def test_pairlist_resolving_with_config(mocker, default_conf):
     patched_configuration_load_config_file(mocker, default_conf)
     arglist = [
-        '--config', 'config.json',
         'download-data',
+        '--config', 'config.json',
     ]
 
     args = Arguments(arglist).get_parsed_arg()
@@ -820,8 +820,8 @@ def test_pairlist_resolving_with_config(mocker, default_conf):
 
     # Override pairs
     arglist = [
-        '--config', 'config.json',
         'download-data',
+        '--config', 'config.json',
         '--pairs', 'ETH/BTC', 'XRP/BTC',
     ]
 
@@ -842,8 +842,8 @@ def test_pairlist_resolving_with_config_pl(mocker, default_conf):
     mocker.patch.object(Path, "open", MagicMock(return_value=MagicMock()))
 
     arglist = [
-        '--config', 'config.json',
         'download-data',
+        '--config', 'config.json',
         '--pairs-file', 'pairs.json',
     ]
 
@@ -864,8 +864,8 @@ def test_pairlist_resolving_with_config_pl_not_exists(mocker, default_conf):
     mocker.patch.object(Path, "exists", MagicMock(return_value=False))
 
     arglist = [
-        '--config', 'config.json',
         'download-data',
+        '--config', 'config.json',
         '--pairs-file', 'pairs.json',
     ]
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -212,7 +212,6 @@ def test_load_config(default_conf, mocker) -> None:
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
-    assert validated_conf.get('strategy') == 'DefaultStrategy'
     assert validated_conf.get('strategy_path') is None
     assert 'edge' not in validated_conf
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -304,6 +304,23 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     assert validated_conf.get('db_url') == DEFAULT_DB_DRYRUN_URL
 
 
+@pytest.mark.parametrize("config_value,expected,arglist", [
+    (True, True, ['trade', '--dry-run']),  # Leave config untouched
+    (False, True, ['trade', '--dry-run']),  # Override config untouched
+    (False, False, ['trade']),  # Leave config untouched
+    (True, True, ['trade']),  # Leave config untouched
+])
+def test_load_dry_run(default_conf, mocker, config_value, expected, arglist) -> None:
+
+    default_conf['dry_run'] = config_value
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    configuration = Configuration(Arguments(arglist).get_parsed_arg())
+    validated_conf = configuration.load_config()
+
+    assert validated_conf.get('dry_run') is expected
+
+
 def test_load_custom_strategy(default_conf, mocker) -> None:
     default_conf.update({
         'strategy': 'CustomStrategy',

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -65,7 +65,7 @@ def test_load_config_file(default_conf, mocker, caplog) -> None:
 
 def test__args_to_config(caplog):
 
-    arg_list = ['--strategy-path', 'TestTest']
+    arg_list = ['trade', '--strategy-path', 'TestTest']
     args = Arguments(arg_list).get_parsed_arg()
     configuration = Configuration(args)
     config = {}
@@ -93,7 +93,7 @@ def test_load_config_max_open_trades_zero(default_conf, mocker, caplog) -> None:
     default_conf['max_open_trades'] = 0
     patched_configuration_load_config_file(mocker, default_conf)
 
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
@@ -118,7 +118,7 @@ def test_load_config_combine_dicts(default_conf, mocker, caplog) -> None:
         configsmock
     )
 
-    arg_list = ['-c', 'test_conf.json', '--config', 'test2_conf.json', ]
+    arg_list = ['trade', '-c', 'test_conf.json', '--config', 'test2_conf.json', ]
     args = Arguments(arg_list).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
@@ -184,7 +184,7 @@ def test_load_config_max_open_trades_minus_one(default_conf, mocker, caplog) -> 
     default_conf['max_open_trades'] = -1
     patched_configuration_load_config_file(mocker, default_conf)
 
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
@@ -208,7 +208,7 @@ def test_load_config_file_exception(mocker) -> None:
 def test_load_config(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
@@ -221,6 +221,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path',
         '--db-url', 'sqlite:///someurl',
@@ -240,6 +241,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path'
     ]
@@ -256,6 +258,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path'
     ]
@@ -272,6 +275,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path'
     ]
@@ -290,6 +294,7 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     patched_configuration_load_config_file(mocker, conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--strategy-path', '/some/path'
     ]
@@ -307,7 +312,7 @@ def test_load_custom_strategy(default_conf, mocker) -> None:
     })
     patched_configuration_load_config_file(mocker, default_conf)
 
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 
@@ -319,6 +324,7 @@ def test_show_info(default_conf, mocker, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
+        'trade',
         '--strategy', 'TestStrategy',
         '--db-url', 'sqlite:///tmp/testdb',
     ]
@@ -335,9 +341,9 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
-        'backtesting'
     ]
 
     args = Arguments(arglist).get_parsed_arg()
@@ -373,11 +379,11 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
         lambda x, *args, **kwargs: Path(x)
     )
     arglist = [
+        'backtesting',
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
         '--datadir', '/foo/bar',
         '--userdir', "/tmp/freqtrade",
-        'backtesting',
         '--ticker-interval', '1m',
         '--enable-position-stacking',
         '--disable-max-market-positions',
@@ -424,8 +430,8 @@ def test_setup_configuration_with_stratlist(mocker, default_conf, caplog) -> Non
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
-        '--config', 'config.json',
         'backtesting',
+        '--config', 'config.json',
         '--ticker-interval', '1m',
         '--export', '/bar/foo',
         '--strategy-list',
@@ -552,7 +558,7 @@ def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:
 
     # Prevent setting loggers
     mocker.patch('freqtrade.loggers._set_loggers', MagicMock)
-    arglist = ['-vvv']
+    arglist = ['trade', '-vvv']
     args = Arguments(arglist).get_parsed_arg()
 
     configuration = Configuration(args)
@@ -604,7 +610,7 @@ def test_set_logfile(default_conf, mocker):
     patched_configuration_load_config_file(mocker, default_conf)
 
     arglist = [
-        '--logfile', 'test_file.log',
+        'trade', '--logfile', 'test_file.log',
     ]
     args = Arguments(arglist).get_parsed_arg()
     configuration = Configuration(args)
@@ -620,7 +626,7 @@ def test_load_config_warn_forcebuy(default_conf, mocker, caplog) -> None:
     default_conf['forcebuy_enable'] = True
     patched_configuration_load_config_file(mocker, default_conf)
 
-    args = Arguments([]).get_parsed_arg()
+    args = Arguments(['trade']).get_parsed_arg()
     configuration = Configuration(args)
     validated_conf = configuration.load_config()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,8 +11,14 @@ from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State
 from freqtrade.worker import Worker
-from tests.conftest import (log_has, patch_exchange,
+from tests.conftest import (log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
+
+
+def test_parse_args_None(caplog) -> None:
+    with pytest.raises(SystemExit):
+        main([])
+    assert log_has_re(r"Usage of freqtrade requires a subcommand\.", caplog)
 
 
 def test_parse_args_backtesting(mocker) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,7 +58,7 @@ def test_main_fatal_exception(mocker, default_conf, caplog) -> None:
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
-    args = ['-c', 'config.json.example']
+    args = ['trade', '-c', 'config.json.example']
 
     # Test Main + the KeyboardInterrupt exception
     with pytest.raises(SystemExit):
@@ -75,7 +75,7 @@ def test_main_keyboard_interrupt(mocker, default_conf, caplog) -> None:
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
-    args = ['-c', 'config.json.example']
+    args = ['trade', '-c', 'config.json.example']
 
     # Test Main + the KeyboardInterrupt exception
     with pytest.raises(SystemExit):
@@ -95,7 +95,7 @@ def test_main_operational_exception(mocker, default_conf, caplog) -> None:
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
-    args = ['-c', 'config.json.example']
+    args = ['trade', '-c', 'config.json.example']
 
     # Test Main + the KeyboardInterrupt exception
     with pytest.raises(SystemExit):
@@ -114,15 +114,15 @@ def test_main_reload_conf(mocker, default_conf, caplog) -> None:
                                          OperationalException("Oh snap!")])
     mocker.patch('freqtrade.worker.Worker._worker', worker_mock)
     patched_configuration_load_config_file(mocker, default_conf)
-    reconfigure_mock = mocker.patch('freqtrade.main.Worker._reconfigure', MagicMock())
+    reconfigure_mock = mocker.patch('freqtrade.worker.Worker._reconfigure', MagicMock())
 
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
-    args = Arguments(['-c', 'config.json.example']).get_parsed_arg()
+    args = Arguments(['trade', '-c', 'config.json.example']).get_parsed_arg()
     worker = Worker(args=args, config=default_conf)
     with pytest.raises(SystemExit):
-        main(['-c', 'config.json.example'])
+        main(['trade', '-c', 'config.json.example'])
 
     assert log_has('Using config: config.json.example ...', caplog)
     assert worker_mock.call_count == 4
@@ -141,7 +141,7 @@ def test_reconfigure(mocker, default_conf) -> None:
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
 
-    args = Arguments(['-c', 'config.json.example']).get_parsed_arg()
+    args = Arguments(['trade', '-c', 'config.json.example']).get_parsed_arg()
     worker = Worker(args=args, config=default_conf)
     freqtrade = worker.freqtrade
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,7 @@ def test_parse_args_backtesting(mocker) -> None:
     call_args = backtesting_mock.call_args[0][0]
     assert call_args["config"] == ['config.json']
     assert call_args["verbosity"] == 0
-    assert call_args["subparser"] == 'backtesting'
+    assert call_args["command"] == 'backtesting'
     assert call_args["func"] is not None
     assert callable(call_args["func"])
     assert call_args["ticker_interval"] is None
@@ -45,7 +45,7 @@ def test_main_start_hyperopt(mocker) -> None:
     call_args = hyperopt_mock.call_args[0][0]
     assert call_args["config"] == ['config.json']
     assert call_args["verbosity"] == 0
-    assert call_args["subparser"] == 'hyperopt'
+    assert call_args["command"] == 'hyperopt'
     assert call_args["func"] is not None
     assert callable(call_args["func"])
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -281,8 +281,8 @@ def test_generate_profit_graph(testdatadir):
 def test_start_plot_dataframe(mocker):
     aup = mocker.patch("freqtrade.plot.plotting.load_and_plot_trades", MagicMock())
     args = [
-        "--config", "config.json.example",
         "plot-dataframe",
+        "--config", "config.json.example",
         "--pairs", "ETH/BTC"
     ]
     start_plot_dataframe(get_args(args))
@@ -323,8 +323,8 @@ def test_load_and_plot_trades(default_conf, mocker, caplog, testdatadir):
 def test_start_plot_profit(mocker):
     aup = mocker.patch("freqtrade.plot.plotting.plot_profit", MagicMock())
     args = [
-        "--config", "config.json.example",
         "plot-profit",
+        "--config", "config.json.example",
         "--pairs", "ETH/BTC"
     ]
     start_plot_profit(get_args(args))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from tests.conftest import get_args, log_has, patch_exchange
 
 def test_setup_utils_configuration():
     args = [
-        '--config', 'config.json.example',
+        'list-exchanges', '--config', 'config.json.example',
     ]
 
     config = setup_utils_configuration(get_args(args), RunMode.OTHER)


### PR DESCRIPTION
## Summary
Currently, running any subcommand requires a specific order of commands.
`freqtrade --config config.json backtesting` is allowed, while `freqtrade backtesting --config config` is not.
This creates a difficult to use CLI interface, since the subcommand MUST be somewhere in the middle.

## changes
This PR tries to address this as follows:

* introduce `freqtrade trade` subcommand for trading in dry / live runs
* Remove usage of `freqtrade ` without subcommand
* only accept arguments after subcommands (so it's aligned throughout the interface)
* use grouped parsers to group common arguments together (for visuals / help printing).

## caveats

Unfortunately, i did not find an simple way to support a transition period.
If `--config` is allowed before the subcommand, but a subcommand is issued, then only the latter is taken
so `freqtrade --config config1.json backtesting --config2.json` results in `{'config': ['config2.json']}`, eliminating / overwriting the first selection.
Worse - `freqtrade --config config1.json backtesting` results in `{'config': None}` - eliminating this config option, which makes old usage patterns broken by default.

To support this, i've included `scripts/args_validation.py` - which includes some tests i did (it will be removed before merging).
It is a simplified example to allow playing with this problem, and shows the problem:

Usage and output:
```
python scripts/args_validation.py  --config aaa test --config bbb
{'config': ['bbb'], 'datadir': None, 'subparser': 'test'}
```


## todo

* [x] discuss if this is the desired behaviour
* [x] validate if all subcommands still have all desired arguments (especially plot-commands)
* [x] update documentation
* [x] remove `scripts/args_validation.py` (I still have it should someone want to have a try with different methods)
