### PR TITLE
Pre-calculate open_trade_price

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -108,7 +108,7 @@ def load_trades_from_db(db_url: str) -> pd.DataFrame:
     trades = pd.DataFrame([(t.pair,
                             t.open_date.replace(tzinfo=timezone.utc),
                             t.close_date.replace(tzinfo=timezone.utc) if t.close_date else None,
-                            t.calc_profit(), t.calc_profit_percent(),
+                            t.calc_profit(), t.calc_profit_ratio(),
                             t.open_rate, t.close_rate, t.amount,
                             (round((t.close_date.timestamp() - t.open_date.timestamp()) / 60, 2)
                                 if t.close_date else None),

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -555,6 +555,7 @@ class FreqtradeBot:
                     order['amount'] = new_amount
                     # Fee was applied, so set to 0
                     trade.fee_open = 0
+                    trade.recalc_open_trade_price()
 
             except DependencyException as exception:
                 logger.warning("Could not update trade amount: %s", exception)
@@ -850,6 +851,7 @@ class FreqtradeBot:
                 trade.amount = new_amount
                 # Fee was applied, so set to 0
                 trade.fee_open = 0
+                trade.recalc_open_trade_price()
         except DependencyException as e:
             logger.warning("Could not update trade amount: %s", e)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -950,7 +950,7 @@ class FreqtradeBot:
         profit_trade = trade.calc_profit(rate=profit_rate)
         # Use cached ticker here - it was updated seconds ago.
         current_rate = self.get_sell_rate(trade.pair, False)
-        profit_percent = trade.calc_profit_percent(profit_rate)
+        profit_percent = trade.calc_profit_ratio(profit_rate)
         gain = "profit" if profit_percent > 0 else "loss"
 
         msg = {

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -329,7 +329,7 @@ class Backtesting:
                 closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
 
                 return BacktestResult(pair=pair,
-                                      profit_percent=trade.calc_profit_percent(rate=closerate),
+                                      profit_percent=trade.calc_profit_ratio(rate=closerate),
                                       profit_abs=trade.calc_profit(rate=closerate),
                                       open_time=buy_row.date,
                                       close_time=sell_row.date,
@@ -345,7 +345,7 @@ class Backtesting:
             # no sell condition found - trade stil open at end of backtest period
             sell_row = partial_ticker[-1]
             bt_res = BacktestResult(pair=pair,
-                                    profit_percent=trade.calc_profit_percent(rate=sell_row.open),
+                                    profit_percent=trade.calc_profit_ratio(rate=sell_row.open),
                                     profit_abs=trade.calc_profit(rate=sell_row.open),
                                     open_time=buy_row.date,
                                     close_time=sell_row.date,

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -354,7 +354,7 @@ class Trade(_DECL_BASE):
         Recalculate open_trade_price.
         Must be called whenever open_rate or fee_open is changed.
         """
-        self.open_trade_price - self._calc_open_trade_price()
+        self.open_trade_price = self._calc_open_trade_price()
 
     def calc_close_trade_price(self, rate: Optional[float] = None,
                                fee: Optional[float] = None) -> float:

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -342,9 +342,7 @@ class Trade(_DECL_BASE):
 
     def _calc_open_trade_price(self) -> float:
         """
-        Calculate the open_rate including fee.
-        :param fee: fee to use on the open rate (optional).
-        If rate is not set self.fee will be used
+        Calculate the open_rate including open_fee.
         :return: Price in of the open trade incl. Fees
         """
         buy_trade = (Decimal(self.amount) * Decimal(self.open_rate))

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -346,7 +346,7 @@ class Trade(_DECL_BASE):
         Calculate the open_rate including open_fee.
         :return: Price in of the open trade incl. Fees
         """
-        buy_trade = (Decimal(self.amount) * Decimal(self.open_rate))
+        buy_trade = Decimal(self.amount) * Decimal(self.open_rate)
         fees = buy_trade * Decimal(self.fee_open)
         return float(buy_trade + fees)
 
@@ -370,7 +370,7 @@ class Trade(_DECL_BASE):
         if rate is None and not self.close_rate:
             return 0.0
 
-        sell_trade = (Decimal(self.amount) * Decimal(rate or self.close_rate))
+        sell_trade = Decimal(self.amount) * Decimal(rate or self.close_rate)
         fees = sell_trade * Decimal(fee or self.fee_close)
         return float(sell_trade - fees)
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -185,6 +185,7 @@ class Trade(_DECL_BASE):
     fee_close = Column(Float, nullable=False, default=0.0)
     open_rate = Column(Float)
     open_rate_requested = Column(Float)
+    # open_trade_price - calcuated via _calc_open_trade_price
     open_trade_price = Column(Float)
     close_rate = Column(Float)
     close_rate_requested = Column(Float)
@@ -331,7 +332,7 @@ class Trade(_DECL_BASE):
         and marks trade as closed
         """
         self.close_rate = Decimal(rate)
-        self.close_profit = self.calc_profit_percent()
+        self.close_profit = self.calc_profit_ratio()
         self.close_date = datetime.utcnow()
         self.is_open = False
         self.open_order_id = None
@@ -361,9 +362,9 @@ class Trade(_DECL_BASE):
         """
         Calculate the close_rate including fee
         :param fee: fee to use on the close rate (optional).
-        If rate is not set self.fee will be used
+            If rate is not set self.fee will be used
         :param rate: rate to compare with (optional).
-        If rate is not set self.close_rate will be used
+            If rate is not set self.close_rate will be used
         :return: Price in BTC of the open trade
         """
         if rate is None and not self.close_rate:
@@ -378,9 +379,9 @@ class Trade(_DECL_BASE):
         """
         Calculate the absolute profit in stake currency between Close and Open trade
         :param fee: fee to use on the close rate (optional).
-        If rate is not set self.fee will be used
+            If rate is not set self.fee will be used
         :param rate: close rate to compare with (optional).
-        If rate is not set self.close_rate will be used
+            If rate is not set self.close_rate will be used
         :return:  profit in stake currency as float
         """
         close_trade_price = self.calc_close_trade_price(
@@ -390,14 +391,14 @@ class Trade(_DECL_BASE):
         profit = close_trade_price - self.open_trade_price
         return float(f"{profit:.8f}")
 
-    def calc_profit_percent(self, rate: Optional[float] = None,
-                            fee: Optional[float] = None) -> float:
+    def calc_profit_ratio(self, rate: Optional[float] = None,
+                          fee: Optional[float] = None) -> float:
         """
-        Calculates the profit in percentage (including fee).
+        Calculates the profit as ratio (including fee).
         :param rate: rate to compare with (optional).
-        If rate is not set self.close_rate will be used
+            If rate is not set self.close_rate will be used
         :param fee: fee to use on the close rate (optional).
-        :return: profit in percentage as float
+        :return: profit ratio as float
         """
         close_trade_price = self.calc_close_trade_price(
             rate=(rate or self.close_rate),

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -123,7 +123,7 @@ class RPC:
                     current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
-                current_profit = trade.calc_profit_percent(current_rate)
+                current_profit = trade.calc_profit_ratio(current_rate)
                 fmt_close_profit = (f'{round(trade.close_profit * 100, 2):.2f}%'
                                     if trade.close_profit else None)
                 trade_dict = trade.to_json()
@@ -151,7 +151,7 @@ class RPC:
                     current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
-                trade_perc = (100 * trade.calc_profit_percent(current_rate))
+                trade_perc = (100 * trade.calc_profit_ratio(current_rate))
                 trade_profit = trade.calc_profit(current_rate)
                 profit_str = f'{trade_perc:.2f}%'
                 if self._fiat_converter:
@@ -240,7 +240,7 @@ class RPC:
                 durations.append((trade.close_date - trade.open_date).total_seconds())
 
             if not trade.is_open:
-                profit_percent = trade.calc_profit_percent()
+                profit_percent = trade.calc_profit_ratio()
                 profit_closed_coin.append(trade.calc_profit())
                 profit_closed_perc.append(profit_percent)
             else:
@@ -249,7 +249,7 @@ class RPC:
                     current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
                 except DependencyException:
                     current_rate = NAN
-                profit_percent = trade.calc_profit_percent(rate=current_rate)
+                profit_percent = trade.calc_profit_ratio(rate=current_rate)
 
             profit_all_coin.append(
                 trade.calc_profit(rate=trade.close_rate or current_rate)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -296,7 +296,7 @@ class IStrategy(ABC):
         """
         # Set current rate to low for backtesting sell
         current_rate = low or rate
-        current_profit = trade.calc_profit_percent(current_rate)
+        current_profit = trade.calc_profit_ratio(current_rate)
 
         trade.adjust_min_max_rates(high or current_rate)
 
@@ -311,7 +311,7 @@ class IStrategy(ABC):
 
         # Set current rate to high for backtesting sell
         current_rate = high or rate
-        current_profit = trade.calc_profit_percent(current_rate)
+        current_profit = trade.calc_profit_ratio(current_rate)
         config_ask_strategy = self.config.get('ask_strategy', {})
 
         if buy and config_ask_strategy.get('ignore_roi_if_buy_signal', False):
@@ -360,7 +360,7 @@ class IStrategy(ABC):
             sl_offset = self.trailing_stop_positive_offset
 
             # Make sure current_profit is calculated using high for backtesting.
-            high_profit = current_profit if not high else trade.calc_profit_percent(high)
+            high_profit = current_profit if not high else trade.calc_profit_ratio(high)
 
             # Don't update stoploss if trailing_only_offset_is_reached is true.
             if not (self.trailing_only_offset_is_reached and high_profit < sl_offset):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -381,7 +381,7 @@ def test_api_performance(botclient, mocker, ticker, fee):
         close_rate=0.265441,
 
     )
-    trade.close_profit = trade.calc_profit_percent()
+    trade.close_profit = trade.calc_profit_ratio()
     Trade.session.add(trade)
 
     trade = Trade(
@@ -396,7 +396,7 @@ def test_api_performance(botclient, mocker, ticker, fee):
         fee_open=fee.return_value,
         close_rate=0.391
     )
-    trade.close_profit = trade.calc_profit_percent()
+    trade.close_profit = trade.calc_profit_ratio()
     Trade.session.add(trade)
     Trade.session.flush()
 

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -125,6 +125,7 @@ def test_min_roi_reached(default_conf, fee) -> None:
         trade = Trade(
             pair='ETH/BTC',
             stake_amount=0.001,
+            amount=5,
             open_date=arrow.utcnow().shift(hours=-1).datetime,
             fee_open=fee.return_value,
             fee_close=fee.return_value,
@@ -162,6 +163,7 @@ def test_min_roi_reached2(default_conf, fee) -> None:
         trade = Trade(
             pair='ETH/BTC',
             stake_amount=0.001,
+            amount=5,
             open_date=arrow.utcnow().shift(hours=-1).datetime,
             fee_open=fee.return_value,
             fee_close=fee.return_value,
@@ -195,6 +197,7 @@ def test_min_roi_reached3(default_conf, fee) -> None:
     trade = Trade(
             pair='ETH/BTC',
             stake_amount=0.001,
+            amount=5,
             open_date=arrow.utcnow().shift(hours=-1).datetime,
             fee_open=fee.return_value,
             fee_close=fee.return_value,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1543,7 +1543,8 @@ def test_update_trade_state(mocker, default_conf, limit_buy_order, caplog) -> No
     assert log_has_re('Found open order for.*', caplog)
 
 
-def test_update_trade_state_withorderdict(default_conf, trades_for_order, limit_buy_order, fee, mocker):
+def test_update_trade_state_withorderdict(default_conf, trades_for_order, limit_buy_order, fee,
+                                          mocker):
     mocker.patch('freqtrade.exchange.Exchange.get_trades_for_order', return_value=trades_for_order)
     # get_order should not be called!!
     mocker.patch('freqtrade.exchange.Exchange.get_order', MagicMock(side_effect=ValueError))

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -641,6 +641,7 @@ def test_migrate_mid_state(mocker, default_conf, fee, caplog):
     assert trade.max_rate == 0.0
     assert trade.stop_loss == 0.0
     assert trade.initial_stop_loss == 0.0
+    assert trade.open_trade_price == trade._calc_open_trade_price()
     assert log_has("trying trades_bak0", caplog)
     assert log_has("Running database migration - backup available as trades_bak0", caplog)
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -498,6 +498,7 @@ def test_migrate_old(mocker, default_conf, fee):
     assert trade.max_rate == 0.0
     assert trade.stop_loss == 0.0
     assert trade.initial_stop_loss == 0.0
+    assert trade.open_trade_price == 0.26758131848350003
 
 
 def test_migrate_new(mocker, default_conf, fee, caplog):
@@ -580,6 +581,7 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
     assert log_has("trying trades_bak1", caplog)
     assert log_has("trying trades_bak2", caplog)
     assert log_has("Running database migration - backup available as trades_bak2", caplog)
+    assert trade.open_trade_price == 0.26758131848350003
 
 
 def test_migrate_mid_state(mocker, default_conf, fee, caplog):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -226,7 +226,7 @@ def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order, fee):
     assert trade.calc_profit() == 0.00006217
 
     # Profit in percent
-    assert trade.calc_profit_percent() == 0.06201058
+    assert trade.calc_profit_ratio() == 0.06201058
 
 
 @pytest.mark.usefixtures("init_persistence")
@@ -367,7 +367,7 @@ def test_calc_profit(limit_buy_order, limit_sell_order, fee):
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test_calc_profit_percent(limit_buy_order, limit_sell_order, fee):
+def test_calc_profit_ratio(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
@@ -381,17 +381,17 @@ def test_calc_profit_percent(limit_buy_order, limit_sell_order, fee):
     trade.update(limit_buy_order)  # Buy @ 0.00001099
 
     # Get percent of profit with a custom rate (Higher than open rate)
-    assert trade.calc_profit_percent(rate=0.00001234) == 0.11723875
+    assert trade.calc_profit_ratio(rate=0.00001234) == 0.11723875
 
     # Get percent of profit with a custom rate (Lower than open rate)
-    assert trade.calc_profit_percent(rate=0.00000123) == -0.88863828
+    assert trade.calc_profit_ratio(rate=0.00000123) == -0.88863828
 
     # Test when we apply a Sell order. Sell higher than open rate @ 0.00001173
     trade.update(limit_sell_order)
-    assert trade.calc_profit_percent() == 0.06201058
+    assert trade.calc_profit_ratio() == 0.06201058
 
     # Test with a custom fee rate on the close trade
-    assert trade.calc_profit_percent(fee=0.003) == 0.06147824
+    assert trade.calc_profit_ratio(fee=0.003) == 0.06147824
 
 
 @pytest.mark.usefixtures("init_persistence")

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -136,12 +136,13 @@ def test_update_with_bittrex(limit_buy_order, limit_sell_order, fee, caplog):
         id=2,
         pair='ETH/BTC',
         stake_amount=0.001,
+        open_rate=0.01,
+        amount=5,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
     )
     assert trade.open_order_id is None
-    assert trade.open_rate is None
     assert trade.close_profit is None
     assert trade.close_date is None
 
@@ -173,6 +174,8 @@ def test_update_market_order(market_buy_order, market_sell_order, fee, caplog):
         id=1,
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
+        open_rate=0.01,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -205,6 +208,8 @@ def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        open_rate=0.01,
+        amount=5,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -212,7 +217,7 @@ def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order, fee):
 
     trade.open_order_id = 'something'
     trade.update(limit_buy_order)
-    assert trade.calc_open_trade_price() == 0.0010024999999225068
+    assert trade._calc_open_trade_price() == 0.0010024999999225068
 
     trade.update(limit_sell_order)
     assert trade.calc_close_trade_price() == 0.0010646656050132426
@@ -229,6 +234,8 @@ def test_calc_close_trade_price_exception(limit_buy_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        open_rate=0.1,
+        amount=5,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -244,13 +251,14 @@ def test_update_open_order(limit_buy_order):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=1.00,
+        open_rate=0.01,
+        amount=5,
         fee_open=0.1,
         fee_close=0.1,
         exchange='bittrex',
     )
 
     assert trade.open_order_id is None
-    assert trade.open_rate is None
     assert trade.close_profit is None
     assert trade.close_date is None
 
@@ -258,7 +266,6 @@ def test_update_open_order(limit_buy_order):
     trade.update(limit_buy_order)
 
     assert trade.open_order_id is None
-    assert trade.open_rate is None
     assert trade.close_profit is None
     assert trade.close_date is None
 
@@ -268,6 +275,8 @@ def test_update_invalid_order(limit_buy_order):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=1.00,
+        amount=5,
+        open_rate=0.001,
         fee_open=0.1,
         fee_close=0.1,
         exchange='bittrex',
@@ -282,6 +291,8 @@ def test_calc_open_trade_price(limit_buy_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
+        open_rate=0.00001099,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -290,10 +301,10 @@ def test_calc_open_trade_price(limit_buy_order, fee):
     trade.update(limit_buy_order)  # Buy @ 0.00001099
 
     # Get the open rate price with the standard fee rate
-    assert trade.calc_open_trade_price() == 0.0010024999999225068
-
+    assert trade._calc_open_trade_price() == 0.0010024999999225068
+    trade.fee_open = 0.003
     # Get the open rate price with a custom fee rate
-    assert trade.calc_open_trade_price(fee=0.003) == 0.001002999999922468
+    assert trade._calc_open_trade_price() == 0.001002999999922468
 
 
 @pytest.mark.usefixtures("init_persistence")
@@ -301,6 +312,8 @@ def test_calc_close_trade_price(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
+        open_rate=0.00001099,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -324,6 +337,8 @@ def test_calc_profit(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
+        open_rate=0.00001099,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -356,6 +371,8 @@ def test_calc_profit_percent(limit_buy_order, limit_sell_order, fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
+        open_rate=0.00001099,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -630,6 +647,7 @@ def test_adjust_stop_loss(fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',
@@ -681,6 +699,7 @@ def test_adjust_min_max_rates(fee):
     trade = Trade(
         pair='ETH/BTC',
         stake_amount=0.001,
+        amount=5,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         exchange='bittrex',

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -498,7 +498,7 @@ def test_migrate_old(mocker, default_conf, fee):
     assert trade.max_rate == 0.0
     assert trade.stop_loss == 0.0
     assert trade.initial_stop_loss == 0.0
-    assert trade.open_trade_price == 0.26758131848350003
+    assert trade.open_trade_price == trade._calc_open_trade_price()
 
 
 def test_migrate_new(mocker, default_conf, fee, caplog):
@@ -581,7 +581,7 @@ def test_migrate_new(mocker, default_conf, fee, caplog):
     assert log_has("trying trades_bak1", caplog)
     assert log_has("trying trades_bak2", caplog)
     assert log_has("Running database migration - backup available as trades_bak2", caplog)
-    assert trade.open_trade_price == 0.26758131848350003
+    assert trade.open_trade_price == trade._calc_open_trade_price()
 
 
 def test_migrate_mid_state(mocker, default_conf, fee, caplog):


### PR DESCRIPTION
## Summary
Based on the initial work of #2650 (but new commits, since the previous commits are no longer accessible somehow due to forcepush...).

Removes ~10% as pointed out in #1016 from backtesting (similar enhancement will apply to hyperopt...

closes #1016

## Quick changelog

- Calculate open_trade_price (which includes fee) only once per trade and persist this in the database
- removal of unused `fee` argument from `_calc_open_trade_price()`
- Rename `calc_profit_percent()` to `calc_profit_ratio()` - since it does not return a percent value, but a ratio.
