### PR TITLE
[docs] Update Raspberry documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ jobs:
     - script:
       # Test Documentation boxes -
       # !!! <TYPE>: is not allowed!
-      - grep -Er '^!{3}\s\S+:' docs/*; test $? -ne 0
+      # !!! <TYPE> "title" - Title needs to be quoted!
+      - grep -Er '^!{3}\s\S+:|^!{3}\s\S+\s[^"]' docs/*; test $? -ne 0
       name: doc syntax
     - script: mypy freqtrade scripts
       name: mypy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,7 +254,7 @@ Configuration:
 !!! Note
     If `stoploss_on_exchange` is enabled and the stoploss is cancelled manually on the exchange, then the bot will create a new order.
 
-!!! Warning stoploss_on_exchange failures
+!!! Warning "Warning: stoploss_on_exchange failures"
     If stoploss on exchange creation fails for some reason, then an "emergency sell" is initiated. By default, this will sell the asset using a market order. The order-type for the emergency-sell can be changed by setting the `emergencysell` value in the `order_types` dictionary - however this is not advised.
 
 ### Understand order_time_in_force

--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -8,7 +8,7 @@ If no additional parameter is specified, freqtrade will download data for `"1m"`
 Exchange and pairs will come from `config.json` (if specified using `-c/--config`).
 Otherwise `--exchange` becomes mandatory.
 
-!!! Tip Updating existing data
+!!! Tip "Tip: Updating existing data"
     If you already have backtesting data available in your data-directory and would like to refresh this data up to today, use `--days xx` with a number slightly higher than the missing number of days. Freqtrade will keep the available data and only download the missing data.
     Be carefull though: If the number is too small (which would result in a few missing days), the whole dataset will be removed and only xx days will be downloaded.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -26,7 +26,7 @@ To update the image, simply run the above commands again and restart your runnin
 
 Should you require additional libraries, please [build the image yourself](#build-your-own-docker-image).
 
-!!! Note Docker image update frequency
+!!! Note "Docker image update frequency"
     The official docker images with tags `master`, `develop` and `latest` are automatically rebuild once a week to keep the base image uptodate.
     In addition to that, every merge to `develop` will trigger a rebuild for `develop` and `latest`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ sudo apt-get update
 sudo apt-get install build-essential git
 ```
 
-#### Raspberry Pi / Raspbian
+### Raspberry Pi / Raspbian
 
 The following assumes the latest [Raspbian Buster lite image](https://www.raspberrypi.org/downloads/raspbian/) from at least September 2019.
 This image comes with python3.7 preinstalled, making it easy to get freqtrade up and running.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,27 +97,24 @@ sudo apt-get install build-essential git
 
 #### Raspberry Pi / Raspbian
 
-Before installing FreqTrade on a Raspberry Pi running the official Raspbian Image, make sure you have at least Python 3.6 installed. The default image only provides Python 3.5. Probably the easiest way to get a recent version of python is [miniconda](https://repo.continuum.io/miniconda/).
+The following assumes the latest [Raspbian Buster lite image](https://www.raspberrypi.org/downloads/raspbian/) from at least September 2019.
+This image comes with python3.7 preinstalled, making it easy to get freqtrade up and running.
 
-The following assumes that miniconda3 is installed and available in your environment. Since the last miniconda3 installation file uses python 3.4, we will update to python 3.6 on this installation.
-It's recommended to use (mini)conda for this as installation/compilation of `numpy` and `pandas` takes a long time.
-
-Additional package to install on your Raspbian, `libffi-dev` required by cryptography (from python-telegram-bot).
+Tested using a Raspberry Pi 3 with the Raspbian Buster lite image, all updates applied.
 
 ``` bash
-conda config --add channels rpi
-conda install python=3.6
-conda create -n freqtrade python=3.6
-conda activate freqtrade
-conda install pandas numpy
+sudo apt-get install python3-venv libatlas-base-dev
+git clone https://github.com/freqtrade/freqtrade.git
+cd freqtrade
 
-sudo apt install libffi-dev
-python3 -m pip install -r requirements-common.txt
-python3 -m pip install -e .
+bash setup.sh -i
 ```
 
+!!! Note "Installation duration"
+    Depending on your internet speed and the Raspberry Pi version, installation can take multiple hours to complete.
+
 !!! Note
-    This does not install hyperopt dependencies. To install these, please use `python3 -m pip install -e .[hyperopt]`.
+    The above does not install hyperopt dependencies. To install these, please use `python3 -m pip install -e .[hyperopt]`.
     We do not advise to run hyperopt on a Raspberry Pi, since this is a very resource-heavy operation, which should be done on powerful machine.
 
 ### Common

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -79,7 +79,7 @@ The `-p/--pairs` argument can be used to specify pairs you would like to plot.
 Specify custom indicators.
 Use `--indicators1` for the main plot and `--indicators2` for the subplot below (if values are in a different range than prices).
 
-!!! tip
+!!! Tip
     You will almost certainly want to specify a custom strategy! This can be done by adding `-s Classname` / `--strategy ClassName` to the command.
 
 ``` bash

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -16,11 +16,11 @@ Sample configuration:
     },
 ```
 
-!!! Danger Security warning
-  By default, the configuration listens on localhost only (so it's not reachable from other systems). We strongly recommend to not expose this API to the internet and choose a strong, unique password, since others will potentially be able to control your bot.
+!!! Danger "Security warning"
+    By default, the configuration listens on localhost only (so it's not reachable from other systems). We strongly recommend to not expose this API to the internet and choose a strong, unique password, since others will potentially be able to control your bot.
 
-!!! Danger Password selection
-  Please make sure to select a very strong, unique password to protect your bot from unauthorized access.
+!!! Danger "Password selection"
+    Please make sure to select a very strong, unique password to protect your bot from unauthorized access.
 
 You can then access the API by going to `http://127.0.0.1:8080/api/v1/version` to check if the API is running correctly.
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -51,13 +51,13 @@ freqtrade --strategy AwesomeStrategy
 **For the following section we will use the [user_data/strategies/sample_strategy.py](https://github.com/freqtrade/freqtrade/blob/develop/user_data/strategies/sample_strategy.py)
 file as reference.**
 
-!!! Note Strategies and Backtesting
+!!! Note "Strategies and Backtesting"
     To avoid problems and unexpected differences between Backtesting and dry/live modes, please be aware
     that during backtesting the full time-interval is passed to the `populate_*()` methods at once.
     It is therefore best to use vectorized operations (across the whole dataframe, not loops) and
     avoid index referencing (`df.iloc[-1]`), but instead use `df.shift()` to get to the previous candle.
 
-!!! Warning Using future data
+!!! Warning "Warning: Using future data"
     Since backtesting passes the full time interval to the `populate_*()` methods, the strategy author
     needs to take care to avoid having the strategy utilize data from the future.
     Some common patterns for this are listed in the [Common Mistakes](#common-mistakes-when-developing-strategies) section of this document.
@@ -330,12 +330,12 @@ if self.dp:
                                              ticker_interval=inf_timeframe)
 ```
 
-!!! Warning Warning about backtesting
+!!! Warning "Warning about backtesting"
     Be carefull when using dataprovider in backtesting. `historic_ohlcv()` (and `get_pair_dataframe()`
     for the backtesting runmode) provides the full time-range in one go,
     so please be aware of it and make sure to not "look into the future" to avoid surprises when running in dry/live mode).
 
-!!! Warning Warning in hyperopt
+!!! Warning "Warning in hyperopt"
     This option cannot currently be used during hyperopt.
 
 #### Orderbook

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -93,7 +93,7 @@ Once all positions are sold, run `/stop` to completely stop the bot.
 
 `/reload_conf` resets "max_open_trades" to the value set in the configuration and resets this command. 
 
-!!! warning
+!!! Warning
    The stop-buy signal is ONLY active while the bot is running, and is not persisted anyway, so restarting the bot will cause this to reset.
 
 ### /status


### PR DESCRIPTION
## Summary
Update documentation to install freqtrade on a raspberry.

The instruction was overly complex, and without hyperopt "regular" installation works just fine.

Also fixed some "box"-titles which were not rendering correctly.
