### PR TITLE
Add versions to doc theme

### DIFF
--- a/docs/partials/header.html
+++ b/docs/partials/header.html
@@ -49,4 +49,6 @@
     </nav>
     <!-- Place this tag in your head or just before your close body tag. -->
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"
+        integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 </header>

--- a/docs/stylesheets/ft.extra.css
+++ b/docs/stylesheets/ft.extra.css
@@ -1,0 +1,14 @@
+.rst-versions  {
+    font-size: .7rem;
+    color: white;
+}
+
+.rst-versions.rst-badge .rst-current-version {
+    font-size: .7rem;
+    color: white;
+}
+
+.rst-versions .rst-other-versions {
+    color: white;
+    text-decoration: underline;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ theme:
   palette:
     primary: 'blue grey'
     accent: 'tear'
+extra_css:
+  - 'stylesheets/ft.extra.css'
 markdown_extensions:
     - admonition
     - codehilite:


### PR DESCRIPTION
## Summary
Allow selection of different versions in the documentations

https://www.freqtrade.io/en/latest/

![2019-10-08-062349_1603x959_scrot](https://user-images.githubusercontent.com/5024695/66367379-39765a00-e994-11e9-86e0-215743392392.png)

closes #1619

## Quick changelog

- Include jquery - so ReadTheDocs can load the version window correctly
- Add some basic styling since the whole `div` is added via JS later, there is only soo much we can style with JS.

**Note**: Changes to the css file will be cached for 4 hours - so don't be surprised if it does not change immediately.


## After merge:
switch default branch on RTD back to develop!