### PR TITLE
Prepare reorg install doc : explain differences between master and develop

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,7 @@ cd freqtrade
 ./setup.sh --install
 ```
 
+    When cloning the repository the default working branch is name `develop`. This branch contains the last features (can be considered as relatively stable thanks to automated tests). The `master` branch contains the code of the last release (done once per month with a one week old snapshot of the `develop` branch to prevent packaging bugs so potentially more stable).
 !!! Note
     Windows installation is explained [here](#windows).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,6 @@ Freqtrade provides a Linux/MacOS script to install all dependencies and help you
 ```bash
 git clone git@github.com:freqtrade/freqtrade.git
 cd freqtrade
-git checkout develop
 ./setup.sh --install
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,9 @@ cd freqtrade
 ./setup.sh --install
 ```
 
+!!! Note "Version considerations"
     When cloning the repository the default working branch is name `develop`. This branch contains the last features (can be considered as relatively stable thanks to automated tests). The `master` branch contains the code of the last release (done once per month with a one week old snapshot of the `develop` branch to prevent packaging bugs so potentially more stable).
+
 !!! Note
     Windows installation is explained [here](#windows).
 


### PR DESCRIPTION
Hi,

- I have try to explain the differences between master and develop.
- I have delete the `git checkout develop` as we are already in this branch when cloning so we tell the end user to do something that has no impact and so confusing.