### PR TITLE
Gracefully handle download-data startup errors

### DIFF
--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -27,6 +27,14 @@ def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
     logger.info("Checking exchange...")
 
     exchange = config.get('exchange', {}).get('name').lower()
+    if not exchange:
+        raise OperationalException(
+            f'This command requires a configured exchange. You can use either '
+            f'`--exchange <exchange_name` or use a configuration via `--config`.\n'
+            f'The following exchanges are supported by ccxt: '
+            f'{", ".join(available_exchanges())}'
+        )
+
     if not is_exchange_available(exchange):
         raise OperationalException(
                 f'Exchange "{exchange}" is not supported by ccxt '

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -29,8 +29,8 @@ def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
     exchange = config.get('exchange', {}).get('name').lower()
     if not exchange:
         raise OperationalException(
-            f'This command requires a configured exchange. You can use either '
-            f'`--exchange <exchange_name` or use a configuration via `--config`.\n'
+            f'This command requires a configured exchange. You should either use '
+            f'`--exchange <exchange_name>` or specify a configuration file via `--config`.\n'
             f'The following exchanges are supported by ccxt: '
             f'{", ".join(available_exchanges())}'
         )

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -73,7 +73,7 @@ def start_download_data(args: Dict[str, Any]) -> None:
 
     if 'pairs' not in config:
         raise OperationalException(
-            "Downloading data requires a list of pairs."
+            "Downloading data requires a list of pairs. "
             "Please check the documentation on how to configure this.")
 
     dl_path = Path(config['datadir'])

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 import arrow
 
+from freqtrade import OperationalException
 from freqtrade.configuration import Configuration, TimeRange
 from freqtrade.configuration.directory_operations import create_userdata_dir
 from freqtrade.data.history import refresh_backtest_ohlcv_data
@@ -69,6 +70,11 @@ def start_download_data(args: Dict[str, Any]) -> None:
     if 'days' in config:
         time_since = arrow.utcnow().shift(days=-config['days']).strftime("%Y%m%d")
         timerange = TimeRange.parse_timerange(f'{time_since}-')
+
+    if 'pairs' not in config:
+        raise OperationalException(
+            "Downloading data requires a list of pairs."
+            "Please check the documentation on how to configure this.")
 
     dl_path = Path(config['datadir'])
     logger.info(f'About to download pairs: {config["pairs"]}, '

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -546,6 +546,13 @@ def test_check_exchange(default_conf, caplog) -> None:
     default_conf['runmode'] = RunMode.PLOT
     assert check_exchange(default_conf)
 
+    # Test no exchange...
+    default_conf.get('exchange').update({'name': ''})
+    default_conf['runmode'] = RunMode.OTHER
+    with pytest.raises(OperationalException,
+                       match=r'This command requires a configured exchange.*'):
+        check_exchange(default_conf)
+
 
 def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)


### PR DESCRIPTION

## Summary
Download-data requires both exchange and pairs  to be set either directly or through configuration / pairs-file.
If it's not set, we should fail gracefully, not raising key-errors which is not clear for the usre.

Closes #2229
