### PR TITLE
Hyperopt test use case

### DIFF
--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -38,8 +38,6 @@ def hyperopt_results():
             'profit_percent': [0.1, 0.2, 0.3],
             'profit_abs': [0.2, 0.4, 0.5],
             'trade_duration': [10, 30, 10],
-            'profit': [2, 0, 0],
-            'loss': [0, 0, 1],
             'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
         }
     )

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -35,10 +35,10 @@ def hyperopt_results():
     return pd.DataFrame(
         {
             'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
-            'profit_percent': [0.1, 0.2, 0.3],
-            'profit_abs': [0.2, 0.4, 0.5],
+            'profit_percent': [-0.1, 0.2, 0.3],
+            'profit_abs': [-0.2, 0.4, 0.6],
             'trade_duration': [10, 30, 10],
-            'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
+            'sell_reason': [SellType.STOP_LOSS, SellType.ROI, SellType.ROI]
         }
     )
 


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? 

Yes

## Summary

Change the dataframe fixtures of hyperopt results to more realistic one.

## Quick changelog

- b7da02a realistic usecase introduce a losing trade (don't associate a profit_percent postive with SellType.STOP_LOSS for example )
- f3e3a8f remove unused datas

## What's new?

Try to create a more realistic dataset fixtures

Have a nice day