### PR TITLE
minor: Cleanup in hyperopt

### DIFF
--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -560,6 +560,7 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     }
 
     hyperopt = Hyperopt(default_conf)
+    hyperopt.dimensions = hyperopt.hyperopt_space()
     generate_optimizer_value = hyperopt.generate_optimizer(list(optimizer_param.values()))
     assert generate_optimizer_value == response_expected
 


### PR DESCRIPTION
* The `*_space()` methods are no longer called from default/custom hyperopt class for every epoch. We already have optimizer space prepared, no need to make it for every epoch.
* Besides slight speedup, it eliminates noisy log messages printed for each epoch (visible with `-j 1`):
```
2019-09-16 20:38:00,257 - freqtrade.optimize.hyperopt_interface - INFO - Min roi table: {0: 0.03, 10: 0.02, 20: 0.01, 30: 0}
2019-09-16 20:38:00,257 - freqtrade.optimize.hyperopt_interface - INFO - Max roi table: {0: 0.31, 40: 0.11, 100: 0.04, 220: 0}
*    1/100:     16 trades. Avg profit -0.24%. Total profit -38.65417749 USDT (  -3.86Σ%). Avg duration 1431.6 mins. Objective: 100000.00000
2019-09-16 20:38:01,087 - freqtrade.optimize.hyperopt_interface - INFO - Min roi table: {0: 0.03, 10: 0.02, 20: 0.01, 30: 0}
2019-09-16 20:38:01,087 - freqtrade.optimize.hyperopt_interface - INFO - Max roi table: {0: 0.31, 40: 0.11, 100: 0.04, 220: 0}
*    2/100:    155 trades. Avg profit -0.31%. Total profit -477.50519896 USDT ( -47.70Σ%). Avg duration 2172.0 mins. Objective: 1.15901
2019-09-16 20:38:06,598 - freqtrade.optimize.hyperopt_interface - INFO - Min roi table: {0: 0.03, 10: 0.02, 20: 0.01, 30: 0}
2019-09-16 20:38:06,598 - freqtrade.optimize.hyperopt_interface - INFO - Max roi table: {0: 0.31, 40: 0.11, 100: 0.04, 220: 0}
*    3/100:      0 trades. Avg profit   nan%. Total profit  0.00000000 USDT (   0.00Σ%). Avg duration   nan mins. Objective: 100000.00000
2019-09-16 20:38:07,064 - freqtrade.optimize.hyperopt_interface - INFO - Min roi table: {0: 0.03, 10: 0.02, 20: 0.01, 30: 0}
2019-09-16 20:38:07,065 - freqtrade.optimize.hyperopt_interface - INFO - Max roi table: {0: 0.31, 40: 0.11, 100: 0.04, 220: 0}
*    4/100:      1 trades. Avg profit  0.00%. Total profit  0.00000000 USDT (   0.00Σ%). Avg duration 1015.0 mins. Objective: 100000.00000
```
-- that's the main goal for this change.

* Assignment of `self.backtesting.strategy.advise_indicators` to  `self.custom_hyperopt.populate_indicators` moved to the `__init__` method to be aligned with other similar assignments.
