### PR TITLE
Refactor resolvers to static resolvers

### DIFF
--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -44,9 +44,9 @@ candles.head()
 ```python
 # Load strategy using values set above
 from freqtrade.resolvers import StrategyResolver
-strategy = StrategyResolver({'strategy': strategy_name,
-                            'user_data_dir': user_data_dir,
-                            'strategy_path': strategy_location}).strategy
+strategy = StrategyResolver.load_strategy({'strategy': strategy_name,
+                                          'user_data_dir': user_data_dir,
+                                          'strategy_path': strategy_location})
 
 # Generate buy/sell signals using strategy
 df = strategy.analyze_ticker(candles, {'pair': pair})

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -60,7 +60,7 @@ class FreqtradeBot:
         # Check config consistency here since strategies can set certain options
         validate_config_consistency(config)
 
-        self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
+        self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
 
         persistence.init(self.config.get('db_url', None),
                          clean_open_orders=self.config.get('dry_run', False))

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -55,7 +55,7 @@ class FreqtradeBot:
 
         self.heartbeat_interval = self.config.get('internals', {}).get('heartbeat_interval', 60)
 
-        self.strategy: IStrategy = StrategyResolver(self.config).strategy
+        self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 
         # Check config consistency here since strategies can set certain options
         validate_config_consistency(config)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -75,12 +75,12 @@ class Backtesting:
             for strat in list(self.config['strategy_list']):
                 stratconf = deepcopy(self.config)
                 stratconf['strategy'] = strat
-                self.strategylist.append(StrategyResolver(stratconf).strategy)
+                self.strategylist.append(StrategyResolver.load_strategy(stratconf))
                 validate_config_consistency(stratconf)
 
         else:
             # No strategy list specified, only one strategy
-            self.strategylist.append(StrategyResolver(self.config).strategy)
+            self.strategylist.append(StrategyResolver.load_strategy(self.config))
             validate_config_consistency(self.config)
 
         if "ticker_interval" not in self.config:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -60,7 +60,7 @@ class Backtesting:
         # Reset keys for backtesting
         remove_credentials(self.config)
         self.strategylist: List[IStrategy] = []
-        self.exchange = ExchangeResolver(self.config['exchange']['name'], self.config).exchange
+        self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
 
         if config.get('fee'):
             self.fee = config['fee']

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -34,7 +34,7 @@ class EdgeCli:
         remove_credentials(self.config)
         self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
         self.exchange = Exchange(self.config)
-        self.strategy = StrategyResolver(self.config).strategy
+        self.strategy = StrategyResolver.load_strategy(self.config)
 
         validate_config_consistency(self.config)
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -64,7 +64,7 @@ class Hyperopt:
 
         self.backtesting = Backtesting(self.config)
 
-        self.custom_hyperopt = HyperOptResolver(self.config).hyperopt
+        self.custom_hyperopt = HyperOptResolver.load_hyperopt(self.config)
 
         self.custom_hyperoptloss = HyperOptLossResolver(self.config).hyperoptloss
         self.calculate_loss = self.custom_hyperoptloss.hyperopt_loss_function

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -66,7 +66,7 @@ class Hyperopt:
 
         self.custom_hyperopt = HyperOptResolver.load_hyperopt(self.config)
 
-        self.custom_hyperoptloss = HyperOptLossResolver(self.config).hyperoptloss
+        self.custom_hyperoptloss = HyperOptLossResolver.load_hyperoptloss(self.config)
         self.calculate_loss = self.custom_hyperoptloss.hyperopt_loss_function
 
         self.trials_file = (self.config['user_data_dir'] /

--- a/freqtrade/pairlist/pairlistmanager.py
+++ b/freqtrade/pairlist/pairlistmanager.py
@@ -28,13 +28,13 @@ class PairListManager():
             if 'method' not in pl:
                 logger.warning(f"No method in {pl}")
                 continue
-            pairl = PairListResolver(pl.get('method'),
-                                     exchange=exchange,
-                                     pairlistmanager=self,
-                                     config=config,
-                                     pairlistconfig=pl,
-                                     pairlist_pos=len(self._pairlists)
-                                     ).pairlist
+            pairl = PairListResolver.load_pairlist(pl.get('method'),
+                                                   exchange=exchange,
+                                                   pairlistmanager=self,
+                                                   config=config,
+                                                   pairlistconfig=pl,
+                                                   pairlist_pos=len(self._pairlists)
+                                                   )
             self._tickers_needed = pairl.needstickers or self._tickers_needed
             self._pairlists.append(pairl)
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -340,7 +340,7 @@ def load_and_plot_trades(config: Dict[str, Any]):
     - Generate plot files
     :return: None
     """
-    strategy = StrategyResolver(config).strategy
+    strategy = StrategyResolver.load_strategy(config)
 
     plot_elements = init_plotscript(config)
     trades = plot_elements['trades']

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -15,9 +15,8 @@ class ExchangeResolver(IResolver):
     This class contains all the logic to load a custom exchange class
     """
 
-    __slots__ = ['exchange']
-
-    def __init__(self, exchange_name: str, config: dict, validate: bool = True) -> None:
+    @staticmethod
+    def load_exchange(exchange_name: str, config: dict, validate: bool = True) -> Exchange:
         """
         Load the custom class from config parameter
         :param config: configuration dictionary
@@ -25,17 +24,20 @@ class ExchangeResolver(IResolver):
         # Map exchange name to avoid duplicate classes for identical exchanges
         exchange_name = MAP_EXCHANGE_CHILDCLASS.get(exchange_name, exchange_name)
         exchange_name = exchange_name.title()
+        exchange = None
         try:
-            self.exchange = self._load_exchange(exchange_name, kwargs={'config': config,
-                                                                       'validate': validate})
+            exchange = ExchangeResolver._load_exchange(exchange_name,
+                                                       kwargs={'config': config,
+                                                               'validate': validate})
         except ImportError:
             logger.info(
                 f"No {exchange_name} specific subclass found. Using the generic class instead.")
-        if not hasattr(self, "exchange"):
-            self.exchange = Exchange(config, validate=validate)
+        if not exchange:
+            exchange = Exchange(config, validate=validate)
+        return exchange
 
-    def _load_exchange(
-            self, exchange_name: str, kwargs: dict) -> Exchange:
+    @staticmethod
+    def _load_exchange(exchange_name: str, kwargs: dict) -> Exchange:
         """
         Loads the specified exchange.
         Only checks for exchanges exported in freqtrade.exchanges

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -20,11 +20,11 @@ class HyperOptResolver(IResolver):
     """
     This class contains all the logic to load custom hyperopt class
     """
-    __slots__ = ['hyperopt']
 
-    def __init__(self, config: Dict) -> None:
+    @staticmethod
+    def load_hyperopt(config: Dict) -> IHyperOpt:
         """
-        Load the custom class from config parameter
+        Load the custom hyperopt class from config parameter
         :param config: configuration dictionary
         """
         if not config.get('hyperopt'):
@@ -33,21 +33,23 @@ class HyperOptResolver(IResolver):
 
         hyperopt_name = config['hyperopt']
 
-        self.hyperopt = self._load_hyperopt(hyperopt_name, config,
-                                            extra_dir=config.get('hyperopt_path'))
+        hyperopt = HyperOptResolver._load_hyperopt(hyperopt_name, config,
+                                                   extra_dir=config.get('hyperopt_path'))
 
-        if not hasattr(self.hyperopt, 'populate_indicators'):
+        if not hasattr(hyperopt, 'populate_indicators'):
             logger.warning("Hyperopt class does not provide populate_indicators() method. "
                            "Using populate_indicators from the strategy.")
-        if not hasattr(self.hyperopt, 'populate_buy_trend'):
+        if not hasattr(hyperopt, 'populate_buy_trend'):
             logger.warning("Hyperopt class does not provide populate_buy_trend() method. "
                            "Using populate_buy_trend from the strategy.")
-        if not hasattr(self.hyperopt, 'populate_sell_trend'):
+        if not hasattr(hyperopt, 'populate_sell_trend'):
             logger.warning("Hyperopt class does not provide populate_sell_trend() method. "
                            "Using populate_sell_trend from the strategy.")
+        return hyperopt
 
+    @staticmethod
     def _load_hyperopt(
-            self, hyperopt_name: str, config: Dict, extra_dir: Optional[str] = None) -> IHyperOpt:
+            hyperopt_name: str, config: Dict, extra_dir: Optional[str] = None) -> IHyperOpt:
         """
         Search and loads the specified hyperopt.
         :param hyperopt_name: name of the module to import
@@ -57,11 +59,12 @@ class HyperOptResolver(IResolver):
         """
         current_path = Path(__file__).parent.parent.joinpath('optimize').resolve()
 
-        abs_paths = self.build_search_paths(config, current_path=current_path,
-                                            user_subdir=USERPATH_HYPEROPTS, extra_dir=extra_dir)
+        abs_paths = IResolver.build_search_paths(config, current_path=current_path,
+                                                 user_subdir=USERPATH_HYPEROPTS,
+                                                 extra_dir=extra_dir)
 
-        hyperopt = self._load_object(paths=abs_paths, object_type=IHyperOpt,
-                                     object_name=hyperopt_name, kwargs={'config': config})
+        hyperopt = IResolver._load_object(paths=abs_paths, object_type=IHyperOpt,
+                                          object_name=hyperopt_name, kwargs={'config': config})
         if hyperopt:
             return hyperopt
         raise OperationalException(

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -17,7 +17,8 @@ class IResolver:
     This class contains all the logic to load custom classes
     """
 
-    def build_search_paths(self, config, current_path: Path, user_subdir: Optional[str] = None,
+    @staticmethod
+    def build_search_paths(config, current_path: Path, user_subdir: Optional[str] = None,
                            extra_dir: Optional[str] = None) -> List[Path]:
 
         abs_paths: List[Path] = [current_path]

--- a/freqtrade/resolvers/pairlist_resolver.py
+++ b/freqtrade/resolvers/pairlist_resolver.py
@@ -18,8 +18,6 @@ class PairListResolver(IResolver):
     This class contains all the logic to load custom PairList class
     """
 
-    __slots__ = []
-
     @staticmethod
     def load_pairlist(pairlist_name: str, exchange, pairlistmanager,
                       config: dict, pairlistconfig: dict, pairlist_pos: int) -> IPairList:
@@ -40,7 +38,6 @@ class PairListResolver(IResolver):
                                                        'config': config,
                                                        'pairlistconfig': pairlistconfig,
                                                        'pairlist_pos': pairlist_pos})
-
 
     @staticmethod
     def _load_pairlist(pairlist_name: str, config: dict, kwargs: dict) -> IPairList:

--- a/freqtrade/resolvers/pairlist_resolver.py
+++ b/freqtrade/resolvers/pairlist_resolver.py
@@ -18,23 +18,32 @@ class PairListResolver(IResolver):
     This class contains all the logic to load custom PairList class
     """
 
-    __slots__ = ['pairlist']
+    __slots__ = []
 
-    def __init__(self, pairlist_name: str, exchange, pairlistmanager,
-                 config: dict, pairlistconfig: dict, pairlist_pos: int) -> None:
+    @staticmethod
+    def load_pairlist(pairlist_name: str, exchange, pairlistmanager,
+                      config: dict, pairlistconfig: dict, pairlist_pos: int) -> IPairList:
         """
-        Load the custom class from config parameter
-        :param config: configuration dictionary or None
+        Load the pairlist with pairlist_name
+        :param pairlist_name: Classname of the pairlist
+        :param exchange: Initialized exchange class
+        :param pairlistmanager: Initialized pairlist manager
+        :param config: configuration dictionary
+        :param pairlistconfig: Configuration dedicated to this pairlist
+        :param pairlist_pos: Position of the pairlist in the list of pairlists
+        :return: initialized Pairlist class
         """
-        self.pairlist = self._load_pairlist(pairlist_name, config,
-                                            kwargs={'exchange': exchange,
-                                                    'pairlistmanager': pairlistmanager,
-                                                    'config': config,
-                                                    'pairlistconfig': pairlistconfig,
-                                                    'pairlist_pos': pairlist_pos})
 
-    def _load_pairlist(
-            self, pairlist_name: str, config: dict, kwargs: dict) -> IPairList:
+        return PairListResolver._load_pairlist(pairlist_name, config,
+                                               kwargs={'exchange': exchange,
+                                                       'pairlistmanager': pairlistmanager,
+                                                       'config': config,
+                                                       'pairlistconfig': pairlistconfig,
+                                                       'pairlist_pos': pairlist_pos})
+
+
+    @staticmethod
+    def _load_pairlist(pairlist_name: str, config: dict, kwargs: dict) -> IPairList:
         """
         Search and loads the specified pairlist.
         :param pairlist_name: name of the module to import
@@ -44,11 +53,11 @@ class PairListResolver(IResolver):
         """
         current_path = Path(__file__).parent.parent.joinpath('pairlist').resolve()
 
-        abs_paths = self.build_search_paths(config, current_path=current_path,
-                                            user_subdir=None, extra_dir=None)
+        abs_paths = IResolver.build_search_paths(config, current_path=current_path,
+                                                 user_subdir=None, extra_dir=None)
 
-        pairlist = self._load_object(paths=abs_paths, object_type=IPairList,
-                                     object_name=pairlist_name, kwargs=kwargs)
+        pairlist = IResolver._load_object(paths=abs_paths, object_type=IPairList,
+                                          object_name=pairlist_name, kwargs=kwargs)
         if pairlist:
             return pairlist
         raise OperationalException(

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -20,12 +20,11 @@ logger = logging.getLogger(__name__)
 
 class StrategyResolver(IResolver):
     """
-    This class contains all the logic to load custom strategy class
+    This class contains the logic to load custom strategy class
     """
 
-    __slots__ = ['strategy']
-
-    def __init__(self, config: Optional[Dict] = None) -> None:
+    @staticmethod
+    def load_strategy(config: Optional[Dict] = None) -> IStrategy:
         """
         Load the custom class from config parameter
         :param config: configuration dictionary or None
@@ -37,9 +36,9 @@ class StrategyResolver(IResolver):
                                        "the strategy class to use.")
 
         strategy_name = config['strategy']
-        self.strategy: IStrategy = self._load_strategy(strategy_name,
-                                                       config=config,
-                                                       extra_dir=config.get('strategy_path'))
+        strategy: IStrategy = StrategyResolver._load_strategy(
+            strategy_name, config=config,
+            extra_dir=config.get('strategy_path'))
 
         # make sure ask_strategy dict is available
         if 'ask_strategy' not in config:
@@ -68,9 +67,11 @@ class StrategyResolver(IResolver):
                       ]
         for attribute, default, ask_strategy in attributes:
             if ask_strategy:
-                self._override_attribute_helper(config['ask_strategy'], attribute, default)
+                StrategyResolver._override_attribute_helper(strategy, config['ask_strategy'],
+                                                            attribute, default)
             else:
-                self._override_attribute_helper(config, attribute, default)
+                StrategyResolver._override_attribute_helper(strategy, config,
+                                                            attribute, default)
 
         # Loop this list again to have output combined
         for attribute, _, exp in attributes:
@@ -80,14 +81,16 @@ class StrategyResolver(IResolver):
                 logger.info("Strategy using %s: %s", attribute, config[attribute])
 
         # Sort and apply type conversions
-        self.strategy.minimal_roi = OrderedDict(sorted(
-            {int(key): value for (key, value) in self.strategy.minimal_roi.items()}.items(),
+        strategy.minimal_roi = OrderedDict(sorted(
+            {int(key): value for (key, value) in strategy.minimal_roi.items()}.items(),
             key=lambda t: t[0]))
-        self.strategy.stoploss = float(self.strategy.stoploss)
+        strategy.stoploss = float(strategy.stoploss)
 
-        self._strategy_sanity_validations()
+        StrategyResolver._strategy_sanity_validations(strategy)
+        return strategy
 
-    def _override_attribute_helper(self, config, attribute: str, default):
+    @staticmethod
+    def _override_attribute_helper(strategy, config, attribute: str, default):
         """
         Override attributes in the strategy.
         Prevalence:
@@ -96,30 +99,32 @@ class StrategyResolver(IResolver):
         - default (if not None)
         """
         if attribute in config:
-            setattr(self.strategy, attribute, config[attribute])
+            setattr(strategy, attribute, config[attribute])
             logger.info("Override strategy '%s' with value in config file: %s.",
                         attribute, config[attribute])
-        elif hasattr(self.strategy, attribute):
-            val = getattr(self.strategy, attribute)
+        elif hasattr(strategy, attribute):
+            val = getattr(strategy, attribute)
             # None's cannot exist in the config, so do not copy them
             if val is not None:
                 config[attribute] = val
         # Explicitly check for None here as other "falsy" values are possible
         elif default is not None:
-            setattr(self.strategy, attribute, default)
+            setattr(strategy, attribute, default)
             config[attribute] = default
 
-    def _strategy_sanity_validations(self):
-        if not all(k in self.strategy.order_types for k in constants.REQUIRED_ORDERTYPES):
-            raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
+    @staticmethod
+    def _strategy_sanity_validations(strategy):
+        if not all(k in strategy.order_types for k in constants.REQUIRED_ORDERTYPES):
+            raise ImportError(f"Impossible to load Strategy '{strategy.__class__.__name__}'. "
                               f"Order-types mapping is incomplete.")
 
-        if not all(k in self.strategy.order_time_in_force for k in constants.REQUIRED_ORDERTIF):
-            raise ImportError(f"Impossible to load Strategy '{self.strategy.__class__.__name__}'. "
+        if not all(k in strategy.order_time_in_force for k in constants.REQUIRED_ORDERTIF):
+            raise ImportError(f"Impossible to load Strategy '{strategy.__class__.__name__}'. "
                               f"Order-time-in-force mapping is incomplete.")
 
-    def _load_strategy(
-            self, strategy_name: str, config: dict, extra_dir: Optional[str] = None) -> IStrategy:
+    @staticmethod
+    def _load_strategy(strategy_name: str,
+                       config: dict, extra_dir: Optional[str] = None) -> IStrategy:
         """
         Search and loads the specified strategy.
         :param strategy_name: name of the module to import
@@ -129,9 +134,9 @@ class StrategyResolver(IResolver):
         """
         current_path = Path(__file__).parent.parent.joinpath('strategy').resolve()
 
-        abs_paths = self.build_search_paths(config, current_path=current_path,
-                                            user_subdir=constants.USERPATH_STRATEGY,
-                                            extra_dir=extra_dir)
+        abs_paths = IResolver.build_search_paths(config, current_path=current_path,
+                                                 user_subdir=constants.USERPATH_STRATEGY,
+                                                 extra_dir=extra_dir)
 
         if ":" in strategy_name:
             logger.info("loading base64 encoded strategy")
@@ -149,8 +154,8 @@ class StrategyResolver(IResolver):
                 # register temp path with the bot
                 abs_paths.insert(0, temp.resolve())
 
-        strategy = self._load_object(paths=abs_paths, object_type=IStrategy,
-                                     object_name=strategy_name, kwargs={'config': config})
+        strategy = IResolver._load_object(paths=abs_paths, object_type=IStrategy,
+                                          object_name=strategy_name, kwargs={'config': config})
         if strategy:
             strategy._populate_fun_len = len(getfullargspec(strategy.populate_indicators).args)
             strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -73,9 +73,9 @@
    "source": [
     "# Load strategy using values set above\n",
     "from freqtrade.resolvers import StrategyResolver\n",
-    "strategy = StrategyResolver({'strategy': strategy_name,\n",
-    "                            'user_data_dir': user_data_dir,\n",
-    "                            'strategy_path': strategy_location}).strategy\n",
+    "strategy = StrategyResolver.load_strategy({'strategy': strategy_name,\n",
+    "                                          'user_data_dir': user_data_dir,\n",
+    "                                          'strategy_path': strategy_location})\n",
     "\n",
     "# Generate buy/sell signals using strategy\n",
     "df = strategy.analyze_ticker(candles, {'pair': pair})\n",

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -198,7 +198,7 @@ def start_download_data(args: Dict[str, Any]) -> None:
     pairs_not_available: List[str] = []
 
     # Init exchange
-    exchange = ExchangeResolver(config['exchange']['name'], config).exchange
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config)
     try:
 
         if config.get('download_trades'):
@@ -233,7 +233,7 @@ def start_list_timeframes(args: Dict[str, Any]) -> None:
     config['ticker_interval'] = None
 
     # Init exchange
-    exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
 
     if args['print_one_column']:
         print('\n'.join(exchange.timeframes))
@@ -252,7 +252,7 @@ def start_list_markets(args: Dict[str, Any], pairs_only: bool = False) -> None:
     config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE)
 
     # Init exchange
-    exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
 
     # By default only active pairs/markets are to be shown
     active_only = not args.get('list_pairs_all', False)
@@ -333,7 +333,7 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
     from freqtrade.pairlist.pairlistmanager import PairListManager
     config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE)
 
-    exchange = ExchangeResolver(config['exchange']['name'], config, validate=False).exchange
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
 
     quote_currencies = args.get('quote_currencies')
     if not quote_currencies:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def get_patched_exchange(mocker, config, api_mock=None, id='bittrex',
     patch_exchange(mocker, api_mock, id, mock_markets)
     config["exchange"]["name"] = id
     try:
-        exchange = ExchangeResolver(id, config).exchange
+        exchange = ExchangeResolver.load_exchange(id, config)
     except ImportError:
         exchange = Exchange(config)
     return exchange

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -124,19 +124,19 @@ def test_exchange_resolver(default_conf, mocker, caplog):
     mocker.patch('freqtrade.exchange.Exchange._load_async_markets', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
-    exchange = ExchangeResolver('Bittrex', default_conf).exchange
+    exchange = ExchangeResolver.load_exchange('Bittrex', default_conf)
     assert isinstance(exchange, Exchange)
     assert log_has_re(r"No .* specific subclass found. Using the generic class instead.", caplog)
     caplog.clear()
 
-    exchange = ExchangeResolver('kraken', default_conf).exchange
+    exchange = ExchangeResolver.load_exchange('kraken', default_conf)
     assert isinstance(exchange, Exchange)
     assert isinstance(exchange, Kraken)
     assert not isinstance(exchange, Binance)
     assert not log_has_re(r"No .* specific subclass found. Using the generic class instead.",
                           caplog)
 
-    exchange = ExchangeResolver('binance', default_conf).exchange
+    exchange = ExchangeResolver.load_exchange('binance', default_conf)
     assert isinstance(exchange, Exchange)
     assert isinstance(exchange, Binance)
     assert not isinstance(exchange, Kraken)
@@ -145,7 +145,7 @@ def test_exchange_resolver(default_conf, mocker, caplog):
                           caplog)
 
     # Test mapping
-    exchange = ExchangeResolver('binanceus', default_conf).exchange
+    exchange = ExchangeResolver.load_exchange('binanceus', default_conf)
     assert isinstance(exchange, Exchange)
     assert isinstance(exchange, Binance)
     assert not isinstance(exchange, Kraken)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -163,7 +163,7 @@ def test_hyperoptresolver(mocker, default_conf, caplog) -> None:
         MagicMock(return_value=hyperopt(default_conf))
     )
     default_conf.update({'hyperopt': 'DefaultHyperOpt'})
-    x = HyperOptResolver(default_conf).hyperopt
+    x = HyperOptResolver.load_hyperopt(default_conf)
     assert not hasattr(x, 'populate_indicators')
     assert not hasattr(x, 'populate_buy_trend')
     assert not hasattr(x, 'populate_sell_trend')
@@ -180,7 +180,7 @@ def test_hyperoptresolver_wrongname(mocker, default_conf, caplog) -> None:
     default_conf.update({'hyperopt': "NonExistingHyperoptClass"})
 
     with pytest.raises(OperationalException, match=r'Impossible to load Hyperopt.*'):
-        HyperOptResolver(default_conf).hyperopt
+        HyperOptResolver.load_hyperopt(default_conf)
 
 
 def test_hyperoptresolver_noname(default_conf):
@@ -188,7 +188,7 @@ def test_hyperoptresolver_noname(default_conf):
     with pytest.raises(OperationalException,
                        match="No Hyperopt set. Please use `--hyperopt` to specify "
                              "the Hyperopt class to use."):
-        HyperOptResolver(default_conf)
+        HyperOptResolver.load_hyperopt(default_conf)
 
 
 def test_hyperoptlossresolver(mocker, default_conf, caplog) -> None:

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -198,7 +198,7 @@ def test_hyperoptlossresolver(mocker, default_conf, caplog) -> None:
         'freqtrade.resolvers.hyperopt_resolver.HyperOptLossResolver._load_hyperoptloss',
         MagicMock(return_value=hl)
     )
-    x = HyperOptLossResolver(default_conf).hyperoptloss
+    x = HyperOptLossResolver.load_hyperoptloss(default_conf)
     assert hasattr(x, "hyperopt_loss_function")
 
 
@@ -206,7 +206,7 @@ def test_hyperoptlossresolver_wrongname(mocker, default_conf, caplog) -> None:
     default_conf.update({'hyperopt_loss': "NonExistingLossClass"})
 
     with pytest.raises(OperationalException, match=r'Impossible to load HyperoptLoss.*'):
-        HyperOptLossResolver(default_conf).hyperopt
+        HyperOptLossResolver.load_hyperoptloss(default_conf)
 
 
 def test_start_not_installed(mocker, default_conf, caplog, import_fails) -> None:
@@ -286,7 +286,7 @@ def test_start_filelock(mocker, default_conf, caplog) -> None:
 
 
 def test_loss_calculation_prefer_correct_trade_count(default_conf, hyperopt_results) -> None:
-    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     correct = hl.hyperopt_loss_function(hyperopt_results, 600)
     over = hl.hyperopt_loss_function(hyperopt_results, 600 + 100)
     under = hl.hyperopt_loss_function(hyperopt_results, 600 - 100)
@@ -298,7 +298,7 @@ def test_loss_calculation_prefer_shorter_trades(default_conf, hyperopt_results) 
     resultsb = hyperopt_results.copy()
     resultsb.loc[1, 'trade_duration'] = 20
 
-    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     longer = hl.hyperopt_loss_function(hyperopt_results, 100)
     shorter = hl.hyperopt_loss_function(resultsb, 100)
     assert shorter < longer
@@ -310,7 +310,7 @@ def test_loss_calculation_has_limited_profit(default_conf, hyperopt_results) -> 
     results_under = hyperopt_results.copy()
     results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
 
-    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     correct = hl.hyperopt_loss_function(hyperopt_results, 600)
     over = hl.hyperopt_loss_function(results_over, 600)
     under = hl.hyperopt_loss_function(results_under, 600)
@@ -325,7 +325,7 @@ def test_sharpe_loss_prefers_higher_profits(default_conf, hyperopt_results) -> N
     results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
 
     default_conf.update({'hyperopt_loss': 'SharpeHyperOptLoss'})
-    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
                                         datetime(2019, 1, 1), datetime(2019, 5, 1))
     over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),
@@ -343,7 +343,7 @@ def test_onlyprofit_loss_prefers_higher_profits(default_conf, hyperopt_results) 
     results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
 
     default_conf.update({'hyperopt_loss': 'OnlyProfitHyperOptLoss'})
-    hl = HyperOptLossResolver(default_conf).hyperoptloss
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
                                         datetime(2019, 1, 1), datetime(2019, 5, 1))
     over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -53,7 +53,7 @@ def test_load_pairlist_noexist(mocker, markets, default_conf):
     with pytest.raises(OperationalException,
                        match=r"Impossible to load Pairlist 'NonexistingPairList'. "
                              r"This class does not exist or contains Python code errors."):
-        PairListResolver('NonexistingPairList', bot.exchange, plm, default_conf, {}, 1)
+        PairListResolver.load_pairlist('NonexistingPairList', bot.exchange, plm, default_conf, {}, 1)
 
 
 def test_refresh_market_pair_not_in_whitelist(mocker, markets, static_pl_conf):

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -53,7 +53,8 @@ def test_load_pairlist_noexist(mocker, markets, default_conf):
     with pytest.raises(OperationalException,
                        match=r"Impossible to load Pairlist 'NonexistingPairList'. "
                              r"This class does not exist or contains Python code errors."):
-        PairListResolver.load_pairlist('NonexistingPairList', bot.exchange, plm, default_conf, {}, 1)
+        PairListResolver.load_pairlist('NonexistingPairList', bot.exchange, plm,
+                                       default_conf, {}, 1)
 
 
 def test_refresh_market_pair_not_in_whitelist(mocker, markets, static_pl_conf):

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -58,7 +58,8 @@ def test_load_strategy_base64(result, caplog, default_conf):
 def test_load_strategy_invalid_directory(result, caplog, default_conf):
     default_conf['strategy'] = 'DefaultStrategy'
     extra_dir = Path.cwd() / 'some/path'
-    strategy = StrategyResolver._load_strategy('DefaultStrategy', config=default_conf, extra_dir=extra_dir)
+    strategy = StrategyResolver._load_strategy('DefaultStrategy', config=default_conf,
+                                               extra_dir=extra_dir)
 
     assert log_has_re(r'Path .*' + r'some.*path.*' + r'.* does not exist', caplog)
 

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -39,8 +39,8 @@ def test_load_strategy(default_conf, result):
     default_conf.update({'strategy': 'SampleStrategy',
                          'strategy_path': str(Path(__file__).parents[2] / 'freqtrade/templates')
                          })
-    resolver = StrategyResolver(default_conf)
-    assert 'rsi' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+    assert 'rsi' in strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 
 
 def test_load_strategy_base64(result, caplog, default_conf):
@@ -48,8 +48,8 @@ def test_load_strategy_base64(result, caplog, default_conf):
         encoded_string = urlsafe_b64encode(file.read()).decode("utf-8")
     default_conf.update({'strategy': 'SampleStrategy:{}'.format(encoded_string)})
 
-    resolver = StrategyResolver(default_conf)
-    assert 'rsi' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+    assert 'rsi' in strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
     # Make sure strategy was loaded from base64 (using temp directory)!!
     assert log_has_re(r"Using resolved strategy SampleStrategy from '"
                       r".*(/|\\).*(/|\\)SampleStrategy\.py'\.\.\.", caplog)
@@ -57,13 +57,12 @@ def test_load_strategy_base64(result, caplog, default_conf):
 
 def test_load_strategy_invalid_directory(result, caplog, default_conf):
     default_conf['strategy'] = 'DefaultStrategy'
-    resolver = StrategyResolver(default_conf)
     extra_dir = Path.cwd() / 'some/path'
-    resolver._load_strategy('DefaultStrategy', config=default_conf, extra_dir=extra_dir)
+    strategy = StrategyResolver._load_strategy('DefaultStrategy', config=default_conf, extra_dir=extra_dir)
 
     assert log_has_re(r'Path .*' + r'some.*path.*' + r'.* does not exist', caplog)
 
-    assert 'rsi' in resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
+    assert 'rsi' in strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 
 
 def test_load_not_found_strategy(default_conf):
@@ -71,7 +70,7 @@ def test_load_not_found_strategy(default_conf):
     with pytest.raises(OperationalException,
                        match=r"Impossible to load Strategy 'NotFoundStrategy'. "
                              r"This class does not exist or contains Python code errors."):
-        StrategyResolver(default_conf)
+        StrategyResolver.load_strategy(default_conf)
 
 
 def test_load_strategy_noname(default_conf):
@@ -79,30 +78,30 @@ def test_load_strategy_noname(default_conf):
     with pytest.raises(OperationalException,
                        match="No strategy set. Please use `--strategy` to specify "
                              "the strategy class to use."):
-        StrategyResolver(default_conf)
+        StrategyResolver.load_strategy(default_conf)
 
 
 def test_strategy(result, default_conf):
     default_conf.update({'strategy': 'DefaultStrategy'})
 
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
     metadata = {'pair': 'ETH/BTC'}
-    assert resolver.strategy.minimal_roi[0] == 0.04
+    assert strategy.minimal_roi[0] == 0.04
     assert default_conf["minimal_roi"]['0'] == 0.04
 
-    assert resolver.strategy.stoploss == -0.10
+    assert strategy.stoploss == -0.10
     assert default_conf['stoploss'] == -0.10
 
-    assert resolver.strategy.ticker_interval == '5m'
+    assert strategy.ticker_interval == '5m'
     assert default_conf['ticker_interval'] == '5m'
 
-    df_indicators = resolver.strategy.advise_indicators(result, metadata=metadata)
+    df_indicators = strategy.advise_indicators(result, metadata=metadata)
     assert 'adx' in df_indicators
 
-    dataframe = resolver.strategy.advise_buy(df_indicators, metadata=metadata)
+    dataframe = strategy.advise_buy(df_indicators, metadata=metadata)
     assert 'buy' in dataframe.columns
 
-    dataframe = resolver.strategy.advise_sell(df_indicators, metadata=metadata)
+    dataframe = strategy.advise_sell(df_indicators, metadata=metadata)
     assert 'sell' in dataframe.columns
 
 
@@ -114,9 +113,9 @@ def test_strategy_override_minimal_roi(caplog, default_conf):
             "0": 0.5
         }
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.minimal_roi[0] == 0.5
+    assert strategy.minimal_roi[0] == 0.5
     assert log_has("Override strategy 'minimal_roi' with value in config file: {'0': 0.5}.", caplog)
 
 
@@ -126,9 +125,9 @@ def test_strategy_override_stoploss(caplog, default_conf):
         'strategy': 'DefaultStrategy',
         'stoploss': -0.5
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.stoploss == -0.5
+    assert strategy.stoploss == -0.5
     assert log_has("Override strategy 'stoploss' with value in config file: -0.5.", caplog)
 
 
@@ -138,10 +137,10 @@ def test_strategy_override_trailing_stop(caplog, default_conf):
         'strategy': 'DefaultStrategy',
         'trailing_stop': True
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.trailing_stop
-    assert isinstance(resolver.strategy.trailing_stop, bool)
+    assert strategy.trailing_stop
+    assert isinstance(strategy.trailing_stop, bool)
     assert log_has("Override strategy 'trailing_stop' with value in config file: True.", caplog)
 
 
@@ -153,13 +152,13 @@ def test_strategy_override_trailing_stop_positive(caplog, default_conf):
         'trailing_stop_positive_offset': -0.2
 
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.trailing_stop_positive == -0.1
+    assert strategy.trailing_stop_positive == -0.1
     assert log_has("Override strategy 'trailing_stop_positive' with value in config file: -0.1.",
                    caplog)
 
-    assert resolver.strategy.trailing_stop_positive_offset == -0.2
+    assert strategy.trailing_stop_positive_offset == -0.2
     assert log_has("Override strategy 'trailing_stop_positive' with value in config file: -0.1.",
                    caplog)
 
@@ -172,10 +171,10 @@ def test_strategy_override_ticker_interval(caplog, default_conf):
         'ticker_interval': 60,
         'stake_currency': 'ETH'
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.ticker_interval == 60
-    assert resolver.strategy.stake_currency == 'ETH'
+    assert strategy.ticker_interval == 60
+    assert strategy.stake_currency == 'ETH'
     assert log_has("Override strategy 'ticker_interval' with value in config file: 60.",
                    caplog)
 
@@ -187,9 +186,9 @@ def test_strategy_override_process_only_new_candles(caplog, default_conf):
         'strategy': 'DefaultStrategy',
         'process_only_new_candles': True
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.process_only_new_candles
+    assert strategy.process_only_new_candles
     assert log_has("Override strategy 'process_only_new_candles' with value in config file: True.",
                    caplog)
 
@@ -207,11 +206,11 @@ def test_strategy_override_order_types(caplog, default_conf):
         'strategy': 'DefaultStrategy',
         'order_types': order_types
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.order_types
+    assert strategy.order_types
     for method in ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']:
-        assert resolver.strategy.order_types[method] == order_types[method]
+        assert strategy.order_types[method] == order_types[method]
 
     assert log_has("Override strategy 'order_types' with value in config file:"
                    " {'buy': 'market', 'sell': 'limit', 'stoploss': 'limit',"
@@ -225,7 +224,7 @@ def test_strategy_override_order_types(caplog, default_conf):
     with pytest.raises(ImportError,
                        match=r"Impossible to load Strategy 'DefaultStrategy'. "
                              r"Order-types mapping is incomplete."):
-        StrategyResolver(default_conf)
+        StrategyResolver.load_strategy(default_conf)
 
 
 def test_strategy_override_order_tif(caplog, default_conf):
@@ -240,11 +239,11 @@ def test_strategy_override_order_tif(caplog, default_conf):
         'strategy': 'DefaultStrategy',
         'order_time_in_force': order_time_in_force
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.order_time_in_force
+    assert strategy.order_time_in_force
     for method in ['buy', 'sell']:
-        assert resolver.strategy.order_time_in_force[method] == order_time_in_force[method]
+        assert strategy.order_time_in_force[method] == order_time_in_force[method]
 
     assert log_has("Override strategy 'order_time_in_force' with value in config file:"
                    " {'buy': 'fok', 'sell': 'gtc'}.", caplog)
@@ -257,7 +256,7 @@ def test_strategy_override_order_tif(caplog, default_conf):
     with pytest.raises(ImportError,
                        match=r"Impossible to load Strategy 'DefaultStrategy'. "
                              r"Order-time-in-force mapping is incomplete."):
-        StrategyResolver(default_conf)
+        StrategyResolver.load_strategy(default_conf)
 
 
 def test_strategy_override_use_sell_signal(caplog, default_conf):
@@ -265,9 +264,9 @@ def test_strategy_override_use_sell_signal(caplog, default_conf):
     default_conf.update({
         'strategy': 'DefaultStrategy',
     })
-    resolver = StrategyResolver(default_conf)
-    assert resolver.strategy.use_sell_signal
-    assert isinstance(resolver.strategy.use_sell_signal, bool)
+    strategy = StrategyResolver.load_strategy(default_conf)
+    assert strategy.use_sell_signal
+    assert isinstance(strategy.use_sell_signal, bool)
     # must be inserted to configuration
     assert 'use_sell_signal' in default_conf['ask_strategy']
     assert default_conf['ask_strategy']['use_sell_signal']
@@ -278,10 +277,10 @@ def test_strategy_override_use_sell_signal(caplog, default_conf):
             'use_sell_signal': False,
         },
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert not resolver.strategy.use_sell_signal
-    assert isinstance(resolver.strategy.use_sell_signal, bool)
+    assert not strategy.use_sell_signal
+    assert isinstance(strategy.use_sell_signal, bool)
     assert log_has("Override strategy 'use_sell_signal' with value in config file: False.", caplog)
 
 
@@ -290,9 +289,9 @@ def test_strategy_override_use_sell_profit_only(caplog, default_conf):
     default_conf.update({
         'strategy': 'DefaultStrategy',
     })
-    resolver = StrategyResolver(default_conf)
-    assert not resolver.strategy.sell_profit_only
-    assert isinstance(resolver.strategy.sell_profit_only, bool)
+    strategy = StrategyResolver.load_strategy(default_conf)
+    assert not strategy.sell_profit_only
+    assert isinstance(strategy.sell_profit_only, bool)
     # must be inserted to configuration
     assert 'sell_profit_only' in default_conf['ask_strategy']
     assert not default_conf['ask_strategy']['sell_profit_only']
@@ -303,10 +302,10 @@ def test_strategy_override_use_sell_profit_only(caplog, default_conf):
             'sell_profit_only': True,
         },
     })
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
 
-    assert resolver.strategy.sell_profit_only
-    assert isinstance(resolver.strategy.sell_profit_only, bool)
+    assert strategy.sell_profit_only
+    assert isinstance(strategy.sell_profit_only, bool)
     assert log_has("Override strategy 'sell_profit_only' with value in config file: True.", caplog)
 
 
@@ -315,11 +314,11 @@ def test_deprecate_populate_indicators(result, default_conf):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     default_conf.update({'strategy': 'TestStrategyLegacy',
                          'strategy_path': default_location})
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        indicators = resolver.strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
+        indicators = strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "deprecated - check out the Sample strategy to see the current function headers!" \
@@ -328,7 +327,7 @@ def test_deprecate_populate_indicators(result, default_conf):
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        resolver.strategy.advise_buy(indicators, {'pair': 'ETH/BTC'})
+        strategy.advise_buy(indicators, {'pair': 'ETH/BTC'})
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "deprecated - check out the Sample strategy to see the current function headers!" \
@@ -337,7 +336,7 @@ def test_deprecate_populate_indicators(result, default_conf):
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        resolver.strategy.advise_sell(indicators, {'pair': 'ETH_BTC'})
+        strategy.advise_sell(indicators, {'pair': 'ETH_BTC'})
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "deprecated - check out the Sample strategy to see the current function headers!" \
@@ -349,47 +348,47 @@ def test_call_deprecated_function(result, monkeypatch, default_conf):
     default_location = path.join(path.dirname(path.realpath(__file__)))
     default_conf.update({'strategy': 'TestStrategyLegacy',
                          'strategy_path': default_location})
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
     metadata = {'pair': 'ETH/BTC'}
 
     # Make sure we are using a legacy function
-    assert resolver.strategy._populate_fun_len == 2
-    assert resolver.strategy._buy_fun_len == 2
-    assert resolver.strategy._sell_fun_len == 2
-    assert resolver.strategy.INTERFACE_VERSION == 1
+    assert strategy._populate_fun_len == 2
+    assert strategy._buy_fun_len == 2
+    assert strategy._sell_fun_len == 2
+    assert strategy.INTERFACE_VERSION == 1
 
-    indicator_df = resolver.strategy.advise_indicators(result, metadata=metadata)
+    indicator_df = strategy.advise_indicators(result, metadata=metadata)
     assert isinstance(indicator_df, DataFrame)
     assert 'adx' in indicator_df.columns
 
-    buydf = resolver.strategy.advise_buy(result, metadata=metadata)
+    buydf = strategy.advise_buy(result, metadata=metadata)
     assert isinstance(buydf, DataFrame)
     assert 'buy' in buydf.columns
 
-    selldf = resolver.strategy.advise_sell(result, metadata=metadata)
+    selldf = strategy.advise_sell(result, metadata=metadata)
     assert isinstance(selldf, DataFrame)
     assert 'sell' in selldf
 
 
 def test_strategy_interface_versioning(result, monkeypatch, default_conf):
     default_conf.update({'strategy': 'DefaultStrategy'})
-    resolver = StrategyResolver(default_conf)
+    strategy = StrategyResolver.load_strategy(default_conf)
     metadata = {'pair': 'ETH/BTC'}
 
     # Make sure we are using a legacy function
-    assert resolver.strategy._populate_fun_len == 3
-    assert resolver.strategy._buy_fun_len == 3
-    assert resolver.strategy._sell_fun_len == 3
-    assert resolver.strategy.INTERFACE_VERSION == 2
+    assert strategy._populate_fun_len == 3
+    assert strategy._buy_fun_len == 3
+    assert strategy._sell_fun_len == 3
+    assert strategy.INTERFACE_VERSION == 2
 
-    indicator_df = resolver.strategy.advise_indicators(result, metadata=metadata)
+    indicator_df = strategy.advise_indicators(result, metadata=metadata)
     assert isinstance(indicator_df, DataFrame)
     assert 'adx' in indicator_df.columns
 
-    buydf = resolver.strategy.advise_buy(result, metadata=metadata)
+    buydf = strategy.advise_buy(result, metadata=metadata)
     assert isinstance(buydf, DataFrame)
     assert 'buy' in buydf.columns
 
-    selldf = resolver.strategy.advise_sell(result, metadata=metadata)
+    selldf = strategy.advise_sell(result, metadata=metadata)
     assert isinstance(selldf, DataFrame)
     assert 'sell' in selldf


### PR DESCRIPTION
## Summary
Creating an instance of the resolvers is not necessary, since we're just calling a few methods in sequence and then return exactly one result.

Also, if the resolver does not move out of scope it'll be kept in memory for the whole run-time of the bot ... which is unnecessary.

## Quick changelog

- Convert resolvers to static classes, using a `load_*()` method instead of `__init__()`.
