### PR TITLE
Allow use of config in custom hyperopt methods

### DIFF
--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -36,6 +36,12 @@ class IHyperOpt(ABC):
     """
     ticker_interval: str
 
+    def __init__(self, config: dict) -> None:
+        self.config = config
+
+        # Assign ticker_interval to be used in hyperopt
+        IHyperOpt.ticker_interval = str(config['ticker_interval'])
+
     @staticmethod
     @abstractmethod
     def populate_indicators(dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -34,9 +34,6 @@ class HyperOptResolver(IResolver):
         self.hyperopt = self._load_hyperopt(hyperopt_name, config,
                                             extra_dir=config.get('hyperopt_path'))
 
-        # Assign ticker_interval to be used in hyperopt
-        IHyperOpt.ticker_interval = str(config['ticker_interval'])
-
         if not hasattr(self.hyperopt, 'populate_buy_trend'):
             logger.warning("Hyperopt class does not provide populate_buy_trend() method. "
                            "Using populate_buy_trend from the strategy.")
@@ -65,7 +62,7 @@ class HyperOptResolver(IResolver):
             abs_paths.insert(0, Path(extra_dir).resolve())
 
         hyperopt = self._load_object(paths=abs_paths, object_type=IHyperOpt,
-                                     object_name=hyperopt_name)
+                                     object_name=hyperopt_name, kwargs={'config': config})
         if hyperopt:
             return hyperopt
         raise OperationalException(

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -153,7 +153,7 @@ def test_hyperoptresolver(mocker, default_conf, caplog) -> None:
     delattr(hyperopts, 'populate_sell_trend')
     mocker.patch(
         'freqtrade.resolvers.hyperopt_resolver.HyperOptResolver._load_hyperopt',
-        MagicMock(return_value=hyperopts)
+        MagicMock(return_value=hyperopts(default_conf))
     )
     x = HyperOptResolver(default_conf, ).hyperopt
     assert not hasattr(x, 'populate_buy_trend')


### PR DESCRIPTION
This PR passes config into hyperopt interface init method and saves it in the attributes.

This will allow to use values from the config in the custom populate_* methods (for example, compare values against stake_amount, use stake_currency for creation the names of the columns, etc. -- all as in the strategies).
