### PR TITLE
Don't return None from load_pair_history

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -146,7 +146,7 @@ def load_pair_history(pair: str,
     :param fill_up_missing: Fill missing values with "No action"-candles
     :param drop_incomplete: Drop last candle assuming it may be incomplete.
     :param startup_candles: Additional candles to load at the start of the period
-    :return: DataFrame with ohlcv data
+    :return: DataFrame with ohlcv data, or empty DataFrame
     """
 
     timerange_startup = deepcopy(timerange)
@@ -174,7 +174,7 @@ def load_pair_history(pair: str,
             f'No history data for pair: "{pair}", timeframe: {timeframe}. '
             'Use `freqtrade download-data` to download the data'
         )
-        return None
+        return DataFrame()
 
 
 def load_data(datadir: Path,
@@ -216,7 +216,7 @@ def load_data(datadir: Path,
                                  exchange=exchange,
                                  fill_up_missing=fill_up_missing,
                                  startup_candles=startup_candles)
-        if hist is not None:
+        if not hist.empty:
             result[pair] = hist
 
     if fail_without_data and not result:

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -74,8 +74,8 @@ def test_load_data_30min_ticker(mocker, caplog, default_conf, testdatadir) -> No
 
 def test_load_data_7min_ticker(mocker, caplog, default_conf, testdatadir) -> None:
     ld = history.load_pair_history(pair='UNITTEST/BTC', timeframe='7m', datadir=testdatadir)
-    assert not isinstance(ld, DataFrame)
-    assert ld is None
+    assert isinstance(ld, DataFrame)
+    assert ld.empty
     assert log_has(
         'No history data for pair: "UNITTEST/BTC", timeframe: 7m. '
         'Use `freqtrade download-data` to download the data', caplog

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -494,7 +494,7 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog, testdatadir) ->
     def get_timeframe(input1):
         return Arrow(2017, 11, 14, 21, 17), Arrow(2017, 11, 14, 22, 59)
 
-    mocker.patch('freqtrade.data.history.load_pair_history', MagicMock(return_value=None))
+    mocker.patch('freqtrade.data.history.load_pair_history', MagicMock(return_value=pd.DataFrame()))
     mocker.patch('freqtrade.data.history.get_timeframe', get_timeframe)
     mocker.patch('freqtrade.exchange.Exchange.refresh_latest_ohlcv', MagicMock())
     patch_exchange(mocker)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -249,7 +249,7 @@ def test_start(mocker, default_conf, caplog) -> None:
 
 def test_start_no_data(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
-    mocker.patch('freqtrade.data.history.load_pair_history', MagicMock(return_value=None))
+    mocker.patch('freqtrade.data.history.load_pair_history', MagicMock(return_value=pd.DataFrame))
     mocker.patch(
         'freqtrade.optimize.hyperopt.get_timeframe',
         MagicMock(return_value=(datetime(2017, 12, 10), datetime(2017, 12, 13)))


### PR DESCRIPTION

## Summary
`load_pair_history()` should have predictable return values, so returning an empty DataFrame does make more sense than None (it also makes checking easier, as `len(data)` can be applied without type-error risks.

closes #2609

## Quick changelog

- Return empty dataframe if no data is found.
