### PR TITLE
[minor] Add trailing_only_offset to template and sample

### DIFF
--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -47,6 +47,7 @@ class {{ strategy }}(IStrategy):
 
     # Trailing stoploss
     trailing_stop = False
+    # trailing_only_offset_is_reached = False
     # trailing_stop_positive = 0.01
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 

--- a/freqtrade/templates/sample_strategy.py
+++ b/freqtrade/templates/sample_strategy.py
@@ -48,6 +48,7 @@ class SampleStrategy(IStrategy):
 
     # Trailing stoploss
     trailing_stop = False
+    # trailing_only_offset_is_reached = False
     # trailing_stop_positive = 0.01
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 


### PR DESCRIPTION
## Summary
we should have `trailing_stop_positive_offset` in the sample strategy (and template) too - it's an important setting with trailing_stoploss and should be set intentionally to true or false

## Quick changelog

- add `trailing_stop_positive_offset` to sample and template
