### PR TITLE
remove underline from docs style

### DIFF
--- a/docs/stylesheets/ft.extra.css
+++ b/docs/stylesheets/ft.extra.css
@@ -10,5 +10,4 @@
 
 .rst-versions .rst-other-versions {
     color: white;
-    text-decoration: underline;
 }


### PR DESCRIPTION

## Summary
Followup to #2353

The underline looks odd as there are also "spaces" with underlines ...
