### PR TITLE
[Docs] stoploss documentation improvements

### DIFF
--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -15,14 +15,14 @@ At this stage the bot contains the following stoploss support modes:
 1. Static stop loss.
 2. Trailing stop loss.
 3. Trailing stop loss, custom positive loss.
-4. Trailing stop loss only once the trade has reached a certain offset,
+4. Trailing stop loss only once the trade has reached a certain offset.
 
 Those stoploss modes can be *on exchange* or *off exchange*. If the stoploss is *on exchange* it means a stoploss limit order is placed on the exchange immediately after buy order happens successfully. This will protect you against sudden crashes in market as the order will be in the queue immediately and if market goes down then the order has more chance of being fulfilled.
 
 In case of stoploss on exchange there is another parameter called `stoploss_on_exchange_interval`. This configures the interval in seconds at which the bot will check the stoploss and update it if necessary.
 
 For example, assuming the stoploss is on exchange, and trailing stoploss is enabled, and the market is going up, then the bot automatically cancels the previous stoploss order and puts a new one with a stop value higher than the previous stoploss order.
-The bot cannot do this every 5 seconds, otherwise it would get banned by the exchange.
+The bot cannot do this every 5 seconds (at each iteration), otherwise it would get banned by the exchange.
 So this parameter will tell the bot how often it should update the stoploss order. The default value is 60 (1 minute).
 This same logic will reapply a stoploss order on the exchange should you cancel it accidentally.
 
@@ -31,7 +31,7 @@ This same logic will reapply a stoploss order on the exchange should you cancel 
 
 ## Static Stop Loss
 
-This is very simple, you define a stop loss of x. This will try to sell the asset once the loss exceeds the defined loss.
+This is very simple, you define a stop loss of x (as a ratio of price, i.e. x * 100% of price). This will try to sell the asset once the loss exceeds the defined loss.
 
 ## Trailing Stop Loss
 
@@ -51,7 +51,7 @@ For example, simplified math:
 * the stop loss would get triggered once the asset dropps below 98$
 * assuming the asset now increases to 102$
 * the stop loss will now be 2% of 102$ or 99.96$
-* now the asset drops in value to 101$, the stop loss, will still be 99.96$, and would trigger at 99.96$.
+* now the asset drops in value to 101$, the stop loss will still be 99.96$ and would trigger at 99.96$.
 
 In summary: The stoploss will be adjusted to be always be 2% of the highest observed price.
 

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -4,20 +4,18 @@ The `stoploss` configuration parameter is loss in percentage that should trigger
 For example, value `-0.10` will cause immediate sell if the profit dips below -10% for a given trade. This parameter is optional.
 
 Most of the strategy files already include the optimal `stoploss` value.
-Stoploss parameters need to be set in either strategy or configuration file.
-Parameters in the configuration will overwrite settings within the strategy.
+
+!!! Info
+    All stoploss properties mentioned in this file can be set in the Strategy, or in the configuration. Configuration values will override the strategy values.
 
 ## Stop Loss Types
 
 At this stage the bot contains the following stoploss support modes:
 
-1. static stop loss, defined in either the strategy or configuration.
-2. trailing stop loss, defined in the configuration.
-3. trailing stop loss, custom positive loss, defined in configuration.
-4. trailing stop loss only once the trade has reached a certain offset,
-
-!!! Note
-    All stoploss properties can be configured in either Strategy or configuration. Configuration values override strategy values.
+1. Static stop loss.
+2. Trailing stop loss.
+3. Trailing stop loss, custom positive loss.
+4. Trailing stop loss only once the trade has reached a certain offset,
 
 Those stoploss modes can be *on exchange* or *off exchange*. If the stoploss is *on exchange* it means a stoploss limit order is placed on the exchange immediately after buy order happens successfully. This will protect you against sudden crashes in market as the order will be in the queue immediately and if market goes down then the order has more chance of being fulfilled.
 
@@ -37,11 +35,11 @@ This is very simple, you define a stop loss of x. This will try to sell the asse
 
 ## Trailing Stop Loss
 
-The initial value for this is `stoploss`, set either in the strategy or in the configuration file. Just as you would define your Stop loss normally.
-To enable this Feauture all you have to do is to define the configuration element:
+The initial value for this is `stoploss`, just as you would define your static Stop loss.
+To enable trailing stoploss:
 
-``` json
-"trailing_stop" : True
+``` python
+trailing_stop = True
 ```
 
 This will now activate an algorithm, which automatically moves the stop loss up every time the price of your asset increases.
@@ -62,31 +60,36 @@ In summary: The stoploss will be adjusted to be always be 2% of the highest obse
 It is also possible to have a default stop loss, when you are in the red with your buy, but once your profit surpasses a certain percentage, the system will utilize a new stop loss, which can have a different value.
 For example your default stop loss is 5%, but once you have 1.1% profit, it will be changed to be only a 1% stop loss, which trails the green candles until it goes below them.
 
-Both values can be configured in the strategy or configuration file and requires `"trailing_stop": true` to be set to true.
+Both values require `trailing_stop` to be set to true.
 
-``` json
-    "trailing_stop_positive":  0.01,
-    "trailing_stop_positive_offset":  0.011,
+``` python
+    trailing_stop_positive = 0.01
+    trailing_stop_positive_offset = 0.011
 ```
 
 The 0.01 would translate to a 1% stop loss, once you hit 1.1% profit.
+Before this, `stoploss` is used for the trailing stoploss.
 
-You should also make sure to have this value (`trailing_stop_positive_offset`) lower than your minimal ROI, otherwise minimal ROI will apply first and sell your trade.
+Read the [next section](#trailing-only-once-offset-is-reached) to keep stoploss at 5% of the entry point.
+
+!!! Tip
+    Make sure to have this value (`trailing_stop_positive_offset`) lower than minimal ROI, otherwise minimal ROI will apply first and sell the trade.
 
 ### Trailing only once offset is reached
 
-It is also possible to use a static stoploss until the offset is reached, and then trail the trade to take profits once the market goes down again.
+It is also possible to use a static stoploss until the offset is reached, and then trail the trade to take profits once the market turns.
 
 If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached. Until then, the stoploss remains at the configured `stoploss`.
 This option can be used with or without `trailing_stop_positive`, but uses `trailing_stop_positive_offset` as offset.
 
-``` json
-    "trailing_only_offset_is_reached": true,
+``` python
+    trailing_stop_positive_offset = 0.011
+    trailing_only_offset_is_reached = true
 ```
 
 Simplified example:
 
-```python
+``` python
     stoploss = 0.05
     trailing_stop_positive_offset = 0.03
     trailing_only_offset_is_reached = True

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -3,74 +3,98 @@
 The `stoploss` configuration parameter is loss in percentage that should trigger a sale.
 For example, value `-0.10` will cause immediate sell if the profit dips below -10% for a given trade. This parameter is optional.
 
-Most of the strategy files already include the optimal `stoploss`
-value. This parameter is optional. If you use it in the configuration file, it will take over the
-`stoploss` value from the strategy file.
+Most of the strategy files already include the optimal `stoploss` value.
+Stoploss parameters need to be set in either strategy or configuration file.
+Parameters in the configuration will overwrite settings within the strategy.
 
-## Stop Loss support
+## Stop Loss Types
 
 At this stage the bot contains the following stoploss support modes:
 
 1. static stop loss, defined in either the strategy or configuration.
 2. trailing stop loss, defined in the configuration.
 3. trailing stop loss, custom positive loss, defined in configuration.
+4. trailing stop loss only once the trade has reached a certain offset,
 
 !!! Note
     All stoploss properties can be configured in either Strategy or configuration. Configuration values override strategy values.
 
-Those stoploss modes can be *on exchange* or *off exchange*. If the stoploss is *on exchange* it means a stoploss limit order is placed on the exchange immediately after buy order happens successfuly. This will protect you against sudden crashes in market as the order will be in the queue immediately and if market goes down then the order has more chance of being fulfilled.
+Those stoploss modes can be *on exchange* or *off exchange*. If the stoploss is *on exchange* it means a stoploss limit order is placed on the exchange immediately after buy order happens successfully. This will protect you against sudden crashes in market as the order will be in the queue immediately and if market goes down then the order has more chance of being fulfilled.
 
-In case of stoploss on exchange there is another parameter called `stoploss_on_exchange_interval`. This configures the interval in seconds at which the bot will check the stoploss and update it if necessary. As an example in case of trailing stoploss if the order is on the exchange and the market is going up then the bot automatically cancels the previous stoploss order and put a new one with a stop value higher than previous one. It is clear that the bot cannot do it every 5 seconds otherwise it gets banned. So this parameter will tell the bot how often it should update the stoploss order. The default value is 60 (1 minute).
+In case of stoploss on exchange there is another parameter called `stoploss_on_exchange_interval`. This configures the interval in seconds at which the bot will check the stoploss and update it if necessary.
+
+For example, assuming the stoploss is on exchange, and trailing stoploss is enabled, and the market is going up, then the bot automatically cancels the previous stoploss order and puts a new one with a stop value higher than the previous stoploss order.
+The bot cannot do this every 5 seconds, otherwise it would get banned by the exchange.
+So this parameter will tell the bot how often it should update the stoploss order. The default value is 60 (1 minute).
+This same logic will reapply a stoploss order on the exchange should you cancel it accidentally.
 
 !!! Note
     Stoploss on exchange is only supported for Binance as of now.
 
 ## Static Stop Loss
 
-This is very simple, basically you define a stop loss of x in your strategy file or alternative in the configuration, which
-will overwrite the strategy definition. This will basically try to sell your asset, the second the loss exceeds the defined loss.
+This is very simple, you define a stop loss of x. This will try to sell the asset once the loss exceeds the defined loss.
 
 ## Trailing Stop Loss
 
-The initial value for this stop loss, is defined in your strategy or configuration. Just as you would define your Stop Loss normally.
+The initial value for this is `stoploss`, set either in the strategy or in the configuration file. Just as you would define your Stop loss normally.
 To enable this Feauture all you have to do is to define the configuration element:
 
 ``` json
 "trailing_stop" : True
 ```
 
-This will now activate an algorithm, which automatically moves your stop loss up every time the price of your asset increases.
+This will now activate an algorithm, which automatically moves the stop loss up every time the price of your asset increases.
 
-For example, simplified math,
+For example, simplified math:
 
-* you buy an asset at a price of 100$
-* your stop loss is defined at 2%
-* which means your stop loss, gets triggered once your asset dropped below 98$
-* assuming your asset now increases to 102$
-* your stop loss, will now be 2% of 102$ or 99.96$
-* now your asset drops in value to 101$, your stop loss, will still be 99.96$
+* the bot buys an asset at a price of 100$
+* the stop loss is defined at 2%
+* the stop loss would get triggered once the asset dropps below 98$
+* assuming the asset now increases to 102$
+* the stop loss will now be 2% of 102$ or 99.96$
+* now the asset drops in value to 101$, the stop loss, will still be 99.96$, and would trigger at 99.96$.
 
-basically what this means is that your stop loss will be adjusted to be always be 2% of the highest observed price
+In summary: The stoploss will be adjusted to be always be 2% of the highest observed price.
 
-### Custom positive loss
+### Custom positive stoploss
 
-Due to demand, it is possible to have a default stop loss, when you are in the red with your buy, but once your profit surpasses a certain percentage,
-the system will utilize a new stop loss, which can be a different value. For example your default stop loss is 5%, but once you have 1.1% profit,
-it will be changed to be only a 1% stop loss, which trails the green candles until it goes below them.
+It is also possible to have a default stop loss, when you are in the red with your buy, but once your profit surpasses a certain percentage, the system will utilize a new stop loss, which can have a different value.
+For example your default stop loss is 5%, but once you have 1.1% profit, it will be changed to be only a 1% stop loss, which trails the green candles until it goes below them.
 
-Both values can be configured in the main configuration file and requires `"trailing_stop": true` to be set to true.
+Both values can be configured in the strategy or configuration file and requires `"trailing_stop": true` to be set to true.
 
 ``` json
     "trailing_stop_positive":  0.01,
     "trailing_stop_positive_offset":  0.011,
-    "trailing_only_offset_is_reached": false
 ```
 
 The 0.01 would translate to a 1% stop loss, once you hit 1.1% profit.
 
 You should also make sure to have this value (`trailing_stop_positive_offset`) lower than your minimal ROI, otherwise minimal ROI will apply first and sell your trade.
 
-If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached. Until then, the stoploss remains at the configured`stoploss`.
+### Trailing only once offset is reached
+
+It is also possible to use a static stoploss until the offset is reached, and then trail the trade to take profits once the market goes down again.
+
+If `"trailing_only_offset_is_reached": true` then the trailing stoploss is only activated once the offset is reached. Until then, the stoploss remains at the configured `stoploss`.
+This option can be used with or without `trailing_stop_positive`, but uses `trailing_stop_positive_offset` as offset.
+
+``` json
+    "trailing_only_offset_is_reached": true,
+```
+
+Simplified example:
+
+```python
+    stoploss = 0.05
+    trailing_stop_positive_offset = 0.03
+    trailing_only_offset_is_reached = True
+```
+
+* the bot buys an asset at a price of 100$
+* the stop loss is defined at 5%
+* the stop loss will remain at 95% until profit reaches +3%
 
 ## Changing stoploss on open trades
 


### PR DESCRIPTION
## Summary
Improve the stoploss documentation 

closes #2428 

## Quick changelog

- by simplifying the documentation by not repeating that everything can be set in configuration or strategy
- changing code-samples to python (all user samples i've seen so far use stoploss in the strategy, not from the configuration) - so i assume this is the primary place to configure this
- split `trailing_only_offset_is_reached` from `trailing_stop_positive` to not create confusion 
