### PR TITLE
Change loglevel of repeated message to debug

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -120,7 +120,7 @@
     "forcebuy_enable": false,
     "internals": {
         "process_throttle_secs": 5,
-        "keep_alive_interval": 60
+        "heartbeat_interval": 60
     },
     "strategy": "DefaultStrategy",
     "strategy_path": "user_data/strategies/"

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -119,7 +119,8 @@
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {
-        "process_throttle_secs": 5
+        "process_throttle_secs": 5,
+        "keep_alive_interval": 60
     },
     "strategy": "DefaultStrategy",
     "strategy_path": "user_data/strategies/"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `strategy` | DefaultStrategy | Defines Strategy class to use.
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a directory).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
+| `internals.keep_alive_interval` | 60 | Print keepalive message every X seconds. Set to 0 to disable keepalive messages.
 | `internals.sd_notify` | false | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details.
 | `logfile` | | Specify Logfile. Uses a rolling strategy of 10 files, with 1Mb per file.
 | `user_data_dir` | cwd()/user_data | Directory containing user data. Defaults to `./user_data/`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `strategy` | DefaultStrategy | Defines Strategy class to use.
 | `strategy_path` | null | Adds an additional strategy lookup path (must be a directory).
 | `internals.process_throttle_secs` | 5 | **Required.** Set the process throttle. Value in second.
-| `internals.keep_alive_interval` | 60 | Print keepalive message every X seconds. Set to 0 to disable keepalive messages.
+| `internals.heartbeat_interval` | 60 | Print heartbeat message every X seconds. Set to 0 to disable heartbeat messages.
 | `internals.sd_notify` | false | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details.
 | `logfile` | | Specify Logfile. Uses a rolling strategy of 10 files, with 1Mb per file.
 | `user_data_dir` | cwd()/user_data | Directory containing user data. Defaults to `./user_data/`.

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -443,7 +443,7 @@ class FreqtradeBot:
         try:
             # Create entity and execute trade
             if not self.create_trades():
-                logger.info('Found no buy signals for whitelisted currencies. Trying again...')
+                logger.debug('Found no buy signals for whitelisted currencies. Trying again...')
         except DependencyException as exception:
             logger.warning('Unable to create trade: %s', exception)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -53,7 +53,7 @@ class FreqtradeBot:
 
         self._heartbeat_msg = 0
 
-        self.hearbeat_interval = self.config.get('internals', {}).get('heartbeat_interval', 60)
+        self.heartbeat_interval = self.config.get('internals', {}).get('heartbeat_interval', 60)
 
         self.strategy: IStrategy = StrategyResolver(self.config).strategy
 
@@ -155,9 +155,9 @@ class FreqtradeBot:
             self.check_handle_timedout()
             Trade.session.flush()
 
-        if (self.hearbeat_interval
-            and (arrow.utcnow().timestamp - self._heartbeat_msg > self.hearbeat_interval)):
-            logger.info(f"Freqtrade heartbeat. PID={getpid()}")
+        if (self.heartbeat_interval
+           and (arrow.utcnow().timestamp - self._heartbeat_msg > self.heartbeat_interval)):
+            logger.info(f"Bot heartbeat. PID={getpid()}")
             self._heartbeat_msg = arrow.utcnow().timestamp
 
     def _extend_whitelist_with_trades(self, whitelist: List[str], trades: List[Any]):

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3656,7 +3656,7 @@ def test_process_i_am_alive(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
 
     ftbot = get_patched_freqtradebot(mocker, default_conf)
-    message = r"Freqtrade heartbeat. PID=.*"
+    message = r"Bot heartbeat\. PID=.*"
     ftbot.process()
     assert log_has_re(message, caplog)
     assert ftbot._heartbeat_msg != 0

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3656,19 +3656,19 @@ def test_process_i_am_alive(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
 
     ftbot = get_patched_freqtradebot(mocker, default_conf)
-    message = "I am alive."
+    message = r"Freqtrade heartbeat. PID=.*"
     ftbot.process()
-    assert log_has(message, caplog)
-    assert ftbot._last_alive_msg != 0
+    assert log_has_re(message, caplog)
+    assert ftbot._heartbeat_msg != 0
 
     caplog.clear()
     # Message is not shown before interval is up
     ftbot.process()
-    assert not log_has(message, caplog)
+    assert not log_has_re(message, caplog)
 
     caplog.clear()
     # Set clock - 70 seconds
-    ftbot._last_alive_msg -= 70
+    ftbot._heartbeat_msg -= 70
 
     ftbot.process()
-    assert log_has(message, caplog)
+    assert log_has_re(message, caplog)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1521,6 +1521,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
 
 
 def test_process_maybe_execute_buys(mocker, default_conf, caplog) -> None:
+    caplog.set_level(logging.DEBUG)
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.create_trades', MagicMock(return_value=False))


### PR DESCRIPTION
## Summary
Disable repeated log message from default output (makes reading the logs very difficult).

closes partially #2408 (closes it in combination with #2418).

## Quick changelog

- Switch log-level to Debug for repeated message.