### PR TITLE
[minor] Fix UnicodeError in hyperopt output

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -4,9 +4,9 @@
 This module contains the hyperopt logic
 """
 
+import locale
 import logging
 import sys
-
 from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
@@ -14,10 +14,10 @@ from pprint import pprint
 from typing import Any, Dict, List, Optional
 
 import rapidjson
-
-from colorama import init as colorama_init
 from colorama import Fore, Style
-from joblib import Parallel, delayed, dump, load, wrap_non_picklable_objects, cpu_count
+from colorama import init as colorama_init
+from joblib import (Parallel, cpu_count, delayed, dump, load,
+                    wrap_non_picklable_objects)
 from pandas import DataFrame
 from skopt import Optimizer
 from skopt.space import Dimension
@@ -28,8 +28,8 @@ from freqtrade.optimize.backtesting import Backtesting
 # Import IHyperOpt and IHyperOptLoss to allow unpickling classes from these modules
 from freqtrade.optimize.hyperopt_interface import IHyperOpt  # noqa: F4
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F4
-from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver, HyperOptLossResolver
-
+from freqtrade.resolvers.hyperopt_resolver import (HyperOptLossResolver,
+                                                   HyperOptResolver)
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ class Hyperopt:
             if print_all:
                 print(log_str)
             else:
-                print('\n' + log_str)
+                print(f'\n{log_str}')
         else:
             print('.', end='')
             sys.stdout.flush()
@@ -335,7 +335,9 @@ class Hyperopt:
 
         return (f'{trades:6d} trades. Avg profit {avg_profit: 5.2f}%. '
                 f'Total profit {total_profit: 11.8f} {stake_cur} '
-                f'({profit: 7.2f}Σ%). Avg duration {duration:5.1f} mins.')
+                f'({profit: 7.2f}\N{GREEK CAPITAL LETTER SIGMA}%). '
+                f'Avg duration {duration:5.1f} mins.'
+                ).encode(locale.getpreferredencoding(), 'replace').decode('utf-8')
 
     def get_optimizer(self, dimensions, cpu_count) -> Optimizer:
         return Optimizer(

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -1,4 +1,5 @@
 # pragma pylint: disable=missing-docstring,W0212,C0103
+import locale
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock
@@ -565,8 +566,9 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     }
     response_expected = {
         'loss': 1.9840569076926293,
-        'results_explanation': '     1 trades. Avg profit  2.31%. Total profit  0.00023300 BTC '
-                               '(   2.31Σ%). Avg duration 100.0 mins.',
+        'results_explanation': ('     1 trades. Avg profit  2.31%. Total profit  0.00023300 BTC '
+                                '(   2.31\N{GREEK CAPITAL LETTER SIGMA}%). Avg duration 100.0 mins.'
+                                ).encode(locale.getpreferredencoding(), 'replace').decode('utf-8'),
         'params': optimizer_param,
         'total_profit': 0.00023300
     }


### PR DESCRIPTION
## Summary
Depending on the system locale settings, we can encounter UnicodeErrors during hyperopt output. This is caused by the Sigma (sum sign) - which cannot be converted to some non-utf8 encodings.

To fix this, we can convert the data to the users configured locale - and back.

On "supported" systems (utf-8 locale) - the output will be as usual 

```
*    1/5:     72 trades. Avg profit  0.29%. Total profit  0.01064443 BTC (  21.24Σ%). Avg duration  69.6 mins. Objective: 1.86128
```

On unsupported systems, the "non-displayable" sign is converted to a questionmark

```
*    1/5:     72 trades. Avg profit  0.29%. Total profit  0.01064443 BTC (  21.24?%). Avg duration  69.6 mins. Objective: 1.86128
```

This is visible [here](https://github.com/xmatthias/freqtrade/commit/e02e970ba0348e88eaa53e83e8d193dac96d9ba4/checks?check_suite_id=298731672) - click on "hyperopt" and scroll all the way down.