### PR TITLE
Fix non-terminating bot

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -27,7 +27,6 @@ def main(sysargv: List[str] = None) -> None:
     """
 
     return_code: Any = 1
-    worker = None
     try:
         arguments = Arguments(sysargv)
         args = arguments.get_parsed_arg()
@@ -57,8 +56,6 @@ def main(sysargv: List[str] = None) -> None:
     except Exception:
         logger.exception('Fatal exception!')
     finally:
-        if worker:
-            worker.exit()
         sys.exit(return_code)
 
 

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -45,8 +45,15 @@ def start_trading(args: Dict[str, Any]) -> int:
     """
     from freqtrade.worker import Worker
     # Load and run worker
-    worker = Worker(args)
-    worker.run()
+    try:
+        worker = Worker(args)
+        worker.run()
+    except KeyboardInterrupt:
+        logger.info('SIGINT received, aborting ...')
+    finally:
+        if worker:
+            logger.info("worker found ... calling exit")
+            worker.exit()
     return 0
 
 

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -45,6 +45,7 @@ def start_trading(args: Dict[str, Any]) -> int:
     """
     from freqtrade.worker import Worker
     # Load and run worker
+    worker = None
     try:
         worker = Worker(args)
         worker.run()


### PR DESCRIPTION
## Summary
since we're now calling `freqtrade trade` - worker does not exist in main anymore, causing bots to "not stop" when used with telegram and trying to sigint the bot.

Solve the issue: from slack ...

## Quick changelog

- Move keyboardinterrupt and `worker.exit()` to `utils.py` (where it belongs).
