### PR TITLE
Fix bug in dry-run wallet 

### DIFF
--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -58,13 +58,15 @@ class Wallets:
         - Subtract currently tied up stake_amount in open trades
         - update balances for currencies currently in trades
         """
+        # Recreate _wallets to reset closed trade balances
+        _wallets = {}
         closed_trades = Trade.get_trades(Trade.is_open.is_(False)).all()
         open_trades = Trade.get_trades(Trade.is_open.is_(True)).all()
         tot_profit = sum([trade.calc_profit() for trade in closed_trades])
         tot_in_trades = sum([trade.stake_amount for trade in open_trades])
 
         current_stake = self.start_cap + tot_profit - tot_in_trades
-        self._wallets[self._config['stake_currency']] = Wallet(
+        _wallets[self._config['stake_currency']] = Wallet(
             self._config['stake_currency'],
             current_stake,
             0,
@@ -73,12 +75,13 @@ class Wallets:
 
         for trade in open_trades:
             curr = trade.pair.split('/')[0]
-            self._wallets[curr] = Wallet(
+            _wallets[curr] = Wallet(
                 curr,
                 trade.amount,
                 0,
                 trade.amount
             )
+        self._wallets = _wallets
 
     def _update_live(self) -> None:
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -118,12 +118,10 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     default_conf['max_open_trades'] = 5
     default_conf['forcebuy_enable'] = True
     default_conf['stake_amount'] = 'unlimited'
+    default_conf['dry_run_wallet'] = 1000
     default_conf['exchange']['name'] = 'binance'
     default_conf['telegram']['enabled'] = True
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
-    mocker.patch('freqtrade.wallets.Wallets.get_free', MagicMock(
-        side_effect=[1000, 800, 600, 400, 200]
-    ))
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_ticker=ticker,
@@ -138,6 +136,14 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
         update_trade_state=MagicMock(),
         _notify_sell=MagicMock(),
     )
+    should_sell_mock = MagicMock(side_effect=[
+        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
+        SellCheckTuple(sell_flag=True, sell_type=SellType.SELL_SIGNAL),
+        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
+        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
+        SellCheckTuple(sell_flag=None, sell_type=SellType.NONE)]
+    )
+    mocker.patch("freqtrade.strategy.interface.IStrategy.should_sell", should_sell_mock)
 
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
     rpc = RPC(freqtrade)
@@ -158,3 +164,20 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
 
     for trade in trades:
         assert trade.stake_amount == 200
+        # Reset trade open order id's
+        trade.open_order_id = None
+    trades = Trade.get_open_trades()
+    assert len(trades) == 5
+    bals = freqtrade.wallets.get_all_balances()
+
+    freqtrade.process_maybe_execute_sells(trades)
+    trades = Trade.get_open_trades()
+    # One trade sold
+    assert len(trades) == 4
+    # Validate that balance of sold trade is not in dry-run balances anymore.
+    bals2 = freqtrade.wallets.get_all_balances()
+    assert bals != bals2
+    assert len(bals) == 6
+    assert len(bals2) == 5
+    assert 'LTC' in bals
+    assert 'LTC' not in bals2


### PR DESCRIPTION
## Summary
The bug causes closed trade balances to stick around since the balance is never reset (it's not in open trades, and we don't loop closed trades).

When then calling /balance after some time, you'll see more than `max_open_trades +1` assets in the list - and the total amount does not correspond to the real value.

This can simply be mitigated by recreating the whole wallet dict.


## Quick changelog

- Recreate wallet dict and replace it after calculations
- Update integration test to include testing dry-run wallet (that's what integration tests are for, no?)
