### PR TITLE
Interface options should not use config

### DIFF
--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -95,7 +95,10 @@ class StrategyResolver(IResolver):
             logger.info("Override strategy '%s' with value in config file: %s.",
                         attribute, config[attribute])
         elif hasattr(self.strategy, attribute):
-            config[attribute] = getattr(self.strategy, attribute)
+            val = getattr(self.strategy, attribute)
+            # None's cannot exist in the config, so do not copy them
+            if val is not None:
+                config[attribute] = val
         # Explicitly check for None here as other "falsy" values are possible
         elif default is not None:
             setattr(self.strategy, attribute, default)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -361,8 +361,8 @@ class IStrategy(ABC):
 
             # Don't update stoploss if trailing_only_offset_is_reached is true.
             if not (self.trailing_only_offset_is_reached and high_profit < sl_offset):
+                # Specific handling for trailing_stop_positive
                 if self.trailing_stop_positive is not None and high_profit > sl_offset:
-                    # Ignore mypy error check in configuration that this is a float
                     stop_loss_value = self.trailing_stop_positive
                     logger.debug(f"{trade.pair} - Using positive stoploss: {stop_loss_value} "
                                  f"offset: {sl_offset:.4g} profit: {current_profit:.4f}%")

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -78,7 +78,7 @@ class IStrategy(ABC):
 
     # trailing stoploss
     trailing_stop: bool = False
-    trailing_stop_positive: float
+    trailing_stop_positive: Optional[float] = None
     trailing_stop_positive_offset: float = 0.0
     trailing_only_offset_is_reached = False
 
@@ -361,8 +361,7 @@ class IStrategy(ABC):
 
             # Don't update stoploss if trailing_only_offset_is_reached is true.
             if not (self.trailing_only_offset_is_reached and high_profit < sl_offset):
-                # Specific handling for trailing_stop_positive
-                if 'trailing_stop_positive' in self.__dict__ and high_profit > sl_offset:
+                if self.trailing_stop_positive is not None and high_profit > sl_offset:
                     # Ignore mypy error check in configuration that this is a float
                     stop_loss_value = self.trailing_stop_positive
                     logger.debug(f"{trade.pair} - Using positive stoploss: {stop_loss_value} "

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -362,9 +362,9 @@ class IStrategy(ABC):
             # Don't update stoploss if trailing_only_offset_is_reached is true.
             if not (self.trailing_only_offset_is_reached and high_profit < sl_offset):
                 # Specific handling for trailing_stop_positive
-                if 'trailing_stop_positive' in self.config and high_profit > sl_offset:
+                if 'trailing_stop_positive' in self.__dict__ and high_profit > sl_offset:
                     # Ignore mypy error check in configuration that this is a float
-                    stop_loss_value = self.config.get('trailing_stop_positive')  # type: ignore
+                    stop_loss_value = self.trailing_stop_positive
                     logger.debug(f"{trade.pair} - Using positive stoploss: {stop_loss_value} "
                                  f"offset: {sl_offset:.4g} profit: {current_profit:.4f}%")
 


### PR DESCRIPTION
## Summary
We keep these options in both config and strategy. 
By using the values from Strategy, we enable hyperopting these values and speed up the code (no dictionary lookups, but attribute gets).


enables further work on #2363 

## Quick changelog

- use `strategy.*` instead of `config.get(*)`