### PR TITLE
[minor][doc]Fix backtesting format since sublist does not render correctly

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -199,8 +199,9 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Low happens before high for stoploss, protecting capital first.
 - ROI sells are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the sell will be at 2%)
 - Stoploss sells happen exactly at stoploss price, even if low was lower
-- Trailing stoploss: High happens first - adjusting stoploss
-- Trailing stoploss: Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
+- Trailing stoploss
+  - High happens first - adjusting stoploss
+  - Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
 - Sell-reason does not explain if a trade was positive or negative, just what triggered the sell (this can look odd if negative ROI values are used)
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -199,9 +199,8 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Low happens before high for stoploss, protecting capital first.
 - ROI sells are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the sell will be at 2%)
 - Stoploss sells happen exactly at stoploss price, even if low was lower
-- Trailing stoploss
-  - High happens first - adjusting stoploss
-  - Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
+- Trailing stoploss: High happens first - adjusting stoploss
+- Trailing stoploss: Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
 - Sell-reason does not explain if a trade was positive or negative, just what triggered the sell (this can look odd if negative ROI values are used)
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,1 +1,2 @@
 mkdocs-material==4.4.3
+mdx_truly_sane_lists==1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,3 +52,4 @@ markdown_extensions:
     - pymdownx.tasklist:
         custom_checkbox: true
     - pymdownx.tilde
+    - mdx_truly_sane_lists


### PR DESCRIPTION
Fix backtesting doc formatting since sublist does not render correctly on readthedocs.


https://www.freqtrade.io/en/latest/backtesting/#assumptions-made-by-backtesting