### PR TITLE
/balance should not convert to BTC

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -341,13 +341,14 @@ class RPC:
                 raise RPCException('All balances are zero.')
 
         symbol = fiat_display_currency
-        value = self._fiat_converter.convert_amount(total, 'BTC',
+        value = self._fiat_converter.convert_amount(total, stake_currency,
                                                     symbol) if self._fiat_converter else 0
         return {
             'currencies': output,
             'total': total,
             'symbol': symbol,
             'value': value,
+            'stake': stake_currency,
             'note': 'Simulated balances' if self._freqtrade.config.get('dry_run', False) else ''
         }
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -335,7 +335,7 @@ class Telegram(RPC):
             output = ''
             if self._config['dry_run']:
                 output += (
-                    f"*Warning:*Simulated balances in Dry Mode.\n"
+                    f"*Warning:* Simulated balances in Dry Mode.\n"
                     "This mode is still experimental!\n"
                     "Starting capital: "
                     f"`{self._config['dry_run_wallet']}` {self._config['stake_currency']}.\n"
@@ -358,7 +358,7 @@ class Telegram(RPC):
                     output += curr_output
 
             output += "\n*Estimated Value*:\n" \
-                      "\t`BTC: {total: .8f}`\n" \
+                      "\t`{stake}: {total: .8f}`\n" \
                       "\t`{symbol}: {value: .2f}`\n".format(**result)
             self._send_msg(output)
         except RPCException as e:

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -534,7 +534,7 @@ def test_balance_handle_empty_response_dry(default_conf, update, mocker) -> None
     telegram._balance(update=update, context=MagicMock())
     result = msg_mock.call_args_list[0][0][0]
     assert msg_mock.call_count == 1
-    assert "*Warning:*Simulated balances in Dry Mode." in result
+    assert "*Warning:* Simulated balances in Dry Mode." in result
     assert "Starting capital: `1000` BTC" in result
 
 


### PR DESCRIPTION
## Summary
Align /balance output to show everything in stake currency the conversation to BTC does not make sense

## Quick changelog

- fix typo
- convert total amount to stake-currency instead of BTC
