### PR TITLE
Allow to use market data in the strategies

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -85,6 +85,14 @@ class DataProvider:
             logger.warning(f"No data found for ({pair}, {ticker_interval}).")
         return data
 
+    def market(self, pair: str):
+        """
+        Return market data for the pair
+        :param pair: Pair to get the data for
+        :return: Market data dict from ccxt or None if market info is not available for the pair
+        """
+        return self._exchange.markets.get(pair)
+
     def ticker(self, pair: str):
         """
         Return last ticker data


### PR DESCRIPTION
...via dataprovider.

This will allow to use limits and precisions (for any reasons, if it's needed), fees, check the status of activity for informative pairs, and get the quote/base currency for the pair without any parsing (ccxt has already parsed it for us):

```
def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
...
    data1 = self.dp.ohlcv(pair=f'{self.dp.market(metadata["pair"])["base"]}/USDT', ticker_interval='1h')
```

This should also be available for backtesting (with current activity flags for the pairs though; all 'static' data as fees, base/quote strings, limits and precisions are okay)

TODO:
* [ ] add description to the docs