### PR TITLE
Fix UTC handling of timestamp() conversation in fetch_my_trades

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import numpy as np
 import pandas as pd
-import pytz
+from datetime import timezone
 
 from freqtrade import persistence
 from freqtrade.misc import json_load
@@ -106,8 +106,8 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
                "stop_loss", "initial_stop_loss", "strategy", "ticker_interval"]
 
     trades = pd.DataFrame([(t.pair,
-                            t.open_date.replace(tzinfo=pytz.UTC),
-                            t.close_date.replace(tzinfo=pytz.UTC) if t.close_date else None,
+                            t.open_date.replace(tzinfo=timezone.utc),
+                            t.close_date.replace(tzinfo=timezone.utc) if t.close_date else None,
                             t.calc_profit(), t.calc_profit_percent(),
                             t.open_rate, t.close_rate, t.amount,
                             (round((t.close_date.timestamp() - t.open_date.timestamp()) / 60, 2)

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -9,12 +9,11 @@ Includes:
 import logging
 import operator
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import arrow
-import pytz
 from pandas import DataFrame
 
 from freqtrade import OperationalException, misc
@@ -56,10 +55,10 @@ def trim_dataframe(df: DataFrame, timerange: TimeRange) -> DataFrame:
     Trim dataframe based on given timerange
     """
     if timerange.starttype == 'date':
-        start = datetime.fromtimestamp(timerange.startts, tz=pytz.utc)
+        start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
         df = df.loc[df['date'] >= start, :]
     if timerange.stoptype == 'date':
-        stop = datetime.fromtimestamp(timerange.stopts, tz=pytz.utc)
+        stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc)
         df = df.loc[df['date'] <= stop, :]
     return df
 


### PR DESCRIPTION
## Summary
trade.open_date and trade.close_date are in UTC timezone. After querying from the database, we get them as tz-native objects back - so calling `.timestamp()` on them results in different results depending on the timezone.
For UTC+ offsets this is not a problem, since we get trades for the last X hours - however UTC- offsets (Americas ...) will encounter update poblems as the "since" parameter sent to the exchange is in the future.

We can easily fix this by replacing the timezone with the utc-timezone (we don't convert to timestamp very often).

Closes #2490

## Quick changelog

- check all occurences of `.timestamp()`
- fix bug
- Test (for some reason my pc think's it's in Americas - and i'm not ...)