### PR TITLE
Convert datadir within config to Path

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -403,7 +403,7 @@ class Configuration:
             config['pairs'] = config.get('exchange', {}).get('pair_whitelist')
         else:
             # Fall back to /dl_path/pairs.json
-            pairs_file = Path(config['datadir']) / "pairs.json"
+            pairs_file = config['datadir'] / "pairs.json"
             if pairs_file.exists():
                 with pairs_file.open('r') as f:
                     config['pairs'] = json_load(f)

--- a/freqtrade/configuration/directory_operations.py
+++ b/freqtrade/configuration/directory_operations.py
@@ -9,7 +9,7 @@ from freqtrade.constants import USER_DATA_FILES
 logger = logging.getLogger(__name__)
 
 
-def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> str:
+def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> Path:
 
     folder = Path(datadir) if datadir else Path(f"{config['user_data_dir']}/data")
     if not datadir:
@@ -20,7 +20,7 @@ def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> str
     if not folder.is_dir():
         folder.mkdir(parents=True)
         logger.info(f'Created data directory: {datadir}')
-    return str(folder)
+    return folder
 
 
 def create_userdata_dir(directory: str, create_dir=False) -> Path:

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -5,7 +5,6 @@ including Klines, tickers, historic data
 Common Interface for bot and strategy to access data.
 """
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from pandas import DataFrame
@@ -65,7 +64,7 @@ class DataProvider:
         """
         return load_pair_history(pair=pair,
                                  timeframe=timeframe or self._config['ticker_interval'],
-                                 datadir=Path(self._config['datadir'])
+                                 datadir=self._config['datadir']
                                  )
 
     def get_pair_dataframe(self, pair: str, timeframe: str = None) -> DataFrame:

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -96,7 +96,7 @@ class Edge:
 
         if self._refresh_pairs:
             history.refresh_data(
-                datadir=Path(self.config['datadir']),
+                datadir=self.config['datadir'],
                 pairs=pairs,
                 exchange=self.exchange,
                 timeframe=self.strategy.ticker_interval,
@@ -104,7 +104,7 @@ class Edge:
             )
 
         data = history.load_data(
-            datadir=Path(self.config['datadir']),
+            datadir=self.config['datadir'],
             pairs=pairs,
             timeframe=self.strategy.ticker_interval,
             timerange=self._timerange,

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -1,7 +1,6 @@
 # pragma pylint: disable=W0603
 """ Edge positioning package """
 import logging
-from pathlib import Path
 from typing import Any, Dict, NamedTuple
 
 import arrow

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -109,7 +109,7 @@ class Backtesting:
             'timerange') is None else str(self.config.get('timerange')))
 
         data = history.load_data(
-            datadir=Path(self.config['datadir']),
+            datadir=self.config['datadir'],
             pairs=self.config['exchange']['pair_whitelist'],
             timeframe=self.timeframe,
             timerange=timerange,

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -37,7 +37,7 @@ def init_plotscript(config):
     timerange = TimeRange.parse_timerange(config.get("timerange"))
 
     tickers = history.load_data(
-        datadir=Path(str(config.get("datadir"))),
+        datadir=config.get("datadir"),
         pairs=pairs,
         timeframe=config.get('ticker_interval', '5m'),
         timerange=timerange,

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -191,9 +191,8 @@ def start_download_data(args: Dict[str, Any]) -> None:
             "Downloading data requires a list of pairs. "
             "Please check the documentation on how to configure this.")
 
-    dl_path = Path(config['datadir'])
     logger.info(f'About to download pairs: {config["pairs"]}, '
-                f'intervals: {config["timeframes"]} to {dl_path}')
+                f'intervals: {config["timeframes"]} to {config["datadir"]}')
 
     pairs_not_available: List[str] = []
 
@@ -203,17 +202,17 @@ def start_download_data(args: Dict[str, Any]) -> None:
 
         if config.get('download_trades'):
             pairs_not_available = refresh_backtest_trades_data(
-                exchange, pairs=config["pairs"], datadir=Path(config['datadir']),
+                exchange, pairs=config["pairs"], datadir=config['datadir'],
                 timerange=timerange, erase=config.get("erase"))
 
             # Convert downloaded trade data to different timeframes
             convert_trades_to_ohlcv(
                 pairs=config["pairs"], timeframes=config["timeframes"],
-                datadir=Path(config['datadir']), timerange=timerange, erase=config.get("erase"))
+                datadir=config['datadir'], timerange=timerange, erase=config.get("erase"))
         else:
             pairs_not_available = refresh_backtest_ohlcv_data(
                 exchange, pairs=config["pairs"], timeframes=config["timeframes"],
-                datadir=Path(config['datadir']), timerange=timerange, erase=config.get("erase"))
+                datadir=config['datadir'], timerange=timerange, erase=config.get("erase"))
 
     except KeyboardInterrupt:
         sys.exit("SIGINT received, aborting ...")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -977,7 +977,7 @@ def test_pairlist_resolving_fallback(mocker):
 
     assert config['pairs'] == ['ETH/BTC', 'XRP/BTC']
     assert config['exchange']['name'] == 'binance'
-    assert config['datadir'] == str(Path.cwd() / "user_data/data/binance")
+    assert config['datadir'] == Path.cwd() / "user_data/data/binance"
 
 
 @pytest.mark.parametrize("setting", [


### PR DESCRIPTION
## Summary
Currently, we convert datadir to Path every time we use it.

By converting when config is initialized, we can avoid this 100fold conversation.

It's a real / visible performance improvement - but it's unnecessary and clutters our code with unnecessary Path() calls and imports.