### PR TITLE
Use first pair of pairlist to get fee

### DIFF
--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -80,7 +80,7 @@ class Edge:
         if config.get('fee'):
             self.fee = config['fee']
         else:
-            self.fee = self.exchange.get_fee()
+            self.fee = self.exchange.get_fee(symbol=self.config['exchange']['pair_whitelist'][0])
 
     def calculate(self) -> bool:
         pairs = self.config['exchange']['pair_whitelist']

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -921,7 +921,7 @@ class Exchange:
             raise OperationalException(e) from e
 
     @retrier
-    def get_fee(self, symbol='ETH/BTC', type='', side='', amount=1,
+    def get_fee(self, symbol, type='', side='', amount=1,
                 price=1, taker_or_maker='maker') -> float:
         try:
             # validate that markets are loaded before trying to get fee

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -65,7 +65,7 @@ class Backtesting:
         if config.get('fee'):
             self.fee = config['fee']
         else:
-            self.fee = self.exchange.get_fee()
+            self.fee = self.exchange.get_fee(symbol=self.config['exchange']['pair_whitelist'][0])
 
         if self.config.get('runmode') != RunMode.HYPEROPT:
             self.dataprovider = DataProvider(self.config, self.exchange)

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -334,7 +334,7 @@ def test_process_expectancy(mocker, edge_conf):
     edge_conf['edge']['min_trade_number'] = 2
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
 
-    def get_fee():
+    def get_fee(*args, **kwargs):
         return 0.001
 
     freqtrade.exchange.get_fee = get_fee

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1646,10 +1646,10 @@ def test_get_fee(default_conf, mocker, exchange_name):
     })
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
-    assert exchange.get_fee() == 0.025
+    assert exchange.get_fee('ETH/BTC') == 0.025
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
-                           'get_fee', 'calculate_fee')
+                           'get_fee', 'calculate_fee', symbol="ETH/BTC")
 
 
 def test_stoploss_limit_order_unsupported_exchange(default_conf, mocker):


### PR DESCRIPTION
## Summary
get_fee for backtesting and edge should not use ETH/BTC, but the first pair in the pairlist instead.

closes #2653
## Quick changelog

- Send first pair from pairlist as symbol to `get_fee()`