### PR TITLE
backtesting - Sell reason counts

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -137,12 +137,12 @@ A backtesting result will look like that:
 | ZEC/BTC  |          22 |          -0.46 |         -10.18 |      -0.00050971 |          -5.09 | 2:22:00        |        7 |     15 |
 | TOTAL    |         429 |           0.36 |         152.41 |       0.00762792 |          76.20 | 4:12:00        |      186 |    243 |
 ========================================================= SELL REASON STATS =========================================================
-| Sell Reason        |   Count |
-|:-------------------|--------:|
-| trailing_stop_loss |     205 |
-| stop_loss          |     166 |
-| sell_signal        |      56 |
-| force_sell         |       2 |
+| Sell Reason        |   Count |   Profit |   Loss |
+|:-------------------|--------:|---------:|-------:|
+| trailing_stop_loss |     205 |      150 |     55 |
+| stop_loss          |     166 |        0 |    166 |
+| sell_signal        |      56 |       36 |     20 |
+| force_sell         |       2 |        0 |      2 |
 ====================================================== LEFT OPEN TRADES REPORT ======================================================
 | pair     |   buy count |   avg profit % |   cum profit % |   tot profit BTC |   tot profit % | avg duration   |   profit |   loss |
 |:---------|------------:|---------------:|---------------:|-----------------:|---------------:|:---------------|---------:|-------:|
@@ -154,6 +154,7 @@ A backtesting result will look like that:
 The 1st table contains all trades the bot made, including "left open trades".
 
 The 2nd table contains a recap of sell reasons.
+This table can tell you which area needs some additional work (i.e. all `sell_signal` trades are losses, so we should disable the sell-signal or work on improving that).
 
 The 3rd table contains all trades the bot had to `forcesell` at the end of the backtest period to present a full picture.
 This is necessary to simulate realistic behaviour, since the backtest period has to end at some point, while realistically, you could leave the bot running forever.

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -183,9 +183,11 @@ class Backtesting:
         Generate small table outlining Backtest results
         """
         tabular_data = []
-        headers = ['Sell Reason', 'Count']
+        headers = ['Sell Reason', 'Count', 'Profit', 'Loss']
         for reason, count in results['sell_reason'].value_counts().iteritems():
-            tabular_data.append([reason.value,  count])
+            profit = len(results[(results['sell_reason'] == reason) & (results['profit_abs'] >= 0)])
+            loss = len(results[(results['sell_reason'] == reason) & (results['profit_abs'] < 0)])
+            tabular_data.append([reason.value, count, profit, loss])
         return tabulate(tabular_data, headers=headers, tablefmt="pipe")
 
     def _generate_text_table_strategy(self, all_results: dict) -> str:

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -394,8 +394,8 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
     results = pd.DataFrame(
         {
             'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
-            'profit_percent': [0.1, 0.2, 0.3],
-            'profit_abs': [0.2, 0.4, 0.5],
+            'profit_percent': [0.1, 0.2, -0.3],
+            'profit_abs': [0.2, 0.4, -0.5],
             'trade_duration': [10, 30, 10],
             'profit': [2, 0, 0],
             'loss': [0, 0, 1],
@@ -404,10 +404,10 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
     )
 
     result_str = (
-        '| Sell Reason   |   Count |\n'
-        '|:--------------|--------:|\n'
-        '| roi           |       2 |\n'
-        '| stop_loss     |       1 |'
+        '| Sell Reason   |   Count |   Profit |   Loss |\n'
+        '|:--------------|--------:|---------:|-------:|\n'
+        '| roi           |       2 |        2 |      0 |\n'
+        '| stop_loss     |       1 |        0 |      1 |'
     )
     assert backtesting._generate_text_table_sell_reason(
         data={'ETH/BTC': {}}, results=results) == result_str


### PR DESCRIPTION
## Summary
Enhance backtest result with sell-reason profit / loss statistics.

This can be show important details for certain types of sell reasons (mainly trailing stoploss and sell-signal) and will help to determine which area of the strategy can be worked on to be improved.

e.g. if most sell-signals produce losses, and all gains come from ROI, it may be best to try the strategy without sell signal.

## Quick changelog

- add sell reason counts to output
