### PR TITLE
Minor: Fix helpstring for list-timeframes

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -29,9 +29,9 @@ ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
 
 ARGS_EDGE = ARGS_COMMON_OPTIMIZE + ["stoploss_range"]
 
-ARGS_LIST_EXCHANGES = ["print_one_column", "list_exchanges_all"]
+ARGS_LIST_EXCHANGES = ["list_exchanges_all", "list_exchanges_print_one_column"]
 
-ARGS_LIST_TIMEFRAMES = ["exchange", "print_one_column"]
+ARGS_LIST_TIMEFRAMES = ["exchange", "list_timeframes_print_one_column"]
 
 ARGS_CREATE_USERDIR = ["user_data_dir"]
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -245,7 +245,7 @@ AVAILABLE_CLI_OPTIONS = {
         default=constants.DEFAULT_HYPEROPT_LOSS,
     ),
     # List exchanges
-    "print_one_column": Arg(
+    "list_exchanges_print_one_column": Arg(
         '-1', '--one-column',
         help='Print exchanges in one column.',
         action='store_true',
@@ -253,6 +253,12 @@ AVAILABLE_CLI_OPTIONS = {
     "list_exchanges_all": Arg(
         '-a', '--all',
         help='Print all exchanges known to the ccxt library.',
+        action='store_true',
+    ),
+    # List timeframes
+    "list_timeframes_print_one_column": Arg(
+        '-1', '--one-column',
+        help='Print timeframes in one column.',
         action='store_true',
     ),
     # Script options

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -40,7 +40,7 @@ def start_list_exchanges(args: Dict[str, Any]) -> None:
     :return: None
     """
     exchanges = ccxt_exchanges() if args['list_exchanges_all'] else available_exchanges()
-    if args['print_one_column']:
+    if args['list_exchanges_print_one_column']:
         print('\n'.join(exchanges))
     else:
         if args['list_exchanges_all']:
@@ -112,7 +112,7 @@ def start_list_timeframes(args: Dict[str, Any]) -> None:
     # Init exchange
     exchange = ExchangeResolver(config['exchange']['name'], config).exchange
 
-    if args['print_one_column']:
+    if args['list_timeframes_print_one_column']:
         print('\n'.join(exchange.timeframes))
     else:
         print(f"Timeframes available for the exchange `{config['exchange']['name']}`: "


### PR DESCRIPTION
Set different helpstrings for the `-1` option for list-exchanges and list-timeframes subcommands.

Currently the helpstring for list-timframes errorneously says about printing exchanges.
