### PR TITLE
Refactor create trades

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -313,7 +313,7 @@ class FreqtradeBot:
 
         if buy and not sell:
             if not self.get_free_open_trades():
-                logger.debug("Can't open a new trade: max number of trades is reached")
+                logger.debug("Can't open a new trade: max number of trades is reached.")
                 return False
 
             stake_amount = self.get_trade_stake_amount(pair)
@@ -324,11 +324,10 @@ class FreqtradeBot:
             logger.info(f"Buy signal found: about create a new trade with stake_amount: "
                         f"{stake_amount} ...")
 
-            bidstrat_check_depth_of_market = self.config.get('bid_strategy', {}).\
-                get('check_depth_of_market', {})
-            if (bidstrat_check_depth_of_market.get('enabled', False)) and\
-                    (bidstrat_check_depth_of_market.get('bids_to_ask_delta', 0) > 0):
-                if self._check_depth_of_market_buy(pair, bidstrat_check_depth_of_market):
+            bid_check_dom = self.config.get('bid_strategy', {}).get('check_depth_of_market', {})
+            if ((bid_check_dom.get('enabled', False)) and
+                    (bid_check_dom.get('bids_to_ask_delta', 0) > 0)):
+                if self._check_depth_of_market_buy(pair, bid_check_dom):
                     return self.execute_buy(pair, stake_amount)
                 else:
                     return False

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -485,7 +485,7 @@ class FreqtradeBot:
                     try:
                         trades_created += self.create_trade(pair)
                     except DependencyException as exception:
-                        logger.warning('Unable to create trade: %s', exception)
+                        logger.warning('Unable to create trade for %s: %s', pair, exception)
 
                 if not trades_created:
                     logger.debug("Found no buy signals for whitelisted currencies. "

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -296,8 +296,11 @@ class FreqtradeBot:
 
     def create_trade(self, pair: str) -> bool:
         """
-        Check the implemented trading strategy for buy-signals.
-        If the pair triggers the buy_signal a new trade record gets created.
+        Check the implemented trading strategy for buy signals.
+
+        If the pair triggers the buy signal a new trade record gets created
+        and the buy-order opening the trade gets issued towards the exchange.
+
         :return: True if a trade has been created.
         """
         logger.debug(f"create_trade for pair {pair}")
@@ -467,7 +470,7 @@ class FreqtradeBot:
         if not whitelist:
             logger.info("Active pair whitelist is empty.")
         else:
-            # Remove currently opened and latest pairs from whitelist
+            # Remove pairs for currently opened trades from the whitelist
             for trade in Trade.get_open_trades():
                 if trade.pair in whitelist:
                     whitelist.remove(trade.pair)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -132,8 +132,8 @@ class FreqtradeBot:
         self.dataprovider.refresh(self._create_pair_whitelist(self.active_pair_whitelist),
                                   self.strategy.informative_pairs())
 
-        # First process current opened trades
-        self.process_maybe_execute_sells(trades)
+        # First process current opened trades (positions)
+        self.exit_positions(trades)
 
         # Then looking for buy opportunities
         if self.get_free_open_trades():
@@ -493,9 +493,9 @@ class FreqtradeBot:
 
         return trades_created
 
-    def process_maybe_execute_sells(self, trades: List[Any]) -> int:
+    def exit_positions(self, trades: List[Any]) -> int:
         """
-        Tries to execute sell orders for trades in a safe way
+        Tries to execute sell orders for open trades (positions)
         """
         trades_closed = 0
         for trade in trades:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -137,7 +137,7 @@ class FreqtradeBot:
 
         # Then looking for buy opportunities
         if self.get_free_open_trades():
-            self.process_maybe_execute_buys()
+            self.enter_positions()
 
         # Check and handle any timed out open orders
         self.check_handle_timedout()
@@ -460,9 +460,9 @@ class FreqtradeBot:
 
         return True
 
-    def process_maybe_execute_buys(self) -> int:
+    def enter_positions(self) -> int:
         """
-        Tries to execute buy orders for trades in a safe way
+        Tries to execute buy orders for new trades (positions)
         """
         trades_created = 0
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -41,7 +41,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active trade*'):
         rpc._rpc_trade_status()
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     results = rpc._rpc_trade_status()
     assert {
         'trade_id': 1,
@@ -116,7 +116,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active order*'):
         rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
 
     result, headers = rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
     assert "Since" in headers
@@ -162,7 +162,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     assert trade
 
@@ -217,7 +217,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
         rpc._rpc_trade_statistics(stake_currency, fiat_display_currency)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -231,7 +231,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     trade.close_date = datetime.utcnow()
     trade.is_open = False
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -299,7 +299,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -529,7 +529,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
@@ -563,7 +563,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     assert cancel_order_mock.call_count == 1
     assert trade.amount == filled_amount
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.filter(Trade.id == '2').first()
     amount = trade.amount
     # make an limit-buy open trade, if there is no 'filled', don't sell it
@@ -582,7 +582,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     assert cancel_order_mock.call_count == 2
     assert trade.amount == amount
 
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     # make an limit-sell open trade
     mocker.patch(
         'freqtrade.exchange.Exchange.get_order',
@@ -613,7 +613,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     assert trade
 
@@ -649,7 +649,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     assert counts["current"] == 0
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     counts = rpc._rpc_count()
     assert counts["current"] == 1
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -41,7 +41,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active trade*'):
         rpc._rpc_trade_status()
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     results = rpc._rpc_trade_status()
     assert {
         'trade_id': 1,
@@ -116,7 +116,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
     with pytest.raises(RPCException, match=r'.*no active order*'):
         rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
 
     result, headers = rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
     assert "Since" in headers
@@ -162,7 +162,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter()
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     assert trade
 
@@ -217,7 +217,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
         rpc._rpc_trade_statistics(stake_currency, fiat_display_currency)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -231,7 +231,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     trade.close_date = datetime.utcnow()
     trade.is_open = False
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -299,7 +299,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -529,7 +529,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     msg = rpc._rpc_forcesell('all')
     assert msg == {'result': 'Created sell orders for all open trades.'}
 
@@ -563,7 +563,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     assert cancel_order_mock.call_count == 1
     assert trade.amount == filled_amount
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.filter(Trade.id == '2').first()
     amount = trade.amount
     # make an limit-buy open trade, if there is no 'filled', don't sell it
@@ -582,7 +582,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     assert cancel_order_mock.call_count == 2
     assert trade.amount == amount
 
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     # make an limit-sell open trade
     mocker.patch(
         'freqtrade.exchange.Exchange.get_order',
@@ -613,7 +613,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     assert trade
 
@@ -649,7 +649,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     assert counts["current"] == 0
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     counts = rpc._rpc_count()
     assert counts["current"] == 1
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -267,7 +267,7 @@ def test_api_count(botclient, mocker, ticker, fee, markets):
     assert rc.json["max"] == 1.0
 
     # Create some test data
-    ftbot.create_trades()
+    ftbot.process_maybe_execute_buys()
     rc = client_get(client, f"{BASE_URI}/count")
     assert_response(rc)
     assert rc.json["current"] == 1.0
@@ -333,7 +333,7 @@ def test_api_profit(botclient, mocker, ticker, fee, markets, limit_buy_order, li
     assert len(rc.json) == 1
     assert rc.json == {"error": "Error querying _profit: no closed trade"}
 
-    ftbot.create_trades()
+    ftbot.process_maybe_execute_buys()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -422,7 +422,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 200)
     assert rc.json == []
 
-    ftbot.create_trades()
+    ftbot.process_maybe_execute_buys()
     rc = client_get(client, f"{BASE_URI}/status")
     assert_response(rc)
     assert len(rc.json) == 1
@@ -552,7 +552,7 @@ def test_api_forcesell(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 502)
     assert rc.json == {"error": "Error querying _forcesell: invalid argument"}
 
-    ftbot.create_trades()
+    ftbot.process_maybe_execute_buys()
 
     rc = client_post(client, f"{BASE_URI}/forcesell",
                      data='{"tradeid": "1"}')

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -267,7 +267,7 @@ def test_api_count(botclient, mocker, ticker, fee, markets):
     assert rc.json["max"] == 1.0
 
     # Create some test data
-    ftbot.process_maybe_execute_buys()
+    ftbot.enter_positions()
     rc = client_get(client, f"{BASE_URI}/count")
     assert_response(rc)
     assert rc.json["current"] == 1.0
@@ -333,7 +333,7 @@ def test_api_profit(botclient, mocker, ticker, fee, markets, limit_buy_order, li
     assert len(rc.json) == 1
     assert rc.json == {"error": "Error querying _profit: no closed trade"}
 
-    ftbot.process_maybe_execute_buys()
+    ftbot.enter_positions()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -422,7 +422,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 200)
     assert rc.json == []
 
-    ftbot.process_maybe_execute_buys()
+    ftbot.enter_positions()
     rc = client_get(client, f"{BASE_URI}/status")
     assert_response(rc)
     assert len(rc.json) == 1
@@ -552,7 +552,7 @@ def test_api_forcesell(botclient, mocker, ticker, fee, markets):
     assert_response(rc, 502)
     assert rc.json == {"error": "Error querying _forcesell: invalid argument"}
 
-    ftbot.process_maybe_execute_buys()
+    ftbot.enter_positions()
 
     rc = client_post(client, f"{BASE_URI}/forcesell",
                      data='{"tradeid": "1"}')

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -188,8 +188,8 @@ def test_status(default_conf, update, mocker, fee, ticker,) -> None:
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    for _ in range(3):
-        freqtradebot.process_maybe_execute_buys()
+    n = freqtradebot.enter_positions()
+    assert n == 1
 
     telegram._status(update=update, context=MagicMock())
     assert msg_mock.call_count == 1
@@ -236,7 +236,7 @@ def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     # Trigger status while we have a fulfilled order for the open trade
     telegram._status(update=update, context=MagicMock())
 
@@ -285,7 +285,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
 
     telegram._status_table(update=update, context=MagicMock())
 
@@ -322,7 +322,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     assert trade
 
@@ -352,7 +352,8 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     msg_mock.reset_mock()
     freqtradebot.config['max_open_trades'] = 2
     # Add two other trades
-    freqtradebot.process_maybe_execute_buys()
+    n = freqtradebot.enter_positions()
+    assert n == 2
 
     trades = Trade.query.all()
     for trade in trades:
@@ -431,7 +432,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -709,7 +710,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
 
     trade = Trade.query.first()
     assert trade
@@ -764,7 +765,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
 
     # Decrease the price and sell it
     mocker.patch.multiple(
@@ -821,7 +822,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     rpc_mock.reset_mock()
 
     # /forcesell all
@@ -971,7 +972,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     trade = Trade.query.first()
     assert trade
 
@@ -1014,7 +1015,7 @@ def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     freqtradebot.state = State.RUNNING
 
     # Create some test data
-    freqtradebot.process_maybe_execute_buys()
+    freqtradebot.enter_positions()
     msg_mock.reset_mock()
     telegram._count(update=update, context=MagicMock())
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -148,11 +148,6 @@ def test_status(default_conf, update, mocker, fee, ticker,) -> None:
     default_conf['telegram']['enabled'] = False
     default_conf['telegram']['chat_id'] = "123"
 
-    mocker.patch.multiple(
-        'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
-        get_fee=fee,
-    )
     msg_mock = MagicMock()
     status_table = MagicMock()
     mocker.patch.multiple(
@@ -184,12 +179,7 @@ def test_status(default_conf, update, mocker, fee, ticker,) -> None:
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
-    patch_get_signal(freqtradebot, (True, False))
     telegram = Telegram(freqtradebot)
-
-    # Create some test data
-    n = freqtradebot.enter_positions()
-    assert n == 1
 
     telegram._status(update=update, context=MagicMock())
     assert msg_mock.call_count == 1

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -189,7 +189,7 @@ def test_status(default_conf, update, mocker, fee, ticker,) -> None:
 
     # Create some test data
     for _ in range(3):
-        freqtradebot.create_trades()
+        freqtradebot.process_maybe_execute_buys()
 
     telegram._status(update=update, context=MagicMock())
     assert msg_mock.call_count == 1
@@ -236,7 +236,7 @@ def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     # Trigger status while we have a fulfilled order for the open trade
     telegram._status(update=update, context=MagicMock())
 
@@ -285,7 +285,7 @@ def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
 
     telegram._status_table(update=update, context=MagicMock())
 
@@ -322,7 +322,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     assert trade
 
@@ -352,7 +352,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     msg_mock.reset_mock()
     freqtradebot.config['max_open_trades'] = 2
     # Add two other trades
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
 
     trades = Trade.query.all()
     for trade in trades:
@@ -431,7 +431,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -709,7 +709,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
 
     trade = Trade.query.first()
     assert trade
@@ -764,7 +764,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
 
     # Decrease the price and sell it
     mocker.patch.multiple(
@@ -821,7 +821,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     rpc_mock.reset_mock()
 
     # /forcesell all
@@ -971,7 +971,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     trade = Trade.query.first()
     assert trade
 
@@ -1014,7 +1014,7 @@ def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     freqtradebot.state = State.RUNNING
 
     # Create some test data
-    freqtradebot.create_trades()
+    freqtradebot.process_maybe_execute_buys()
     msg_mock.reset_mock()
     telegram._count(update=update, context=MagicMock())
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1454,7 +1454,8 @@ def test_enter_positions(mocker, default_conf, caplog) -> None:
     n = freqtrade.enter_positions()
     assert n == 0
     assert log_has('Found no buy signals for whitelisted currencies. Trying again...', caplog)
-    assert mock_ct.call_count == 4
+    # create_trade should be called once for every pair in the whitelist.
+    assert mock_ct.call_count == len(default_conf['exchange']['pair_whitelist'])
 
 
 def test_enter_positions_exception(mocker, default_conf, caplog) -> None:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1449,10 +1449,12 @@ def test_enter_positions(mocker, default_conf, caplog) -> None:
     caplog.set_level(logging.DEBUG)
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.create_trade', MagicMock(return_value=False))
+    mock_ct = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.create_trade',
+                           MagicMock(return_value=False))
     n = freqtrade.enter_positions()
     assert n == 0
     assert log_has('Found no buy signals for whitelisted currencies. Trying again...', caplog)
+    assert mock_ct.call_count == 4
 
 
 def test_enter_positions_exception(mocker, default_conf, caplog) -> None:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1468,7 +1468,7 @@ def test_enter_positions_exception(mocker, default_conf, caplog) -> None:
     n = freqtrade.enter_positions()
     assert n == 0
     assert mock_ct.call_count == len(default_conf['exchange']['pair_whitelist'])
-    assert log_has('Unable to create trade: ', caplog)
+    assert log_has('Unable to create trade for ETH/BTC: ', caplog)
 
 
 def test_exit_positions(mocker, default_conf, limit_buy_order, caplog) -> None:
@@ -3642,6 +3642,6 @@ def test_sync_wallet_dry_run(mocker, default_conf, ticker, fee, limit_buy_order,
     bot.config['max_open_trades'] = 3
     n = bot.enter_positions()
     assert n == 0
-    assert log_has_re(r"Unable to create trade: "
+    assert log_has_re(r"Unable to create trade for XRP/BTC: "
                       r"Available balance \(0 BTC\) is lower than stake amount \(0.001 BTC\)",
                       caplog)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1458,12 +1458,13 @@ def test_enter_positions(mocker, default_conf, caplog) -> None:
 def test_enter_positions_exception(mocker, default_conf, caplog) -> None:
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
-    mocker.patch(
+    mock_ct = mocker.patch(
         'freqtrade.freqtradebot.FreqtradeBot.create_trade',
         MagicMock(side_effect=DependencyException)
     )
     n = freqtrade.enter_positions()
     assert n == 0
+    assert mock_ct.call_count == len(default_conf['exchange']['pair_whitelist'])
     assert log_has('Unable to create trade: ', caplog)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,7 +90,8 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
         trade.stoploss_order_id = 3
         trade.open_order_id = None
 
-    freqtrade.process_maybe_execute_sells(trades)
+    n = freqtrade.exit_positions(trades)
+    assert n == 2
     assert should_sell_mock.call_count == 2
 
     # Only order for 3rd trade needs to be cancelled
@@ -170,7 +171,8 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     assert len(trades) == 5
     bals = freqtrade.wallets.get_all_balances()
 
-    freqtrade.process_maybe_execute_sells(trades)
+    n = freqtrade.exit_positions(trades)
+    assert n == 1
     trades = Trade.get_open_trades()
     # One trade sold
     assert len(trades) == 4

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,7 +80,7 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
     patch_get_signal(freqtrade)
 
     # Create some test data
-    freqtrade.create_trades()
+    freqtrade.process_maybe_execute_buys()
     wallets_mock.reset_mock()
     Trade.session = MagicMock()
 
@@ -153,7 +153,7 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     patch_get_signal(freqtrade)
 
     # Create 4 trades
-    freqtrade.create_trades()
+    freqtrade.process_maybe_execute_buys()
 
     trades = Trade.query.all()
     assert len(trades) == 4

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,7 +80,7 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
     patch_get_signal(freqtrade)
 
     # Create some test data
-    freqtrade.process_maybe_execute_buys()
+    freqtrade.enter_positions()
     wallets_mock.reset_mock()
     Trade.session = MagicMock()
 
@@ -154,7 +154,8 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     patch_get_signal(freqtrade)
 
     # Create 4 trades
-    freqtrade.process_maybe_execute_buys()
+    n = freqtrade.enter_positions()
+    assert n == 4
 
     trades = Trade.query.all()
     assert len(trades) == 4


### PR DESCRIPTION
This PR refactors the `create_trades()` method of Freqtradebot (continuation of #2718):

* move `for pair` loop to `process_maybe_execute_buys()` from `create_trades()`. This aligns `process_maybe_execute_buys()` to be similar in the structure to `process_maybe_execute_sells()`, it also contains the loop for pairs (trades) and calls `handle_*()` methods that work for single trade (pair).
* `create_trades()` renamed to `create_trade()` accordingly
* tests adjusted
* handing of DependencyException improved. Currently, if this exception happens during creation of a trade for any pair, this terminates the whole `for pair` loop and other trades can only be processed at the next throttling iteration (where same exception can also happen).

The changes are quite simple, but not very visible in the diffs. It's easier to review on per-commit basis...

TBD, possible further (minor) enhancements, not for this PR:
* probably both `process_maybe_execute_buys()` and `process_maybe_execute_sells()` should return bool again (True if buy/sell happened). For more effective and simple checks in the tests, this is not needed for the bot internals.

TODO (not for this PR):
* an integration test for handling DependencyException should be added. It should check that if the exception happens during creation of one trade, other trades were still created during one call to `process_maybe_execute_buys()`. This may be done alone with the integration test mentioned in #2718