### PR TITLE
Cleanup buy/sell notification in freqtradebot

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -498,15 +498,9 @@ class FreqtradeBot:
             'limit': trade.open_rate,
             'order_type': order_type,
             'stake_amount': trade.stake_amount,
+            'stake_currency': self.config['stake_currency'],
+            'fiat_currency': self.config.get('fiat_display_currency', None),
         }
-
-        if 'stake_currency' in self.config and 'fiat_display_currency' in self.config:
-            stake_currency = self.config['stake_currency']
-            fiat_currency = self.config['fiat_display_currency']
-            msg.update({
-                'stake_currency': stake_currency,
-                'fiat_currency': fiat_currency,
-            })
 
         # Send the message
         self.rpc.send_msg(msg)
@@ -966,13 +960,12 @@ class FreqtradeBot:
             'sell_reason': trade.sell_reason,
             'open_date': trade.open_date,
             'close_date': trade.close_date or datetime.utcnow(),
+            'stake_currency': self.config['stake_currency'],
         }
 
-        if 'stake_currency' in self.config and 'fiat_display_currency' in self.config:
-            stake_currency = self.config['stake_currency']
+        if 'fiat_display_currency' in self.config:
             fiat_currency = self.config['fiat_display_currency']
             msg.update({
-                'stake_currency': stake_currency,
                 'fiat_currency': fiat_currency,
             })
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -400,8 +400,6 @@ class FreqtradeBot:
         :param pair: pair for which we want to create a LIMIT_BUY
         :return: None
         """
-        stake_currency = self.config['stake_currency']
-        fiat_currency = self.config.get('fiat_display_currency', None)
         time_in_force = self.strategy.order_time_in_force['buy']
 
         if price:
@@ -458,17 +456,6 @@ class FreqtradeBot:
             amount = order['amount']
             buy_limit_filled_price = order['price']
 
-        self.rpc.send_msg({
-            'type': RPCMessageType.BUY_NOTIFICATION,
-            'exchange': self.exchange.name.capitalize(),
-            'pair': pair,
-            'limit': buy_limit_filled_price,
-            'order_type': order_type,
-            'stake_amount': stake_amount,
-            'stake_currency': stake_currency,
-            'fiat_currency': fiat_currency
-        })
-
         # Fee is applied twice because we make a LIMIT_BUY and LIMIT_SELL
         fee = self.exchange.get_fee(symbol=pair, taker_or_maker='maker')
         trade = Trade(
@@ -486,6 +473,8 @@ class FreqtradeBot:
             ticker_interval=timeframe_to_minutes(self.config['ticker_interval'])
         )
 
+        self._notify_buy(trade, order_type)
+
         # Update fees if order is closed
         if order_status == 'closed':
             self.update_trade_state(trade, order)
@@ -497,6 +486,30 @@ class FreqtradeBot:
         self.wallets.update()
 
         return True
+
+    def _notify_buy(self, trade: Trade, order_type: str):
+        """
+        Sends rpc notification when a buy occured.
+        """
+        msg = {
+            'type': RPCMessageType.BUY_NOTIFICATION,
+            'exchange': self.exchange.name.capitalize(),
+            'pair': trade.pair,
+            'limit': trade.open_rate,
+            'order_type': order_type,
+            'stake_amount': trade.stake_amount,
+        }
+
+        if 'stake_currency' in self.config and 'fiat_display_currency' in self.config:
+            stake_currency = self.config['stake_currency']
+            fiat_currency = self.config['fiat_display_currency']
+            msg.update({
+                'stake_currency': stake_currency,
+                'fiat_currency': fiat_currency,
+            })
+
+        # Send the message
+        self.rpc.send_msg(msg)
 
 #
 # SELL / exit positions / close trades logic and methods
@@ -952,10 +965,9 @@ class FreqtradeBot:
             'profit_percent': profit_percent,
             'sell_reason': trade.sell_reason,
             'open_date': trade.open_date,
-            'close_date': trade.close_date or datetime.utcnow()
+            'close_date': trade.close_date or datetime.utcnow(),
         }
 
-        # For regular case, when the configuration exists
         if 'stake_currency' in self.config and 'fiat_display_currency' in self.config:
             stake_currency = self.config['stake_currency']
             fiat_currency = self.config['fiat_display_currency']

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -964,9 +964,8 @@ class FreqtradeBot:
         }
 
         if 'fiat_display_currency' in self.config:
-            fiat_currency = self.config['fiat_display_currency']
             msg.update({
-                'fiat_currency': fiat_currency,
+                'fiat_currency': self.config['fiat_display_currency'],
             })
 
         # Send the message

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -913,16 +913,16 @@ class FreqtradeBot:
             except InvalidOrderException:
                 logger.exception(f"Could not cancel stoploss order {trade.stoploss_order_id}")
 
-        ordertype = self.strategy.order_types[sell_type]
+        order_type = self.strategy.order_types[sell_type]
         if sell_reason == SellType.EMERGENCY_SELL:
             # Emergencysells (default to market!)
-            ordertype = self.strategy.order_types.get("emergencysell", "market")
+            order_type = self.strategy.order_types.get("emergencysell", "market")
 
         amount = self._safe_sell_amount(trade.pair, trade.amount)
 
         # Execute sell and update trade record
         order = self.exchange.sell(pair=str(trade.pair),
-                                   ordertype=ordertype,
+                                   ordertype=order_type,
                                    amount=amount, rate=limit,
                                    time_in_force=self.strategy.order_time_in_force['sell']
                                    )
@@ -938,7 +938,7 @@ class FreqtradeBot:
         # Lock pair for one candle to prevent immediate rebuys
         self.strategy.lock_pair(trade.pair, timeframe_to_next_date(self.config['ticker_interval']))
 
-        self._notify_sell(trade, ordertype)
+        self._notify_sell(trade, order_type)
 
     def _notify_sell(self, trade: Trade, order_type: str):
         """


### PR DESCRIPTION
* Introduce `_notify_buy()`, which is aligned to existing `_notify_sell`. This simplifies the code in `execute_buy()` a bit, since no configuration params that are needed only for notification should be fetched there.
* Minor cleanup of creation the sell msg

To be discussed/possibly fixed (changed) here, pls review this separately:
* should not the call to `_notify_buy()` be moved in `execute_buy()` to be at the end, right before `return`? Or after `Trade.session.add()` and `Trade.session.flush()` to contain data possibly updated by `self.update_trade_state()`? Now it's left in its place to have same info as in the current implementation...
