### PR TITLE
Update python base to 3.7.5 and install hyperopt dependencies in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-slim-stretch
+FROM python:3.7.5-slim-stretch
 
 RUN apt-get update \
     && apt-get -y install curl build-essential libssl-dev \
@@ -16,9 +16,9 @@ RUN cd /tmp && /tmp/install_ta-lib.sh && rm -r /tmp/*ta-lib*
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Install dependencies
-COPY requirements.txt requirements-common.txt /freqtrade/
+COPY requirements.txt requirements-common.txt requirements-hyperopt.txt /freqtrade/
 RUN pip install numpy --no-cache-dir \
-  && pip install -r requirements.txt --no-cache-dir
+  && pip install -r requirements-hyperopt.txt --no-cache-dir
 
 # Install and execute
 COPY . /freqtrade/

--- a/requirements-hyperopt.txt
+++ b/requirements-hyperopt.txt
@@ -1,5 +1,5 @@
 # Include all requirements to run the bot.
-# -r requirements.txt
+-r requirements.txt
 
 # Required for hyperopt
 scipy==1.3.1


### PR DESCRIPTION
## Summary
Update image to python 3.7.5 (intentionally not 3.8.0 - since i think we'll need to do some more testing before defaulting to that - however i don't expect many problems).
Reenable hyperopt dependencies in docker image

closes #2385 
