### PR TITLE
Add fix for bibox exchange

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -15,3 +15,4 @@ from freqtrade.exchange.exchange import (market_is_active,  # noqa: F401
                                          symbol_is_pair)
 from freqtrade.exchange.kraken import Kraken  # noqa: F401
 from freqtrade.exchange.binance import Binance  # noqa: F401
+from freqtrade.exchange.bibox import Bibox  # noqa: F401

--- a/freqtrade/exchange/bibox.py
+++ b/freqtrade/exchange/bibox.py
@@ -17,5 +17,6 @@ class Bibox(Exchange):
     may still not work as expected.
     """
 
-    # Adjust ccxt exchange API metadata info
-    _ccxt_has: Dict = {"fetchCurrencies": False}
+    # fetchCurrencies API point requires authentication for Bibox,
+    # so switch it off for Freqtrade load_markets()
+    _ccxt_config: Dict = {"has": {"fetchCurrencies": False}}

--- a/freqtrade/exchange/bibox.py
+++ b/freqtrade/exchange/bibox.py
@@ -1,0 +1,21 @@
+""" Bibox exchange subclass """
+import logging
+from typing import Dict
+
+from freqtrade.exchange import Exchange
+
+logger = logging.getLogger(__name__)
+
+
+class Bibox(Exchange):
+    """
+    Bibox exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+
+    Please note that this exchange is not included in the list of exchanges
+    officially supported by the Freqtrade development team. So some features
+    may still not work as expected.
+    """
+
+    # Adjust ccxt exchange API metadata info
+    _ccxt_has: Dict = {"fetchCurrencies": False}

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -30,6 +30,9 @@ class Exchange:
 
     _config: Dict = {}
 
+    # Adjustments to ccxt exchange API metadata info (ccxt exchange `has` options)
+    _ccxt_has: Dict = {}
+
     # Parameters to add directly to buy/sell calls (like agreeing to trading agreement)
     _params: Dict = {}
 
@@ -151,6 +154,10 @@ class Exchange:
             raise OperationalException(f'Exchange {name} is not supported') from e
         except ccxt.BaseError as e:
             raise OperationalException(f"Initialization of ccxt failed. Reason: {e}") from e
+
+        # Adjust ccxt API metadata info (`has` options) for the exchange
+        for k, v in self._ccxt_has.items():
+            api.has[k] = v
 
         self.set_sandbox(api, exchange_config, name)
 


### PR DESCRIPTION
* Particularly, fixes #2474 
* <s>Adds a generic mechanism to override the ccxt exchange API metadata info (ccxt exchange `has` options). Can be useful/needed for other exchanges in the future.</s>
* Add a generic mechanism to specify exchange-specific part of ccxt_config in the exchange-specific class, which is then merged with custom ccxt_config/ccxt_async_config from user's config.

Command to test:
```
freqtrade list-pairs --exchange bibox
```