### PR TITLE
Don't use main.py as entry point in documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -257,14 +257,12 @@ As compiling from source on windows has heavy dependencies (requires a partial v
 ```cmd
 >cd \path\freqtrade-develop
 >python -m venv .env
->cd .env\Scripts
->activate.bat
->cd \path\freqtrade-develop
+>.env\Scripts\activate.bat
 REM optionally install ta-lib from wheel
 REM >pip install TA_Lib‑0.4.17‑cp36‑cp36m‑win32.whl
 >pip install -r requirements.txt
 >pip install -e .
->python freqtrade\main.py
+>freqtrade
 ```
 
 > Thanks [Owdr](https://github.com/Owdr) for the commands. Source: [Issue #222](https://github.com/freqtrade/freqtrade/issues/222)


### PR DESCRIPTION
## Summary
Don't use main.py as entry point in documentation
we should be consistent and always use `freqtrade ...` as commands to execute.

as pointed out in #2302 

## Quick changelog

- Removed some odd directory changing in cmd documentation
- don't use main.py

