### PR TITLE
show percent in sell hover message.

### DIFF
--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -120,8 +120,8 @@ def plot_trades(fig, trades: pd.DataFrame) -> make_subplots:
             )
         )
         # Create description for sell summarizing the trade
-        desc = trades.apply(lambda row: f"{round(row['profitperc'], 3)}%, {row['sell_reason']}, "
-                                        f"{row['duration']} min",
+        desc = trades.apply(lambda row: f"{round(row['profitperc'] * 100, 1)}%, "
+                                        f"{row['sell_reason']}, {row['duration']} min",
                             axis=1)
         trade_sells = go.Scatter(
             x=trades["close_time"],

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -119,6 +119,7 @@ def test_plot_trades(testdatadir, caplog):
     assert trade_sell.yaxis == 'y'
     assert len(trades) == len(trade_sell.x)
     assert trade_sell.marker.color == 'red'
+    assert trade_sell.text[0] == "4.0%, roi, 15 min"
 
 
 def test_generate_candlestick_graph_no_signals_no_trades(default_conf, mocker, testdatadir, caplog):


### PR DESCRIPTION
## Summary
Even though the column is called profit_perc - it contains a ratio in both cases (from DB or from backtest result.

## Quick changelog

- Plotting - fix incorrect visualization showing stoplosses of 0.05% instead of 5%