### PR TITLE
[minor][plot] Plotting trades from database should show correct duration

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -93,7 +93,7 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
                             t.close_date.replace(tzinfo=pytz.UTC) if t.close_date else None,
                             t.calc_profit(), t.calc_profit_percent(),
                             t.open_rate, t.close_rate, t.amount,
-                            (t.close_date.timestamp() - t.open_date.timestamp()
+                            (round((t.close_date.timestamp() - t.open_date.timestamp()) / 60, 2)
                                 if t.close_date else None),
                             t.sell_reason,
                             t.fee_open, t.fee_close,


### PR DESCRIPTION
## Summary
Duration expects minutes - subtracting timestamps results in seconds - so we need to convert this to minutes.

Otherwise, the hover-element of sell trades shows wrong minutes (2400min instead of 40min).
