### PR TITLE
Validate stake-currency against pairlist

### DIFF
--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -131,3 +131,10 @@ def _validate_whitelist(conf: Dict[str, Any]) -> None:
         if (pl.get('method') == 'StaticPairList'
                 and not conf.get('exchange', {}).get('pair_whitelist')):
             raise OperationalException("StaticPairList requires pair_whitelist to be set.")
+
+        if pl.get('method') == 'StaticPairList':
+            stake = conf['stake_currency']
+            pairlist = conf['exchange'].get('pair_whitelist')
+            if not all([p.endswith(f'/{stake}') for p in pairlist]):
+                raise OperationalException(
+                    f"Stake-currency {stake} not compatible with pair-whitelist.")

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -134,7 +134,12 @@ def _validate_whitelist(conf: Dict[str, Any]) -> None:
 
         if pl.get('method') == 'StaticPairList':
             stake = conf['stake_currency']
-            pairlist = conf['exchange'].get('pair_whitelist')
-            if not all([p.endswith(f'/{stake}') for p in pairlist]):
+            invalid_pairs = []
+            for pair in conf['exchange'].get('pair_whitelist'):
+                if not pair.endswith(f'/{stake}'):
+                    invalid_pairs.append(pair)
+
+            if invalid_pairs:
                 raise OperationalException(
-                    f"Stake-currency {stake} not compatible with pair-whitelist.")
+                    f"Stake-currency '{stake}' not compatible with pair-whitelist. "
+                    f"Please remove the following pairs: {invalid_pairs}")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -801,7 +801,7 @@ def test_validate_whitelist(default_conf):
     conf = deepcopy(default_conf)
     conf['stake_currency'] = 'USDT'
     with pytest.raises(OperationalException,
-                       match="Stake-currency USDT not compatible with pair-whitelist."):
+                       match=r"Stake-currency 'USDT' not compatible with pair-whitelist.*"):
         validate_config_consistency(conf)
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -798,6 +798,12 @@ def test_validate_whitelist(default_conf):
 
     validate_config_consistency(conf)
 
+    conf = deepcopy(default_conf)
+    conf['stake_currency'] = 'USDT'
+    with pytest.raises(OperationalException,
+                       match="Stake-currency USDT not compatible with pair-whitelist."):
+        validate_config_consistency(conf)
+
 
 def test_load_config_test_comments() -> None:
     """


### PR DESCRIPTION
## Summary
We should verify that only correct pairs are in the whitelist.
Otherwise backtesting may have irritating results (#2622) - and it'll result in the static-pairlist outputting "removing pair from whtitelist" once per iteration for all incompatible pairs.

Closes #2622

## Quick changelog

- Check that pairlist only contains pairs with correct stake-currency
