### PR TITLE
[Minor] Edge-cli should use exchangeresolver

### DIFF
--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -12,8 +12,7 @@ from freqtrade import constants
 from freqtrade.configuration import (TimeRange, remove_credentials,
                                      validate_config_consistency)
 from freqtrade.edge import Edge
-from freqtrade.exchange import Exchange
-from freqtrade.resolvers import StrategyResolver
+from freqtrade.resolvers import StrategyResolver, ExchangeResolver
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ class EdgeCli:
         # Reset keys for edge
         remove_credentials(self.config)
         self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
-        self.exchange = Exchange(self.config)
+        self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
         self.strategy = StrategyResolver.load_strategy(self.config)
 
         validate_config_consistency(self.config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -448,6 +448,9 @@ def test_create_datadir(caplog, mocker):
     # Ensure that caplog is empty before starting ...
     # Should prevent random failures.
     caplog.clear()
+    # Added assert here to analyze random test-failures ...
+    assert len(caplog.record_tuples) == 0
+
     cud = mocker.patch("freqtrade.utils.create_userdata_dir", MagicMock())
     csf = mocker.patch("freqtrade.utils.copy_sample_files", MagicMock())
     args = [


### PR DESCRIPTION
## Summary
Edge-cli should use Exchangeresolver just as everything else.

Also added a small debug-assert trying to find the root-cause for the random test-failures (which are not reproducible with the same random seed).