### PR TITLE
Allow skipping of exchange validation

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -155,7 +155,7 @@ class Exchange:
     }
     _ft_has: Dict = {}
 
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict, validate: bool = True) -> None:
         """
         Initializes this module with the given config,
         it does basic validation whether the specified exchange and pairs are valid.
@@ -209,13 +209,13 @@ class Exchange:
         # Converts the interval provided in minutes in config to seconds
         self.markets_refresh_interval: int = exchange_config.get(
             "markets_refresh_interval", 60) * 60
-        # Initial markets load
-        self._load_markets()
-
-        # Check if all pairs are available
-        self.validate_pairs(config['exchange']['pair_whitelist'])
-        self.validate_ordertypes(config.get('order_types', {}))
-        self.validate_order_time_in_force(config.get('order_time_in_force', {}))
+        if validate:
+            # Initial markets load
+            self._load_markets()
+            # Check if all pairs are available
+            self.validate_pairs(config['exchange']['pair_whitelist'])
+            self.validate_ordertypes(config.get('order_types', {}))
+            self.validate_order_time_in_force(config.get('order_time_in_force', {}))
 
     def __del__(self):
         """

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -17,14 +17,15 @@ class ExchangeResolver(IResolver):
 
     __slots__ = ['exchange']
 
-    def __init__(self, exchange_name: str, config: dict) -> None:
+    def __init__(self, exchange_name: str, config: dict, validate: bool = True) -> None:
         """
         Load the custom class from config parameter
         :param config: configuration dictionary
         """
         exchange_name = exchange_name.title()
         try:
-            self.exchange = self._load_exchange(exchange_name, kwargs={'config': config})
+            self.exchange = self._load_exchange(exchange_name, kwargs={'config': config,
+                                                                       'validate': validate})
         except ImportError:
             logger.info(
                 f"No {exchange_name} specific subclass found. Using the generic class instead.")
@@ -43,7 +44,7 @@ class ExchangeResolver(IResolver):
         try:
             ex_class = getattr(exchanges, exchange_name)
 
-            exchange = ex_class(kwargs['config'])
+            exchange = ex_class(**kwargs)
             if exchange:
                 logger.info(f"Using resolved exchange '{exchange_name}'...")
                 return exchange

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -110,7 +110,7 @@ def start_list_timeframes(args: Dict[str, Any]) -> None:
     config['ticker_interval'] = None
 
     # Init exchange
-    exchange = ExchangeResolver(config['exchange']['name'], config).exchange
+    exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
 
     if args['print_one_column']:
         print('\n'.join(exchange.timeframes))


### PR DESCRIPTION
## Summary
Utils should not run certain validations for the exchange.

There is no need to add another level of exchange classes - it's a simple "flag" mechanism.

replaces: #2368
Resolves #2367


## future improvements

If needed, this can be extended to allow disabling of single checks - so `download-data` can disable different checks than `list-timeframes`.

