### PR TITLE
Introduce remove_credentials to remove code duplication

### DIFF
--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,4 +1,5 @@
 from freqtrade.configuration.arguments import Arguments  # noqa: F401
+from freqtrade.configuration.check_exchange import check_exchange, remove_credentials  # noqa: F401
 from freqtrade.configuration.timerange import TimeRange  # noqa: F401
 from freqtrade.configuration.configuration import Configuration  # noqa: F401
 from freqtrade.configuration.config_validation import validate_config_consistency  # noqa: F401

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -10,6 +10,19 @@ from freqtrade.state import RunMode
 logger = logging.getLogger(__name__)
 
 
+def remove_credentials(config: Dict[str, Any]):
+    """
+    Removes exchange keys from the configuration and specifies dry-run
+    Used for backtesting / hyperopt / edge and utils.
+    Modifies the input dict!
+    """
+    config['exchange']['key'] = ''
+    config['exchange']['secret'] = ''
+    config['exchange']['password'] = ''
+    config['exchange']['uid'] = ''
+    config['dry_run'] = True
+
+
 def check_exchange(config: Dict[str, Any], check_for_bad: bool = True) -> bool:
     """
     Check if the exchange name in the config file is supported by Freqtrade

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -10,9 +10,10 @@ from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional
 
 from pandas import DataFrame
+from tabulate import tabulate
 
 from freqtrade import OperationalException
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration import TimeRange, remove_credentials
 from freqtrade.data import history
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
@@ -21,7 +22,6 @@ from freqtrade.persistence import Trade
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.state import RunMode
 from freqtrade.strategy.interface import IStrategy, SellType
-from tabulate import tabulate
 
 logger = logging.getLogger(__name__)
 
@@ -57,11 +57,7 @@ class Backtesting:
         self.config = config
 
         # Reset keys for backtesting
-        self.config['exchange']['key'] = ''
-        self.config['exchange']['secret'] = ''
-        self.config['exchange']['password'] = ''
-        self.config['exchange']['uid'] = ''
-        self.config['dry_run'] = True
+        remove_credentials(self.config)
         self.strategylist: List[IStrategy] = []
         self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
 

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -4,12 +4,13 @@
 This module contains the edge backtesting interface
 """
 import logging
-from typing import Dict, Any
-from tabulate import tabulate
-from freqtrade import constants
-from freqtrade.edge import Edge
+from typing import Any, Dict
 
-from freqtrade.configuration import TimeRange
+from tabulate import tabulate
+
+from freqtrade import constants
+from freqtrade.configuration import TimeRange, remove_credentials
+from freqtrade.edge import Edge
 from freqtrade.exchange import Exchange
 from freqtrade.resolvers import StrategyResolver
 
@@ -29,12 +30,8 @@ class EdgeCli:
         self.config = config
 
         # Reset keys for edge
-        self.config['exchange']['key'] = ''
-        self.config['exchange']['secret'] = ''
-        self.config['exchange']['password'] = ''
-        self.config['exchange']['uid'] = ''
+        remove_credentials(self.config)
         self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
-        self.config['dry_run'] = True
         self.exchange = Exchange(self.config)
         self.strategy = StrategyResolver(self.config).strategy
 

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -10,7 +10,7 @@ import rapidjson
 from tabulate import tabulate
 
 from freqtrade import OperationalException
-from freqtrade.configuration import Configuration, TimeRange
+from freqtrade.configuration import Configuration, TimeRange, remove_credentials
 from freqtrade.configuration.directory_operations import create_userdata_dir
 from freqtrade.data.history import (convert_trades_to_ohlcv,
                                     refresh_backtest_ohlcv_data,
@@ -33,10 +33,8 @@ def setup_utils_configuration(args: Dict[str, Any], method: RunMode) -> Dict[str
     configuration = Configuration(args, method)
     config = configuration.get_config()
 
-    config['exchange']['dry_run'] = True
     # Ensure we do not use Exchange credentials
-    config['exchange']['key'] = ''
-    config['exchange']['secret'] = ''
+    remove_credentials(config)
 
     return config
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -10,13 +10,13 @@ import pytest
 from jsonschema import Draft4Validator, ValidationError, validate
 
 from freqtrade import OperationalException, constants
-from freqtrade.configuration import (Arguments, Configuration,
+from freqtrade.configuration import (Arguments, Configuration, check_exchange,
+                                     remove_credentials,
                                      validate_config_consistency)
-from freqtrade.configuration.check_exchange import check_exchange
 from freqtrade.configuration.config_validation import validate_config_schema
-from freqtrade.configuration.deprecated_settings import (check_conflicting_settings,
-                                                         process_deprecated_setting,
-                                                         process_temporary_deprecated_settings)
+from freqtrade.configuration.deprecated_settings import (
+    check_conflicting_settings, process_deprecated_setting,
+    process_temporary_deprecated_settings)
 from freqtrade.configuration.directory_operations import (create_datadir,
                                                           create_userdata_dir)
 from freqtrade.configuration.load_config import load_config_file
@@ -549,6 +549,18 @@ def test_check_exchange(default_conf, caplog) -> None:
     with pytest.raises(OperationalException,
                        match=r'This command requires a configured exchange.*'):
         check_exchange(default_conf)
+
+
+def test_remove_credentials(default_conf, caplog) -> None:
+    conf = deepcopy(default_conf)
+    conf['dry_run'] = False
+    remove_credentials(conf)
+
+    assert conf['dry_run'] is True
+    assert conf['exchange']['key'] == ''
+    assert conf['exchange']['secret'] == ''
+    assert conf['exchange']['password'] == ''
+    assert conf['exchange']['uid'] == ''
 
 
 def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_setup_utils_configuration():
 
     config = setup_utils_configuration(get_args(args), RunMode.OTHER)
     assert "exchange" in config
-    assert config['exchange']['dry_run'] is True
+    assert config['dry_run'] is True
     assert config['exchange']['key'] == ''
     assert config['exchange']['secret'] == ''
 


### PR DESCRIPTION
## Summary
we should only have one place to remove credentials from the configuration.
This will reduce code duplication, and will allow easy circumvention should this be needed for some tests.

closes #2474 

## Quick changelog

- have one place to remove credentials (api keys , ...).