### PR TITLE
args - Add config no allowed list to skip loading config.json

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -41,7 +41,9 @@ ARGS_PLOT_DATAFRAME = ["pairs", "indicators1", "indicators2", "plot_limit", "db_
 ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
                     "trade_source", "ticker_interval"]
 
-NO_CONF_REQURIED = ["create-userdir", "download-data", "plot-dataframe", "plot-profit"]
+NO_CONF_REQURIED = ["download-data", "plot-dataframe", "plot-profit"]
+
+NO_CONF_ALLOWED = ["create-userdir", "list-exchanges"]
 
 
 class Arguments:
@@ -75,12 +77,15 @@ class Arguments:
         parsed_arg = self.parser.parse_args(self.args)
 
         # When no config is provided, but a config exists, use that configuration!
+        subparser = parsed_arg.subparser if 'subparser' in parsed_arg else None
 
         # Workaround issue in argparse with action='append' and default value
         # (see https://bugs.python.org/issue16399)
         # Allow no-config for certain commands (like downloading / plotting)
-        if (parsed_arg.config is None and ((Path.cwd() / constants.DEFAULT_CONFIG).is_file() or
-           not ('subparser' in parsed_arg and parsed_arg.subparser in NO_CONF_REQURIED))):
+        if (parsed_arg.config is None
+                and subparser not in NO_CONF_ALLOWED
+                and ((Path.cwd() / constants.DEFAULT_CONFIG).is_file()
+                     or (subparser not in NO_CONF_REQURIED))):
             parsed_arg.config = [constants.DEFAULT_CONFIG]
 
         return parsed_arg

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,5 +1,7 @@
 # pragma pylint: disable=missing-docstring, C0103
 import argparse
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -175,6 +177,44 @@ def test_plot_profit_options() -> None:
     assert pargs["trade_source"] == "DB"
     assert pargs["pairs"] == ["UNITTEST/BTC"]
     assert pargs["db_url"] == "sqlite:///whatever.sqlite"
+
+
+def test_config_notallowed(mocker) -> None:
+    mocker.patch.object(Path, "is_file", MagicMock(return_value=False))
+    args = [
+        'create-userdir',
+    ]
+    pargs = Arguments(args).get_parsed_arg()
+
+    assert pargs["config"] is None
+
+    # When file exists:
+    mocker.patch.object(Path, "is_file", MagicMock(return_value=True))
+    args = [
+        'create-userdir',
+    ]
+    pargs = Arguments(args).get_parsed_arg()
+    # config is not added even if it exists, since create-userdir is in the notallowed list
+    assert pargs["config"] is None
+
+
+def test_config_notrequired(mocker) -> None:
+    mocker.patch.object(Path, "is_file", MagicMock(return_value=False))
+    args = [
+        'download-data',
+    ]
+    pargs = Arguments(args).get_parsed_arg()
+
+    assert pargs["config"] is None
+
+    # When file exists:
+    mocker.patch.object(Path, "is_file", MagicMock(return_value=True))
+    args = [
+        'download-data',
+    ]
+    pargs = Arguments(args).get_parsed_arg()
+    # config is added if it exists
+    assert pargs["config"] == ['config.json']
 
 
 def test_check_int_positive() -> None:


### PR DESCRIPTION
## Summary
Don't load `config.json` when it's not needed.

## Quick changelog

- use a "Not_allowed" list to exclude loading config.json for some utils commands where it could cause problems.