### PR TITLE
Pairlists transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,9 @@ jobs:
         # Allow failure for coveralls
         # Fake travis environment to get coveralls working correctly
         export TRAVIS_PULL_REQUEST="https://github.com/${GITHUB_REPOSITORY}/pull/$(cat $GITHUB_EVENT_PATH | jq -r .number)"
-        export CI_BRANCH=${GITHUB_REF#"ref/heads"}
-        export CI_BRANCH=${HEAD_REF}
-        echo "${CI_BRANCH}"
+        export TRAVIS_BRANCH=${GITHUB_REF#"ref/heads"}
+        export TRAVIS_BRANCH=${HEAD_REF}
+        echo "${TRAVIS_BRANCH}"
         coveralls || true
 
     - name: Backtesting

--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -58,6 +58,13 @@ def process_temporary_deprecated_settings(config: Dict[str, Any]) -> None:
     process_deprecated_setting(config, 'ask_strategy', 'ignore_roi_if_buy_signal',
                                'experimental', 'ignore_roi_if_buy_signal')
 
+    if not config.get('pairlists') and not config.get('pairlists'):
+        config['pairlists'] = [{'method': 'StaticPairList'}]
+        logger.warning(
+            "DEPRECATED: "
+            "Pairlists must be defined explicitly in the future."
+            "Defaulting to StaticPairList for now.")
+
     if config.get('pairlist', {}).get("method") == 'VolumePairList':
         logger.warning(
             "DEPRECATED: "


### PR DESCRIPTION
## Summary
Followup to #2442 ... we should allow a "smooth" transition from "very old" configs (no explicit pairlist selection) to the new pairlists method.

So if neither pairlists - nor "pairlist" is configured, we add staticpairlist as default for now (this used to be the default in the past, too).


Also trying to fix coveralls (if it comments here, anyway).

closes #2567