### PR TITLE
Freqtradebot refactoring

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1,7 +1,6 @@
 """
 Freqtrade is the main module of this bot. It contains the class Freqtrade()
 """
-
 import copy
 import logging
 import traceback
@@ -135,12 +134,11 @@ class FreqtradeBot:
                                   self.strategy.informative_pairs())
 
         # First process current opened trades
-        for trade in trades:
-            self.process_maybe_execute_sell(trade)
+        self.process_maybe_execute_sells(trades)
 
         # Then looking for buy opportunities
         if len(trades) < self.config['max_open_trades']:
-            self.process_maybe_execute_buy()
+            self.process_maybe_execute_buys()
 
         if 'unfilledtimeout' in self.config:
             # Check and handle any timed out open orders
@@ -262,11 +260,10 @@ class FreqtradeBot:
         Checks pairs as long as the open trade count is below `max_open_trades`.
         :return: True if at least one trade has been created.
         """
-        interval = self.strategy.ticker_interval
         whitelist = copy.deepcopy(self.active_pair_whitelist)
 
         if not whitelist:
-            logger.warning("Whitelist is empty.")
+            logger.info("Active pair whitelist is empty.")
             return False
 
         # Remove currently opened and latest pairs from whitelist
@@ -276,7 +273,8 @@ class FreqtradeBot:
                 logger.debug('Ignoring %s in pair whitelist', trade.pair)
 
         if not whitelist:
-            logger.info("No currency pair in whitelist, but checking to sell open trades.")
+            logger.info("No currency pair in active pair whitelist, "
+                        "but checking to sell open trades.")
             return False
 
         buycount = 0
@@ -285,8 +283,10 @@ class FreqtradeBot:
             if self.strategy.is_pair_locked(_pair):
                 logger.info(f"Pair {_pair} is currently locked.")
                 continue
+
             (buy, sell) = self.strategy.get_signal(
-                _pair, interval, self.dataprovider.ohlcv(_pair, self.strategy.ticker_interval))
+                _pair, self.strategy.ticker_interval,
+                self.dataprovider.ohlcv(_pair, self.strategy.ticker_interval))
 
             if buy and not sell and len(Trade.get_open_trades()) < self.config['max_open_trades']:
                 stake_amount = self._get_trade_stake_amount(_pair)
@@ -431,10 +431,9 @@ class FreqtradeBot:
 
         return True
 
-    def process_maybe_execute_buy(self) -> None:
+    def process_maybe_execute_buys(self) -> None:
         """
-        Tries to execute a buy trade in a safe way
-        :return: True if executed
+        Tries to execute buy trades in a safe way
         """
         try:
             # Create entity and execute trade
@@ -443,33 +442,28 @@ class FreqtradeBot:
         except DependencyException as exception:
             logger.warning('Unable to create trade: %s', exception)
 
-    def process_maybe_execute_sell(self, trade: Trade) -> bool:
+    def process_maybe_execute_sells(self, trades: List[Any]) -> None:
         """
-        Tries to execute a sell trade
-        :return: True if executed
+        Tries to execute sell trades in a safe way
         """
-        try:
-            self.update_trade_state(trade)
+        for trade in trades:
+            try:
+                self.update_trade_state(trade)
 
-            if self.strategy.order_types.get('stoploss_on_exchange') and trade.is_open:
-                result = self.handle_stoploss_on_exchange(trade)
-                if result:
-                    self.wallets.update()
-                    return result
+                if trade.is_open:
+                    result = False
+                    if self.strategy.order_types.get('stoploss_on_exchange'):
+                        result = self.handle_stoploss_on_exchange(trade)
+                    elif trade.open_order_id is None:
+                        # Check if we can sell our current pair
+                        result = self.handle_trade(trade)
 
-            if trade.is_open and trade.open_order_id is None:
-                # Check if we can sell our current pair
-                result = self.handle_trade(trade)
+                    # Updating wallets if any trade occured
+                    if result:
+                        self.wallets.update()
 
-                # Updating wallets if any trade occured
-                if result:
-                    self.wallets.update()
-
-                return result
-
-        except DependencyException as exception:
-            logger.warning('Unable to sell trade: %s', exception)
-        return False
+            except DependencyException as exception:
+                logger.warning('Unable to sell trade: %s', exception)
 
     def get_real_amount(self, trade: Trade, order: Dict) -> float:
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -433,7 +433,7 @@ class FreqtradeBot:
 
     def process_maybe_execute_buys(self) -> None:
         """
-        Tries to execute buy trades in a safe way
+        Tries to execute buy orders for trades in a safe way
         """
         try:
             # Create entity and execute trade
@@ -444,7 +444,7 @@ class FreqtradeBot:
 
     def process_maybe_execute_sells(self, trades: List[Any]) -> None:
         """
-        Tries to execute sell trades in a safe way
+        Tries to execute sell orders for trades in a safe way
         """
         result = False
         for trade in trades:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2422,13 +2422,6 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf,
     default_conf['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)
-    mocker.patch.multiple(
-        'freqtrade.exchange.Exchange',
-        get_ticker=ticker,
-        get_fee=fee,
-        markets=PropertyMock(return_value=markets)
-    )
-
     stoploss_limit = MagicMock(return_value={
         'id': 123,
         'info': {
@@ -2437,11 +2430,16 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf,
     })
 
     cancel_order = MagicMock(return_value=True)
-
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.stoploss_limit', stoploss_limit)
-    mocker.patch('freqtrade.exchange.Exchange.cancel_order', cancel_order)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        get_ticker=ticker,
+        get_fee=fee,
+        markets=PropertyMock(return_value=markets),
+        symbol_amount_prec=lambda s, x, y: y,
+        symbol_price_prec=lambda s, x, y: y,
+        stoploss_limit=stoploss_limit,
+        cancel_order=cancel_order,
+    )
 
     freqtrade = FreqtradeBot(default_conf)
     freqtrade.strategy.order_types['stoploss_on_exchange'] = True
@@ -2482,7 +2480,9 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(return_value=markets)
+        markets=PropertyMock(return_value=markets),
+        symbol_amount_prec=lambda s, x, y: y,
+        symbol_price_prec=lambda s, x, y: y,
     )
 
     stoploss_limit = MagicMock(return_value={
@@ -2492,8 +2492,6 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf,
         }
     })
 
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
     mocker.patch('freqtrade.exchange.Binance.stoploss_limit', stoploss_limit)
 
     freqtrade = FreqtradeBot(default_conf)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1915,7 +1915,7 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order,
     trade.update(limit_sell_order)
     assert trade.is_open is False
 
-    with pytest.raises(ValueError, match=r'.*closed trade.*'):
+    with pytest.raises(DependencyException, match=r'.*closed trade.*'):
         freqtrade.handle_trade(trade)
 
 


### PR DESCRIPTION
* `process_maybe_execute_buy()` renamed to `process_maybe_execute_buys()` because it executes mutiple buys.
* Same for `process_maybe_execute_sell()`, to be symmetric.
* `process_maybe_execute_sell()` (now `process_maybe_execute_sells()`) accepts now the list of trades and iterate through them internally.
* Code of `process_maybe_execute_sells()` cleaned up, pls review.
* "Whitelist is empty." message should not be a warning.
* 'whitelist' was changed to 'active pair whitelist' in some of the log messages. (so probably this is enough to be applied instead of #2313 )
* Tests adjusted accordingly
