### PR TITLE
Backtest no fees / custom fees

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -74,7 +74,7 @@ freqtrade backtesting --export trades --export-filename=backtest_samplestrategy.
 
 #### Supplying custom fee value
 
-Sometimes your account has certain fee rabates, which are not visible to ccxt.
+Sometimes your account has certain fee rebates (fee reductions starting with a certain account size or monthly volume), which are not visible to ccxt.
 To account for this in backtesting, you can use `--fee 0.001` to supply this value to backtesting.
 This fee must be a percentage, and will be applied twice (once for trade entry, and once for trade exit).
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -72,6 +72,17 @@ The exported trades can be used for [further analysis](#further-backtest-result-
 freqtrade backtesting --export trades --export-filename=backtest_samplestrategy.json
 ```
 
+#### Supplying custom fee value
+
+Sometimes your account has certain fee rabates, which are not visible to ccxt.
+To account for this in backtesting, you can use `--fee 0.001` to supply this value to backtesting.
+This fee must be a percentage, and will be applied twice (once for trade entry, and once for trade exit).
+
+```bash
+freqtrade backtesting --fee 0.001
+```
+
+
 #### Running backtest with smaller testset by using timerange
 
 Use the `--timerange` argument to change how much of the testset you want to use.

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -168,22 +168,25 @@ Backtesting also uses the config specified via `-c/--config`.
 
 ```
 usage: freqtrade backtesting [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                           [--max_open_trades MAX_OPEN_TRADES]
-                           [--stake_amount STAKE_AMOUNT] [-r] [--eps] [--dmmp]
-                           [-l]
-                           [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
-                           [--export EXPORT] [--export-filename PATH]
+                             [--max_open_trades INT]
+                             [--stake_amount STAKE_AMOUNT] [--fee FLOAT]
+                             [--eps] [--dmmp]
+                             [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
+                             [--export EXPORT] [--export-filename PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades MAX_OPEN_TRADES
+  --max_open_trades INT
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
+  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
+                        (on trade entry and exit).
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
                         stacking).
@@ -193,19 +196,21 @@ optional arguments:
                         number).
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
                         Provide a space-separated list of strategies to
-                        backtest Please note that ticker-interval needs to be
+                        backtest. Please note that ticker-interval needs to be
                         set either in config or via command line. When using
-                        this together with --export trades, the strategy-name
-                        is injected into the filename (so backtest-data.json
-                        becomes backtest-data-DefaultStrategy.json
-  --export EXPORT       Export backtest results, argument are: trades. Example
-                        --export=trades
+                        this together with `--export trades`, the strategy-
+                        name is injected into the filename (so `backtest-
+                        data.json` becomes `backtest-data-
+                        DefaultStrategy.json`
+  --export EXPORT       Export backtest results, argument are: trades.
+                        Example: `--export=trades`
   --export-filename PATH
-                        Save backtest results to this filename requires
-                        --export to be set as well Example --export-
-                        filename=user_data/backtest_results/backtest_today.json
-                        (default: user_data/backtest_results/backtest-
-                        result.json)
+                        Save backtest results to the file with this filename
+                        (default: `user_data/backtest_results/backtest-
+                        result.json`). Requires `--export` to be set as well.
+                        Example: `--export-filename=user_data/backtest_results
+                        /backtest_today.json`
+
 ```
 
 ### Getting historic data for backtesting
@@ -222,13 +227,13 @@ to find optimal parameter values for your stategy.
 ```
 usage: freqtrade hyperopt [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
                           [--max_open_trades INT]
-                          [--stake_amount STAKE_AMOUNT] [-r]
+                          [--stake_amount STAKE_AMOUNT] [--fee FLOAT]
                           [--customhyperopt NAME] [--hyperopt-path PATH]
                           [--eps] [-e INT]
                           [-s {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
-                          [--dmmp] [--print-all] [--no-color] [-j JOBS]
-                          [--random-state INT] [--min-trades INT] [--continue]
-                          [--hyperopt-loss NAME]
+                          [--dmmp] [--print-all] [--no-color] [--print-json]
+                          [-j JOBS] [--random-state INT] [--min-trades INT]
+                          [--continue] [--hyperopt-loss NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -241,6 +246,8 @@ optional arguments:
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
+  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
+                        (on trade entry and exit).
   --customhyperopt NAME
                         Specify hyperopt class name (default:
                         `DefaultHyperOpts`).
@@ -260,6 +267,7 @@ optional arguments:
   --print-all           Print all results, not only the best ones.
   --no-color            Disable colorization of hyperopt results. May be
                         useful if you are redirecting output to a file.
+  --print-json          Print best result detailization in JSON format.
   -j JOBS, --job-workers JOBS
                         The number of concurrently running jobs for
                         hyperoptimization (hyperopt worker processes). If -1
@@ -278,8 +286,8 @@ optional arguments:
                         generate completely different results, since the
                         target for optimization is different. Built-in
                         Hyperopt-loss-functions are: DefaultHyperOptLoss,
-                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.
-                        (default: `DefaultHyperOptLoss`).
+                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss.(default:
+                        `DefaultHyperOptLoss`).
 ```
 
 ## Edge commands
@@ -288,25 +296,28 @@ To know your trade expectancy and winrate against historical data, you can use E
 
 ```
 usage: freqtrade edge [-h] [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                    [--max_open_trades MAX_OPEN_TRADES]
-                    [--stake_amount STAKE_AMOUNT] [-r]
-                    [--stoplosses STOPLOSS_RANGE]
+                      [--max_open_trades INT] [--stake_amount STAKE_AMOUNT]
+                      [--fee FLOAT] [--stoplosses STOPLOSS_RANGE]
 
 optional arguments:
   -h, --help            show this help message and exit
   -i TICKER_INTERVAL, --ticker-interval TICKER_INTERVAL
-                        Specify ticker interval (1m, 5m, 30m, 1h, 1d).
+                        Specify ticker interval (`1m`, `5m`, `30m`, `1h`,
+                        `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades MAX_OPEN_TRADES
+  --max_open_trades INT
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
+  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
+                        (on trade entry and exit).
   --stoplosses STOPLOSS_RANGE
-                        Defines a range of stoploss against which edge will
-                        assess the strategy the format is "min,max,step"
-                        (without any space).example:
-                        --stoplosses=-0.01,-0.1,-0.001
+                        Defines a range of stoploss values against which edge
+                        will assess the strategy. The format is "min,max,step"
+                        (without any space). Example:
+                        `--stoplosses=-0.01,-0.1,-0.001`
+
 ```
 
 To understand edge and how to read the results, please read the [edge documentation](edge.md).

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -185,8 +185,8 @@ optional arguments:
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
-  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
-                        (on trade entry and exit).
+  --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
+                        entry and exit).
   --eps, --enable-position-stacking
                         Allow buying the same pair multiple times (position
                         stacking).
@@ -246,8 +246,8 @@ optional arguments:
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
-  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
-                        (on trade entry and exit).
+  --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
+                        entry and exit).
   --customhyperopt NAME
                         Specify hyperopt class name (default:
                         `DefaultHyperOpts`).
@@ -310,8 +310,8 @@ optional arguments:
                         Specify max_open_trades to use.
   --stake_amount STAKE_AMOUNT
                         Specify stake_amount.
-  --fee FLOAT           Specify fee %. Should be in %, will be applied twice
-                        (on trade entry and exit).
+  --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
+                        entry and exit).
   --stoplosses STOPLOSS_RANGE
                         Defines a range of stoploss values against which edge
                         will assess the strategy. The format is "min,max,step"

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -15,7 +15,7 @@ ARGS_STRATEGY = ["strategy", "strategy_path"]
 ARGS_MAIN = ARGS_COMMON + ARGS_STRATEGY + ["db_url", "sd_notify"]
 
 ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange",
-                        "max_open_trades", "stake_amount"]
+                        "max_open_trades", "stake_amount", "fee"]
 
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
                                         "strategy_list", "export", "exportfilename"]

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -146,7 +146,7 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "fee": Arg(
         '--fee',
-        help='Specify fee %%. Should be in %%, will be applied twice (on trade entry and exit).',
+        help='Specify fee ratio. Will be applied twice (on trade entry and exit).',
         type=float,
         metavar='FLOAT',
     ),

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -144,6 +144,12 @@ AVAILABLE_CLI_OPTIONS = {
         default=os.path.join('user_data', 'backtest_results',
                              'backtest-result.json'),
     ),
+    "fee": Arg(
+        '--fee',
+        help='Specify fee %%. Should be in %%, will be applied twice (on trade entry and exit).',
+        type=float,
+        metavar='FLOAT',
+    ),
     # Edge
     "stoploss_range": Arg(
         '--stoplosses',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -328,7 +328,7 @@ class Configuration:
                         configuration instead of the content)
         """
         if (argname in self.args and self.args[argname] is not None
-            and self.args[argname] is not False):
+           and self.args[argname] is not False):
 
             config.update({argname: self.args[argname]})
             if logfun:

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -210,6 +210,10 @@ class Configuration:
                              logstring='Parameter --stake_amount detected, '
                              'overriding stake_amount to: {} ...')
 
+        self._args_to_config(config, argname='fee',
+                             logstring='Parameter --fee detected, '
+                             'setting fee to: {} ...')
+
         self._args_to_config(config, argname='timerange',
                              logstring='Parameter --timerange detected: {} ...')
 
@@ -323,7 +327,8 @@ class Configuration:
                         sample: logfun=len (prints the length of the found
                         configuration instead of the content)
         """
-        if argname in self.args and self.args[argname]:
+        if (argname in self.args and self.args[argname] is not None
+            and self.args[argname] is not False):
 
             config.update({argname: self.args[argname]})
             if logfun:

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -77,8 +77,10 @@ class Edge:
 
         self._timerange: TimeRange = TimeRange.parse_timerange("%s-" % arrow.now().shift(
             days=-1 * self._since_number_of_days).format('YYYYMMDD'))
-
-        self.fee = self.exchange.get_fee()
+        if config.get('fee'):
+            self.fee = config['fee']
+        else:
+            self.fee = self.exchange.get_fee()
 
     def calculate(self) -> bool:
         pairs = self.config['exchange']['pair_whitelist']

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -63,9 +63,12 @@ class Backtesting:
         self.config['exchange']['uid'] = ''
         self.config['dry_run'] = True
         self.strategylist: List[IStrategy] = []
-
         self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
-        self.fee = self.exchange.get_fee()
+
+        if config.get('fee'):
+            self.fee = config['fee']
+        else:
+            self.fee = self.exchange.get_fee()
 
         if self.config.get('runmode') != RunMode.HYPEROPT:
             self.dataprovider = DataProvider(self.config, self.exchange)

--- a/tests/optimize/test_edge_cli.py
+++ b/tests/optimize/test_edge_cli.py
@@ -98,6 +98,16 @@ def test_edge_init(mocker, edge_conf) -> None:
     assert callable(edge_cli.edge.calculate)
 
 
+def test_edge_init_fee(mocker, edge_conf) -> None:
+    patch_exchange(mocker)
+    edge_conf['fee'] = 0.1234
+    edge_conf['stake_amount'] = 20
+    fee_mock = mocker.patch('freqtrade.exchange.Exchange.get_fee', MagicMock(return_value=0.5))
+    edge_cli = EdgeCli(edge_conf)
+    assert edge_cli.edge.fee == 0.1234
+    assert fee_mock.call_count == 0
+
+
 def test_generate_edge_table(edge_conf, mocker):
     patch_exchange(mocker)
     edge_cli = EdgeCli(edge_conf)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -403,7 +403,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert log_has('Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
                    caplog)
 
-    assert 'position_stacking'in config
+    assert 'position_stacking' in config
     assert log_has('Parameter --enable-position-stacking detected ...', caplog)
 
     assert 'use_max_market_positions' in config


### PR DESCRIPTION
## Summary
Allow specifying fee percentage to be applied during backtesting.

This can be usefull if you'r exchange account has some rabates applied (for high volume, for example), which ccxt does not detect (it'll always show the basic fees for each exchange).

This can also be "abused" to add slippage, by specifying a slightly higher value than what the exchange applies.
It can also be applied to test a "ideal" world, where no fees apply (although that is unrealistic).

closes #2223
Remotely related to #1059, which explains behaviour of different exchanges related to this ... this PR only applies to backtesting, so will not fix this issue.

## Quick changelog

- Add `--fee` parameter to backtest/hyperopt/edge commands

