### PR TITLE
Align Edge documentation to configuration page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,8 +38,8 @@ The prevelance for all Options is as follows:
 
 Mandatory parameters are marked as **Required**, which means that they are required to be set in one of the possible ways.
 
-|  Command | Description |
-|----------|-------------|
+|  Parameter | Description |
+|------------|-------------|
 | `max_open_trades` | **Required.** Number of trades open your bot will have. If -1 then it is ignored (i.e. potentially unlimited open trades).<br> ***Datatype:*** *Positive integer or -1.*
 | `stake_currency` | **Required.** Crypto-currency used for trading. [Strategy Override](#parameters-in-the-strategy). <br> ***Datatype:*** *String*
 | `stake_amount` | **Required.** Amount of crypto-currency your bot will use for each trade. Set it to `"unlimited"` to allow the bot to use all available balance. [More information below](#understand-stake_amount). [Strategy Override](#parameters-in-the-strategy). <br> ***Datatype:*** *Positive float or `"unlimited"`.*
@@ -72,9 +72,9 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `order_time_in_force` | Configure time in force for buy and sell orders. [More information below](#understand-order_time_in_force). [Strategy Override](#parameters-in-the-strategy). <br> ***Datatype:*** *Dict*
 | `exchange.name` | **Required.** Name of the exchange class to use. [List below](#user-content-what-values-for-exchangename). <br> ***Datatype:*** *String*
 | `exchange.sandbox` | Use the 'sandbox' version of the exchange, where the exchange provides a sandbox for risk-free integration. See [here](sandbox-testing.md) in more details.<br> ***Datatype:*** *Boolean*
-| `exchange.key` | API key to use for the exchange. Only required when you are in production mode. **Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
-| `exchange.secret` | API secret to use for the exchange. Only required when you are in production mode. **Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
-| `exchange.password` | API password to use for the exchange. Only required when you are in production mode and for exchanges that use password for API requests. **Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
+| `exchange.key` | API key to use for the exchange. Only required when you are in production mode.<br>**Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
+| `exchange.secret` | API secret to use for the exchange. Only required when you are in production mode.<br>**Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
+| `exchange.password` | API password to use for the exchange. Only required when you are in production mode and for exchanges that use password for API requests.<br>**Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
 | `exchange.pair_whitelist` | List of pairs to use by the bot for trading and to check for potential trades during backtesting. Not used by VolumePairList (see [below](#dynamic-pairlists)). <br> ***Datatype:*** *List*
 | `exchange.pair_blacklist` | List of pairs the bot must absolutely avoid for trading and backtesting (see [below](#dynamic-pairlists)). <br> ***Datatype:*** *List*
 | `exchange.ccxt_config` | Additional CCXT parameters passed to the regular ccxt instance. Parameters may differ from exchange to exchange and are documented in the [ccxt documentation](https://ccxt.readthedocs.io/en/latest/manual.html#instantiation) <br> ***Datatype:*** *Dict*
@@ -84,8 +84,8 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `experimental.block_bad_exchanges` | Block exchanges known to not work with freqtrade. Leave on default unless you want to test if that exchange works now. <br>*Defaults to `true`.* <br> ***Datatype:*** *Boolean*
 | `pairlists` | Define one or more pairlists to be used. [More information below](#dynamic-pairlists). <br>*Defaults to `StaticPairList`.*  <br> ***Datatype:*** *List of Dicts*
 | `telegram.enabled` | Enable the usage of Telegram. <br> ***Datatype:*** *Boolean*
-| `telegram.token` | Your Telegram bot token. Only required if `telegram.enabled` is `true`. **Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
-| `telegram.chat_id` | Your personal Telegram account id. Only required if `telegram.enabled` is `true`. **Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
+| `telegram.token` | Your Telegram bot token. Only required if `telegram.enabled` is `true`. <br>**Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
+| `telegram.chat_id` | Your personal Telegram account id. Only required if `telegram.enabled` is `true`. <br>**Keep it in secret, do not disclose publicly.** <br> ***Datatype:*** *String*
 | `webhook.enabled` | Enable usage of Webhook notifications <br> ***Datatype:*** *Boolean*
 | `webhook.url` | URL for the webhook. Only required if `webhook.enabled` is `true`. See the [webhook documentation](webhook-config.md) for more details. <br> ***Datatype:*** *String*
 | `webhook.webhookbuy` | Payload to send on buy. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details. <br> ***Datatype:*** *String*
@@ -93,9 +93,9 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `webhook.webhookstatus` | Payload to send on status calls. Only required if `webhook.enabled` is `true`. See the [webhook documentationV](webhook-config.md) for more details. <br> ***Datatype:*** *String*
 | `api_server.enabled` | Enable usage of API Server. See the [API Server documentation](rest-api.md) for more details. <br> ***Datatype:*** *Boolean*
 | `api_server.listen_ip_address` | Bind IP address. See the [API Server documentation](rest-api.md) for more details. <br> ***Datatype:*** *IPv4*
-| `api_server.listen_port` | Bind Port. See the [API Server documentation](rest-api.md) for more details. <br> ***Datatype:*** *Integer between 1024 and 65535*
-| `api_server.username` | Username for API server. See the [API Server documentation](rest-api.md) for more details. **Keep it in secret, do not disclose publicly.**<br> ***Datatype:*** *String*
-| `api_server.password` | Password for API server. See the [API Server documentation](rest-api.md) for more details. **Keep it in secret, do not disclose publicly.**<br> ***Datatype:*** *String*
+| `api_server.listen_port` | Bind Port. See the [API Server documentation](rest-api.md) for more details. <br>***Datatype:*** *Integer between 1024 and 65535*
+| `api_server.username` | Username for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> ***Datatype:*** *String*
+| `api_server.password` | Password for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> ***Datatype:*** *String*
 | `db_url` | Declares database URL to use. NOTE: This defaults to `sqlite:///tradesv3.dryrun.sqlite` if `dry_run` is `true`, and to `sqlite:///tradesv3.sqlite` for production instances. <br> ***Datatype:*** *String, SQLAlchemy connect string*
 | `initial_state` | Defines the initial application state. More information below. <br>*Defaults to `stopped`.* <br> ***Datatype:*** *Enum, either `stopped` or `running`*
 | `forcebuy_enable` | Enables the RPC Commands to force a buy. More information below. <br> ***Datatype:*** *Boolean*

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -1,4 +1,4 @@
-#  Edge positioning
+# Edge positioning
 
 This page explains how to use Edge Positioning module in your bot in order to enter into a trade only if the trade has a reasonable win rate and risk reward ratio, and consequently adjust your position size and stoploss.
 
@@ -9,6 +9,7 @@ This page explains how to use Edge Positioning module in your bot in order to en
     Edge does not consider anything else than buy/sell/stoploss signals. So trailing stoploss, ROI, and everything else are ignored in its calculation.
 
 ## Introduction
+
 Trading is all about probability. No one can claim that he has a strategy working all the time. You have to assume that sometimes you lose.
 
 But it doesn't mean there is no rule, it only means rules should work "most of the time". Let's play a game: we toss a coin, heads: I give you 10$, tails: you give me 10$. Is it an interesting game? No, it's quite boring, isn't it?
@@ -22,43 +23,61 @@ Let's complicate it more: you win 80% of the time but only 2$, I win 20% of the 
 The question is: How do you calculate that? How do you know if you wanna play?
 
 The answer comes to two factors:
+
 - Win Rate
 - Risk Reward Ratio
 
 ### Win Rate
+
 Win Rate (*W*) is is the mean over some amount of trades (*N*) what is the percentage of winning trades to total number of trades (note that we don't consider how much you gained but only if you won or not).
 
-    W = (Number of winning trades) / (Total number of trades) = (Number of winning trades) / N
+```
+W = (Number of winning trades) / (Total number of trades) = (Number of winning trades) / N
+```
 
 Complementary Loss Rate (*L*) is defined as
 
-    L = (Number of losing trades) / (Total number of trades) = (Number of losing trades) / N
+```
+L = (Number of losing trades) / (Total number of trades) = (Number of losing trades) / N
+```
 
 or, which is the same, as
 
-    L = 1 – W
+```
+L = 1 – W
+```
 
 ### Risk Reward Ratio
+
 Risk Reward Ratio (*R*) is a formula used to measure the expected gains of a given investment against the risk of loss. It is basically what you potentially win divided by what you potentially lose:
 
-    R = Profit / Loss
+```
+R = Profit / Loss
+```
 
 Over time, on many trades, you can calculate your risk reward by dividing your average profit on winning trades by your average loss on losing trades:
 
-    Average profit = (Sum of profits) / (Number of winning trades)
+```
+Average profit = (Sum of profits) / (Number of winning trades)
 
-    Average loss = (Sum of losses) / (Number of losing trades)
+Average loss = (Sum of losses) / (Number of losing trades)
 
-    R = (Average profit) / (Average loss)
+R = (Average profit) / (Average loss)
+```
 
 ### Expectancy
+
 At this point we can combine *W* and *R* to create an expectancy ratio. This is a simple process of multiplying the risk reward ratio by the percentage of winning trades and subtracting the percentage of losing trades, which is calculated as follows:
 
-    Expectancy Ratio = (Risk Reward Ratio X Win Rate) – Loss Rate = (R X W) – L
+```
+Expectancy Ratio = (Risk Reward Ratio X Win Rate) – Loss Rate = (R X W) – L
+```
 
 So lets say your Win rate is 28% and your Risk Reward Ratio is 5:
 
-    Expectancy = (5 X 0.28) – 0.72 = 0.68
+```
+Expectancy = (5 X 0.28) – 0.72 = 0.68
+```
 
 Superficially, this means that on average you expect this strategy’s trades to return .68 times the size of your loses. This is important for two reasons: First, it may seem obvious, but you know right away that you have a positive return. Second, you now have a number you can compare to other candidate systems to make decisions about which ones you employ.
 
@@ -69,6 +88,7 @@ You can also use this value to evaluate the effectiveness of modifications to th
 **NOTICE:** It's important to keep in mind that Edge is testing your expectancy using historical data, there's no guarantee that you will have a similar edge in the future. It's still vital to do this testing in order to build confidence in your methodology, but be wary of "curve-fitting" your approach to the historical data as things are unlikely to play out the exact same way for future trades.
 
 ## How does it work?
+
 If enabled in config, Edge will go through historical data with a range of stoplosses in order to find buy and sell/stoploss signals. It then calculates win rate and expectancy over *N* trades for each stoploss. Here is an example:
 
 | Pair   |      Stoploss      |  Win Rate | Risk Reward Ratio | Expectancy |
@@ -83,6 +103,7 @@ The goal here is to find the best stoploss for the strategy in order to have the
 Edge module then forces stoploss value it evaluated to your strategy dynamically.
 
 ### Position size
+
 Edge also dictates the stake amount for each trade to the bot according to the following factors:
 
 - Allowed capital at risk
@@ -90,13 +111,17 @@ Edge also dictates the stake amount for each trade to the bot according to the f
 
 Allowed capital at risk is calculated as follows:
 
-    Allowed capital at risk = (Capital available_percentage) X (Allowed risk per trade)
+```
+Allowed capital at risk = (Capital available_percentage) X (Allowed risk per trade)
+```
 
 Stoploss is calculated as described above against historical data.
 
 Your position size then will be:
 
-    Position size = (Allowed capital at risk) / Stoploss
+```
+Position size = (Allowed capital at risk) / Stoploss
+```
 
 Example:
 
@@ -115,100 +140,30 @@ Available capital doesn’t change before a position is sold. Let’s assume tha
 So the Bot receives another buy signal for trade 4 with a stoploss at 2% then your position size would be **0.055 / 0.02 = 2.75 ETH**.
 
 ## Configurations
+
 Edge module has following configuration options:
 
-#### enabled
-If true, then Edge will run periodically.
-
-(defaults to false)
-
-#### process_throttle_secs
-How often should Edge run in seconds?
-
-(defaults to 3600 so one hour)
-
-#### calculate_since_number_of_days
-Number of days of data against which Edge calculates Win Rate, Risk Reward and Expectancy
-Note that it downloads historical data so increasing this number would lead to slowing down the bot.
-
-(defaults to 7)
-
-#### capital_available_percentage
-This is the percentage of the total capital on exchange in stake currency.
-
-As an example if you have 10 ETH available in your wallet on the exchange and this value is 0.5 (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers it as available capital.
-
-(defaults to 0.5)
-
-#### allowed_risk
-Percentage of allowed risk per trade.
-
-(defaults to 0.01 so 1%)
-
-#### stoploss_range_min
-
-Minimum stoploss.
-
-(defaults to -0.01)
-
-#### stoploss_range_max
-
-Maximum stoploss.
-
-(defaults to -0.10)
-
-#### stoploss_range_step
-
-As an example if this is set to -0.01 then Edge will test the strategy for \[-0.01, -0,02, -0,03 ..., -0.09, -0.10\] ranges.
-Note than having a smaller step means having a bigger range which could lead to slow calculation.
-
-If you set this parameter to -0.001, you then slow down the Edge calculation by a factor of 10.
-
-(defaults to -0.01)
-
-#### minimum_winrate
-
-It filters out pairs which don't have at least minimum_winrate.
-
-This comes handy if you want to be conservative and don't comprise win rate in favour of risk reward ratio.
-
-(defaults to 0.60)
-
-#### minimum_expectancy
-
-It filters out pairs which have the expectancy lower than this number.
-
-Having an expectancy of 0.20 means if you put 10$ on a trade you expect a 12$ return.
-
-(defaults to 0.20)
-
-#### min_trade_number
-
-When calculating *W*, *R* and *E* (expectancy) against historical data, you always want to have a minimum number of trades. The more this number is the more Edge is reliable.
-
-Having a win rate of 100% on a single trade doesn't mean anything at all. But having a win rate of 70% over past 100 trades means clearly something.
-
-(defaults to 10, it is highly recommended not to decrease this number)
-
-#### max_trade_duration_minute
-
-Edge will filter out trades with long duration. If a trade is profitable after 1 month, it is hard to evaluate the strategy based on it. But if most of trades are profitable and they have maximum duration of 30 minutes, then it is clearly a good sign.
-
-**NOTICE:** While configuring this value, you should take into consideration your ticker interval. As an example filtering out trades having duration less than one day for a strategy which has 4h interval does not make sense. Default value is set assuming your strategy interval is relatively small (1m or 5m, etc.).
-
-(defaults to 1 day, i.e. to 60 * 24 = 1440 minutes)
-
-#### remove_pumps
-
-Edge will remove sudden pumps in a given market while going through historical data. However, given that pumps happen very often in crypto markets, we recommend you keep this off.
-
-(defaults to false)
+|  Parameter | Description |
+|------------|-------------|
+| `enabled` | If true, then Edge will run periodically. <br>*Defaults to `false`.* <br> ***Datatype:*** *Boolean*
+| `process_throttle_secs` | How often should Edge run in seconds. <br>*Defaults to `3600` (once per hour).* <br> ***Datatype:*** *Integer*
+| `calculate_since_number_of_days` | Number of days of data against which Edge calculates Win Rate, Risk Reward and Expectancy. <br> **Note** that it downloads historical data so increasing this number would lead to slowing down the bot. <br>*Defaults to `7` (once per hour).* <br> ***Datatype:*** *Integer*
+| `capital_available_percentage` | This is the percentage of the total capital on exchange in stake currency. <br>As an example if you have 10 ETH available in your wallet on the exchange and this value is 0.5 (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers it as available capital. <br>*Defaults to `0.5` (once per hour).* <br> ***Datatype:*** *Float*
+| `allowed_risk` | Ratio of allowed risk per trade. <br>*Defaults to `0.01` (1%)).* <br> ***Datatype:*** *Float*
+| `stoploss_range_min` | Minimum stoploss. <br>*Defaults to `-0.01`.* <br> ***Datatype:*** *Float*
+| `stoploss_range_max` | Maximum stoploss. <br>*Defaults to `-0.10`.* <br> ***Datatype:*** *Float*
+| `stoploss_range_step` | As an example if this is set to -0.01 then Edge will test the strategy for `[-0.01, -0,02, -0,03 ..., -0.09, -0.10]` ranges. <br> **Note** than having a smaller step means having a bigger range which could lead to slow calculation. <br> If you set this parameter to -0.001, you then slow down the Edge calculation by a factor of 10. <br>*Defaults to `-0.001`.* <br> ***Datatype:*** *Float*
+| `minimum_winrate` | It filters out pairs which don't have at least minimum_winrate. <br>This comes handy if you want to be conservative and don't comprise win rate in favour of risk reward ratio. <br>*Defaults to `0.60`.* <br> ***Datatype:*** *Float*
+| `minimum_expectancy` | It filters out pairs which have the expectancy lower than this number. <br>Having an expectancy of 0.20 means if you put 10$ on a trade you expect a 12$ return. <br>*Defaults to `0.20`.* <br> ***Datatype:*** *Float*
+| `min_trade_number` | When calculating *W*, *R* and *E* (expectancy) against historical data, you always want to have a minimum number of trades. The more this number is the more Edge is reliable. <br>Having a win rate of 100% on a single trade doesn't mean anything at all. But having a win rate of 70% over past 100 trades means clearly something. <br>*Defaults to `10` (it is highly recommended not to decrease this number).* <br> ***Datatype:*** *Integer*
+| `max_trade_duration_minute` | Edge will filter out trades with long duration. If a trade is profitable after 1 month, it is hard to evaluate the strategy based on it. But if most of trades are profitable and they have maximum duration of 30 minutes, then it is clearly a good sign.<br>**NOTICE:** While configuring this value, you should take into consideration your ticker interval. As an example filtering out trades having duration less than one day for a strategy which has 4h interval does not make sense. Default value is set assuming your strategy interval is relatively small (1m or 5m, etc.).<br>*Defaults to `1440` (one day).* <br> ***Datatype:*** *Integer*
+| `remove_pumps` | Edge will remove sudden pumps in a given market while going through historical data. However, given that pumps happen very often in crypto markets, we recommend you keep this off.<br>*Defaults to `false`.* <br> ***Datatype:*** *Boolean*
 
 ## Running Edge independently
 
 You can run Edge independently in order to see in details the result. Here is an example:
 
-```bash
+``` bash
 freqtrade edge
 ```
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -147,8 +147,8 @@ Edge module has following configuration options:
 |------------|-------------|
 | `enabled` | If true, then Edge will run periodically. <br>*Defaults to `false`.* <br> ***Datatype:*** *Boolean*
 | `process_throttle_secs` | How often should Edge run in seconds. <br>*Defaults to `3600` (once per hour).* <br> ***Datatype:*** *Integer*
-| `calculate_since_number_of_days` | Number of days of data against which Edge calculates Win Rate, Risk Reward and Expectancy. <br> **Note** that it downloads historical data so increasing this number would lead to slowing down the bot. <br>*Defaults to `7` (once per hour).* <br> ***Datatype:*** *Integer*
-| `capital_available_percentage` | This is the percentage of the total capital on exchange in stake currency. <br>As an example if you have 10 ETH available in your wallet on the exchange and this value is 0.5 (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers it as available capital. <br>*Defaults to `0.5` (once per hour).* <br> ***Datatype:*** *Float*
+| `calculate_since_number_of_days` | Number of days of data against which Edge calculates Win Rate, Risk Reward and Expectancy. <br> **Note** that it downloads historical data so increasing this number would lead to slowing down the bot. <br>*Defaults to `7`.* <br> ***Datatype:*** *Integer*
+| `capital_available_percentage` | This is the percentage of the total capital on exchange in stake currency. <br>As an example if you have 10 ETH available in your wallet on the exchange and this value is 0.5 (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers it as available capital. <br>*Defaults to `0.5`.* <br> ***Datatype:*** *Float*
 | `allowed_risk` | Ratio of allowed risk per trade. <br>*Defaults to `0.01` (1%)).* <br> ***Datatype:*** *Float*
 | `stoploss_range_min` | Minimum stoploss. <br>*Defaults to `-0.01`.* <br> ***Datatype:*** *Float*
 | `stoploss_range_max` | Maximum stoploss. <br>*Defaults to `-0.10`.* <br> ***Datatype:*** *Float*


### PR DESCRIPTION
## Summary
We should use the same style when documenting a set of configuration options.
Also renamed the Header of the tables to Parameter instead of Command - since these are parameters / configurations, not commands.

##
* convert edge documentation to table
* newline before "Keep it seecret" to improve appearance in the doc pages