### PR TITLE
Add tests for orderbook and market in dataprovider

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -6,7 +6,7 @@ Common Interface for bot and strategy to access data.
 """
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from pandas import DataFrame
 
@@ -85,7 +85,7 @@ class DataProvider:
             logger.warning(f"No data found for ({pair}, {ticker_interval}).")
         return data
 
-    def market(self, pair: str):
+    def market(self, pair: str) -> Optional[Dict[str, Any]]:
         """
         Return market data for the pair
         :param pair: Pair to get the data for
@@ -100,9 +100,9 @@ class DataProvider:
         # TODO: Implement me
         pass
 
-    def orderbook(self, pair: str, maximum: int):
+    def orderbook(self, pair: str, maximum: int) -> Dict[str, List]:
         """
-        return latest orderbook data
+        fetch latest orderbook data
         :param pair: pair to get the data for
         :param maximum: Maximum number of orderbook entries to query
         :return: dict including bids/asks with a total of `maximum` entries.

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -120,3 +120,35 @@ def test_refresh(mocker, default_conf, ticker_history):
     assert len(refresh_mock.call_args[0]) == 1
     assert len(refresh_mock.call_args[0][0]) == len(pairs) + len(pairs_non_trad)
     assert refresh_mock.call_args[0][0] == pairs + pairs_non_trad
+
+
+def test_orderbook(mocker, default_conf, order_book_l2):
+    api_mock = MagicMock()
+    api_mock.fetch_l2_order_book = order_book_l2
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock)
+
+    dp = DataProvider(default_conf, exchange)
+    res = dp.orderbook('ETH/BTC', 5)
+    assert order_book_l2.call_count == 1
+    assert order_book_l2.call_args_list[0][0][0] == 'ETH/BTC'
+    assert order_book_l2.call_args_list[0][0][1] == 5
+
+    assert type(res) is dict
+    assert 'bids' in res
+    assert 'asks' in res
+
+
+def test_market(mocker, default_conf, markets):
+    api_mock = MagicMock()
+    api_mock.markets = markets
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock)
+
+    dp = DataProvider(default_conf, exchange)
+    res = dp.market('ETH/BTC')
+
+    assert type(res) is dict
+    assert 'symbol' in res
+    assert res['symbol'] == 'ETH/BTC'
+
+    res = dp.market('UNITTEST/BTC')
+    assert res is None


### PR DESCRIPTION
## Summary
Add tests and typehints (since these are user-facing functions) for dataprovider methods.

The tests cannot guarantee correct returns from the exchange, however we can make sure that the correct ccxt-method is being called.

