### PR TITLE
Btanalysis align columns

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -47,7 +47,7 @@ def load_backtest_data(filename) -> pd.DataFrame:
                                       utc=True,
                                       infer_datetime_format=True
                                       )
-    df['profitabs'] = df['close_rate'] - df['open_rate']
+    df['profit'] = df['close_rate'] - df['open_rate']
     df = df.sort_values("open_time").reset_index(drop=True)
     return df
 

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -20,7 +20,7 @@ def test_load_backtest_data(testdatadir):
     filename = testdatadir / "backtest-result_test.json"
     bt_data = load_backtest_data(filename)
     assert isinstance(bt_data, DataFrame)
-    assert list(bt_data.columns) == BT_DATA_COLUMNS + ["profitabs"]
+    assert list(bt_data.columns) == BT_DATA_COLUMNS + ["profit"]
     assert len(bt_data) == 179
 
     # Test loading from string (must yield same result)


### PR DESCRIPTION
## Summary
Align columns between `load_backtest_data()` and `load_trades_from_db()` where content is aligned (profit) - reported on Slack a while ago.

Also removes an obsolete folder in user_data i've accidentally (on purpose) discovered...