### PR TITLE
Fix hyperopt with ticker_interval from strategy

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -54,9 +54,9 @@ class Hyperopt:
     def __init__(self, config: Dict[str, Any]) -> None:
         self.config = config
 
-        self.custom_hyperopt = HyperOptResolver(self.config).hyperopt
-
         self.backtesting = Backtesting(self.config)
+
+        self.custom_hyperopt = HyperOptResolver(self.config).hyperopt
 
         self.custom_hyperoptloss = HyperOptLossResolver(self.config).hyperoptloss
         self.calculate_loss = self.custom_hyperoptloss.hyperopt_loss_function

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -435,7 +435,8 @@ def test_start_calls_optimizer(mocker, default_conf, caplog, capsys) -> None:
                                  'params': {'buy': {}, 'sell': {}, 'roi': {}, 'stoploss': 0.0}}])
     )
     patch_exchange(mocker)
-
+    # Co-test loading ticker-interval from strategy
+    del default_conf['ticker_interval']
     default_conf.update({'config': 'config.json.example',
                          'hyperopt': 'DefaultHyperOpt',
                          'epochs': 1,


### PR DESCRIPTION
## Summary
We support loading ticker_interval from the strategy - so i have it in almost none of my configurations.
However it fails with hyperopt - since the strategy is loaded after the hyperopt file.
By simply reversing the order of initialization between the custom hyperopt file and backtesting, we can support this again.

## Quick changelog
- fix bug
- add test ensuring we're not reintroducing this