### PR TITLE
Add documentation about ohlcv_partial_candle

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -183,17 +183,19 @@ raw = ct.fetch_ohlcv(pair, timeframe=timeframe)
 # convert to dataframe
 df1 = parse_ticker_dataframe(raw, timeframe, pair=pair, drop_incomplete=False)
 
-print(df1["date"].tail(1))
+print(df1.tail(1))
 print(datetime.utcnow())
 ```
 
 ``` output
-19   2019-06-08 00:00:00+00:00
+                         date      open      high       low     close  volume  
+499 2019-06-08 00:00:00+00:00  0.000007  0.000007  0.000007  0.000007   26264344.0  
 2019-06-09 12:30:27.873327
 ```
 
 The output will show the last entry from the Exchange as well as the current UTC date.
 If the day shows the same day, then the last candle can be assumed as incomplete and should be dropped (leave the setting `"ohlcv_partial_candle"` from the exchange-class untouched / True). Otherwise, set `"ohlcv_partial_candle"` to `False` to not drop Candles (shown in the example above).
+Another way is to run this command multiple times in a row and observe if the volume is changing (while the date remains the same).
 
 ## Updating example notebooks
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -61,3 +61,24 @@ print(res)
 ```shell
 $ pip3 install web3
 ```
+
+### Send incomplete candles to the strategy
+
+Most exchanges return incomplete candles via their ohlcv / klines interface.
+By default, Freqtrade assumes that incomplete candles are returned and removes the last candle assuming it's an incomplete candle.
+
+Wether your exchange returns incomplete candles or not can be checked using [the helper script](developer.md#Incomplete-candles) from the Contributor documentation.
+
+If the exchange does return incomplete candles and you would like to have incomplete candles in your strategy, you can set the following parameter in the configuration file.
+
+``` json
+{
+
+    "exchange": {
+        "_ft_has_params": {"ohlcv_partial_candle": false}
+    }
+}
+```
+
+!!! Warning "Danger of repainting"
+    Changing this parameter makes the strategy responsible to avoid repainting and handle this accordingly. Doing this is therefore not recommended, and should only be performed by experienced users who are fully aware of the impact this setting has.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -67,7 +67,7 @@ $ pip3 install web3
 Most exchanges return incomplete candles via their ohlcv / klines interface.
 By default, Freqtrade assumes that incomplete candles are returned and removes the last candle assuming it's an incomplete candle.
 
-Wether your exchange returns incomplete candles or not can be checked using [the helper script](developer.md#Incomplete-candles) from the Contributor documentation.
+Whether your exchange returns incomplete candles or not can be checked using [the helper script](developer.md#Incomplete-candles) from the Contributor documentation.
 
 If the exchange does return incomplete candles and you would like to have incomplete candles in your strategy, you can set the following parameter in the configuration file.
 


### PR DESCRIPTION
## Summary
Document how to get incomplete candles within a strategy (and warn about the dangers of these).

Closes #2202

## Quick changelog

- Add docs about `ohlcv_partial_candle`
- improve documentation how to discover incomplete candles from a exchange return value.