### PR TITLE
Subcommand: test-pairlist

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -11,13 +11,14 @@ Now you have good Buy and Sell strategies and some historic data, you want to te
 real data. This is what we call
 [backtesting](https://en.wikipedia.org/wiki/Backtesting).
 
-Backtesting will use the crypto-currencies (pairs) from your config file
-and load ticker data from `user_data/data/<exchange>` by default.
-If no data is available for the exchange / pair / ticker interval combination, backtesting will
-ask you to download them first using `freqtrade download-data`.
+Backtesting will use the crypto-currencies (pairs) from your config file and load ticker data from `user_data/data/<exchange>` by default.
+If no data is available for the exchange / pair / ticker interval combination, backtesting will ask you to download them first using `freqtrade download-data`.
 For details on downloading, please refer to the [Data Downloading](data-download.md) section in the documentation.
 
 The result of backtesting will confirm if your bot has better odds of making a profit than a loss.
+
+!!! Tip "Using dynamic pairlists for backtesting"
+    While using dynamic pairlists during backtesting is not possible, a dynamic pairlist using current data can be generated via the [`test-pairlist`](utils.md#test-pairlist) command, and needs to be specified as `"pair_whitelist"` attribute in the configuration.
 
 ### Run a backtesting against the currencies listed in your config file
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -405,6 +405,9 @@ Inactive markets and blacklisted pairs are always removed from the resulting `pa
 * [`PrecisionFilter`](#precision-filter)
 * [`PriceFilter`](#price-pair-filter)
 
+!!! Tip "Testing pairlists"
+    Pairlist configurations can be quite tricky to get right. Best use the [`test-pairlist`](utils.md#test-pairlist) subcommand to test your configuration quickly.
+
 #### Static Pair List
 
 By default, the `StaticPairList` method is used, which uses a statically defined pair whitelist from the configuration. 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -234,3 +234,35 @@ $ freqtrade -c config_binance.json list-pairs --all --base BTC ETH --quote USDT 
 ```
 $ freqtrade list-markets --exchange kraken --all
 ```
+
+## Test pairlist
+
+Use the `test-pairlist` subcommand to test the configuration of [dynamic pairlists](configuration.md#pairlists).
+
+Requires a configuration with specified `pairlists` attribute.
+Can be used to generate static pairlists to be used during backtesting / hyperopt.
+
+### Examples
+
+Show whitelist when using a [dynamic pairlist](configuration.md#pairlists).
+
+```
+freqtrade test-pairlist --config config.json --quote USDT BTC
+```
+
+```
+usage: freqtrade test-pairlist [-h] [-c PATH]
+                               [--quote QUOTE_CURRENCY [QUOTE_CURRENCY ...]]
+                               [-1] [--print-json]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default: `config.json`).
+                        Multiple --config options may be used. Can be set to
+                        `-` to read config from stdin.
+  --quote QUOTE_CURRENCY [QUOTE_CURRENCY ...]
+                        Specify quote currency(-ies). Space-separated list.
+  -1, --one-column      Print output in one column.
+  --print-json          Print list of pairs or market symbols in JSON format.
+```

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -43,20 +43,6 @@ The file will be named inline with your class name, and will not overwrite exist
 
 Results will be located in `user_data/strategies/<strategyclassname>.py`.
 
-### Sample usage of new-strategy
-
-```bash
-freqtrade new-strategy --strategy AwesomeStrategy
-```
-
-With custom user directory
-
-```bash
-freqtrade new-strategy --userdir ~/.freqtrade/ --strategy AwesomeStrategy
-```
-
-### new-strategy complete options
-
 ``` output
 usage: freqtrade new-strategy [-h] [--userdir PATH] [-s NAME]
                               [--template {full,minimal}]
@@ -75,26 +61,24 @@ optional arguments:
 
 ```
 
+### Sample usage of new-strategy
+
+```bash
+freqtrade new-strategy --strategy AwesomeStrategy
+```
+
+With custom user directory
+
+```bash
+freqtrade new-strategy --userdir ~/.freqtrade/ --strategy AwesomeStrategy
+```
+
 ## Create new hyperopt
 
 Creates a new hyperopt from a template similar to SampleHyperopt.
 The file will be named inline with your class name, and will not overwrite existing files.
 
 Results will be located in `user_data/hyperopts/<classname>.py`.
-
-### Sample usage of new-hyperopt
-
-```bash
-freqtrade new-hyperopt --hyperopt AwesomeHyperopt
-```
-
-With custom user directory
-
-```bash
-freqtrade new-hyperopt --userdir ~/.freqtrade/ --hyperopt AwesomeHyperopt
-```
-
-### new-hyperopt complete options
 
 ``` output
 usage: freqtrade new-hyperopt [-h] [--userdir PATH] [--hyperopt NAME]
@@ -110,6 +94,18 @@ optional arguments:
                         Use a template which is either `minimal` or `full`
                         (containing multiple sample indicators). Default:
                         `full`.
+```
+
+### Sample usage of new-hyperopt
+
+```bash
+freqtrade new-hyperopt --hyperopt AwesomeHyperopt
+```
+
+With custom user directory
+
+```bash
+freqtrade new-hyperopt --userdir ~/.freqtrade/ --hyperopt AwesomeHyperopt
 ```
 
 ## List Exchanges
@@ -242,14 +238,6 @@ Use the `test-pairlist` subcommand to test the configuration of [dynamic pairlis
 Requires a configuration with specified `pairlists` attribute.
 Can be used to generate static pairlists to be used during backtesting / hyperopt.
 
-### Examples
-
-Show whitelist when using a [dynamic pairlist](configuration.md#pairlists).
-
-```
-freqtrade test-pairlist --config config.json --quote USDT BTC
-```
-
 ```
 usage: freqtrade test-pairlist [-h] [-c PATH]
                                [--quote QUOTE_CURRENCY [QUOTE_CURRENCY ...]]
@@ -265,4 +253,12 @@ optional arguments:
                         Specify quote currency(-ies). Space-separated list.
   -1, --one-column      Print output in one column.
   --print-json          Print list of pairs or market symbols in JSON format.
+```
+
+### Examples
+
+Show whitelist when using a [dynamic pairlist](configuration.md#pairlists).
+
+```
+freqtrade test-pairlist --config config.json --quote USDT BTC
 ```

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -37,6 +37,8 @@ ARGS_LIST_TIMEFRAMES = ["exchange", "print_one_column"]
 ARGS_LIST_PAIRS = ["exchange", "print_list", "list_pairs_print_json", "print_one_column",
                    "print_csv", "base_currencies", "quote_currencies", "list_pairs_all"]
 
+ARGS_TEST_PAIRLIST = ["config", "quote_currencies"]
+
 ARGS_CREATE_USERDIR = ["user_data_dir", "reset"]
 
 ARGS_BUILD_STRATEGY = ["user_data_dir", "strategy", "template"]
@@ -63,6 +65,7 @@ class Arguments:
     """
     Arguments Class. Manage the arguments received by the cli
     """
+
     def __init__(self, args: Optional[List[str]]) -> None:
         self.args = args
         self._parsed_arg: Optional[argparse.Namespace] = None
@@ -122,7 +125,7 @@ class Arguments:
         from freqtrade.utils import (start_create_userdir, start_download_data,
                                      start_list_exchanges, start_list_markets,
                                      start_new_hyperopt, start_new_strategy,
-                                     start_list_timeframes, start_trading)
+                                     start_list_timeframes, start_test_pairlist, start_trading)
         from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
 
         subparsers = self.parser.add_subparsers(dest='command',
@@ -210,6 +213,14 @@ class Arguments:
         )
         list_pairs_cmd.set_defaults(func=partial(start_list_markets, pairs_only=True))
         self._build_args(optionlist=ARGS_LIST_PAIRS, parser=list_pairs_cmd)
+
+        # Add test-pairlist subcommand
+        test_pairlist_cmd = subparsers.add_parser(
+            'test-pairlist',
+            help='Test your pairlist configuration.',
+        )
+        test_pairlist_cmd.set_defaults(func=start_test_pairlist)
+        self._build_args(optionlist=ARGS_TEST_PAIRLIST, parser=test_pairlist_cmd)
 
         # Add download-data subcommand
         download_data_cmd = subparsers.add_parser(

--- a/freqtrade/configuration/arguments.py
+++ b/freqtrade/configuration/arguments.py
@@ -37,7 +37,7 @@ ARGS_LIST_TIMEFRAMES = ["exchange", "print_one_column"]
 ARGS_LIST_PAIRS = ["exchange", "print_list", "list_pairs_print_json", "print_one_column",
                    "print_csv", "base_currencies", "quote_currencies", "list_pairs_all"]
 
-ARGS_TEST_PAIRLIST = ["config", "quote_currencies"]
+ARGS_TEST_PAIRLIST = ["config", "quote_currencies", "print_one_column", "list_pairs_print_json"]
 
 ARGS_CREATE_USERDIR = ["user_data_dir", "reset"]
 

--- a/freqtrade/pairlist/PrecisionFilter.py
+++ b/freqtrade/pairlist/PrecisionFilter.py
@@ -48,6 +48,7 @@ class PrecisionFilter(IPairList):
         """
         Filters and sorts pairlists and assigns and returns them again.
         """
+        stoploss = None
         if self._config.get('stoploss') is not None:
             # Precalculate sanitized stoploss value to avoid recalculation for every pair
             stoploss = 1 - abs(self._config.get('stoploss'))

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -322,3 +322,23 @@ def start_list_markets(args: Dict[str, Any], pairs_only: bool = False) -> None:
                   args.get('list_pairs_print_json', False) or
                   args.get('print_csv', False)):
             print(f"{summary_str}.")
+
+
+def start_test_pairlist(args: Dict[str, Any]) -> None:
+    """
+    Test Pairlists
+    """
+    from freqtrade.pairlist.pairlistmanager import PairListManager
+    config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE)
+
+    exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
+
+    quote_currencies = args.get('quote_currencies', [config.get('stake_currency')])
+
+    for curr in quote_currencies:
+        config['stake_currency'] = curr
+        # Do not use ticker_interval set in the config
+        pairlists = PairListManager(exchange, config)
+        pairlists.refresh_pairlist()
+        print(f"Pairs for {curr}: ")
+        print(pairlists.whitelist)

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -346,11 +346,8 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
 
     for curr, pairlist in results.items():
         print(f"Pairs for {curr}: ")
-        summary_str = ""
-        if args.get('print_list', False):
-            # print data as a list, with human-readable summary
-            print(f"{summary_str}: {', '.join(pairlist)}.")
-        elif args.get('print_one_column', False):
+
+        if args.get('print_one_column', False):
             print('\n'.join(pairlist))
         elif args.get('list_pairs_print_json', False):
             print(rapidjson.dumps(list(pairlist), default=str))

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -344,4 +344,13 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
 
     for curr, pairlist in results.items():
         print(f"Pairs for {curr}: ")
-        print(pairlist)
+        summary_str = ""
+        if args.get('print_list', False):
+            # print data as a list, with human-readable summary
+            print(f"{summary_str}: {', '.join(pairlist)}.")
+        elif args.get('print_one_column', False):
+            print('\n'.join(pairlist))
+        elif args.get('list_pairs_print_json', False):
+            print(rapidjson.dumps(list(pairlist), default=str))
+        else:
+            print(pairlist)

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -334,11 +334,14 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
     exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
 
     quote_currencies = args.get('quote_currencies', [config.get('stake_currency')])
-
+    results = {}
     for curr in quote_currencies:
         config['stake_currency'] = curr
         # Do not use ticker_interval set in the config
         pairlists = PairListManager(exchange, config)
         pairlists.refresh_pairlist()
+        results[curr] = pairlists.whitelist
+
+    for curr, pairlist in results.items():
         print(f"Pairs for {curr}: ")
-        print(pairlists.whitelist)
+        print(pairlist)

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -333,7 +333,9 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
 
     exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
 
-    quote_currencies = args.get('quote_currencies', [config.get('stake_currency')])
+    quote_currencies = args.get('quote_currencies')
+    if not quote_currencies:
+        quote_currencies = [config.get('stake_currency')]
     results = {}
     for curr in quote_currencies:
         config['stake_currency'] = curr

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -345,7 +345,8 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
         results[curr] = pairlists.whitelist
 
     for curr, pairlist in results.items():
-        print(f"Pairs for {curr}: ")
+        if not args.get('print_one_column', False):
+            print(f"Pairs for {curr}: ")
 
         if args.get('print_one_column', False):
             print('\n'.join(pairlist))

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -326,7 +326,7 @@ def start_list_markets(args: Dict[str, Any], pairs_only: bool = False) -> None:
 
 def start_test_pairlist(args: Dict[str, Any]) -> None:
     """
-    Test Pairlists
+    Test Pairlist configuration
     """
     from freqtrade.pairlist.pairlistmanager import PairListManager
     config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE)


### PR DESCRIPTION
## Summary
Configuring pairlists can be quite complex, and different sequences of configurations can generate different results. 
To test these quickly, a new subcommand, `freqtrade test-pairlist` will be introduced.

This will also solve #935 (althought through a manual step) to use a dynamically generated pairlist for backtesting. For that, simply use `freqtrade test-pairlist` and insert the output as pair_whitelist into the configuration.

Closes #935

## Quick changelog

- new subcommand
- Document usage of this command

