### PR TITLE
Add --dry-run to trade command

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -44,8 +44,8 @@ optional arguments:
                         deployments (default: `sqlite:///tradesv3.sqlite` for
                         Live Run mode, `sqlite://` for Dry Run).
   --sd-notify           Notify systemd service manager.
-  --dry-run             Enforce dry-run for trading, removes API keys and
-                        simulates trades.
+  --dry-run             Enforce dry-run for trading (removes Exchange secrets
+                        and simulates trades).
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -36,7 +36,7 @@ optional arguments:
 ```
 usage: freqtrade trade [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                        [--userdir PATH] [-s NAME] [--strategy-path PATH]
-                       [--db-url PATH] [--sd-notify]
+                       [--db-url PATH] [--sd-notify] [--dry-run]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -44,6 +44,8 @@ optional arguments:
                         deployments (default: `sqlite:///tradesv3.sqlite` for
                         Live Run mode, `sqlite://` for Dry Run).
   --sd-notify           Notify systemd service manager.
+  --dry-run             Enforce dry-run for trading, removes API keys and
+                        simulates trades.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
@@ -63,7 +65,6 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
-
 ```
 
 ### How to specify which configuration file be used?

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -12,7 +12,7 @@ ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_dat
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 
-ARGS_TRADE = ["db_url", "sd_notify"]
+ARGS_TRADE = ["db_url", "sd_notify", "dry_run"]
 
 ARGS_COMMON_OPTIMIZE = ["ticker_interval", "timerange", "max_open_trades", "stake_amount"]
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -86,6 +86,11 @@ AVAILABLE_CLI_OPTIONS = {
         help='Notify systemd service manager.',
         action='store_true',
     ),
+    "dry_run": Arg(
+        '--dry-run',
+        help='Enforce dry-run for trading, removes API keys and simulates trades.',
+        action='store_true',
+    ),
     # Optimize common
     "ticker_interval": Arg(
         '-i', '--ticker-interval',

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -88,7 +88,7 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "dry_run": Arg(
         '--dry-run',
-        help='Enforce dry-run for trading, removes API keys and simulates trades.',
+        help='Enforce dry-run for trading (removes Exchange secrets and simulates trades).',
         action='store_true',
     ),
     # Optimize common

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -162,6 +162,10 @@ class Configuration:
         if 'sd_notify' in self.args and self.args["sd_notify"]:
             config['internals'].update({'sd_notify': True})
 
+        self._args_to_config(config, argname='dry_run',
+                             logstring='Parameter --dry-run detected, '
+                             'overriding dry_run to: {} ...')
+
     def _process_datadir_options(self, config: Dict[str, Any]) -> None:
         """
         Extract information for sys.argv and load directory configurations

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -304,6 +304,23 @@ def test_load_config_with_params(default_conf, mocker) -> None:
     assert validated_conf.get('db_url') == DEFAULT_DB_DRYRUN_URL
 
 
+@pytest.mark.parametrize("config_value,expected,arglist", [
+    (True, True, ['trade', '--dry-run']),  # Leave config untouched
+    (False, True, ['trade', '--dry-run']),  # Override config untouched
+    (False, False, ['trade']),  # Leave config untouched
+    (True, True, ['trade']),  # Leave config untouched
+])
+def test_load_dry_run(default_conf, mocker, config_value, expected, arglist) -> None:
+
+    default_conf['dry_run'] = config_value
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    configuration = Configuration(Arguments(arglist).get_parsed_arg())
+    validated_conf = configuration.load_config()
+
+    assert validated_conf.get('dry_run') is expected
+
+
 def test_load_custom_strategy(default_conf, mocker) -> None:
     default_conf.update({
         'strategy': 'CustomStrategy',


### PR DESCRIPTION
## Summary
Allow `freqtrade trade --dry-run` to force dry-run mode.

as discussed in https://github.com/freqtrade/freqtrade/pull/2264#issuecomment-541839416.

I opted for option 2, since this keeps the possibility to have this configured in the configuration.

## Quick changelog

- Add `--dry-run`
- add test for `--dry-run`


## Note:
once `args_aftersubcommand2` is merged to the feature branch, we'll merge develop into that branch, and redo the command output documentation since other new features have been added.