### PR TITLE
Refactor Exceptions to their own file

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -11,34 +11,3 @@ if __version__ == 'develop':
     except Exception:
         # git not available, ignore
         pass
-
-
-class DependencyException(Exception):
-    """
-    Indicates that an assumed dependency is not met.
-    This could happen when there is currently not enough money on the account.
-    """
-
-
-class OperationalException(Exception):
-    """
-    Requires manual intervention and will usually stop the bot.
-    This happens when an exchange returns an unexpected error during runtime
-    or given configuration is invalid.
-    """
-
-
-class InvalidOrderException(Exception):
-    """
-    This is returned when the order is not valid. Example:
-    If stoploss on exchange order is hit, then trying to cancel the order
-    should return this exception.
-    """
-
-
-class TemporaryError(Exception):
-    """
-    Temporary network or exchange related error.
-    This could happen when an exchange is congested, unavailable, or the user
-    has networking problems. Usually resolves itself after a time.
-    """

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any, Dict
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import (available_exchanges, get_exchange_bad_reason,
-                                is_exchange_known_ccxt, is_exchange_bad,
+                                is_exchange_bad, is_exchange_known_ccxt,
                                 is_exchange_officially_supported)
 from freqtrade.state import RunMode
 

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -4,7 +4,8 @@ from typing import Any, Dict
 from jsonschema import Draft4Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
 
-from freqtrade import constants, OperationalException
+from freqtrade import constants
+from freqtrade.exceptions import OperationalException
 from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -7,15 +7,16 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from freqtrade import OperationalException, constants
+from freqtrade import constants
 from freqtrade.configuration.check_exchange import check_exchange
 from freqtrade.configuration.deprecated_settings import process_temporary_deprecated_settings
 from freqtrade.configuration.directory_operations import (create_datadir,
                                                           create_userdata_dir)
 from freqtrade.configuration.load_config import load_config_file
+from freqtrade.exceptions import OperationalException
 from freqtrade.loggers import setup_logging
 from freqtrade.misc import deep_merge_dicts, json_load
-from freqtrade.state import RunMode, TRADING_MODES, NON_UTIL_MODES
+from freqtrade.state import NON_UTIL_MODES, TRADING_MODES, RunMode
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -5,7 +5,7 @@ Functions to handle deprecated settings
 import logging
 from typing import Any, Dict
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/configuration/directory_operations.py
+++ b/freqtrade/configuration/directory_operations.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.constants import USER_DATA_FILES
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/configuration/load_config.py
+++ b/freqtrade/configuration/load_config.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from typing import Any, Dict
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -16,10 +16,12 @@ from typing import Any, Dict, List, Optional, Tuple
 import arrow
 from pandas import DataFrame
 
-from freqtrade import OperationalException, misc
+from freqtrade import misc
 from freqtrade.configuration import TimeRange
 from freqtrade.data.converter import parse_ticker_dataframe, trades_to_ohlcv
-from freqtrade.exchange import Exchange, timeframe_to_minutes, timeframe_to_seconds
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange import (Exchange, timeframe_to_minutes,
+                                timeframe_to_seconds)
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/edge/__init__.py
+++ b/freqtrade/edge/__init__.py
@@ -8,11 +8,11 @@ import numpy as np
 import utils_find_1st as utf1st
 from pandas import DataFrame
 
-from freqtrade import constants, OperationalException
+from freqtrade import constants
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
+from freqtrade.exceptions import OperationalException
 from freqtrade.strategy.interface import SellType
-
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/exceptions.py
+++ b/freqtrade/exceptions.py
@@ -1,0 +1,31 @@
+
+
+class DependencyException(Exception):
+    """
+    Indicates that an assumed dependency is not met.
+    This could happen when there is currently not enough money on the account.
+    """
+
+
+class OperationalException(Exception):
+    """
+    Requires manual intervention and will usually stop the bot.
+    This happens when an exchange returns an unexpected error during runtime
+    or given configuration is invalid.
+    """
+
+
+class InvalidOrderException(Exception):
+    """
+    This is returned when the order is not valid. Example:
+    If stoploss on exchange order is hit, then trying to cancel the order
+    should return this exception.
+    """
+
+
+class TemporaryError(Exception):
+    """
+    Temporary network or exchange related error.
+    This could happen when an exchange is congested, unavailable, or the user
+    has networking problems. Usually resolves itself after a time.
+    """

--- a/freqtrade/exceptions.py
+++ b/freqtrade/exceptions.py
@@ -1,21 +1,27 @@
 
 
-class DependencyException(Exception):
+class FreqtradeException(Exception):
+    """
+    Freqtrade base exception. Handled at the outermost level.
+    All other exception types are subclasses of this exception type.
+    """
+
+
+class OperationalException(FreqtradeException):
+    """
+    Requires manual intervention and will stop the bot.
+    Most of the time, this is caused by an invalid Configuration.
+    """
+
+
+class DependencyException(FreqtradeException):
     """
     Indicates that an assumed dependency is not met.
     This could happen when there is currently not enough money on the account.
     """
 
 
-class OperationalException(Exception):
-    """
-    Requires manual intervention and will usually stop the bot.
-    This happens when an exchange returns an unexpected error during runtime
-    or given configuration is invalid.
-    """
-
-
-class InvalidOrderException(Exception):
+class InvalidOrderException(FreqtradeException):
     """
     This is returned when the order is not valid. Example:
     If stoploss on exchange order is hit, then trying to cancel the order
@@ -23,7 +29,7 @@ class InvalidOrderException(Exception):
     """
 
 
-class TemporaryError(Exception):
+class TemporaryError(FreqtradeException):
     """
     Temporary network or exchange related error.
     This could happen when an exchange is congested, unavailable, or the user

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -4,8 +4,8 @@ from typing import Dict
 
 import ccxt
 
-from freqtrade import (DependencyException, InvalidOrderException,
-                       OperationalException, TemporaryError)
+from freqtrade.exceptions import (DependencyException, InvalidOrderException,
+                                  OperationalException, TemporaryError)
 from freqtrade.exchange import Exchange
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -1,6 +1,6 @@
 import logging
 
-from freqtrade import DependencyException, TemporaryError
+from freqtrade.exceptions import DependencyException, TemporaryError
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -17,9 +17,9 @@ import ccxt.async_support as ccxt_async
 from ccxt.base.decimal_to_precision import ROUND_DOWN, ROUND_UP
 from pandas import DataFrame
 
-from freqtrade import (DependencyException, InvalidOrderException,
-                       OperationalException, TemporaryError)
 from freqtrade.data.converter import parse_ticker_dataframe
+from freqtrade.exceptions import (DependencyException, InvalidOrderException,
+                                  OperationalException, TemporaryError)
 from freqtrade.exchange.common import BAD_EXCHANGES, retrier, retrier_async
 from freqtrade.misc import deep_merge_dicts
 

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 import ccxt
 
-from freqtrade import OperationalException, TemporaryError
+from freqtrade.exceptions import OperationalException, TemporaryError
 from freqtrade.exchange import Exchange
 from freqtrade.exchange.exchange import retrier
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -12,17 +12,17 @@ from typing import Any, Dict, List, Optional, Tuple
 import arrow
 from requests.exceptions import RequestException
 
-from freqtrade import (DependencyException, InvalidOrderException, __version__,
-                       constants, persistence)
+from freqtrade import __version__, constants, persistence
 from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
+from freqtrade.exceptions import DependencyException, InvalidOrderException
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
+from freqtrade.pairlist.pairlistmanager import PairListManager
 from freqtrade.persistence import Trade
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.rpc import RPCManager, RPCMessageType
-from freqtrade.pairlist.pairlistmanager import PairListManager
 from freqtrade.state import State
 from freqtrade.strategy.interface import IStrategy, SellType
 from freqtrade.wallets import Wallets

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -5,7 +5,7 @@ from logging import Formatter
 from logging.handlers import RotatingFileHandler, SysLogHandler
 from typing import Any, Dict, List
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -13,8 +13,8 @@ if sys.version_info < (3, 6):
 import logging
 from typing import Any, List
 
-from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
+from freqtrade.exceptions import OperationalException
 
 
 logger = logging.getLogger('freqtrade')

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -4,6 +4,7 @@ Main Freqtrade bot script.
 Read the documentation to know what cli arguments you need.
 """
 
+from freqtrade.exceptions import FreqtradeException, OperationalException
 import sys
 # check min. python version
 if sys.version_info < (3, 6):
@@ -14,7 +15,6 @@ import logging
 from typing import Any, List
 
 from freqtrade.configuration import Arguments
-from freqtrade.exceptions import OperationalException
 
 
 logger = logging.getLogger('freqtrade')
@@ -50,7 +50,7 @@ def main(sysargv: List[str] = None) -> None:
     except KeyboardInterrupt:
         logger.info('SIGINT received, aborting ...')
         return_code = 0
-    except OperationalException as e:
+    except FreqtradeException as e:
         logger.error(str(e))
         return_code = 2
     except Exception:

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Dict
 
-from freqtrade import DependencyException, constants, OperationalException
+from freqtrade import constants
+from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.state import RunMode
 from freqtrade.utils import setup_utils_configuration
-
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -12,11 +12,11 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from pandas import DataFrame
 from tabulate import tabulate
 
-from freqtrade import OperationalException
 from freqtrade.configuration import (TimeRange, remove_credentials,
                                      validate_config_consistency)
 from freqtrade.data import history
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.misc import file_dump_json
 from freqtrade.persistence import Trade

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -22,13 +22,13 @@ from joblib import (Parallel, cpu_count, delayed, dump, load,
                     wrap_non_picklable_objects)
 from pandas import DataFrame
 
-from freqtrade import OperationalException
 from freqtrade.data.history import get_timerange, trim_dataframe
+from freqtrade.exceptions import OperationalException
 from freqtrade.misc import plural, round_dict
 from freqtrade.optimize.backtesting import Backtesting
 # Import IHyperOpt and IHyperOptLoss to allow unpickling classes from these modules
-from freqtrade.optimize.hyperopt_interface import IHyperOpt  # noqa: F4
-from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F4
+from freqtrade.optimize.hyperopt_interface import IHyperOpt  # noqa: F401
+from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F401
 from freqtrade.resolvers.hyperopt_resolver import (HyperOptLossResolver,
                                                    HyperOptResolver)
 

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -4,16 +4,14 @@ This module defines the interface to apply for hyperopt
 """
 import logging
 import math
-
 from abc import ABC
-from typing import Dict, Any, Callable, List
+from typing import Any, Callable, Dict, List
 
 from skopt.space import Categorical, Dimension, Integer, Real
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.misc import round_dict
-
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -8,7 +8,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.pairlist.IPairList import IPairList
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/pairlist/pairlistmanager.py
+++ b/freqtrade/pairlist/pairlistmanager.py
@@ -4,11 +4,12 @@ Static List provider
 Provides lists as configured in config.json
 
  """
-from cachetools import TTLCache, cached
 import logging
 from typing import Dict, List
 
-from freqtrade import OperationalException
+from cachetools import TTLCache, cached
+
+from freqtrade.exceptions import OperationalException
 from freqtrade.pairlist.IPairList import IPairList
 from freqtrade.resolvers import PairListResolver
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/plot/plot_utils.py
+++ b/freqtrade/plot/plot_utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.state import RunMode
 from freqtrade.utils import setup_utils_configuration
 

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -7,8 +7,8 @@ import logging
 from pathlib import Path
 from typing import Dict
 
-from freqtrade import OperationalException
 from freqtrade.constants import DEFAULT_HYPEROPT_LOSS, USERPATH_HYPEROPTS
+from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss
 from freqtrade.resolvers import IResolver

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 
 logger = logging.getLogger(__name__)
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -11,9 +11,9 @@ from inspect import getfullargspec
 from pathlib import Path
 from typing import Dict, Optional
 
-from freqtrade import OperationalException
 from freqtrade.constants import (REQUIRED_ORDERTIF, REQUIRED_ORDERTYPES,
                                  USERPATH_STRATEGY)
+from freqtrade.exceptions import OperationalException
 from freqtrade.resolvers import IResolver
 from freqtrade.strategy.interface import IStrategy
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import arrow
 from numpy import NAN, mean
 
-from freqtrade import DependencyException, TemporaryError
+from freqtrade.exceptions import DependencyException, TemporaryError
 from freqtrade.misc import shorten_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter

--- a/freqtrade/utils.py
+++ b/freqtrade/utils.py
@@ -11,7 +11,6 @@ import rapidjson
 from colorama import init as colorama_init
 from tabulate import tabulate
 
-from freqtrade import OperationalException
 from freqtrade.configuration import (Configuration, TimeRange,
                                      remove_credentials)
 from freqtrade.configuration.directory_operations import (copy_sample_files,
@@ -20,6 +19,7 @@ from freqtrade.constants import USERPATH_HYPEROPTS, USERPATH_STRATEGY
 from freqtrade.data.history import (convert_trades_to_ohlcv,
                                     refresh_backtest_ohlcv_data,
                                     refresh_backtest_trades_data)
+from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import (available_exchanges, ccxt_exchanges,
                                 market_is_active, symbol_is_pair)
 from freqtrade.misc import plural, render_template

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -8,9 +8,9 @@ from typing import Any, Callable, Dict, Optional
 
 import sdnotify
 
-from freqtrade import (OperationalException, TemporaryError, __version__,
-                       constants)
+from freqtrade import __version__, constants
 from freqtrade.configuration import Configuration
+from freqtrade.exceptions import OperationalException, TemporaryError
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.rpc import RPCMessageType
 from freqtrade.state import State

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from pandas import DataFrame, to_datetime
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.edge import Edge, PairInfo
 from freqtrade.strategy.interface import SellType

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 import ccxt
 import pytest
 
-from freqtrade import (DependencyException, InvalidOrderException,
-                       OperationalException, TemporaryError)
+from freqtrade.exceptions import (DependencyException, InvalidOrderException,
+                                  OperationalException, TemporaryError)
 from tests.conftest import get_patched_exchange
 
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -11,8 +11,8 @@ import ccxt
 import pytest
 from pandas import DataFrame
 
-from freqtrade import (DependencyException, InvalidOrderException,
-                       OperationalException, TemporaryError)
+from freqtrade.exceptions import (DependencyException, InvalidOrderException,
+                                  OperationalException, TemporaryError)
 from freqtrade.exchange import Binance, Exchange, Kraken
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import (market_is_active, symbol_is_pair,

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -10,13 +10,14 @@ import pandas as pd
 import pytest
 from arrow import Arrow
 
-from freqtrade import DependencyException, OperationalException, constants
+from freqtrade import constants
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import evaluate_result_multi
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange
+from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.optimize import setup_configuration, start_backtesting
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.state import RunMode
@@ -24,7 +25,6 @@ from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
-
 
 ORDER_TYPES = [
     {

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -9,7 +9,7 @@ import pytest
 from arrow import Arrow
 from filelock import Timeout
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.data.history import load_tickerdata_file
 from freqtrade.optimize import setup_configuration, start_hyperopt

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.constants import AVAILABLE_PAIRLISTS
 from freqtrade.resolvers import PairListResolver
 from freqtrade.pairlist.pairlistmanager import PairListManager

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -7,13 +7,13 @@ from unittest.mock import ANY, MagicMock, PropertyMock
 import pytest
 from numpy import isnan
 
-from freqtrade import DependencyException, TemporaryError
 from freqtrade.edge import PairInfo
+from freqtrade.exceptions import DependencyException, TemporaryError
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPC, RPCException
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.state import State
-from tests.conftest import patch_get_signal, get_patched_freqtradebot
+from tests.conftest import get_patched_freqtradebot, patch_get_signal
 
 
 # Functions for recurrent object patching

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from pandas import DataFrame
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.resolvers import StrategyResolver
 from freqtrade.strategy.interface import IStrategy
 from tests.conftest import log_has, log_has_re

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 import pytest
 from jsonschema import ValidationError
 
-from freqtrade import OperationalException
 from freqtrade.configuration import (Arguments, Configuration, check_exchange,
                                      remove_credentials,
                                      validate_config_consistency)
@@ -20,6 +19,7 @@ from freqtrade.configuration.deprecated_settings import (
     process_temporary_deprecated_settings)
 from freqtrade.configuration.load_config import load_config_file
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
+from freqtrade.exceptions import OperationalException
 from freqtrade.loggers import _set_loggers, setup_logging
 from freqtrade.state import RunMode
 from tests.conftest import (log_has, log_has_re,

--- a/tests/test_directory_operations.py
+++ b/tests/test_directory_operations.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from freqtrade import OperationalException
 from freqtrade.configuration.directory_operations import (copy_sample_files,
                                                           create_datadir,
                                                           create_userdata_dir)
+from freqtrade.exceptions import OperationalException
 from tests.conftest import log_has, log_has_re
 
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -11,9 +11,9 @@ import arrow
 import pytest
 import requests
 
-from freqtrade import (DependencyException, InvalidOrderException,
-                       OperationalException, TemporaryError, constants)
-from freqtrade.constants import MATH_CLOSE_PREC
+from freqtrade.constants import MATH_CLOSE_PREC, UNLIMITED_STAKE_AMOUNT
+from freqtrade.exceptions import (DependencyException, InvalidOrderException,
+                                  OperationalException, TemporaryError)
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Trade
 from freqtrade.rpc import RPCMessageType
@@ -163,7 +163,7 @@ def test_get_trade_stake_amount_unlimited_amount(default_conf, ticker,
     )
 
     conf = deepcopy(default_conf)
-    conf['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
+    conf['stake_amount'] = UNLIMITED_STAKE_AMOUNT
     conf['max_open_trades'] = 2
 
     freqtrade = FreqtradeBot(conf)
@@ -564,7 +564,7 @@ def test_create_trades_limit_reached(default_conf, ticker, limit_buy_order,
         get_fee=fee,
     )
     default_conf['max_open_trades'] = 0
-    default_conf['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
+    default_conf['stake_amount'] = UNLIMITED_STAKE_AMOUNT
 
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 
 from freqtrade.configuration import Arguments
-from freqtrade.exceptions import OperationalException
+from freqtrade.exceptions import OperationalException, FreqtradeException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State
@@ -96,7 +96,7 @@ def test_main_operational_exception(mocker, default_conf, caplog) -> None:
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.cleanup', MagicMock())
     mocker.patch(
         'freqtrade.worker.Worker._worker',
-        MagicMock(side_effect=OperationalException('Oh snap!'))
+        MagicMock(side_effect=FreqtradeException('Oh snap!'))
     )
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.wallets.Wallets.update', MagicMock())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
-from freqtrade import OperationalException
 from freqtrade.configuration import Arguments
+from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
 from freqtrade.state import State

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -6,7 +6,8 @@ import arrow
 import pytest
 from sqlalchemy import create_engine
 
-from freqtrade import OperationalException, constants
+from freqtrade import constants
+from freqtrade.exceptions import OperationalException
 from freqtrade.persistence import Trade, clean_dry_run_db, init
 from tests.conftest import log_has
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,17 +7,17 @@ import plotly.graph_objects as go
 import pytest
 from plotly.subplots import make_subplots
 
-from freqtrade import OperationalException
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import create_cum_profit, load_backtest_data
+from freqtrade.exceptions import OperationalException
 from freqtrade.plot.plot_utils import start_plot_dataframe, start_plot_profit
 from freqtrade.plot.plotting import (add_indicators, add_profit,
-                                     load_and_plot_trades,
                                      generate_candlestick_graph,
                                      generate_plot_filename,
                                      generate_profit_graph, init_plotscript,
-                                     plot_profit, plot_trades, store_plot_file)
+                                     load_and_plot_trades, plot_profit,
+                                     plot_trades, store_plot_file)
 from freqtrade.strategy.default_strategy import DefaultStrategy
 from tests.conftest import get_args, log_has, log_has_re
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
-from freqtrade import OperationalException
+from freqtrade.exceptions import OperationalException
 from freqtrade.state import RunMode
 from freqtrade.utils import (setup_utils_configuration, start_create_userdir,
                              start_download_data, start_hyperopt_list,


### PR DESCRIPTION
## Summary
This will move exceptions into their own file.
Also, this introduces a base-exception (`FreqtradeException`) which is the parent of all other exception types - and is captured at the outermost level (`main.py:main`) and shows the error, should any other custom exception bubble up to this level.

Due to the nature of this change (location of central classes have been changed) there are a lot of files with small differences - but  there are only a handfull of files with changes to anything other than imports:

* `freqtrade/__main__.py` - removal of exception classes
* `freqtrade/exceptions.py` - new file for exceptions
* `freqtrade/main.py` - capture FreqtradeException instead of OperationalException
* `test_main.py` - Test new exception type is captured correctly.
