### PR TITLE
Round amount to precision also for dry-runs

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -379,15 +379,16 @@ class Exchange:
     def dry_run_order(self, pair: str, ordertype: str, side: str, amount: float,
                       rate: float, params: Dict = {}) -> Dict[str, Any]:
         order_id = f'dry_run_{side}_{randint(0, 10**6)}'
+        _amount = self.symbol_amount_prec(pair, amount)
         dry_order = {
             "id": order_id,
             'pair': pair,
             'price': rate,
-            'amount': amount,
-            "cost": amount * rate,
+            'amount': _amount,
+            "cost": _amount * rate,
             'type': ordertype,
             'side': side,
-            'remaining': amount,
+            'remaining': _amount,
             'datetime': arrow.utcnow().isoformat(),
             'status': "closed" if ordertype == "market" else "open",
             'fee': None,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -786,7 +786,10 @@ def test_process_trade_no_whitelist_pair(default_conf, ticker, limit_buy_order,
     )
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
-    pair = 'NOCLUE/BTC'
+    pair = 'BLK/BTC'
+    # Ensure the pair is not in the whitelist!
+    assert pair not in default_conf['exchange']['pair_whitelist']
+
     # create open trade not in whitelist
     Trade.session.add(Trade(
         pair=pair,


### PR DESCRIPTION
## Summary
Round amount to precision also for dry-runs - so it's more realistic.

otherwise we can have amounts with 100ds of decimals - since amount-rounding happens within create_trade - which is never reached in dry-mode.

## Quick changelog

- apply Amount to precision for dry-run trades.