### PR TITLE
Don't check exchange for Utils commands

### DIFF
--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -21,7 +21,7 @@ def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
              and thus is not known for the Freqtrade at all.
     """
 
-    if (config['runmode'] in [RunMode.PLOT, RunMode.UTIL_NO_EXCHANGE]
+    if (config['runmode'] in [RunMode.PLOT, RunMode.UTIL_NO_EXCHANGE, RunMode.OTHER]
        and not config.get('exchange', {}).get('name')):
         # Skip checking exchange in plot mode, since it requires no exchange
         return True

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -545,7 +545,7 @@ def test_check_exchange(default_conf, caplog) -> None:
 
     # Test no exchange...
     default_conf.get('exchange').update({'name': ''})
-    default_conf['runmode'] = RunMode.OTHER
+    default_conf['runmode'] = RunMode.UTIL_EXCHANGE
     with pytest.raises(OperationalException,
                        match=r'This command requires a configured exchange.*'):
         check_exchange(default_conf)


### PR DESCRIPTION
## Summary
Other is only used for "custom" commands, probably run from a REPL or interactive environment.
For this, we can omit checking exchange. This will allow loading a base Configuration easily as follows:

``` python
from freqtrade.configuration import Configuration
Configuration.from_files([])
```

closes #2078
## Quick changelog

- don't check exchange for Runmode Other.