### PR TITLE
Update docker doc (new note about restart policy)

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -170,6 +170,9 @@ docker run -d \
 !!! Note
     All available bot command line parameters can be added to the end of the `docker run` command.
 
+!!! Note
+    you can define a [restart policy](https://docs.docker.com/config/containers/start-containers-automatically/) in docker. It can be useful in some cases to use the `--restart unless-stopped` flag (crash of freqtrade or reboot of your system).
+
 ### Monitor your Docker instance
 
 You can use the following commands to monitor and manage your container:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -171,7 +171,7 @@ docker run -d \
     All available bot command line parameters can be added to the end of the `docker run` command.
 
 !!! Note
-    you can define a [restart policy](https://docs.docker.com/config/containers/start-containers-automatically/) in docker. It can be useful in some cases to use the `--restart unless-stopped` flag (crash of freqtrade or reboot of your system).
+    You can define a [restart policy](https://docs.docker.com/config/containers/start-containers-automatically/) in docker. It can be useful in some cases to use the `--restart unless-stopped` flag (crash of freqtrade or reboot of your system).
 
 ### Monitor your Docker instance
 


### PR DESCRIPTION
## Summary

Explain to end user docker is able to have a restart policy for the container and that the 
 `unless-stopped` policy could be useful.

Have a nice day.