### PR TITLE
Check if markets.info is a dict before using it

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -278,7 +278,15 @@ class Exchange:
                 raise OperationalException(
                     f'Pair {pair} is not available on {self.name}. '
                     f'Please remove {pair} from your whitelist.')
-            elif self.markets[pair].get('info', {}).get('IsRestricted', False):
+
+                # From ccxt Documentation:
+                # markets.info: An associative array of non-common market properties,
+                # including fees, rates, limits and other general market information.
+                # The internal info array is different for each particular market,
+                # its contents depend on the exchange.
+                # It can also be a string or similar ... so we need to verify that first.
+            elif (isinstance(self.markets[pair].get('info', None), dict)
+                  and self.markets[pair].get('info', {}).get('IsRestricted', False)):
                 # Warn users about restricted pairs in whitelist.
                 # We cannot determine reliably if Users are affected.
                 logger.warning(f"Pair {pair} is restricted for some users on this exchange."

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -363,7 +363,7 @@ def test_validate_pairs_exception(default_conf, mocker, caplog):
 def test_validate_pairs_restricted(default_conf, mocker, caplog):
     api_mock = MagicMock()
     type(api_mock).markets = PropertyMock(return_value={
-        'ETH/BTC': {}, 'LTC/BTC': {}, 'NEO/BTC': {},
+        'ETH/BTC': {}, 'LTC/BTC': {},
         'XRP/BTC': {'info': {'IsRestricted': True}},
         'NEO/BTC': {'info': 'TestString'},  # info can also be a string ...
     })

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -364,7 +364,8 @@ def test_validate_pairs_restricted(default_conf, mocker, caplog):
     api_mock = MagicMock()
     type(api_mock).markets = PropertyMock(return_value={
         'ETH/BTC': {}, 'LTC/BTC': {}, 'NEO/BTC': {},
-        'XRP/BTC': {'info': {'IsRestricted': True}}
+        'XRP/BTC': {'info': {'IsRestricted': True}},
+        'NEO/BTC': {'info': 'TestString'},  # info can also be a string ...
     })
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())


### PR DESCRIPTION
## Summary
Markets.info does not need to be a dict - but contains the raw content from the exchange - in case of gemini, that's a string, so we need to verify the type here first.

closes #2716

## Quick changelog

- Ensure we're not failing when markets.info is not a dict.