### PR TITLE
Fix hyperopt position stacking

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -90,7 +90,7 @@ class Hyperopt:
         else:
             logger.debug('Ignoring max_open_trades (--disable-max-market-positions was used) ...')
             self.max_open_trades = 0
-        self.position_stacking = self.config.get('position_stacking', False),
+        self.position_stacking = self.config.get('position_stacking', False)
 
         if self.has_space('sell'):
             # Make sure experimental is enabled


### PR DESCRIPTION
Fixed the bug which caused serious deviations between hyperopt results and backtesting in same conditions.

Details: Position stacking in hyperopt has not been switched off (was a tuple instead of False).

This is one of those moments when I hate python. Simply hate. 👿 

Imho, quite critical. If the upcoming master release will use one of the previous commits as a baseline, this should be cherry-picked.
