### PR TITLE
Docker: Build latest along with develop image

### DIFF
--- a/build_helpers/publish_docker.sh
+++ b/build_helpers/publish_docker.sh
@@ -38,7 +38,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Tag as latest for develop builds
-if [ "${GITHUB_REF}" = "develop" ]; then
+if [ "${TAG}" = "develop" ]; then
     docker tag freqtrade:$TAG ${IMAGE_NAME}:latest
 fi
 


### PR DESCRIPTION
## Summary
DOcker image latest has not been pushed anymore.

[dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/tags).

We used to push latest along with develop, and we should continue to do that.

(100% correct functioning can only be tested once it's merged, since we only run deploy then) - but i'm confident that it works, since the develop-tag is pushed correctly.