### PR TITLE
Allow configuration of stoploss on exchange limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,11 @@ If this is configured, the following 4 values (`buy`, `sell`, `stoploss` and
 `emergencysell` is an optional value, which defaults to `market` and is used when creating stoploss on exchange orders fails.
 The below is the default which is used if this is not configured in either strategy or configuration file.
 
+Since `stoploss_on_exchange` uses limit orders, the exchange needs 2 prices, the stoploss_price and the Limit price.
+`stoploss` defines the stop-price - and limit should be slightly below this. This defaults to 0.99 / 1%.
+Calculation example: we bought the asset at 100$.
+Stop-price is 95$, then limit would be `95 * 0.99 = 94.05$` - so the stoploss will happen between 95$ and 94.05$.
+
 Syntax for Strategy:
 
 ```python
@@ -224,7 +229,8 @@ order_types = {
     "emergencysell": "market",
     "stoploss": "market",
     "stoploss_on_exchange": False,
-    "stoploss_on_exchange_interval": 60
+    "stoploss_on_exchange_interval": 60,
+    "stoploss_on_exchange_limit_ratio": 0.99,
 }
 ```
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -634,8 +634,8 @@ class FreqtradeBot:
         Force-sells the pair (using EmergencySell reason) in case of Problems creating the order.
         :return: True if the order succeeded, and False in case of problems.
         """
-        # Limit price threshold: As limit price should always be below price
-        LIMIT_PRICE_PCT = 0.99
+        # Limit price threshold: As limit price should always be below stop-price
+        LIMIT_PRICE_PCT = self.strategy.order_types.get('stoploss_on_exchange_limit_ratio', 0.99)
 
         try:
             stoploss_order = self.exchange.stoploss_limit(pair=trade.pair, amount=trade.amount,


### PR DESCRIPTION
## Summary
"stoploss on exchange limit" should be configurable and not default to 1% without an easy way to modify this.

closes #1717

## Quick changelog

- add option within order_types to configure stoploss-limit
