### PR TITLE
plot-profit script fails in certain conditions

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -50,16 +50,20 @@ def trim_tickerlist(tickerlist: List[Dict], timerange: TimeRange) -> List[Dict]:
     return tickerlist[start_index:stop_index]
 
 
-def trim_dataframe(df: DataFrame, timerange: TimeRange) -> DataFrame:
+def trim_dataframe(df: DataFrame, timerange: TimeRange, df_date_col: str = 'date') -> DataFrame:
     """
     Trim dataframe based on given timerange
+    :param df: Dataframe to trim
+    :param timerange: timerange (use start and end date if available)
+    :param: df_date_col: Column in the dataframe to use as Date column
+    :return: trimmed dataframe
     """
     if timerange.starttype == 'date':
         start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
-        df = df.loc[df['date'] >= start, :]
+        df = df.loc[df[df_date_col] >= start, :]
     if timerange.stoptype == 'date':
         stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc)
-        df = df.loc[df['date'] <= stop, :]
+        df = df.loc[df[df_date_col] <= stop, :]
     return df
 
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -379,7 +379,12 @@ def plot_profit(config: Dict[str, Any]) -> None:
     plot_elements = init_plotscript(config)
     trades = plot_elements['trades']
     # Filter trades to relevant pairs
-    trades = trades[trades['pair'].isin(plot_elements["pairs"])]
+    # Remove open pairs - we don't know the profit yet so can't calculate profit for these.
+    # Also, If only one open pair is left, then the profit-generation would fail.
+    trades = trades[(trades['pair'].isin(plot_elements["pairs"]))
+                    & (~trades['close_time'].isnull())
+                    ]
+
     # Create an average close price of all the pairs that were involved.
     # this could be useful to gauge the overall market trend
     fig = generate_profit_graph(plot_elements["pairs"], plot_elements["tickers"],

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -47,7 +47,7 @@ def init_plotscript(config):
                          db_url=config.get('db_url'),
                          exportfilename=config.get('exportfilename'),
                          )
-
+    trades = history.trim_dataframe(trades, timerange, 'open_time')
     return {"tickers": tickers,
             "trades": trades,
             "pairs": pairs,
@@ -377,10 +377,7 @@ def plot_profit(config: Dict[str, Any]) -> None:
     in helping out to find a good algorithm.
     """
     plot_elements = init_plotscript(config)
-    trades = load_trades(config['trade_source'],
-                         db_url=str(config.get('db_url')),
-                         exportfilename=str(config.get('exportfilename')),
-                         )
+    trades = plot_elements['trades']
     # Filter trades to relevant pairs
     trades = trades[trades['pair'].isin(plot_elements["pairs"])]
     # Create an average close price of all the pairs that were involved.


### PR DESCRIPTION
## Summary
Plot-profit fails if a pair has only one trade and that trade is still open.
we can mitigate this by filtering this out. The trade would not be counted anyway, since the profit is not yet known (and resample on close-time would not work).

Also, trades should be filtered by timerange if one is given.

Solve the issue: From slack ...

## Quick changelog

- Remove duplicate loading
- filter out open trades
- Filter by timerange
