### PR TITLE
exportfilename should respect configured user_data_dir

### DIFF
--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -2,7 +2,6 @@
 Definition of cli arguments used in arguments.py
 """
 import argparse
-import os
 
 from freqtrade import __version__, constants
 
@@ -141,8 +140,6 @@ AVAILABLE_CLI_OPTIONS = {
         'Requires `--export` to be set as well. '
         'Example: `--export-filename=user_data/backtest_results/backtest_today.json`',
         metavar='PATH',
-        default=os.path.join('user_data', 'backtest_results',
-                             'backtest-result.json'),
     ),
     "fee": Arg(
         '--fee',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -192,6 +192,13 @@ class Configuration:
         config.update({'datadir': create_datadir(config, self.args.get("datadir", None))})
         logger.info('Using data directory: %s ...', config.get('datadir'))
 
+        if self.args.get('exportfilename'):
+            self._args_to_config(config, argname='exportfilename',
+                                 logstring='Storing backtest results to {} ...')
+        else:
+            config['exportfilename'] = (config['user_data_dir']
+                                        / 'backtest_results/backtest-result.json')
+
     def _process_optimize_options(self, config: Dict[str, Any]) -> None:
 
         # This will override the strategy configuration
@@ -234,9 +241,6 @@ class Configuration:
 
         self._args_to_config(config, argname='export',
                              logstring='Parameter --export detected: {} ...')
-
-        self._args_to_config(config, argname='exportfilename',
-                             logstring='Storing backtest results to {} ...')
 
         # Edge section:
         if 'stoploss_range' in self.args and self.args["stoploss_range"]:


### PR DESCRIPTION
## Summary
exportfilename should default to the configured user_data_dir / backtest_results - not be hardcoded to `cwd()/user_data_dir/backtest_results/`

part of #2112 
