### PR TITLE
Fix pandas access warning

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -245,7 +245,8 @@ class Backtesting:
         ticker: Dict = {}
         # Create ticker dict
         for pair, pair_data in processed.items():
-            pair_data['buy'], pair_data['sell'] = 0, 0  # cleanup from previous run
+            pair_data.loc[:, 'buy'] = 0  # cleanup from previous run
+            pair_data.loc[:, 'sell'] = 0  # cleanup from previous run
 
             ticker_data = self.strategy.advise_sell(
                 self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -3,7 +3,6 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from pandas import DataFrame
 
 from freqtrade.data.history import get_timeframe
 from freqtrade.optimize.backtesting import Backtesting
@@ -313,7 +312,7 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
 
     pair = "UNITTEST/BTC"
     # Dummy data as we mock the analyze functions
-    data_processed = {pair: DataFrame()}
+    data_processed = {pair: frame.copy()}
     min_date, max_date = get_timeframe({pair: frame})
     results = backtesting.backtest(
         {


### PR DESCRIPTION
## Summary
Fix pandas access warning during backtesting.
While it's not a problem in our case, it's still unnecessary output which can be avoided VERY easily.

```
See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  pair_data['buy'], pair_data['sell'] = 0, 0  # cleanup from previous run
/home/xmatt/.pyenv/versions/3.7.3/envs/trade3.7.3/lib/python3.7/site-packages/pandas/core/indexing.py:494: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
```

Solve the issue: (brought up on slack ...)

## Quick changelog

- use .loc[] to reset dataframe
