### PR TITLE
DynamicPairlist - pair_whitelist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -417,10 +417,15 @@ section of the configuration.
 `askVolume`, `bidVolume` and `quoteVolume`, defaults to `quoteVolume`.
   * There is a possibility to filter low-value coins that would not allow setting a stop loss
 (set `precision_filter` parameter to `true` for this).
+  * `VolumePairList` does not consider `pair_whitelist`, but builds this automatically based the pairlist configuration.
 
 Example:
 
 ```json
+"exchange": {
+    "pair_whitelist": [],
+    "pair_blacklist": ["BNB/BTC"]
+},
 "pairlist": {
         "method": "VolumePairList",
         "config": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `exchange.key` | '' | API key to use for the exchange. Only required when you are in production mode. ***Keep it in secrete, do not disclose publicly.***
 | `exchange.secret` | '' | API secret to use for the exchange. Only required when you are in production mode. ***Keep it in secrete, do not disclose publicly.***
 | `exchange.password` | '' | API password to use for the exchange. Only required when you are in production mode and for exchanges that use password for API requests. ***Keep it in secrete, do not disclose publicly.***
-| `exchange.pair_whitelist` | [] | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Not used when using VolumePairList (see [below](#dynamic-pairlists)).
+| `exchange.pair_whitelist` | [] | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Not used by VolumePairList (see [below](#dynamic-pairlists)).
 | `exchange.pair_blacklist` | [] | List of pairs the bot must absolutely avoid for trading and backtesting (see [below](#dynamic-pairlists)).
 | `exchange.ccxt_config` | None | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,8 +75,8 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `exchange.key` | '' | API key to use for the exchange. Only required when you are in production mode. ***Keep it in secrete, do not disclose publicly.***
 | `exchange.secret` | '' | API secret to use for the exchange. Only required when you are in production mode. ***Keep it in secrete, do not disclose publicly.***
 | `exchange.password` | '' | API password to use for the exchange. Only required when you are in production mode and for exchanges that use password for API requests. ***Keep it in secrete, do not disclose publicly.***
-| `exchange.pair_whitelist` | [] | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Can be overriden by dynamic pairlists (see [below](#dynamic-pairlists)).
-| `exchange.pair_blacklist` | [] | List of pairs the bot must absolutely avoid for trading and backtesting. Can be overriden by dynamic pairlists (see [below](#dynamic-pairlists)).
+| `exchange.pair_whitelist` | [] | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Not used when using VolumePairList (see [below](#dynamic-pairlists)).
+| `exchange.pair_blacklist` | [] | List of pairs the bot must absolutely avoid for trading and backtesting (see [below](#dynamic-pairlists)).
 | `exchange.ccxt_config` | None | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.ccxt_async_config` | None | Additional CCXT parameters passed to the async ccxt instance. Parameters may differ from exchange to exchange  and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation)
 | `exchange.markets_refresh_interval` | 60 | The interval in minutes in which markets are reloaded.
@@ -418,6 +418,7 @@ section of the configuration.
   * There is a possibility to filter low-value coins that would not allow setting a stop loss
 (set `precision_filter` parameter to `true` for this).
   * `VolumePairList` does not consider `pair_whitelist`, but builds this automatically based the pairlist configuration.
+  * Pairs in `pair_blacklist` are not considered for VolumePairList, even if all other filters would match.
 
 Example:
 

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -179,6 +179,9 @@ class Configuration:
             config['exchange']['name'] = self.args["exchange"]
             logger.info(f"Using exchange {config['exchange']['name']}")
 
+        if 'pair_whitelist' not in config['exchange']:
+            config['exchange']['pair_whitelist'] = []
+
         if 'user_data_dir' in self.args and self.args["user_data_dir"]:
             config.update({'user_data_dir': self.args["user_data_dir"]})
         elif 'user_data_dir' not in config:

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -235,7 +235,7 @@ CONF_SCHEMA = {
                 'ccxt_config': {'type': 'object'},
                 'ccxt_async_config': {'type': 'object'}
             },
-            'required': ['name', 'pair_whitelist']
+            'required': ['name']
         },
         'edge': {
             'type': 'object',

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -54,7 +54,7 @@ class VolumePairList(IPairList):
         """
         # Generate dynamic whitelist
         self._whitelist = self._gen_pair_whitelist(
-            self._config['stake_currency'], self._sort_key)[:self._number_pairs]
+            self._config['stake_currency'], self._sort_key)
 
     @cached(TTLCache(maxsize=1, ttl=1800))
     def _gen_pair_whitelist(self, base_currency: str, key: str) -> List[str]:
@@ -91,6 +91,6 @@ class VolumePairList(IPairList):
                     valid_tickers.remove(t)
 
         pairs = [s['symbol'] for s in valid_tickers]
-        logger.info(f"Searching pairs: {self._whitelist}")
+        logger.info(f"Searching pairs: {pairs[:self._number_pairs]}")
 
         return pairs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,8 +129,7 @@ def patch_freqtradebot(mocker, config) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot._refresh_whitelist',
-                 MagicMock(return_value=config['exchange']['pair_whitelist']))
+    patch_whitelist(mocker, config)
 
 
 def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,13 +55,15 @@ def patched_configuration_load_config_file(mocker, config) -> None:
     )
 
 
-def patch_exchange(mocker, api_mock=None, id='bittrex') -> None:
+def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> None:
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_ordertypes', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.id', PropertyMock(return_value=id))
     mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value=id.title()))
+    if mock_markets:
+        mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(return_value=get_markets()))
 
     if api_mock:
         mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
@@ -69,8 +71,8 @@ def patch_exchange(mocker, api_mock=None, id='bittrex') -> None:
         mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock())
 
 
-def get_patched_exchange(mocker, config, api_mock=None, id='bittrex') -> Exchange:
-    patch_exchange(mocker, api_mock, id)
+def get_patched_exchange(mocker, config, api_mock=None, id='bittrex', mock_markets=True) -> Exchange:
+    patch_exchange(mocker, api_mock, id, mock_markets)
     config["exchange"]["name"] = id
     try:
         exchange = ExchangeResolver(id, config).exchange
@@ -83,6 +85,11 @@ def patch_wallet(mocker, free=999.9) -> None:
     mocker.patch('freqtrade.wallets.Wallets.get_free', MagicMock(
         return_value=free
     ))
+
+
+def patch_whitelist(mocker, conf) -> None:
+    mocker.patch('freqtrade.freqtradebot.FreqtradeBot._refresh_whitelist',
+                 MagicMock(return_value=conf['exchange']['pair_whitelist']))
 
 
 def patch_edge(mocker) -> None:
@@ -120,6 +127,8 @@ def patch_freqtradebot(mocker, config) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.FreqtradeBot._refresh_whitelist',
+                 MagicMock(return_value=config['exchange']['pair_whitelist']))
 
 
 def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
@@ -287,6 +296,10 @@ def ticker_sell_down():
 
 @pytest.fixture
 def markets():
+    return get_markets()
+
+
+def get_markets():
     return {
         'ETH/BTC': {
             'id': 'ethbtc',
@@ -369,7 +382,7 @@ def markets():
             'symbol': 'LTC/BTC',
             'base': 'LTC',
             'quote': 'BTC',
-            'active': False,
+            'active': True,
             'precision': {
                 'price': 8,
                 'amount': 8,
@@ -394,7 +407,7 @@ def markets():
             'symbol': 'XRP/BTC',
             'base': 'XRP',
             'quote': 'BTC',
-            'active': False,
+            'active': True,
             'precision': {
                 'price': 8,
                 'amount': 8,
@@ -419,7 +432,7 @@ def markets():
             'symbol': 'NEO/BTC',
             'base': 'NEO',
             'quote': 'BTC',
-            'active': False,
+            'active': True,
             'precision': {
                 'price': 8,
                 'amount': 8,
@@ -444,7 +457,7 @@ def markets():
             'symbol': 'BTT/BTC',
             'base': 'BTT',
             'quote': 'BTC',
-            'active': True,
+            'active': False,
             'precision': {
                 'base': 8,
                 'quote': 8,
@@ -494,7 +507,7 @@ def markets():
             'symbol': 'LTC/USDT',
             'base': 'LTC',
             'quote': 'USDT',
-            'active': True,
+            'active': False,
             'precision': {
                 'amount': 8,
                 'price': 8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,8 @@ def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> No
     mocker.patch('freqtrade.exchange.Exchange.id', PropertyMock(return_value=id))
     mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value=id.title()))
     if mock_markets:
-        mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(return_value=get_markets()))
+        mocker.patch('freqtrade.exchange.Exchange.markets',
+                     PropertyMock(return_value=get_markets()))
 
     if api_mock:
         mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
@@ -71,7 +72,8 @@ def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> No
         mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock())
 
 
-def get_patched_exchange(mocker, config, api_mock=None, id='bittrex', mock_markets=True) -> Exchange:
+def get_patched_exchange(mocker, config, api_mock=None, id='bittrex',
+                         mock_markets=True) -> Exchange:
     patch_exchange(mocker, api_mock, id, mock_markets)
     config["exchange"]["name"] = id
     try:

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -533,21 +533,22 @@ def test_refresh_backtest_ohlcv_data(mocker, default_conf, markets, caplog, test
 
 def test_download_data_no_markets(mocker, default_conf, caplog, testdatadir):
     dl_mock = mocker.patch('freqtrade.data.history.download_pair_history', MagicMock())
+
+    ex = get_patched_exchange(mocker, default_conf)
     mocker.patch(
         'freqtrade.exchange.Exchange.markets', PropertyMock(return_value={})
     )
-    ex = get_patched_exchange(mocker, default_conf)
     timerange = TimeRange.parse_timerange("20190101-20190102")
-    unav_pairs = refresh_backtest_ohlcv_data(exchange=ex, pairs=["ETH/BTC", "XRP/BTC"],
+    unav_pairs = refresh_backtest_ohlcv_data(exchange=ex, pairs=["BTT/BTC", "LTC/USDT"],
                                              timeframes=["1m", "5m"],
                                              dl_path=testdatadir,
                                              timerange=timerange, erase=False
                                              )
 
     assert dl_mock.call_count == 0
-    assert "ETH/BTC" in unav_pairs
-    assert "XRP/BTC" in unav_pairs
-    assert log_has("Skipping pair ETH/BTC...", caplog)
+    assert "BTT/BTC" in unav_pairs
+    assert "LTC/USDT" in unav_pairs
+    assert log_has("Skipping pair BTT/BTC...", caplog)
 
 
 def test_refresh_backtest_trades_data(mocker, default_conf, markets, caplog, testdatadir):

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -177,16 +177,11 @@ def test_symbol_amount_prec(default_conf, mocker):
     '''
     Test rounds down to 4 Decimal places
     '''
-    api_mock = MagicMock()
-    api_mock.load_markets = MagicMock(return_value={
-        'ETH/BTC': '', 'LTC/BTC': '', 'XRP/BTC': '', 'NEO/BTC': ''
-    })
-    mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value='binance'))
 
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'amount': 4}}})
-    type(api_mock).markets = markets
 
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    exchange = get_patched_exchange(mocker, default_conf, id="binance")
+    mocker.patch('freqtrade.exchange.Exchange.markets', markets)
 
     amount = 2.34559
     pair = 'ETH/BTC'
@@ -198,16 +193,10 @@ def test_symbol_price_prec(default_conf, mocker):
     '''
     Test rounds up to 4 decimal places
     '''
-    api_mock = MagicMock()
-    api_mock.load_markets = MagicMock(return_value={
-        'ETH/BTC': '', 'LTC/BTC': '', 'XRP/BTC': '', 'NEO/BTC': ''
-    })
-    mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value='binance'))
-
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'price': 4}}})
-    type(api_mock).markets = markets
 
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    exchange = get_patched_exchange(mocker, default_conf, id="binance")
+    mocker.patch('freqtrade.exchange.Exchange.markets', markets)
 
     price = 2.34559
     pair = 'ETH/BTC'
@@ -279,7 +268,7 @@ def test__load_markets(default_conf, mocker, caplog):
     api_mock.load_markets = MagicMock(return_value=expected_return)
     type(api_mock).markets = expected_return
     default_conf['exchange']['pair_whitelist'] = ['ETH/BTC']
-    ex = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
+    ex = get_patched_exchange(mocker, default_conf, api_mock, id="binance", mock_markets=False)
     assert ex.markets == expected_return
 
 
@@ -294,7 +283,8 @@ def test__reload_markets(default_conf, mocker, caplog):
     api_mock.load_markets = load_markets
     type(api_mock).markets = initial_markets
     default_conf['exchange']['markets_refresh_interval'] = 10
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance",
+                                    mock_markets=False)
     exchange._last_markets_refresh = arrow.utcnow().timestamp
     updated_markets = {'ETH/BTC': {}, "LTC/BTC": {}}
 
@@ -1715,15 +1705,16 @@ def test_get_valid_pair_combination(default_conf, mocker, markets):
           'LTC/USDT', 'NEO/BTC', 'TKN/BTC', 'XLTCUSDT', 'XRP/BTC']),
         # active markets
         ([], [], False, True,
-         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/USD', 'LTC/USDT',
-          'TKN/BTC', 'XLTCUSDT']),
+         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'NEO/BTC',
+          'TKN/BTC', 'XLTCUSDT', 'XRP/BTC']),
         # all pairs
         ([], [], True, False,
          ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD',
           'LTC/USDT', 'NEO/BTC', 'TKN/BTC', 'XRP/BTC']),
         # active pairs
         ([], [], True, True,
-         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/USD', 'LTC/USDT', 'TKN/BTC']),
+         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'NEO/BTC',
+          'TKN/BTC', 'XRP/BTC']),
         # all markets, base=ETH, LTC
         (['ETH', 'LTC'], [], False, False,
          ['ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'LTC/USDT', 'XLTCUSDT']),

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -80,7 +80,7 @@ def test_refresh_pairlist_dynamic(mocker, markets, tickers, whitelist_conf):
     freqtradebot = get_patched_freqtradebot(mocker, whitelist_conf)
 
     # argument: use the whitelist dynamically by exchange-volume
-    whitelist = ['ETH/BTC', 'TKN/BTC', 'BTT/BTC']
+    whitelist = ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']
     freqtradebot.pairlists.refresh_pairlist()
 
     assert whitelist == freqtradebot.pairlists.whitelist
@@ -108,12 +108,12 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
 
 
 @pytest.mark.parametrize("precision_filter,base_currency,key,whitelist_result", [
-    (False, "BTC", "quoteVolume", ['ETH/BTC', 'TKN/BTC', 'BTT/BTC']),
-    (False, "BTC", "bidVolume", ['BTT/BTC', 'TKN/BTC', 'ETH/BTC']),
-    (False, "USDT", "quoteVolume", ['ETH/USDT', 'LTC/USDT']),
+    (False, "BTC", "quoteVolume", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']),
+    (False, "BTC", "bidVolume", ['LTC/BTC', 'TKN/BTC', 'ETH/BTC']),
+    (False, "USDT", "quoteVolume", ['ETH/USDT']),
     (False, "ETH", "quoteVolume", []),  # this replaces tests that were removed from test_exchange
-    (True, "BTC", "quoteVolume", ["ETH/BTC", "TKN/BTC"]),
-    (True, "BTC", "bidVolume", ["TKN/BTC", "ETH/BTC"])
+    (True, "BTC", "quoteVolume", ["LTC/BTC", "ETH/BTC", "TKN/BTC"]),
+    (True, "BTC", "bidVolume", ["LTC/BTC", "TKN/BTC", "ETH/BTC"])
 ])
 def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, markets, tickers, base_currency, key,
                                       whitelist_result, precision_filter) -> None:
@@ -127,7 +127,7 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, markets, tickers, 
     freqtrade.pairlists._precision_filter = precision_filter
     freqtrade.config['stake_currency'] = base_currency
     whitelist = freqtrade.pairlists._gen_pair_whitelist(base_currency=base_currency, key=key)
-    assert whitelist == whitelist_result
+    assert sorted(whitelist) == sorted(whitelist_result)
 
 
 def test_gen_pair_whitelist_not_supported(mocker, default_conf, tickers) -> None:
@@ -160,7 +160,7 @@ def test_pairlist_class(mocker, whitelist_conf, markets, pairlist):
     (['ETH/BTC', 'TKN/BTC', 'TRX/ETH'], "is not compatible with exchange"),  # TRX/ETH wrong stake
     (['ETH/BTC', 'TKN/BTC', 'BCH/BTC'], "is not compatible with exchange"),  # BCH/BTC not available
     (['ETH/BTC', 'TKN/BTC', 'BLK/BTC'], "is not compatible with exchange"),  # BLK/BTC in blacklist
-    (['ETH/BTC', 'TKN/BTC', 'LTC/BTC'], "Market is not active")  # LTC/BTC is inactive
+    (['ETH/BTC', 'TKN/BTC', 'BTT/BTC'], "Market is not active")  # BTT/BTC is inactive
 ])
 def test_validate_whitelist(mocker, whitelist_conf, markets, pairlist, whitelist, caplog,
                             log_message):

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -9,12 +9,11 @@ from numpy import isnan
 
 from freqtrade import DependencyException, TemporaryError
 from freqtrade.edge import PairInfo
-from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPC, RPCException
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.state import State
-from tests.conftest import patch_exchange, patch_get_signal, get_patched_freqtradebot
+from tests.conftest import patch_get_signal, get_patched_freqtradebot
 
 
 # Functions for recurrent object patching

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -22,7 +22,7 @@ from freqtrade.rpc.telegram import Telegram, authorized_only
 from freqtrade.state import State
 from freqtrade.strategy.interface import SellType
 from tests.conftest import (get_patched_freqtradebot, log_has, patch_exchange,
-                            patch_get_signal)
+                            patch_get_signal, patch_whitelist)
 
 
 class DummyCls(Telegram):
@@ -143,17 +143,15 @@ def test_authorized_only_exception(default_conf, mocker, caplog) -> None:
     assert log_has('Exception occurred within Telegram module', caplog)
 
 
-def test_status(default_conf, update, mocker, fee, ticker, markets) -> None:
+def test_status(default_conf, update, mocker, fee, ticker,) -> None:
     update.message.chat.id = 123
     default_conf['telegram']['enabled'] = False
     default_conf['telegram']['chat_id'] = 123
 
-    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(markets)
     )
     msg_mock = MagicMock()
     status_table = MagicMock()
@@ -184,9 +182,8 @@ def test_status(default_conf, update, mocker, fee, ticker, markets) -> None:
         _status_table=status_table,
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -204,13 +201,11 @@ def test_status(default_conf, update, mocker, fee, ticker, markets) -> None:
     assert status_table.call_count == 1
 
 
-def test_status_handle(default_conf, update, ticker, fee, markets, mocker) -> None:
-    patch_exchange(mocker)
+def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(markets)
     )
     msg_mock = MagicMock()
     status_table = MagicMock()
@@ -220,9 +215,9 @@ def test_status_handle(default_conf, update, ticker, fee, markets, mocker) -> No
         _status_table=status_table,
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+
     patch_get_signal(freqtradebot, (True, False))
 
     telegram = Telegram(freqtradebot)
@@ -256,14 +251,12 @@ def test_status_handle(default_conf, update, ticker, fee, markets, mocker) -> No
     assert 'ETH/BTC' in msg_mock.call_args_list[0][0][0]
 
 
-def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker) -> None:
-    patch_exchange(mocker)
+def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': 'mocked_order_id'}),
         get_fee=fee,
-        markets=PropertyMock(markets)
     )
     msg_mock = MagicMock()
     mocker.patch.multiple(
@@ -271,10 +264,9 @@ def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker)
         _init=MagicMock(),
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
     default_conf['stake_amount'] = 15.0
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
 
     telegram = Telegram(freqtradebot)
@@ -307,8 +299,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, markets, mocker)
 
 
 def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
-                      limit_sell_order, markets, mocker) -> None:
-    patch_exchange(mocker)
+                      limit_sell_order, mocker) -> None:
     default_conf['max_open_trades'] = 1
     mocker.patch(
         'freqtrade.rpc.rpc.CryptoToFiatConverter._find_price',
@@ -318,7 +309,6 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(markets)
     )
     msg_mock = MagicMock()
     mocker.patch.multiple(
@@ -326,9 +316,8 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
         _init=MagicMock(),
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -382,7 +371,6 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
 
 
 def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
-    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker
@@ -393,9 +381,8 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
         _init=MagicMock(),
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -420,14 +407,12 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
 
 
 def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
-                       limit_buy_order, limit_sell_order, markets, mocker) -> None:
-    patch_exchange(mocker)
+                       limit_buy_order, limit_sell_order, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(markets)
     )
     msg_mock = MagicMock()
     mocker.patch.multiple(
@@ -435,9 +420,8 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
         _init=MagicMock(),
         _send_msg=msg_mock
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -724,16 +708,16 @@ def test_reload_conf_handle(default_conf, update, mocker) -> None:
 
 
 def test_forcesell_handle(default_conf, update, ticker, fee,
-                          ticker_sell_up, markets, mocker) -> None:
+                          ticker_sell_up, mocker) -> None:
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
     patch_exchange(mocker)
+    patch_whitelist(mocker, default_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -775,17 +759,18 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
 
 
 def test_forcesell_down_handle(default_conf, update, ticker, fee,
-                               ticker_sell_down, markets, mocker) -> None:
+                               ticker_sell_down, mocker) -> None:
     mocker.patch('freqtrade.rpc.fiat_convert.CryptoToFiatConverter._find_price',
                  return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
     patch_exchange(mocker)
+    patch_whitelist(mocker, default_conf)
+
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
 
     freqtradebot = FreqtradeBot(default_conf)
@@ -830,17 +815,17 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
     } == last_msg
 
 
-def test_forcesell_all_handle(default_conf, update, ticker, fee, markets, mocker) -> None:
+def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.rpc.fiat_convert.CryptoToFiatConverter._find_price',
                  return_value=15000.0)
     rpc_mock = mocker.patch('freqtrade.rpc.telegram.Telegram.send_msg', MagicMock())
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
+    patch_whitelist(mocker, default_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
     default_conf['max_open_trades'] = 4
     freqtradebot = FreqtradeBot(default_conf)
@@ -885,9 +870,8 @@ def test_forcesell_handle_invalid(default_conf, update, mocker) -> None:
         _init=MagicMock(),
         _send_msg=msg_mock
     )
-    patch_exchange(mocker)
 
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -980,8 +964,7 @@ def test_forcebuy_handle_exception(default_conf, update, markets, mocker) -> Non
 
 
 def test_performance_handle(default_conf, update, ticker, fee,
-                            limit_buy_order, limit_sell_order, markets, mocker) -> None:
-    patch_exchange(mocker)
+                            limit_buy_order, limit_sell_order, mocker) -> None:
     msg_mock = MagicMock()
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
@@ -992,10 +975,8 @@ def test_performance_handle(default_conf, update, ticker, fee,
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(markets),
     )
-    mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 
@@ -1018,8 +999,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     assert '<code>ETH/BTC\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
 
 
-def test_count_handle(default_conf, update, ticker, fee, markets, mocker) -> None:
-    patch_exchange(mocker)
+def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock = MagicMock()
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
@@ -1030,10 +1010,9 @@ def test_count_handle(default_conf, update, ticker, fee, markets, mocker) -> Non
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': 'mocked_order_id'}),
-        markets=PropertyMock(markets)
+        get_fee=fee,
     )
-    mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
-    freqtradebot = FreqtradeBot(default_conf)
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -825,7 +825,7 @@ def test_pairlist_resolving():
 
     args = Arguments(arglist).get_parsed_arg()
 
-    configuration = Configuration(args)
+    configuration = Configuration(args, RunMode.OTHER)
     config = configuration.get_config()
 
     assert config['pairs'] == ['ETH/BTC', 'XRP/BTC']

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -729,6 +729,30 @@ def test_validate_edge(edge_conf):
     validate_config_consistency(edge_conf)
 
 
+def test_validate_whitelist(default_conf):
+    default_conf['runmode'] = RunMode.DRY_RUN
+    # Test regular case - has whitelist and uses StaticPairlist
+    validate_config_consistency(default_conf)
+    conf = deepcopy(default_conf)
+    del conf['exchange']['pair_whitelist']
+    # Test error case
+    with pytest.raises(OperationalException,
+                       match="StaticPairList requires pair_whitelist to be set."):
+
+        validate_config_consistency(conf)
+
+    conf = deepcopy(default_conf)
+
+    conf.update({"pairlist": {
+        "method": "VolumePairList",
+    }})
+    # Dynamic whitelist should not care about pair_whitelist
+    validate_config_consistency(conf)
+    del conf['exchange']['pair_whitelist']
+
+    validate_config_consistency(conf)
+
+
 def test_load_config_test_comments() -> None:
     """
     Load config with comments
@@ -895,7 +919,7 @@ def test_pairlist_resolving_fallback(mocker):
     # Fix flaky tests if config.json exists
     args["config"] = None
 
-    configuration = Configuration(args)
+    configuration = Configuration(args, RunMode.OTHER)
     config = configuration.get_config()
 
     assert config['pairs'] == ['ETH/BTC', 'XRP/BTC']

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2951,7 +2951,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee,
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0.01
     patch_whitelist(mocker, default_conf)
-    
+
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -23,7 +23,7 @@ from freqtrade.strategy.interface import SellCheckTuple, SellType
 from freqtrade.worker import Worker
 from tests.conftest import (get_patched_freqtradebot, get_patched_worker,
                             log_has, log_has_re, patch_edge, patch_exchange,
-                            patch_get_signal, patch_wallet)
+                            patch_get_signal, patch_wallet, patch_whitelist)
 
 
 def patch_RPCManager(mocker) -> MagicMock:
@@ -1247,11 +1247,10 @@ def test_create_stoploss_order_invalid_order(mocker, default_conf, caplog, fee,
 
 
 def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
-                                              markets, limit_buy_order, limit_sell_order) -> None:
+                                              limit_buy_order, limit_sell_order) -> None:
     # When trailing stoploss is set
     stoploss_limit = MagicMock(return_value={'id': 13434334})
     patch_RPCManager(mocker)
-    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=MagicMock(return_value={
@@ -1262,7 +1261,6 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         sell=MagicMock(return_value={'id': limit_sell_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
         stoploss_limit=stoploss_limit
     )
 
@@ -1272,7 +1270,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
     # disabling ROI
     default_conf['minimal_roi']['0'] = 999999999
 
-    freqtrade = FreqtradeBot(default_conf)
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
     # enabling stoploss on exchange
     freqtrade.strategy.order_types['stoploss_on_exchange'] = True
@@ -1824,20 +1822,18 @@ def test_handle_overlpapping_signals(default_conf, ticker, limit_buy_order,
 
 
 def test_handle_trade_roi(default_conf, ticker, limit_buy_order,
-                          fee, mocker, markets, caplog) -> None:
+                          fee, mocker, caplog) -> None:
     caplog.set_level(logging.DEBUG)
 
     patch_RPCManager(mocker)
-    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets)
     )
 
-    freqtrade = FreqtradeBot(default_conf)
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtrade, value=(True, False))
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=True)
 
@@ -1858,20 +1854,18 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order,
 
 
 def test_handle_trade_use_sell_signal(
-        default_conf, ticker, limit_buy_order, fee, mocker, markets, caplog) -> None:
+        default_conf, ticker, limit_buy_order, fee, mocker, caplog) -> None:
     # use_sell_signal is True buy default
     caplog.set_level(logging.DEBUG)
     patch_RPCManager(mocker)
-    patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets)
     )
 
-    freqtrade = FreqtradeBot(default_conf)
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtrade)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
     freqtrade.create_trades()
@@ -2236,6 +2230,7 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, markets, moc
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
+    patch_whitelist(mocker, default_conf)
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
@@ -2282,6 +2277,7 @@ def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, markets,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
+    patch_whitelist(mocker, default_conf)
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
@@ -2331,6 +2327,7 @@ def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fe
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
+    patch_whitelist(mocker, default_conf)
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
@@ -2647,6 +2644,7 @@ def test_execute_sell_market_order(default_conf, ticker, fee,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
+    patch_whitelist(mocker, default_conf)
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
@@ -2814,14 +2812,13 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, fee, marke
     assert trade.sell_reason == SellType.SELL_SIGNAL.value
 
 
-def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, markets, mocker, caplog) -> None:
+def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, mocker, caplog) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
         get_fee=fee,
-        markets=PropertyMock(return_value=markets)
     )
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
@@ -2851,7 +2848,7 @@ def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, markets, mock
     assert log_has(f"Pair {trade.pair} is currently locked.", caplog)
 
 
-def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, markets, mocker) -> None:
+def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2863,7 +2860,6 @@ def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, markets, m
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets)
     )
     default_conf['ask_strategy'] = {
         'ignore_roi_if_buy_signal': True
@@ -2885,7 +2881,7 @@ def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, markets, m
     assert trade.sell_reason == SellType.ROI.value
 
 
-def test_trailing_stop_loss(default_conf, limit_buy_order, fee, markets, caplog, mocker) -> None:
+def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2897,9 +2893,9 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, markets, caplog,
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
     default_conf['trailing_stop'] = True
+    patch_whitelist(mocker, default_conf)
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
@@ -2937,7 +2933,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, markets, caplog,
     assert trade.sell_reason == SellType.TRAILING_STOP_LOSS.value
 
 
-def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, markets,
+def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee,
                                      caplog, mocker) -> None:
     buy_price = limit_buy_order['price']
     patch_RPCManager(mocker)
@@ -2951,10 +2947,11 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, markets
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0.01
+    patch_whitelist(mocker, default_conf)
+    
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
@@ -2994,7 +2991,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee, markets
 
 
 def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
-                                   caplog, mocker, markets) -> None:
+                                   caplog, mocker) -> None:
     buy_price = limit_buy_order['price']
     patch_RPCManager(mocker)
     patch_exchange(mocker)
@@ -3007,9 +3004,8 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
-
+    patch_whitelist(mocker, default_conf)
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0.01
     default_conf['trailing_stop_positive_offset'] = 0.011
@@ -3054,7 +3050,7 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
 
 
 def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
-                                 caplog, mocker, markets) -> None:
+                                 caplog, mocker) -> None:
     buy_price = limit_buy_order['price']
     # buy_price: 0.00001099
 
@@ -3069,9 +3065,8 @@ def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
         }),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
-        markets=PropertyMock(return_value=markets),
     )
-
+    patch_whitelist(mocker, default_conf)
     default_conf['trailing_stop'] = True
     default_conf['trailing_stop_positive'] = 0.05
     default_conf['trailing_stop_positive_offset'] = 0.055

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -378,7 +378,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ('["BLK/BTC","ETH/BTC","ETH/USDT","LTC/BTC","LTC/USD","NEO/BTC","TKN/BTC","XLTCUSDT","XRP/BTC"]'
+    assert ('["BLK/BTC","ETH/BTC","ETH/USDT","LTC/BTC","LTC/USD","NEO/BTC",'
+            '"TKN/BTC","XLTCUSDT","XRP/BTC"]'
             in captured.out)
 
     # Test --print-csv

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,8 +188,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 8 active markets: "
-            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/USD, LTC/USDT, TKN/BTC, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 9 active markets: "
+            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, NEO/BTC, TKN/BTC, XLTCUSDT, XRP/BTC.\n"
             in captured.out)
 
     patch_exchange(mocker, api_mock=api_mock, id="binance")
@@ -202,7 +202,7 @@ def test_list_markets(mocker, markets, capsys):
     pargs['config'] = None
     start_list_markets(pargs, False)
     captured = capsys.readouterr()
-    assert re.match("\nExchange Binance has 8 active markets:\n",
+    assert re.match("\nExchange Binance has 9 active markets:\n",
                     captured.out)
 
     patch_exchange(mocker, api_mock=api_mock, id="bittrex")
@@ -227,8 +227,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), True)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 7 active pairs: "
-            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/USD, LTC/USDT, TKN/BTC.\n"
+    assert ("Exchange Bittrex has 8 active pairs: "
+            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, NEO/BTC, TKN/BTC, XRP/BTC.\n"
             in captured.out)
 
     # Test list-pairs subcommand with --all: all pairs
@@ -254,7 +254,7 @@ def test_list_markets(mocker, markets, capsys):
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
     assert ("Exchange Bittrex has 5 active markets with ETH, LTC as base currencies: "
-            "ETH/BTC, ETH/USDT, LTC/USD, LTC/USDT, XLTCUSDT.\n"
+            "ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, base=LTC
@@ -267,7 +267,7 @@ def test_list_markets(mocker, markets, capsys):
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
     assert ("Exchange Bittrex has 3 active markets with LTC as base currency: "
-            "LTC/USD, LTC/USDT, XLTCUSDT.\n"
+            "LTC/BTC, LTC/USD, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, quote=USDT, USD
@@ -279,8 +279,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 4 active markets with USDT, USD as quote currencies: "
-            "ETH/USDT, LTC/USD, LTC/USDT, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 3 active markets with USDT, USD as quote currencies: "
+            "ETH/USDT, LTC/USD, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, quote=USDT
@@ -292,8 +292,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 3 active markets with USDT as quote currency: "
-            "ETH/USDT, LTC/USDT, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 2 active markets with USDT as quote currency: "
+            "ETH/USDT, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, base=LTC, quote=USDT
@@ -305,21 +305,21 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 2 active markets with LTC as base currency and "
-            "with USDT as quote currency: LTC/USDT, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 1 active market with LTC as base currency and "
+            "with USDT as quote currency: XLTCUSDT.\n"
             in captured.out)
 
     # active pairs, base=LTC, quote=USDT
     args = [
         '--config', 'config.json.example',
         "list-pairs",
-        "--base", "LTC", "--quote", "USDT",
+        "--base", "LTC", "--quote", "USD",
         "--print-list",
     ]
     start_list_markets(get_args(args), True)
     captured = capsys.readouterr()
     assert ("Exchange Bittrex has 1 active pair with LTC as base currency and "
-            "with USDT as quote currency: LTC/USDT.\n"
+            "with USD as quote currency: LTC/USD.\n"
             in captured.out)
 
     # active markets, base=LTC, quote=USDT, NONEXISTENT
@@ -331,8 +331,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 2 active markets with LTC as base currency and "
-            "with USDT, NONEXISTENT as quote currencies: LTC/USDT, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 1 active market with LTC as base currency and "
+            "with USDT, NONEXISTENT as quote currencies: XLTCUSDT.\n"
             in captured.out)
 
     # active markets, base=LTC, quote=NONEXISTENT
@@ -355,7 +355,7 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 8 active markets:\n"
+    assert ("Exchange Bittrex has 9 active markets:\n"
             in captured.out)
 
     # Test tabular output, no markets found
@@ -378,7 +378,7 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ('["BLK/BTC","BTT/BTC","ETH/BTC","ETH/USDT","LTC/USD","LTC/USDT","TKN/BTC","XLTCUSDT"]'
+    assert ('["BLK/BTC","ETH/BTC","ETH/USDT","LTC/BTC","LTC/USD","NEO/BTC","TKN/BTC","XLTCUSDT","XRP/BTC"]'
             in captured.out)
 
     # Test --print-csv
@@ -391,7 +391,7 @@ def test_list_markets(mocker, markets, capsys):
     captured = capsys.readouterr()
     assert ("Id,Symbol,Base,Quote,Active,Is pair" in captured.out)
     assert ("blkbtc,BLK/BTC,BLK,BTC,True,True" in captured.out)
-    assert ("BTTBTC,BTT/BTC,BTT,BTC,True,True" in captured.out)
+    assert ("USD-LTC,LTC/USD,LTC,USD,True,True" in captured.out)
 
     # Test --one-column
     args = [
@@ -402,7 +402,7 @@ def test_list_markets(mocker, markets, capsys):
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
     assert re.search(r"^BLK/BTC$", captured.out, re.MULTILINE)
-    assert re.search(r"^BTT/BTC$", captured.out, re.MULTILINE)
+    assert re.search(r"^LTC/USD$", captured.out, re.MULTILINE)
 
 
 def test_create_datadir_failed(caplog):


### PR DESCRIPTION
## Summary
`pair_whitelist` is not mandatory (it's not used at all) if VolumePairList is used.

Improve dynamic pairlist documentation to mention that pair_whitelist is not used and not needed by VolumePairList.

Closes #2414
closes #2413
## Quick changelog

- Lift requirement of having pair_whitelist if not using `StaticPairList`
- Update docs