### PR TITLE
Binance/Kraken default whitelists

### DIFF
--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -37,18 +37,21 @@
             "rateLimit": 200
         },
         "pair_whitelist": [
-            "AST/BTC",
-            "ETC/BTC",
-            "ETH/BTC",
+            "ALGO/BTC",
+            "ATOM/BTC",
+            "BAT/BTC",
+            "BCH/BTC",
+            "BRD/BTC",
             "EOS/BTC",
+            "ETH/BTC",
             "IOTA/BTC",
+            "LINK/BTC",
             "LTC/BTC",
-            "MTH/BTC",
-            "NCASH/BTC",
-            "TNT/BTC",
+            "NEO/BTC",
+            "NXS/BTC",
             "XMR/BTC",
-            "XLM/BTC",
-            "XRP/BTC"
+            "XRP/BTC",
+            "XTZ/BTC"
         ],
         "pair_blacklist": [
             "BNB/BTC"

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -38,9 +38,26 @@
             "rateLimit": 1000
         },
         "pair_whitelist": [
-            "ETH/EUR",
+            "ADA/EUR",
+            "ATOM/EUR",
+            "BAT/EUR",
+            "BCH/EUR",
             "BTC/EUR",
-            "BCH/EUR"
+            "DAI/EUR",
+            "DASH/EUR",
+            "EOS/EUR",
+            "ETC/EUR",
+            "ETH/EUR",
+            "LINK/EUR",
+            "LTC/EUR",
+            "QTUM/EUR",
+            "REP/EUR",
+            "WAVES/EUR",
+            "XLM/EUR",
+            "XMR/EUR",
+            "XRP/EUR",
+            "XTZ/EUR",
+            "ZEC/EUR"
         ],
         "pair_blacklist": [
 


### PR DESCRIPTION
## Summary
Update pairlists to exclude low-value pairs (NCASH - 1 pip (lowest tradable unit) = 7% change). 
Using these pairs is very dangerous as they don't allow setting stoplosses appropriately, and lead to mistakingly high wins in backtesting / hyperopt which can never be reached.

Solve the issue: #2601

## Quick changelog

- new default pairlist for binance
- new default pairlist for kraken

## Side note:

these pairlists have been generated using the volume-tester branch configuration (https://github.com/freqtrade/freqtrade/tree/volume_tester - which i'll do a PR on once i get time to finish it) and with the following configuration:

``` json
"pairlists": [
{
            "method": "VolumePairList",
            "number_assets": 20,
            "sort_key": "quoteVolume",
            "refresh_period": 1800
        },
        {"method": "PrecisionFilter"},
        {"method": "PriceFilter", "low_price_ratio": 0.001
        }
]
```

