### PR TITLE
Update Backtesting fee documentation

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -86,7 +86,7 @@ freqtrade backtesting --fee 0.001
 ```
 
 !!! Note
-    Only supply this parameter if you want to experiment with different fee values. By default, Backtesting fetches the exchange's default fee from the exchange.
+    Only supply this option (or the corresponding configuration parameter) if you want to experiment with different fee values. By default, Backtesting fetches the default fee from the exchange pair/market info.
 
 #### Running backtest with smaller testset by using timerange
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -79,12 +79,14 @@ Please also read about the [strategy startup period](strategy-customization.md#s
 
 Sometimes your account has certain fee rebates (fee reductions starting with a certain account size or monthly volume), which are not visible to ccxt.
 To account for this in backtesting, you can use `--fee 0.001` to supply this value to backtesting.
-This fee must be a percentage, and will be applied twice (once for trade entry, and once for trade exit).
+This fee must be a ratio, and will be applied twice (once for trade entry, and once for trade exit).
 
 ```bash
 freqtrade backtesting --fee 0.001
 ```
 
+!!! Note
+    Only supply this parameter if you want to experiment with different fee values. By default, Backtesting fetches the exchange's default fee from the exchange.
 
 #### Running backtest with smaller testset by using timerange
 


### PR DESCRIPTION
## Summary
Fix documentation - `--fee` is not a percentage but a ratio.
Also include a note that this parameter is usually gotten from the exchange.

closes #2738 
