### PR TITLE
[minor] Add sleep to allow thread to start

### DIFF
--- a/tests/rpc/test_rpc_manager.py
+++ b/tests/rpc/test_rpc_manager.py
@@ -1,5 +1,5 @@
 # pragma pylint: disable=missing-docstring, C0103
-
+import time
 import logging
 from unittest.mock import MagicMock
 
@@ -176,6 +176,8 @@ def test_init_apiserver_enabled(mocker, default_conf, caplog) -> None:
                                   "listen_port": "8080"}
     rpc_manager = RPCManager(get_patched_freqtradebot(mocker, default_conf))
 
+    # Sleep to allow the thread to start
+    time.sleep(0.5)
     assert log_has('Enabling rpc.api_server', caplog)
     assert len(rpc_manager.registered_modules) == 1
     assert 'apiserver' in [mod.name for mod in rpc_manager.registered_modules]


### PR DESCRIPTION
## Summary
Sometimes, this test is fluky (especially in CI).
I think this is related to `thread.start()` - which may not execute the run-mock in time if resources are low. 
Adding a half-second delay to this should help mitigate these random failures.

