### PR TITLE
Fix scoped_session and add Documentation for strategy

### DIFF
--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -405,6 +405,52 @@ if self.wallets:
 - `get_used(asset)` - currently tied up balance (open orders)
 - `get_total(asset)` - total available balance - sum of the 2 above
 
+### Additional data (Trades)
+
+A history of Trades can be retrieved in the strategy by querying the database.
+
+At the top of the file, import Trade.
+
+```python
+from freqtrade.persistence import Trade
+```
+
+The following example queries for the current pair and trades from today, however other filters easily be added.
+
+``` python
+if self.config['runmode'] in ('live', 'dry_run'):
+    trades = Trade.get_trades([Trade.pair == metadata['pair'],
+                               Trade.open_date > datetime.utcnow() - timedelta(days=1),
+                               Trade.is_open == False,
+                ]).order_by(Trade.close_date).all()
+    # Summarize profit for this pair.
+    curdayprofit = sum(trade.close_profit for trade in trades)
+```
+
+Get amount of stake_currency currently invested in Trades:
+
+``` python
+if self.config['runmode'] in ('live', 'dry_run'):
+    total_stakes = Trade.total_open_trades_stakes()
+```
+
+Retrieve performance per pair.
+Returns a List of dicts per pair.
+
+``` python
+if self.config['runmode'] in ('live', 'dry_run'):
+    performance = Trade.get_overall_performance()
+```
+
+Sample return value: ETH/BTC had 5 trades, with a total profit of 1.5%.
+
+``` json
+{'pair': "ETH/BTC", 'profit': 1.5, 'count': 5}
+```
+
+!!! Warning
+    Trade history is not available during backtesting or hyperopt.
+
 ### Print created dataframe
 
 To inspect the created dataframe, you can issue a print-statement in either `populate_buy_trend()` or `populate_sell_trend()`.

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -415,7 +415,7 @@ At the top of the file, import Trade.
 from freqtrade.persistence import Trade
 ```
 
-The following example queries for the current pair and trades from today, however other filters easily be added.
+The following example queries for the current pair and trades from today, however other filters can easily be added.
 
 ``` python
 if self.config['runmode'] in ('live', 'dry_run'):
@@ -442,10 +442,10 @@ if self.config['runmode'] in ('live', 'dry_run'):
     performance = Trade.get_overall_performance()
 ```
 
-Sample return value: ETH/BTC had 5 trades, with a total profit of 1.5%.
+Sample return value: ETH/BTC had 5 trades, with a total profit of 1.5% (ratio of 0.015).
 
 ``` json
-{'pair': "ETH/BTC", 'profit': 1.5, 'count': 5}
+{'pair': "ETH/BTC", 'profit': 0.015, 'count': 5}
 ```
 
 !!! Warning

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -106,7 +106,7 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
                             t.stop_loss, t.initial_stop_loss,
                             t.strategy, t.ticker_interval
                             )
-                           for t in Trade.query.all()],
+                           for t in Trade.get_trades().all()],
                           columns=columns)
 
     return trades

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -768,7 +768,7 @@ class FreqtradeBot:
         buy_timeout_threshold = arrow.utcnow().shift(minutes=-buy_timeout).datetime
         sell_timeout_threshold = arrow.utcnow().shift(minutes=-sell_timeout).datetime
 
-        for trade in Trade.query.filter(Trade.open_order_id.isnot(None)).all():
+        for trade in Trade.get_open_order_trades():
             try:
                 # FIXME: Somehow the query above returns results
                 # where the open_order_id is in fact None.

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -392,6 +392,13 @@ class Trade(_DECL_BASE):
         return float(f"{profit_percent:.8f}")
 
     @staticmethod
+    def get_open_order_trades():
+        """
+        Returns all open trades
+        """
+        return Trade.query.filter(Trade.open_order_id.isnot(None)).all()
+
+    @staticmethod
     def total_open_trades_stakes() -> float:
         """
         Calculates total invested amount in open trades
@@ -403,7 +410,10 @@ class Trade(_DECL_BASE):
         return total_open_stake_amount or 0
 
     @staticmethod
-    def get_overall_performance() -> Dict:
+    def get_overall_performance() -> List[Dict]:
+        """
+        Returns List of dicts containing all Trades, including profit and trade count
+        """
         pair_rates = Trade.session.query(
             Trade.pair,
             func.sum(Trade.close_profit).label('profit_sum'),
@@ -423,6 +433,9 @@ class Trade(_DECL_BASE):
 
     @staticmethod
     def get_best_pair():
+        """
+        Get best pair with closed trade.
+        """
         best_pair = Trade.session.query(
             Trade.pair, func.sum(Trade.close_profit).label('profit_sum')
         ).filter(Trade.is_open.is_(False)) \

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -437,7 +437,7 @@ class Trade(_DECL_BASE):
         return total_open_stake_amount or 0
 
     @staticmethod
-    def get_overall_performance() -> List[Dict]:
+    def get_overall_performance() -> List[Dict[str, Any]]:
         """
         Returns List of dicts containing all Trades, including profit and trade count
         """
@@ -452,7 +452,7 @@ class Trade(_DECL_BASE):
         return [
             {
                 'pair': pair,
-                'profit': round(rate * 100, 2),
+                'profit': rate,
                 'count': count
             }
             for pair, rate, count in pair_rates

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -395,9 +395,12 @@ class Trade(_DECL_BASE):
     @staticmethod
     def get_trades(trade_filter=None) -> Query:
         """
-        Helper function to query Trades using filter.
-        :param trade_filter: Filter to apply to trades
-        :return: Query object
+        Helper function to query Trades using filters.
+        :param trade_filter: Optional filter to apply to trades
+                             Can be either a Filter object, or a List of filters
+                             e.g. `(trade_filter=[Trade.id == trade_id, Trade.is_open.is_(True),])`
+                             e.g. `(trade_filter=Trade.id == trade_id)`
+        :return: unsorted query object
         """
         if trade_filter is not None:
             if not isinstance(trade_filter, list):

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -51,9 +51,11 @@ def init(db_url: str, clean_open_orders: bool = False) -> None:
         raise OperationalException(f"Given value for db_url: '{db_url}' "
                                    f"is no valid database URL! (See {_SQL_DOCS_URL})")
 
-    session = scoped_session(sessionmaker(bind=engine, autoflush=True, autocommit=True))
-    Trade.session = session()
-    Trade.query = session.query_property()
+    # https://docs.sqlalchemy.org/en/13/orm/contextual.html#thread-local-scope
+    # Scoped sessions proxy requests to the appropriate thread-local session.
+    # We should use the scoped_session object - not a seperately initialized version
+    Trade.session = scoped_session(sessionmaker(bind=engine, autoflush=True, autocommit=True))
+    Trade.query = Trade.session.query_property()
     _DECL_BASE.metadata.create_all(engine)
     check_migrate(engine)
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -422,6 +422,15 @@ class Trade(_DECL_BASE):
         ]
 
     @staticmethod
+    def get_best_pair():
+        best_pair = Trade.session.query(
+            Trade.pair, func.sum(Trade.close_profit).label('profit_sum')
+        ).filter(Trade.is_open.is_(False)) \
+            .group_by(Trade.pair) \
+            .order_by(desc('profit_sum')).first()
+        return best_pair
+
+    @staticmethod
     def get_open_trades() -> List[Any]:
         """
         Query trades from persistence layer

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -225,11 +225,7 @@ class RPC:
             )
             profit_all_perc.append(profit_percent)
 
-        best_pair = Trade.session.query(
-            Trade.pair, sql.func.sum(Trade.close_profit).label('profit_sum')
-        ).filter(Trade.is_open.is_(False)) \
-            .group_by(Trade.pair) \
-            .order_by(sql.text('profit_sum DESC')).first()
+        best_pair = Trade.get_best_pair()
 
         if not best_pair:
             raise RPCException('no closed trade')

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -442,18 +442,7 @@ class RPC:
         Handler for performance.
         Shows a performance statistic from finished trades
         """
-
-        pair_rates = Trade.session.query(Trade.pair,
-                                         sql.func.sum(Trade.close_profit).label('profit_sum'),
-                                         sql.func.count(Trade.pair).label('count')) \
-            .filter(Trade.is_open.is_(False)) \
-            .group_by(Trade.pair) \
-            .order_by(sql.text('profit_sum DESC')) \
-            .all()
-        return [
-            {'pair': pair, 'profit': round(rate * 100, 2), 'count': count}
-            for pair, rate, count in pair_rates
-        ]
+        return Trade.get_overall_performance()
 
     def _rpc_count(self) -> Dict[str, float]:
         """ Returns the number of trades running """

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -428,12 +428,15 @@ class RPC:
         else:
             return None
 
-    def _rpc_performance(self) -> List[Dict]:
+    def _rpc_performance(self) -> List[Dict[str, Any]]:
         """
         Handler for performance.
         Shows a performance statistic from finished trades
         """
-        return Trade.get_overall_performance()
+        pair_rates = Trade.get_overall_performance()
+        # Round and convert to %
+        [x.update({'profit': round(x['profit'] * 100, 2)}) for x in pair_rates]
+        return pair_rates
 
     def _rpc_count(self) -> Dict[str, float]:
         """ Returns the number of trades running """

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -859,3 +859,16 @@ def test_get_overall_performance(fee):
     assert 'pair' in res[0]
     assert 'profit' in res[0]
     assert 'count' in res[0]
+
+
+@pytest.mark.usefixtures("init_persistence")
+def test_get_best_pair(fee):
+
+    res = Trade.get_best_pair()
+    assert res is None
+
+    create_mock_trades(fee)
+    res = Trade.get_best_pair()
+    assert len(res) == 2
+    assert res[0] == 'ETC/BTC'
+    assert res[1] == 0.005

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -35,6 +35,8 @@ def create_mock_trades(fee):
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         open_rate=0.123,
+        close_rate=0.128,
+        close_profit=0.005,
         exchange='bittrex',
         is_open=False,
         open_order_id='dry_run_sell_12345'
@@ -835,3 +837,25 @@ def test_stoploss_reinitialization(default_conf, fee):
     assert trade_adj.stop_loss_pct == -0.04
     assert trade_adj.initial_stop_loss == 0.96
     assert trade_adj.initial_stop_loss_pct == -0.04
+
+
+@pytest.mark.usefixtures("init_persistence")
+def test_total_open_trades_stakes(fee):
+
+    res = Trade.total_open_trades_stakes()
+    assert res == 0
+    create_mock_trades(fee)
+    res = Trade.total_open_trades_stakes()
+    assert res == 0.002
+
+
+@pytest.mark.usefixtures("init_persistence")
+def test_get_overall_performance(fee):
+
+    create_mock_trades(fee)
+    res = Trade.get_overall_performance()
+
+    assert len(res) == 1
+    assert 'pair' in res[0]
+    assert 'profit' in res[0]
+    assert 'count' in res[0]

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -61,7 +61,7 @@ def test_init_create_session(default_conf):
     # Check if init create a session
     init(default_conf['db_url'], default_conf['dry_run'])
     assert hasattr(Trade, 'session')
-    assert 'Session' in type(Trade.session).__name__
+    assert 'scoped_session' in type(Trade.session).__name__
 
 
 def test_init_custom_db_url(default_conf, mocker):


### PR DESCRIPTION
## Summary
`scoped_session` from sqlalchemy is a powerfull construct, allowing thread-safe handling of Sqlalchemy objects **if done correctly**.

freqtrade did not - initializing an explicit session and assigning this to `Trade.session` - breaking the scoped-session thread-safe functionality.
This caused problems like #1986 - which effectively is a race-condition (coincidental flushing of both the main and Telegram thread).

Closes #1986
closes #1753

## Quick changelog

- Introduce `Trade.get_trades()`
- Fix `scoped_session` handling
- extract SQL handling from rpc module
- Add documentation for the new query methods (#closes 1753)
