### PR TITLE
[minor] Fix typo causing a trailing "tic" in /show_config output

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -605,7 +605,7 @@ class Telegram(RPC):
             f"*Minimum ROI:* `{val['minimal_roi']}`\n"
             f"{sl_info}"
             f"*Ticker Interval:* `{val['ticker_interval']}`\n"
-            f"*Strategy:* `{val['strategy']}`'"
+            f"*Strategy:* `{val['strategy']}`"
         )
 
     def _send_msg(self, msg: str, parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:


### PR DESCRIPTION
## Summary
The output currently contains a trailing tick (') after the strategy. ...

Erroneous output:

![2019-12-14-195533_466x250_scrot](https://user-images.githubusercontent.com/5024695/70853252-ba2d6700-1eab-11ea-80c2-f924e5cfc6e6.png)
