### PR TITLE
Minor: Please no underscores in cli options

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -192,8 +192,8 @@ Backtesting also uses the config specified via `-c/--config`.
 usage: freqtrade backtesting [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                              [-d PATH] [--userdir PATH] [-s NAME]
                              [--strategy-path PATH] [-i TICKER_INTERVAL]
-                             [--timerange TIMERANGE] [--max_open_trades INT]
-                             [--stake_amount STAKE_AMOUNT] [--fee FLOAT]
+                             [--timerange TIMERANGE] [--max-open-trades INT]
+                             [--stake-amount STAKE_AMOUNT] [--fee FLOAT]
                              [--eps] [--dmmp]
                              [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
                              [--export EXPORT] [--export-filename PATH]
@@ -205,10 +205,12 @@ optional arguments:
                         `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades INT
-                        Specify max_open_trades to use.
-  --stake_amount STAKE_AMOUNT
-                        Specify stake_amount.
+  --max-open-trades INT
+                        Override the value of the `max_open_trades`
+                        configuration setting.
+  --stake-amount STAKE_AMOUNT
+                        Override the value of the `stake_amount` configuration
+                        setting.
   --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
                         entry and exit).
   --eps, --enable-position-stacking
@@ -270,8 +272,8 @@ to find optimal parameter values for your stategy.
 usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                           [--userdir PATH] [-s NAME] [--strategy-path PATH]
                           [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                          [--max_open_trades INT]
-                          [--stake_amount STAKE_AMOUNT] [--fee FLOAT]
+                          [--max-open-trades INT]
+                          [--stake-amount STAKE_AMOUNT] [--fee FLOAT]
                           [--hyperopt NAME] [--hyperopt-path PATH] [--eps]
                           [-e INT]
                           [--spaces {all,buy,sell,roi,stoploss} [{all,buy,sell,roi,stoploss} ...]]
@@ -286,10 +288,12 @@ optional arguments:
                         `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades INT
-                        Specify max_open_trades to use.
-  --stake_amount STAKE_AMOUNT
-                        Specify stake_amount.
+  --max-open-trades INT
+                        Override the value of the `max_open_trades`
+                        configuration setting.
+  --stake-amount STAKE_AMOUNT
+                        Override the value of the `stake_amount` configuration
+                        setting.
   --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
                         entry and exit).
   --hyperopt NAME       Specify hyperopt class name which will be used by the
@@ -360,7 +364,7 @@ To know your trade expectancy and winrate against historical data, you can use E
 usage: freqtrade edge [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                       [--userdir PATH] [-s NAME] [--strategy-path PATH]
                       [-i TICKER_INTERVAL] [--timerange TIMERANGE]
-                      [--max_open_trades INT] [--stake_amount STAKE_AMOUNT]
+                      [--max-open-trades INT] [--stake-amount STAKE_AMOUNT]
                       [--fee FLOAT] [--stoplosses STOPLOSS_RANGE]
 
 optional arguments:
@@ -370,10 +374,12 @@ optional arguments:
                         `1d`).
   --timerange TIMERANGE
                         Specify what timerange of data to use.
-  --max_open_trades INT
-                        Specify max_open_trades to use.
-  --stake_amount STAKE_AMOUNT
-                        Specify stake_amount.
+  --max-open-trades INT
+                        Override the value of the `max_open_trades`
+                        configuration setting.
+  --stake-amount STAKE_AMOUNT
+                        Override the value of the `stake_amount` configuration
+                        setting.
   --fee FLOAT           Specify fee ratio. Will be applied twice (on trade
                         entry and exit).
   --stoplosses STOPLOSS_RANGE

--- a/freqtrade/configuration/cli_options.py
+++ b/freqtrade/configuration/cli_options.py
@@ -118,14 +118,14 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify what timerange of data to use.',
     ),
     "max_open_trades": Arg(
-        '--max_open_trades',
-        help='Specify max_open_trades to use.',
+        '--max-open-trades',
+        help='Override the value of the `max_open_trades` configuration setting.',
         type=int,
         metavar='INT',
     ),
     "stake_amount": Arg(
-        '--stake_amount',
-        help='Specify stake_amount.',
+        '--stake-amount',
+        help='Override the value of the `stake_amount` configuration setting.',
         type=float,
     ),
     # Backtesting

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -223,13 +223,13 @@ class Configuration:
             logger.info('max_open_trades set to unlimited ...')
         elif 'max_open_trades' in self.args and self.args["max_open_trades"]:
             config.update({'max_open_trades': self.args["max_open_trades"]})
-            logger.info('Parameter --max_open_trades detected, '
+            logger.info('Parameter --max-open-trades detected, '
                         'overriding max_open_trades to: %s ...', config.get('max_open_trades'))
         elif config['runmode'] in NON_UTIL_MODES:
             logger.info('Using max_open_trades: %s ...', config.get('max_open_trades'))
 
         self._args_to_config(config, argname='stake_amount',
-                             logstring='Parameter --stake_amount detected, '
+                             logstring='Parameter --stake-amount detected, '
                              'overriding stake_amount to: {} ...')
 
         self._args_to_config(config, argname='fee',


### PR DESCRIPTION
Mixing underscores and dashes in the cli options is at least is of bad style.

* `--max_open_trades` --> `--max-open-trades`
* `--stake_amount` --> `--stake-amount`
* Also, description for the options in the helpstrings improved.

P.S. (Not in this PR) I would deprecate and then remove `--stake-amount`. Since all other options that define stake amount for backtesting are defined in the config. Especially after upcoming implementation of relative stake amount (#2458).

First one (`--max_open_trades`) in the cli may theoretically have sense to see quickly differences in the backtesting to define max value of this parameter which may be needed in the example of the backtesting period.
