### PR TITLE
Allow easy printing of loaded configuration

### DIFF
--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -102,7 +102,7 @@ from freqtrade.configuration import Configuration
 config = Configuration.from_files(["config1.json", "config2.json"])
 
 # Show the config in memory
-print(json.dumps(config, indent=2))
+print(json.dumps(config['original_config'], indent=2))
 ```
 
 For Interactive environments, have an additional configuration specifying `user_data_dir` and pass this in last, so you don't have to change directories while running the bot.

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -90,6 +90,9 @@ class Configuration:
         # Load all configs
         config: Dict[str, Any] = self.load_from_files(self.args["config"])
 
+        # Keep a copy of the original configuration file
+        config['original_config'] = deepcopy(config)
+
         self._process_common_options(config)
 
         self._process_optimize_options(config)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -161,6 +161,27 @@ def test_from_config(default_conf, mocker, caplog) -> None:
     assert validated_conf['fiat_display_currency'] == "EUR"
     assert 'internals' in validated_conf
     assert log_has('Validating configuration ...', caplog)
+    assert isinstance(validated_conf['user_data_dir'], Path)
+
+
+def test_print_config(default_conf, mocker, caplog) -> None:
+    conf1 = deepcopy(default_conf)
+    # Delete non-json elements from default_conf
+    del conf1['user_data_dir']
+    config_files = [conf1]
+
+    configsmock = MagicMock(side_effect=config_files)
+    mocker.patch(
+        'freqtrade.configuration.configuration.load_config_file',
+        configsmock
+    )
+
+    validated_conf = Configuration.from_files(['test_conf.json'])
+
+    assert isinstance(validated_conf['user_data_dir'], Path)
+    assert "user_data_dir" in validated_conf
+    assert "original_config" in validated_conf
+    assert isinstance(json.dumps(validated_conf['original_config']), str)
 
 
 def test_load_config_max_open_trades_minus_one(default_conf, mocker, caplog) -> None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -146,7 +146,7 @@ def test_from_config(default_conf, mocker, caplog) -> None:
     mocker.patch('freqtrade.configuration.configuration.create_datadir', lambda c, x: x)
 
     configsmock = MagicMock(side_effect=config_files)
-    mocker.patch('freqtrade.configuration.configuration.load_config_file',configsmock)
+    mocker.patch('freqtrade.configuration.configuration.load_config_file', configsmock)
 
     validated_conf = Configuration.from_files(['test_conf.json', 'test2_conf.json'])
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -143,12 +143,10 @@ def test_from_config(default_conf, mocker, caplog) -> None:
     conf2['exchange']['pair_whitelist'] += ['NANO/BTC']
     conf2['fiat_display_currency'] = "EUR"
     config_files = [conf1, conf2]
+    mocker.patch('freqtrade.configuration.configuration.create_datadir', lambda c, x: x)
 
     configsmock = MagicMock(side_effect=config_files)
-    mocker.patch(
-        'freqtrade.configuration.configuration.load_config_file',
-        configsmock
-    )
+    mocker.patch('freqtrade.configuration.configuration.load_config_file',configsmock)
 
     validated_conf = Configuration.from_files(['test_conf.json', 'test2_conf.json'])
 
@@ -171,10 +169,8 @@ def test_print_config(default_conf, mocker, caplog) -> None:
     config_files = [conf1]
 
     configsmock = MagicMock(side_effect=config_files)
-    mocker.patch(
-        'freqtrade.configuration.configuration.load_config_file',
-        configsmock
-    )
+    mocker.patch('freqtrade.configuration.configuration.create_datadir', lambda c, x: x)
+    mocker.patch('freqtrade.configuration.configuration.load_config_file', configsmock)
 
     validated_conf = Configuration.from_files(['test_conf.json'])
 


### PR DESCRIPTION
## Summary

Allow easy printing of loaded configuration
(beforechanging types and applying defaults)

Solve the issue: https://github.com/freqtrade/freqtrade/issues/36#issuecomment-533356803


## Quick changelog

- keep originally loaded configuration as part of the configuration, so the combined configuration can be plotted easily.
- will enable the configurator mentioned in #2112 - which will require saving the configuration to disk again.