### PR TITLE
Fix #2295: better logging for whitelist processing

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -116,11 +116,15 @@ class FreqtradeBot:
         # Refresh whitelist
         self.pairlists.refresh_pairlist()
         self.active_pair_whitelist = self.pairlists.whitelist
+        logger.info("Pairlist returned active pair whitelist: "
+                    f"{len(self.active_pair_whitelist)} pairs.")
 
         # Calculating Edge positioning
         if self.edge:
             self.edge.calculate()
             self.active_pair_whitelist = self.edge.adjust(self.active_pair_whitelist)
+            logger.info("Edge adjusted active pair whitelist: "
+                        f"{len(self.active_pair_whitelist)} pairs.")
 
         # Query trades from persistence layer
         trades = Trade.get_open_trades()
@@ -265,7 +269,7 @@ class FreqtradeBot:
         whitelist = copy.deepcopy(self.active_pair_whitelist)
 
         if not whitelist:
-            logger.warning("Whitelist is empty.")
+            logger.info("Active pair whitelist is empty.")
             return False
 
         # Remove currently opened and latest pairs from whitelist

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -116,7 +116,7 @@ class FreqtradeBot:
         # Refresh whitelist
         self.pairlists.refresh_pairlist()
         self.active_pair_whitelist = self.pairlists.whitelist
-        logger.info("Pairlist returned active pair whitelist: "
+        logger.info("PairList returned active pair whitelist: "
                     f"{len(self.active_pair_whitelist)} pairs.")
 
         # Calculating Edge positioning

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -672,7 +672,7 @@ def test_create_trades_no_pairs_in_whitelist(default_conf, ticker, limit_buy_ord
     patch_get_signal(freqtrade)
 
     assert not freqtrade.create_trades()
-    assert log_has("Whitelist is empty.", caplog)
+    assert log_has("Active pair whitelist is empty.", caplog)
 
 
 def test_create_trades_no_signal(default_conf, fee, mocker) -> None:


### PR DESCRIPTION
Fixes: #2295 

Log messages added: I tried to stay not noisy, but provide useful info in the log, which would help to understand manipulations with the active pair whitelist the bot performs.

The log level of the debug message in `create_trades()` was changed to `info` for the same reasons.

Typical bot throttling iterations now look in the log like the following (with the Edge is On):
```
2019-09-28 03:40:53,235 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:40:53,235 - freqtrade.freqtradebot - INFO - Edge adjusted active pair whitelist: 0 pairs.
2019-09-28 03:40:53,240 - freqtrade.freqtradebot - INFO - Active pair whitelist is empty.
2019-09-28 03:40:53,240 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-09-28 03:40:57,239 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:40:57,239 - freqtrade.freqtradebot - INFO - Edge adjusted active pair whitelist: 0 pairs.
2019-09-28 03:40:57,246 - freqtrade.freqtradebot - INFO - Active pair whitelist is empty.
2019-09-28 03:40:57,246 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
```

and with Edge is Off:
```
2019-09-28 03:47:00,657 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:47:01,285 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-09-28 03:47:04,660 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:47:04,675 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-09-28 03:47:08,663 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:47:08,676 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
2019-09-28 03:47:12,667 - freqtrade.freqtradebot - INFO - PairList returned active pair whitelist: 1 pairs.
2019-09-28 03:47:12,677 - freqtrade.freqtradebot - INFO - Found no buy signals for whitelisted currencies. Trying again...
```