### PR TITLE
Fixes strategy config from file logic

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -152,9 +152,9 @@ class Configuration:
 
         self._process_logging_options(config)
 
-        # Set strategy if not specified in config and or if it's non default
-        if self.args.get("strategy") != constants.DEFAULT_STRATEGY or not config.get('strategy'):
-            config.update({'strategy': self.args.get("strategy")})
+        if ("strategy" in self.args and self.args["strategy"] and
+                self.args['strategy'] != constants.DEFAULT_STRATEGY):
+            config.update({'strategy': self.args['strategy']})
 
         self._args_to_config(config, argname='strategy_path',
                              logstring='Using additional Strategy lookup path: {}')
@@ -350,7 +350,7 @@ class Configuration:
                         configuration instead of the content)
         """
         if (argname in self.args and self.args[argname] is not None
-           and self.args[argname] is not False):
+                and self.args[argname] is not False):
 
             config.update({argname: self.args[argname]})
             if logfun:


### PR DESCRIPTION
`Configuration.from_files` was clobbering `config['strategy']` in the arg parsing logic. This PR fixes the bug that overwrites the strategy in config.

ln 353 is a pep8 indentation formatting change.