### PR TITLE
handle and document ROI=-1

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -194,7 +194,10 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Buys happen at open-price
 - Sell signal sells happen at open-price of the following candle
 - Low happens before high for stoploss, protecting capital first.
-- ROI sells are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the sell will be at 2%)
+- ROI
+  - sells are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the sell will be at 2%)
+  - sells are never "below the candle", so a ROI of 2% may result in a sell at 2.4% if low was at 2.4% profit
+  - Forcesells caused by `<N>=-1` ROI entries use low as sell value, unless N falls on the candle open (e.g. `120: -1` for 1h candles)
 - Stoploss sells happen exactly at stoploss price, even if low was lower
 - Trailing stoploss
   - High happens first - adjusting stoploss

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,9 @@ This parameter can be set in either Strategy or Configuration file. If you use i
 `minimal_roi` value from the strategy file.
 If it is not set in either Strategy or Configuration, a default of 1000% `{"0": 10}` is used, and minimal roi is disabled unless your trade generates 1000% profit.
 
+!!! Note "Special case to forcesell after a specific time"
+    A special case presents using `"<N>": -1` as ROI. This forces the bot to sell a trade after N Minutes, no matter if it's positive or negative, so represents a time-limited force-sell.
+
 ### Understand stoploss
 
 Go to the [stoploss documentation](stoploss.md) for more details.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -394,7 +394,7 @@ class IStrategy(ABC):
 
         return SellCheckTuple(sell_flag=False, sell_type=SellType.NONE)
 
-    def min_roi_reached_entry(self, trade_dur: int) -> Optional[float]:
+    def min_roi_reached_entry(self, trade_dur: int) -> Tuple[Optional[int], Optional[float]]:
         """
         Based on trade duration defines the ROI entry that may have been reached.
         :param trade_dur: trade duration in minutes
@@ -403,9 +403,9 @@ class IStrategy(ABC):
         # Get highest entry in ROI dict where key <= trade-duration
         roi_list = list(filter(lambda x: x <= trade_dur, self.minimal_roi.keys()))
         if not roi_list:
-            return None
+            return None, None
         roi_entry = max(roi_list)
-        return self.minimal_roi[roi_entry]
+        return roi_entry, self.minimal_roi[roi_entry]
 
     def min_roi_reached(self, trade: Trade, current_profit: float, current_time: datetime) -> bool:
         """
@@ -415,7 +415,7 @@ class IStrategy(ABC):
         """
         # Check if time matches and current rate is above threshold
         trade_dur = int((current_time.timestamp() - trade.open_date.timestamp()) // 60)
-        roi = self.min_roi_reached_entry(trade_dur)
+        _, roi = self.min_roi_reached_entry(trade_dur)
         if roi is None:
             return False
         else:

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -265,6 +265,22 @@ tc16 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
+# Test 17: Buy, hold for 120 mins, then forcesell using roi=-1
+# Causes negative profit even though sell-reason is ROI.
+# stop-loss: 10%, ROI: 10% (should not apply), -100% after 100 minutes (limits trade duration)
+# Uses open as sell-rate (special case) - since the roi-time is a multiple of the ticker interval.
+tc17 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],
+    [2, 4987, 5300, 4950, 5050, 6172, 0, 0],
+    [3, 4980, 5000, 4940, 4962, 6172, 0, 0],  # ForceSell on ROI (roi=-1)
+    [4, 4962, 4987, 4972, 4950, 6172, 0, 0],
+    [5, 4950, 4975, 4925, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10, "120": -1}, profit_perc=-0.004,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
 TESTS = [
     tc0,
     tc1,
@@ -283,6 +299,7 @@ TESTS = [
     tc14,
     tc15,
     tc16,
+    tc17,
 ]
 
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -281,6 +281,53 @@ tc17 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
+
+# Test 18: Buy, hold for 120 mins, then drop ROI to 1%, causing a sell in candle 3.
+# stop-loss: 10%, ROI: 10% (should not apply), -100% after 100 minutes (limits trade duration)
+# uses open_rate as sell-price
+tc18 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],
+    [2, 4987, 5300, 4950, 5200, 6172, 0, 0],
+    [3, 5200, 5220, 4940, 4962, 6172, 0, 0],  # Sell on ROI (sells on open)
+    [4, 4962, 4987, 4972, 4950, 6172, 0, 0],
+    [5, 4950, 4975, 4925, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10, "120": 0.01}, profit_perc=0.04,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
+# Test 19: Buy, hold for 119 mins, then drop ROI to 1%, causing a sell in candle 3.
+# stop-loss: 10%, ROI: 10% (should not apply), -100% after 100 minutes (limits trade duration)
+# uses calculated ROI (1%) as sell rate, otherwise identical to tc18
+tc19 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],
+    [2, 4987, 5300, 4950, 5200, 6172, 0, 0],
+    [3, 5000, 5300, 4940, 4962, 6172, 0, 0],  # Sell on ROI
+    [4, 4962, 4987, 4972, 4950, 6172, 0, 0],
+    [5, 4550, 4975, 4925, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10, "120": 0.01}, profit_perc=0.01,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
+# Test 20: Buy, hold for 119 mins, then drop ROI to 1%, causing a sell in candle 3.
+# stop-loss: 10%, ROI: 10% (should not apply), -100% after 100 minutes (limits trade duration)
+# uses calculated ROI (1%) as sell rate, otherwise identical to tc18
+tc20 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],
+    [2, 4987, 5300, 4950, 5200, 6172, 0, 0],
+    [3, 5200, 5300, 4940, 4962, 6172, 0, 0],  # Sell on ROI
+    [4, 4962, 4987, 4972, 4950, 6172, 0, 0],
+    [5, 4550, 4975, 4925, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10, "119": 0.01}, profit_perc=0.01,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
+
 TESTS = [
     tc0,
     tc1,
@@ -300,6 +347,9 @@ TESTS = [
     tc15,
     tc16,
     tc17,
+    tc18,
+    tc19,
+    tc20,
 ]
 
 


### PR DESCRIPTION
## Summary
This adds speific handling for ROI=-1 (using close when the roi-entry falls on a candle open and ROI = -1.
We should document ROI=-1.


Closes #2277 
## Quick changelog

- document usage of ROI=-1 as forcesell method
- Refactor `_get_close_rate()` out of `_get_sell_trade_entry()`
- use open if the forcesell entry is a candle open, else low (as before).
