### PR TITLE
Try to get comment from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
     - name: Coveralls
       if: startsWith(matrix.os, 'ubuntu')
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Coveralls token. Not used as secret due to github not providing secrets to forked repositories
+        COVERALLS_REPO_TOKEN: 6D1m0xupS3FgutfuGao8keFf9Hc0FpIXu
       run: |
         # Allow failure for coveralls
         coveralls -v  || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,16 @@ jobs:
         pip install -e .
 
     - name: Tests
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_SERVICE_NAME: travis-ci
-        TRAVIS: "true"
       run: |
         pytest --random-order --cov=freqtrade --cov-config=.coveragerc
+
+    - name: Coveralls
+      if: startsWith(matrix.os, 'ubuntu')
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
         # Allow failure for coveralls
-        # Fake travis environment to get coveralls working correctly
-        export TRAVIS_PULL_REQUEST="https://github.com/${GITHUB_REPOSITORY}/pull/$(cat $GITHUB_EVENT_PATH | jq -r .number)"
-        export TRAVIS_BRANCH=${GITHUB_REF#"ref/heads"}
-        export CI_BRANCH=${GITHUB_REF#"ref/heads"}
-        echo "${TRAVIS_BRANCH}"
-        coveralls || true
+        coveralls -v  || true
 
     - name: Backtesting
       run: |


### PR DESCRIPTION
## Summary
This will reenable Pull request comments when the PR comes from a foreign repository.

I really really don't like that we have to hardcode the token ... 
but github actions currently do not allow passing secrets to PR's from forked repositories.

on the other hand, this token allows only access to the coveralls repository site - and it's quickly rotated should something go wrong ... 