### PR TITLE
/Balance rework

### DIFF
--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -354,7 +354,8 @@ class ApiServer(RPC):
 
         Returns the current status of the trades in json format
         """
-        results = self._rpc_balance(self._config.get('fiat_display_currency', ''))
+        results = self._rpc_balance(self._config['stake_currency'],
+                                    self._config.get('fiat_display_currency', ''))
         return self.rest_dump(results)
 
     @require_login

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -301,6 +301,7 @@ class RPC:
         """ Returns current account balance per crypto """
         output = []
         total = 0.0
+        tickers = self._freqtrade.exchange.get_tickers()
         for coin, balance in self._freqtrade.exchange.get_balances().items():
             if not balance['total']:
                 continue
@@ -310,10 +311,11 @@ class RPC:
             else:
                 try:
                     pair = self._freqtrade.exchange.get_valid_pair_combination(coin, "BTC")
+
                     if pair.startswith("BTC"):
-                        rate = 1.0 / self._freqtrade.get_sell_rate(pair, False)
+                        rate = 1.0 / tickers.get(pair, {}).get('bid', 1)
                     else:
-                        rate = self._freqtrade.get_sell_rate(pair, False)
+                        rate = tickers.get(pair, {}).get('bid', 1)
                 except (TemporaryError, DependencyException):
                     logger.warning(f" Could not get rate for pair {coin}.")
                     continue

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -297,7 +297,7 @@ class RPC:
             'best_rate': round(bp_rate * 100, 2),
         }
 
-    def _rpc_balance(self, fiat_display_currency: str) -> Dict:
+    def _rpc_balance(self, stake_currency: str, fiat_display_currency: str) -> Dict:
         """ Returns current account balance per crypto """
         output = []
         total = 0.0
@@ -310,27 +310,29 @@ class RPC:
             if not balance['total']:
                 continue
 
-            if coin == 'BTC':
+            est_stake: float = 0
+            if coin == stake_currency:
                 rate = 1.0
+                est_stake = balance['total']
             else:
                 try:
-                    pair = self._freqtrade.exchange.get_valid_pair_combination(coin, "BTC")
-
-                    if pair.startswith("BTC"):
-                        rate = 1.0 / tickers.get(pair, {}).get('bid', 1)
-                    else:
-                        rate = tickers.get(pair, {}).get('bid', 1)
+                    pair = self._freqtrade.exchange.get_valid_pair_combination(coin, stake_currency)
+                    rate = tickers.get(pair, {}).get('bid', None)
+                    if rate:
+                        if pair.startswith(stake_currency):
+                            rate = 1.0 / rate
+                        est_stake = rate * balance['total']
                 except (TemporaryError, DependencyException):
                     logger.warning(f" Could not get rate for pair {coin}.")
                     continue
-            est_btc: float = rate * balance['total']
-            total = total + est_btc
+            total = total + (est_stake or 0)
             output.append({
                 'currency': coin,
                 'free': balance['free'] if balance['free'] is not None else 0,
                 'balance': balance['total'] if balance['total'] is not None else 0,
                 'used': balance['used'] if balance['used'] is not None else 0,
-                'est_btc': est_btc,
+                'est_stake': est_stake or 0,
+                'stake': stake_currency,
             })
         if total == 0.0:
             if self._freqtrade.config.get('dry_run', False):

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -301,7 +301,11 @@ class RPC:
         """ Returns current account balance per crypto """
         output = []
         total = 0.0
-        tickers = self._freqtrade.exchange.get_tickers()
+        try:
+            tickers = self._freqtrade.exchange.get_tickers()
+        except (TemporaryError, DependencyException):
+            raise RPCException('Error getting current tickers.')
+
         for coin, balance in self._freqtrade.exchange.get_balances().items():
             if not balance['total']:
                 continue

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -306,14 +306,14 @@ class RPC:
         except (TemporaryError, DependencyException):
             raise RPCException('Error getting current tickers.')
 
-        for coin, balance in self._freqtrade.exchange.get_balances().items():
-            if not balance['total']:
+        for coin, balance in self._freqtrade.wallets.get_all_balances().items():
+            if not balance.total:
                 continue
 
             est_stake: float = 0
             if coin == stake_currency:
                 rate = 1.0
-                est_stake = balance['total']
+                est_stake = balance.total
             else:
                 try:
                     pair = self._freqtrade.exchange.get_valid_pair_combination(coin, stake_currency)
@@ -321,16 +321,16 @@ class RPC:
                     if rate:
                         if pair.startswith(stake_currency):
                             rate = 1.0 / rate
-                        est_stake = rate * balance['total']
+                        est_stake = rate * balance.total
                 except (TemporaryError, DependencyException):
                     logger.warning(f" Could not get rate for pair {coin}.")
                     continue
             total = total + (est_stake or 0)
             output.append({
                 'currency': coin,
-                'free': balance['free'] if balance['free'] is not None else 0,
-                'balance': balance['total'] if balance['total'] is not None else 0,
-                'used': balance['used'] if balance['used'] is not None else 0,
+                'free': balance.free if balance.free is not None else 0,
+                'balance': balance.total if balance.total is not None else 0,
+                'used': balance.used if balance.used is not None else 0,
                 'est_stake': est_stake or 0,
                 'stake': stake_currency,
             })

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -325,15 +325,16 @@ class Telegram(RPC):
     def _balance(self, update: Update, context: CallbackContext) -> None:
         """ Handler for /balance """
         try:
-            result = self._rpc_balance(self._config.get('fiat_display_currency', ''))
+            result = self._rpc_balance(self._config['stake_currency'],
+                                       self._config.get('fiat_display_currency', ''))
             output = ''
             for currency in result['currencies']:
-                if currency['est_btc'] > 0.0001:
+                if currency['est_stake'] > 0.0001:
                     curr_output = "*{currency}:*\n" \
                             "\t`Available: {free: .8f}`\n" \
                             "\t`Balance: {balance: .8f}`\n" \
                             "\t`Pending: {used: .8f}`\n" \
-                            "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
+                            "\t`Est. {stake}: {est_stake: .8f}`\n".format(**currency)
                 else:
                     curr_output = "*{currency}:* not showing <1$ amount \n".format(**currency)
 

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -2,7 +2,7 @@
 """ Wallet """
 
 import logging
-from typing import Dict, NamedTuple
+from typing import Dict, NamedTuple, Any
 from freqtrade.exchange import Exchange
 from freqtrade import constants
 
@@ -72,3 +72,6 @@ class Wallets:
             )
 
         logger.info('Wallets synced.')
+
+    def get_all_balances(self) -> Dict[str, Any]:
+        return self._wallets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -980,6 +980,28 @@ def tickers():
             'quoteVolume': 62.68220262,
             'info': {}
         },
+        'BTC/USDT': {
+            'symbol': 'BTC/USDT',
+            'timestamp': 1573758371399,
+            'datetime': '2019-11-14T19:06:11.399Z',
+            'high': 8800.0,
+            'low': 8582.6,
+            'bid': 8648.16,
+            'bidVolume': 0.238771,
+            'ask': 8648.72,
+            'askVolume': 0.016253,
+            'vwap': 8683.13647806,
+            'open': 8759.7,
+            'close': 8648.72,
+            'last': 8648.72,
+            'previousClose': 8759.67,
+            'change': -110.98,
+            'percentage': -1.267,
+            'average': None,
+            'baseVolume': 35025.943355,
+            'quoteVolume': 304135046.4242901,
+            'info': {}
+        },
         'ETH/USDT': {
             'symbol': 'ETH/USDT',
             'timestamp': 1522014804118,
@@ -1067,7 +1089,29 @@ def tickers():
             'baseVolume': 59698.79897,
             'quoteVolume': 29132399.743954,
             'info': {}
-        }
+        },
+        'XRP/BTC': {
+            'symbol': 'XRP/BTC',
+            'timestamp': 1573758257534,
+            'datetime': '2019-11-14T19:04:17.534Z',
+            'high': 3.126e-05,
+            'low': 3.061e-05,
+            'bid': 3.093e-05,
+            'bidVolume': 27901.0,
+            'ask': 3.095e-05,
+            'askVolume': 10551.0,
+            'vwap': 3.091e-05,
+            'open': 3.119e-05,
+            'close': 3.094e-05,
+            'last': 3.094e-05,
+            'previousClose': 3.117e-05,
+            'change': -2.5e-07,
+            'percentage': -0.802,
+            'average': None,
+            'baseVolume': 37334921.0,
+            'quoteVolume': 1154.19266394,
+            'info': {}
+        },
     })
 
 
@@ -1317,8 +1361,8 @@ def rpc_balance():
             'used': 0.0
         },
         'XRP': {
-            'total': 1.0,
-            'free': 1.0,
+            'total': 0.1,
+            'free': 0.01,
             'used': 0.0
             },
         'EUR': {

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -100,7 +100,7 @@ def test_refresh_pairlist_dynamic(mocker, shitcoinmarkets, tickers, whitelist_co
         markets=PropertyMock(return_value=shitcoinmarkets),
      )
     # argument: use the whitelist dynamically by exchange-volume
-    whitelist = ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'HOT/BTC', 'FUEL/BTC']
+    whitelist = ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC', 'HOT/BTC']
     bot.pairlists.refresh_pairlist()
 
     assert whitelist == bot.pairlists.whitelist
@@ -135,10 +135,10 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
 
 @pytest.mark.parametrize("pairlists,base_currency,whitelist_result", [
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"}],
-        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'HOT/BTC', 'FUEL/BTC']),
+        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC', 'HOT/BTC']),
     # Different sorting depending on quote or bid volume
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "bidVolume"}],
-        "BTC",  ['HOT/BTC', 'FUEL/BTC', 'LTC/BTC', 'TKN/BTC', 'ETH/BTC']),
+        "BTC",  ['HOT/BTC', 'FUEL/BTC', 'XRP/BTC', 'LTC/BTC', 'TKN/BTC']),
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"}],
         "USDT", ['ETH/USDT']),
     # No pair for ETH ...
@@ -146,19 +146,19 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
      "ETH", []),
     # Precisionfilter and quote volume
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
-      {"method": "PrecisionFilter"}], "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'FUEL/BTC']),
+      {"method": "PrecisionFilter"}], "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
     # Precisionfilter bid
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "bidVolume"},
-      {"method": "PrecisionFilter"}], "BTC", ['FUEL/BTC', 'LTC/BTC', 'TKN/BTC', 'ETH/BTC']),
+      {"method": "PrecisionFilter"}], "BTC", ['FUEL/BTC', 'XRP/BTC', 'LTC/BTC', 'TKN/BTC']),
     # PriceFilter and VolumePairList
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
       {"method": "PriceFilter", "low_price_ratio": 0.03}],
-        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'FUEL/BTC']),
+        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
     # Hot is removed by precision_filter, Fuel by low_price_filter.
-    ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
+    ([{"method": "VolumePairList", "number_assets": 6, "sort_key": "quoteVolume"},
       {"method": "PrecisionFilter"},
       {"method": "PriceFilter", "low_price_ratio": 0.02}
-      ], "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']),
+      ], "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
     # StaticPairlist Only
     ([{"method": "StaticPairList"},
       ], "BTC", ['ETH/BTC', 'TKN/BTC']),

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -355,29 +355,18 @@ def test_rpc_balance_handle_error(default_conf, mocker):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=mock_balance),
-        get_ticker=MagicMock(side_effect=TemporaryError('Could not load ticker due to xxx'))
+        get_tickers=MagicMock(side_effect=TemporaryError('Could not load ticker due to xxx'))
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
-
-    result = rpc._rpc_balance(default_conf['fiat_display_currency'])
-    assert prec_satoshi(result['total'], 12)
-    assert prec_satoshi(result['value'], 180000)
-    assert 'USD' == result['symbol']
-    assert result['currencies'] == [{
-        'currency': 'BTC',
-        'free': 10.0,
-        'balance': 12.0,
-        'used': 2.0,
-        'est_btc': 12.0,
-    }]
-    assert result['total'] == 12.0
+    with pytest.raises(RPCException, match="Error getting current tickers."):
+        rpc._rpc_balance(default_conf['fiat_display_currency'])
 
 
-def test_rpc_balance_handle(default_conf, mocker):
+def test_rpc_balance_handle(default_conf, mocker, tickers):
     mock_balance = {
         'BTC': {
             'free': 10.0,
@@ -389,7 +378,7 @@ def test_rpc_balance_handle(default_conf, mocker):
             'total': 5.0,
             'used': 4.0,
         },
-        'PAX': {
+        'USDT': {
             'free': 5.0,
             'total': 10.0,
             'used': 5.0,
@@ -405,10 +394,9 @@ def test_rpc_balance_handle(default_conf, mocker):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=mock_balance),
-        get_ticker=MagicMock(
-            side_effect=lambda p, r: {'bid': 100} if p == "BTC/PAX" else {'bid': 0.01}),
+        get_tickers=tickers,
         get_valid_pair_combination=MagicMock(
-            side_effect=lambda a, b: f"{b}/{a}" if a == "PAX" else f"{a}/{b}")
+            side_effect=lambda a, b: f"{b}/{a}" if a == "USDT" else f"{a}/{b}")
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
@@ -417,8 +405,8 @@ def test_rpc_balance_handle(default_conf, mocker):
     rpc._fiat_converter = CryptoToFiatConverter()
 
     result = rpc._rpc_balance(default_conf['fiat_display_currency'])
-    assert prec_satoshi(result['total'], 12.15)
-    assert prec_satoshi(result['value'], 182250)
+    assert prec_satoshi(result['total'], 12.309096315)
+    assert prec_satoshi(result['value'], 184636.44472997)
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',
@@ -430,16 +418,16 @@ def test_rpc_balance_handle(default_conf, mocker):
         {'free': 1.0,
          'balance': 5.0,
          'currency': 'ETH',
-         'est_btc': 0.05,
+         'est_btc': 0.30794,
          'used': 4.0
          },
         {'free': 5.0,
          'balance': 10.0,
-         'currency': 'PAX',
-         'est_btc': 0.1,
+         'currency': 'USDT',
+         'est_btc': 0.0011563153318162476,
          'used': 5.0}
     ]
-    assert result['total'] == 12.15
+    assert result['total'] == 12.309096315331816
 
 
 def test_rpc_start(mocker, default_conf) -> None:

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -363,7 +363,7 @@ def test_rpc_balance_handle_error(default_conf, mocker):
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
     with pytest.raises(RPCException, match="Error getting current tickers."):
-        rpc._rpc_balance(default_conf['fiat_display_currency'])
+        rpc._rpc_balance(default_conf['stake_currency'], default_conf['fiat_display_currency'])
 
 
 def test_rpc_balance_handle(default_conf, mocker, tickers):
@@ -404,28 +404,33 @@ def test_rpc_balance_handle(default_conf, mocker, tickers):
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
 
-    result = rpc._rpc_balance(default_conf['fiat_display_currency'])
+    result = rpc._rpc_balance(default_conf['stake_currency'], default_conf['fiat_display_currency'])
     assert prec_satoshi(result['total'], 12.309096315)
     assert prec_satoshi(result['value'], 184636.44472997)
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',
-            'free': 10.0,
-            'balance': 12.0,
-            'used': 2.0,
-            'est_btc': 12.0,
+         'free': 10.0,
+         'balance': 12.0,
+         'used': 2.0,
+         'est_stake': 12.0,
+         'stake': 'BTC',
          },
         {'free': 1.0,
          'balance': 5.0,
          'currency': 'ETH',
-         'est_btc': 0.30794,
-         'used': 4.0
+         'est_stake': 0.30794,
+         'used': 4.0,
+         'stake': 'BTC',
+
          },
         {'free': 5.0,
          'balance': 10.0,
          'currency': 'USDT',
-         'est_btc': 0.0011563153318162476,
-         'used': 5.0}
+         'est_stake': 0.0011563153318162476,
+         'used': 5.0,
+         'stake': 'BTC',
+         }
     ]
     assert result['total'] == 12.309096315331816
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -243,9 +243,9 @@ def test_api_balance(botclient, mocker, rpc_balance):
             'last': 0.1,
         }
     mocker.patch('freqtrade.exchange.Exchange.get_balances', return_value=rpc_balance)
-    mocker.patch('freqtrade.exchange.Exchange.get_ticker', side_effect=mock_ticker)
     mocker.patch('freqtrade.exchange.Exchange.get_valid_pair_combination',
                  side_effect=lambda a, b: f"{a}/{b}")
+    ftbot.wallets.update()
 
     rc = client_get(client, f"{BASE_URI}/balance")
     assert_response(rc)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -224,24 +224,6 @@ def test_api_stopbuy(botclient):
 def test_api_balance(botclient, mocker, rpc_balance):
     ftbot, client = botclient
 
-    def mock_ticker(symbol, refresh):
-        if symbol == 'BTC/USDT':
-            return {
-                'bid': 10000.00,
-                'ask': 10000.00,
-                'last': 10000.00,
-            }
-        elif symbol == 'XRP/BTC':
-            return {
-                'bid': 0.00001,
-                'ask': 0.00001,
-                'last': 0.00001,
-            }
-        return {
-            'bid': 0.1,
-            'ask': 0.1,
-            'last': 0.1,
-        }
     mocker.patch('freqtrade.exchange.Exchange.get_balances', return_value=rpc_balance)
     mocker.patch('freqtrade.exchange.Exchange.get_valid_pair_combination',
                  side_effect=lambda a, b: f"{a}/{b}")

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -256,7 +256,8 @@ def test_api_balance(botclient, mocker, rpc_balance):
         'free': 12.0,
         'balance': 12.0,
         'used': 0.0,
-        'est_btc': 12.0,
+        'est_stake': 12.0,
+        'stake': 'BTC',
     }
 
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -461,29 +461,10 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     assert '*Best Performing:* `ETH/BTC: 6.20%`' in msg_mock.call_args_list[-1][0][0]
 
 
-def test_telegram_balance_handle(default_conf, update, mocker, rpc_balance) -> None:
-
-    def mock_ticker(symbol, refresh):
-        if symbol == 'BTC/USDT':
-            return {
-                'bid': 10000.00,
-                'ask': 10000.00,
-                'last': 10000.00,
-            }
-        elif symbol == 'XRP/BTC':
-            return {
-                'bid': 0.00001,
-                'ask': 0.00001,
-                'last': 0.00001,
-            }
-        return {
-            'bid': 0.1,
-            'ask': 0.1,
-            'last': 0.1,
-        }
+def test_telegram_balance_handle(default_conf, update, mocker, rpc_balance, tickers) -> None:
 
     mocker.patch('freqtrade.exchange.Exchange.get_balances', return_value=rpc_balance)
-    mocker.patch('freqtrade.exchange.Exchange.get_ticker', side_effect=mock_ticker)
+    mocker.patch('freqtrade.exchange.Exchange.get_tickers', tickers)
     mocker.patch('freqtrade.exchange.Exchange.get_valid_pair_combination',
                  side_effect=lambda a, b: f"{a}/{b}")
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -545,7 +545,8 @@ def test_balance_handle_too_large_response(default_conf, update, mocker) -> None
             'free': 1.0,
             'used': 0.5,
             'balance': i,
-            'est_btc': 1
+            'est_stake': 1,
+            'stake': 'BTC',
         })
     mocker.patch('freqtrade.rpc.rpc.RPC._rpc_balance', return_value={
         'currencies': balances,


### PR DESCRIPTION
## Summary
`/balance` should not fail if a pair has no bid.
`/balance` also does not need to call each `fetch_ticker()` once - but can use the `fetch_tickers()` method, which will fetch all tickers at once (so it's one call, instead of one per owned currency).

This will also handle "non-bid" situations - where bid is empty as seen in #2515 .

closes #2515 

## Quick changelog

- `/balance` should not fail if a pair has no bid.
- `/balance` also does not need to call each `fetch_ticker()` once - but can use the `fetch_tickers()` method, which will fetch all tickers at once (so it's one call, instead of one per owned currency).
- Allow "empty" bids - these pairs will be filtered from the output though.
- Use stake_currency instead of hardcoding to BTC (if you trade ETH as your stake - you're probably not interrested in the BTC value, but look at either FIAT, or stake).
- Use `freqtradebot.wallets` instead of calling `exchange.get_balance()` - avoiding another RPC call (wallets is refreshed quite often during bot operations).