### PR TITLE
Minor: Fix message in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -263,7 +263,7 @@ function install() {
     echo "-------------------------"
     echo "Run the bot !"
     echo "-------------------------"
-    echo "You can now use the bot by executing 'source .env/bin/activate; freqtrade'."
+    echo "You can now use the bot by executing 'source .env/bin/activate; freqtrade trade'."
 }
 
 function plot() {


### PR DESCRIPTION
We've forgotten to align the message printed in setup.sh to reflect new cli option rules.

From Slack.
