### PR TITLE
Rpc/show config

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -106,6 +106,7 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `stop` | | Stops the trader
 | `stopbuy` | | Stops the trader from opening new trades. Gracefully closes open trades according to their rules.
 | `reload_conf` | | Reloads the configuration file
+| `show_config` | | Shows part of the current configuration with relevant settings to operation
 | `status` | | Lists all open trades
 | `count` | | Displays number of trades used and available
 | `profit` | | Display a summary of your profit/loss from close trades and some stats about your performance
@@ -171,6 +172,10 @@ profit
 reload_conf
         Reload configuration
         :returns: json object
+
+show_config
+        Returns part of the configuration, relevant for trading operations.
+        :return: json object containing the version
 
 start
         Start the bot if it's in stopped state.

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -53,6 +53,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/stop` | | Stops the trader
 | `/stopbuy` | | Stops the trader from opening new trades. Gracefully closes open trades according to their rules.
 | `/reload_conf` | | Reloads the configuration file
+| `/show_config` | | Shows part of the current configuration with relevant settings to operation
 | `/status` | | Lists all open trades
 | `/status table` | | List all open trades in a table format
 | `/count` | | Displays number of trades used and available

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -169,6 +169,8 @@ class ApiServer(RPC):
                               view_func=self._status, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/version', 'version',
                               view_func=self._version, methods=['GET'])
+        self.app.add_url_rule(f'{BASE_URI}/show_config', 'show_config',
+                              view_func=self._show_config, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/ping', 'ping',
                               view_func=self._ping, methods=['GET'])
 
@@ -240,6 +242,14 @@ class ApiServer(RPC):
         Prints the bot's version
         """
         return self.rest_dump({"version": __version__})
+
+    @require_login
+    @rpc_catch_errors
+    def _show_config(self):
+        """
+        Prints the bot's version
+        """
+        return self.rest_dump(self._rpc_show_config())
 
     @require_login
     @rpc_catch_errors

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -80,7 +80,7 @@ class RPC:
     def send_msg(self, msg: Dict[str, str]) -> None:
         """ Sends a message to all registered rpc modules """
 
-    def _rpc_show_config(self) -> Dict:
+    def _rpc_show_config(self) -> Dict[str, Any]:
         """
         Return a dict of config options.
         Explicitly does NOT return the full config to avoid leakage of sensitive
@@ -94,6 +94,9 @@ class RPC:
             'minimal_roi': config['minimal_roi'].copy(),
             'stoploss': config['stoploss'],
             'trailing_stop': config['trailing_stop'],
+            'trailing_stop_positive': config.get('trailing_stop_positive'),
+            'trailing_stop_positive_offset': config.get('trailing_stop_positive_offset'),
+            'trailing_only_offset_is_reached': config.get('trailing_only_offset_is_reached'),
             'ticker_interval': config['ticker_interval'],
             'exchange': config['exchange']['name'],
             'strategy': config['strategy'],

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -80,6 +80,26 @@ class RPC:
     def send_msg(self, msg: Dict[str, str]) -> None:
         """ Sends a message to all registered rpc modules """
 
+    def _rpc_show_config(self) -> Dict:
+        """
+        Return a dict of config options.
+        Explicitly does NOT return the full config to avoid leakage of sensitive
+        information via rpc.
+        """
+        config = self._freqtrade.config
+        val = {
+            'dry_run': config.get('dry_run', False),
+            'stake_currency': config['stake_currency'],
+            'stake_amount': config['stake_amount'],
+            'minimal_roi': config['minimal_roi'].copy(),
+            'stoploss': config['stoploss'],
+            'trailing_stop': config['trailing_stop'],
+            'ticker_interval': config['ticker_interval'],
+            'exchange': config['exchange']['name'],
+            'strategy': config['strategy'],
+        }
+        return val
+
     def _rpc_trade_status(self) -> List[Dict[str, Any]]:
         """
         Below follows the RPC backend it is prefixed with rpc_ to raise awareness that it is

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -101,6 +101,7 @@ class Telegram(RPC):
             CommandHandler('edge', self._edge),
             CommandHandler('help', self._help),
             CommandHandler('version', self._version),
+            CommandHandler('show_config', self._show_config),
         ]
         for handle in handles:
             self._updater.dispatcher.add_handler(handle)
@@ -550,6 +551,7 @@ class Telegram(RPC):
                   "*/balance:* `Show account balance per currency`\n" \
                   "*/stopbuy:* `Stops buying, but handles open trades gracefully` \n" \
                   "*/reload_conf:* `Reload configuration file` \n" \
+                  "*/show_config:* `Show running configuration` \n" \
                   "*/whitelist:* `Show current whitelist` \n" \
                   "*/blacklist [pair]:* `Show current blacklist, or adds one or more pairs " \
                   "to the blacklist.` \n" \
@@ -569,6 +571,26 @@ class Telegram(RPC):
         :return: None
         """
         self._send_msg('*Version:* `{}`'.format(__version__))
+
+    @authorized_only
+    def _show_config(self, update: Update, context: CallbackContext) -> None:
+        """
+        Handler for /show_config.
+        Show config information information
+        :param bot: telegram bot
+        :param update: message update
+        :return: None
+        """
+        val = self._rpc_show_config()
+        self._send_msg(
+            f"*Mode:* `{'Dry-run' if val['dry_run'] else 'Live'}`\n"
+            f"*Exchange:* `{val['exchange']}`\n"
+            f"*Stake per trade:* `{val['stake_amount']} {val['stake_currency']}`\n"
+            f"*Minimum ROI:* `{val['minimal_roi']}`\n"
+            f"*{'Trailing ' if val['trailing_stop'] else ''}Stoploss:* `{val['stoploss']}`\n"
+            f"*Ticker Interval:* `{val['ticker_interval']}`\n"
+            f"*Strategy:* `{val['strategy']}`'"
+        )
 
     def _send_msg(self, msg: str, parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:
         """

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -147,6 +147,13 @@ class FtRestClient():
         """
         return self._get("version")
 
+    def show_config(self):
+        """
+        Returns part of the configuration, relevant for trading operations.
+        :return: json object containing the version
+        """
+        return self._get("show_config")
+
     def whitelist(self):
         """
         Show the current whitelist

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -284,6 +284,18 @@ def test_api_count(botclient, mocker, ticker, fee, markets):
     assert rc.json["max"] == 1.0
 
 
+def test_api_show_config(botclient, mocker):
+    ftbot, client = botclient
+    patch_get_signal(ftbot, (True, False))
+
+    rc = client_get(client, f"{BASE_URI}/show_config")
+    assert_response(rc)
+    assert 'dry_run' in rc.json
+    assert rc.json['exchange'] == 'bittrex'
+    assert rc.json['ticker_interval'] == '5m'
+    assert not rc.json['trailing_stop']
+
+
 def test_api_daily(botclient, mocker, ticker, fee, markets):
     ftbot, client = botclient
     patch_get_signal(ftbot, (True, False))

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1174,6 +1174,23 @@ def test_version_handle(default_conf, update, mocker) -> None:
     assert '*Version:* `{}`'.format(__version__) in msg_mock.call_args_list[0][0][0]
 
 
+def test_show_config_handle(default_conf, update, mocker) -> None:
+    msg_mock = MagicMock()
+    mocker.patch.multiple(
+        'freqtrade.rpc.telegram.Telegram',
+        _init=MagicMock(),
+        _send_msg=msg_mock
+    )
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+    telegram = Telegram(freqtradebot)
+
+    telegram._show_config(update=update, context=MagicMock())
+    assert msg_mock.call_count == 1
+    assert '*Mode:* `{}`'.format('Dry-run') in msg_mock.call_args_list[0][0][0]
+    assert '*Exchange:* `bittrex`' in msg_mock.call_args_list[0][0][0]
+    assert '*Strategy:* `DefaultStrategy`' in msg_mock.call_args_list[0][0][0]
+
+
 def test_send_msg_buy_notification(default_conf, mocker) -> None:
     msg_mock = MagicMock()
     mocker.patch.multiple(


### PR DESCRIPTION
## Summary
Add a "show config" command to RPC methods.

This allows inspection of some key-parameters on a running bot.
It's mainly helpful if while testing multiple strategies in parallel, and intends to quickly show some key strategy parameters (ROI / stoploss/ ticker_interval...).
Additional information (whitelist ...) can be gathered via the appropriate endpoints.

It intentionally does not publish the whole config dictionary, but only a selected subsection, to avoid leakage of sensitive information.

## Quick changelog

- add /show_config to telegram
- add /show_config to api-server

