### PR TITLE
Bt analysis maxopen at any time

### DIFF
--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -107,6 +107,22 @@ trades = load_trades_from_db("sqlite:///tradesv3.sqlite")
 trades.groupby("pair")["sell_reason"].value_counts()
 ```
 
+## Analyze the loaded trades for trade parallelism
+This can be useful to find the best `max_open_trades` parameter, when used with backtesting in conjunction with `--disable-max-market-positions`.
+
+`parallel_trade_analysis()` returns a timeseries dataframe with an "open_trades" column, specifying the number of open trades for each candle.
+
+
+```python
+from freqtrade.data.btanalysis import parallel_trade_analysis
+
+# Analyze the above
+parallel_trades = parallel_trade_analysis(trades, '5m')
+
+
+parallel_trades.plot()
+```
+
 ## Plot results
 
 Freqtrade offers interactive plotting capabilities based on plotly.

--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -110,14 +110,14 @@ trades.groupby("pair")["sell_reason"].value_counts()
 ## Analyze the loaded trades for trade parallelism
 This can be useful to find the best `max_open_trades` parameter, when used with backtesting in conjunction with `--disable-max-market-positions`.
 
-`parallel_trade_analysis()` returns a timeseries dataframe with an "open_trades" column, specifying the number of open trades for each candle.
+`analyze_trade_parallelism()` returns a timeseries dataframe with an "open_trades" column, specifying the number of open trades for each candle.
 
 
 ```python
-from freqtrade.data.btanalysis import parallel_trade_analysis
+from freqtrade.data.btanalysis import analyze_trade_parallelism
 
 # Analyze the above
-parallel_trades = parallel_trade_analysis(trades, '5m')
+parallel_trades = analyze_trade_parallelism(trades, '5m')
 
 
 parallel_trades.plot()

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -52,7 +52,7 @@ def load_backtest_data(filename) -> pd.DataFrame:
     return df
 
 
-def parallel_trade_analysis(results: pd.DataFrame, timeframe: str) -> pd.DataFrame:
+def analyze_trade_parallelism(results: pd.DataFrame, timeframe: str) -> pd.DataFrame:
     """
     Find overlapping trades by expanding each trade once per period it was open
     and then counting overlaps.
@@ -62,7 +62,8 @@ def parallel_trade_analysis(results: pd.DataFrame, timeframe: str) -> pd.DataFra
     """
     from freqtrade.exchange import timeframe_to_minutes
     timeframe_min = timeframe_to_minutes(timeframe)
-    dates = [pd.Series(pd.date_range(row[1].open_time, row[1].close_time, freq=f"{timeframe_min}min"))
+    dates = [pd.Series(pd.date_range(row[1].open_time, row[1].close_time,
+                                     freq=f"{timeframe_min}min"))
              for row in results[['open_time', 'close_time']].iterrows()]
     deltas = [len(x) for x in dates]
     dates = pd.Series(pd.concat(dates).values, name='date')
@@ -85,7 +86,7 @@ def evaluate_result_multi(results: pd.DataFrame, timeframe: str,
     :param max_open_trades: parameter max_open_trades used during backtest run
     :return: dataframe with open-counts per time-period in freq
     """
-    df_final = parallel_trade_analysis(results, timeframe)
+    df_final = analyze_trade_parallelism(results, timeframe)
     return df_final[df_final['open_trades'] > max_open_trades]
 
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -714,9 +714,9 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
     results = backtesting.backtest(backtest_conf)
 
     # Make sure we have parallel trades
-    assert len(evaluate_result_multi(results, '5min', 2)) > 0
+    assert len(evaluate_result_multi(results, '5m', 2)) > 0
     # make sure we don't have trades with more than configured max_open_trades
-    assert len(evaluate_result_multi(results, '5min', 3)) == 0
+    assert len(evaluate_result_multi(results, '5m', 3)) == 0
 
     backtest_conf = {
         'stake_amount': default_conf['stake_amount'],
@@ -727,7 +727,7 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
         'end_date': max_date,
     }
     results = backtesting.backtest(backtest_conf)
-    assert len(evaluate_result_multi(results, '5min', 1)) == 0
+    assert len(evaluate_result_multi(results, '5m', 1)) == 0
 
 
 def test_backtest_record(default_conf, fee, mocker):

--- a/user_data/notebooks/strategy_analysis_example.ipynb
+++ b/user_data/notebooks/strategy_analysis_example.ipynb
@@ -68,9 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load strategy using values set above\n",
@@ -167,6 +165,31 @@
     "\n",
     "# Display results\n",
     "trades.groupby(\"pair\")[\"sell_reason\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze the loaded trades for trade parallelism\n",
+    "This can be useful to find the best `max_open_trades` parameter, when used with backtesting in conjunction with `--disable-max-market-positions`.\n",
+    "\n",
+    "`parallel_trade_analysis()` returns a timeseries dataframe with an \"open_trades\" column, specifying the number of open trades for each candle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from freqtrade.data.btanalysis import parallel_trade_analysis\n",
+    "\n",
+    "# Analyze the above\n",
+    "parallel_trades = parallel_trade_analysis(trades, '5m')\n",
+    "\n",
+    "\n",
+    "parallel_trades.plot()"
    ]
   },
   {

--- a/user_data/notebooks/strategy_analysis_example.ipynb
+++ b/user_data/notebooks/strategy_analysis_example.ipynb
@@ -174,7 +174,7 @@
     "## Analyze the loaded trades for trade parallelism\n",
     "This can be useful to find the best `max_open_trades` parameter, when used with backtesting in conjunction with `--disable-max-market-positions`.\n",
     "\n",
-    "`parallel_trade_analysis()` returns a timeseries dataframe with an \"open_trades\" column, specifying the number of open trades for each candle."
+    "`analyze_trade_parallelism()` returns a timeseries dataframe with an \"open_trades\" column, specifying the number of open trades for each candle."
    ]
   },
   {
@@ -183,10 +183,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from freqtrade.data.btanalysis import parallel_trade_analysis\n",
+    "from freqtrade.data.btanalysis import analyze_trade_parallelism\n",
     "\n",
     "# Analyze the above\n",
-    "parallel_trades = parallel_trade_analysis(trades, '5m')\n",
+    "parallel_trades = analyze_trade_parallelism(trades, '5m')\n",
     "\n",
     "\n",
     "parallel_trades.plot()"


### PR DESCRIPTION
## Summary
Expose the algorithm to get max_open_trades at each candle to users.

Closes #2449

## Quick changelog

- Add `analyze_trade_parallelism()`
- Document `analyze_trade_parallelism()` as part of the juptyer notebook (Export of the notebook is in `strategy_analysis_example.md `).