### PR TITLE
Add option to log to stderr

### DIFF
--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Optional
 from freqtrade import constants
 from freqtrade.configuration.cli_options import AVAILABLE_CLI_OPTIONS
 
-ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_data_dir"]
+ARGS_COMMON = ["verbosity", "log_to_stderr", "logfile", "version", "config", "datadir",
+               "user_data_dir"]
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -34,6 +34,12 @@ AVAILABLE_CLI_OPTIONS = {
         action='count',
         default=0,
     ),
+    "log_to_stderr": Arg(
+        '-E', '--stderr',
+        help='Force log messages to be printed to stderr instead of stdout.',
+        action='store_true',
+        default=False,
+    ),
     "logfile": Arg(
         '--logfile',
         help='Log to the file specified.',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -125,6 +125,8 @@ class Configuration:
         # Log level
         config.update({'verbosity': self.args.get("verbosity", 0)})
 
+        config.update({'log_to_stderr': self.args.get("log_to_stderr", False)})
+
         if 'logfile' in self.args and self.args["logfile"]:
             config.update({'logfile': self.args["logfile"]})
 

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -33,8 +33,9 @@ def setup_logging(config: Dict[str, Any]) -> None:
     # Log level
     verbosity = config['verbosity']
 
-    # Log to stdout, not stderr
-    log_handlers: List[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+    # By default, log to stdout, not stderr
+    stream = sys.stderr if config['log_to_stderr'] else sys.stdout
+    log_handlers: List[logging.Handler] = [logging.StreamHandler(stream)]
 
     if config.get('logfile'):
         log_handlers.append(RotatingFileHandler(config['logfile'],


### PR DESCRIPTION
A new option `-E`/`--stderr` introduced which directs printing of log messages into stderr instead of stdout.

Now it's possible to use machine-readable formats of output for utils:

* Produce .csv file with markets:
```
$ freqtrade -E list-markets --exchange okex --quote USD --print-csv >markets.csv
```

* Iterate markets in shell:
```
for p in `freqtrade -E list-markets -1 --exchange kraken --quote USD 2>/dev/null`; do
  echo "Do something for market symbol $p"
done
```

* Generation of pairs.json for multiple exchanges:
```
for e in binance bittrex; do freqtrade -E list-pairs --exchange $e --all --quote BTC --print-json >user_data/data/$e/pairs.json; done
```

TODO:

[ ] docs
[ ] tests (have no idea how to test it)


@xmatthias I'm ready to close this PR if logs will be changed to be printed to stderr by default, as an alternative, so this option becomes redundant. That would be even a better solution imho.

