### PR TITLE
improve show config when using trailing stop 

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -587,12 +587,23 @@ class Telegram(RPC):
         :return: None
         """
         val = self._rpc_show_config()
+        if val['trailing_stop']:
+            sl_info = (
+                f"*Initial Stoploss:* `{val['stoploss']}`\n"
+                f"*Trailing stop positive:* `{val['trailing_stop_positive']}`\n"
+                f"*Trailing stop offset:* `{val['trailing_stop_positive_offset']}`\n"
+                f"*Only trail above offset:* `{val['trailing_only_offset_is_reached']}`\n"
+            )
+
+        else:
+            sl_info = f"*Stoploss:* `{val['stoploss']}`\n"
+
         self._send_msg(
             f"*Mode:* `{'Dry-run' if val['dry_run'] else 'Live'}`\n"
             f"*Exchange:* `{val['exchange']}`\n"
             f"*Stake per trade:* `{val['stake_amount']} {val['stake_currency']}`\n"
             f"*Minimum ROI:* `{val['minimal_roi']}`\n"
-            f"*{'Trailing ' if val['trailing_stop'] else ''}Stoploss:* `{val['stoploss']}`\n"
+            f"{sl_info}"
             f"*Ticker Interval:* `{val['ticker_interval']}`\n"
             f"*Strategy:* `{val['strategy']}`'"
         )

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1177,6 +1177,16 @@ def test_show_config_handle(default_conf, update, mocker) -> None:
     assert '*Mode:* `{}`'.format('Dry-run') in msg_mock.call_args_list[0][0][0]
     assert '*Exchange:* `bittrex`' in msg_mock.call_args_list[0][0][0]
     assert '*Strategy:* `DefaultStrategy`' in msg_mock.call_args_list[0][0][0]
+    assert '*Stoploss:* `-0.1`' in msg_mock.call_args_list[0][0][0]
+
+    msg_mock.reset_mock()
+    freqtradebot.config['trailing_stop'] = True
+    telegram._show_config(update=update, context=MagicMock())
+    assert msg_mock.call_count == 1
+    assert '*Mode:* `{}`'.format('Dry-run') in msg_mock.call_args_list[0][0][0]
+    assert '*Exchange:* `bittrex`' in msg_mock.call_args_list[0][0][0]
+    assert '*Strategy:* `DefaultStrategy`' in msg_mock.call_args_list[0][0][0]
+    assert '*Initial Stoploss:* `-0.1`' in msg_mock.call_args_list[0][0][0]
 
 
 def test_send_msg_buy_notification(default_conf, mocker) -> None:


### PR DESCRIPTION
## Summary
Improve output of /show_config when trailing_stop is on.

We should not just show the stoploss, but also the parameters of the trailing stoploss.
