### PR TITLE
[docs] Add seperate exchange section in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ git checkout develop
 
 For any other type of installation please refer to [Installation doc](https://www.freqtrade.io/en/latest/installation/).
 
-
 ## Basic Usage
 
 ### Bot commands
@@ -106,7 +105,7 @@ optional arguments:
 
 ### Telegram RPC commands
 
-Telegram is not mandatory. However, this is a great way to control your bot. More details on our [documentation](https://www.freqtrade.io/en/latest/telegram-usage/)
+Telegram is not mandatory. However, this is a great way to control your bot. More details and the full command list on our [documentation](https://www.freqtrade.io/en/latest/telegram-usage/)
 
 - `/start`: Starts the trader
 - `/stop`: Stops the trader
@@ -128,11 +127,6 @@ The project is currently setup in two main branches:
 - `develop` - This branch has often new features, but might also cause breaking changes.
 - `master` - This branch contains the latest stable release. The bot 'should' be stable on this branch, and is generally well tested.
 - `feat/*` - These are feature branches, which are being worked on heavily. Please don't use these unless you want to test a specific feature.
-
-## A note on Binance
-
-For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.
-Accounts having BNB accounts use this to pay for fees - if your first trade happens to be on `BNB`, further trades will consume this position and make the initial BNB order unsellable as the expected amount is not there anymore.
 
 ## Support
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -8,6 +8,9 @@ If you do not know what things mentioned here mean, you probably do not need it.
 
 Copy the `freqtrade.service` file to your systemd user directory (usually `~/.config/systemd/user`) and update `WorkingDirectory` and `ExecStart` to match your setup.
 
+!!! Note
+    Certain systems (like Raspbian) don't load service unit files from the user directory. In this case, copy `freqtrade.service` into `/etc/systemd/user/` (requires superuser permissions).
+
 After that you can start the daemon with:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,19 +357,12 @@ For example, to test the order type `FOK` with Kraken, and modify candle_limit t
 !!! Warning
     Please make sure to fully understand the impacts of these settings before modifying them.
 
-#### Random notes for other exchanges
-
-* The Ocean (ccxt id: 'theocean') exchange uses Web3 functionality and requires web3 package to be installed:
-```shell
-$ pip3 install web3
-```
-
 ### What values can be used for fiat_display_currency?
 
 The `fiat_display_currency` configuration parameter sets the base currency to use for the
 conversion from coin to fiat in the bot Telegram reports.
 
-The valid values are:
+The valid values are:p
 
 ```json
 "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD"
@@ -476,10 +469,12 @@ you run it in production mode.
         "secret": "08a9dc6db3d7b53e1acebd9275677f4b0a04f1a5",
         ...
 }
-
 ```
+
 !!! Note
     If you have an exchange API key yet, [see our tutorial](/pre-requisite).
+
+You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
 
 ### Using proxy with FreqTrade
 

--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -78,10 +78,8 @@ freqtrade download-data --exchange binance --pairs XRP/ETH ETH/BTC --days 20 --d
 !!! Warning
     The historic trades are not available during Freqtrade dry-run and live trade modes because all exchanges tested provide this data with a delay of few 100 candles, so it's not suitable for real-time trading.
 
-### Historic Kraken data
-
-The Kraken API does only provide 720 historic candles, which is sufficient for FreqTrade dry-run and live trade modes, but is a problem for backtesting.
-To download data for the Kraken exchange, using `--dl-trades` is mandatory, otherwise the bot will download the same 720 candles over and over, and you'll not have enough backtest data.
+!!! Note "Kraken user"
+    Kraken users should read [this](exchanges.md#historic-kraken-data) before starting to download data.
 
 ## Next step
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -1,0 +1,35 @@
+# Exchange-specific Notes
+
+This page combines common gotchas and informations which are exchange-specific and most likely don't apply to other exchanges.
+
+## Binance
+
+!!! Tip "Stoploss on Exchange"
+    Binance is currently the only exchange supporting `stoploss_on_exchange`. It provides great advantages, so we recommend to benefit from it.
+
+### Blacklists
+
+For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.
+Accounts having BNB accounts use this to pay for fees - if your first trade happens to be on `BNB`, further trades will consume this position and make the initial BNB order unsellable as the expected amount is not there anymore.
+
+### Binance sites
+
+Binance has been split into 3, and users must use the correct ccxt exchange ID for their exchange, otherwise API keys are not recognized.
+
+* [binance.com](https://www.binance.com/) - International users - ccxt id: `binance`
+* [binance.us](https://www.binance.us/) US based users- ccxt id: `binanceus`
+* [binance.je](https://www.binance.je/) Trading FIAT currencies - ccxt id: `binanceje`
+
+### Kraken
+
+### Historic Kraken data
+
+The Kraken API does only provide 720 historic candles, which is sufficient for FreqTrade dry-run and live trade modes, but is a problem for backtesting.
+To download data for the Kraken exchange, using `--dl-trades` is mandatory, otherwise the bot will download the same 720 candles over and over, and you'll not have enough backtest data.
+
+#### Random notes for other exchanges
+
+* The Ocean (ccxt id: 'theocean') exchange uses Web3 functionality and requires web3 package to be installed:
+```shell
+$ pip3 install web3
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ nav:
     - Hyperopt: hyperopt.md
     - Edge Positioning: edge.md
     - Utility Subcommands: utils.md
-    - Exchanges: exchanges.md
+    - Exchange-specific Notes: exchanges.md
     - FAQ: faq.md
     - Data Analysis:
         - Jupyter Notebooks: data-analysis.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
     - Hyperopt: hyperopt.md
     - Edge Positioning: edge.md
     - Utility Subcommands: utils.md
+    - Exchanges: exchanges.md
     - FAQ: faq.md
     - Data Analysis:
         - Jupyter Notebooks: data-analysis.md


### PR DESCRIPTION
## Summary
Add a seperate exchange section in the documentations, where we can combine exchange-specific informations.
Currently this is distributed all around in the documentation - which is a pain if someone has a question and you seem to remember that we have it documented...

- move exchange-specific infos to seperate document

closes #2480