### PR TITLE
Add support for downloading data for markets with 'bad' characters in the market symbol

### DIFF
--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -224,14 +224,20 @@ def refresh_data(datadir: Path,
                                exchange=exchange)
 
 
+def pair_to_filename(pair: str) -> str:
+    for ch in ['/', ' ', '.']:
+        pair = pair.replace(ch, '_')
+    return pair
+
+
 def pair_data_filename(datadir: Path, pair: str, timeframe: str) -> Path:
-    pair_s = pair.replace("/", "_")
+    pair_s = pair_to_filename(pair)
     filename = datadir.joinpath(f'{pair_s}-{timeframe}.json')
     return filename
 
 
 def pair_trades_filename(datadir: Path, pair: str) -> Path:
-    pair_s = pair.replace("/", "_")
+    pair_s = pair_to_filename(pair)
     filename = datadir.joinpath(f'{pair_s}-trades.json.gz')
     return filename
 

--- a/freqtrade/data/history.py
+++ b/freqtrade/data/history.py
@@ -225,7 +225,7 @@ def refresh_data(datadir: Path,
 
 
 def pair_to_filename(pair: str) -> str:
-    for ch in ['/', ' ', '.']:
+    for ch in ['/', '-', ' ', '.', '@', '$', '+', ':']:
         pair = pair.replace(ch, '_')
     return pair
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -4,10 +4,10 @@ from typing import Any, Dict, List
 
 import pandas as pd
 from freqtrade.configuration import TimeRange
-from freqtrade.data import history
 from freqtrade.data.btanalysis import (combine_tickers_with_mean,
                                        create_cum_profit,
                                        extract_trades_of_period, load_trades)
+from freqtrade.data.history import load_data, pair_to_filename, trim_dataframe
 from freqtrade.resolvers import StrategyResolver
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ def init_plotscript(config):
     # Set timerange to use
     timerange = TimeRange.parse_timerange(config.get("timerange"))
 
-    tickers = history.load_data(
+    tickers = load_data(
         datadir=config.get("datadir"),
         pairs=pairs,
         timeframe=config.get('ticker_interval', '5m'),
@@ -47,7 +47,7 @@ def init_plotscript(config):
                          db_url=config.get('db_url'),
                          exportfilename=config.get('exportfilename'),
                          )
-    trades = history.trim_dataframe(trades, timerange, 'open_time')
+    trades = trim_dataframe(trades, timerange, 'open_time')
     return {"tickers": tickers,
             "trades": trades,
             "pairs": pairs,
@@ -304,8 +304,8 @@ def generate_plot_filename(pair, timeframe) -> str:
     """
     Generate filenames per pair/timeframe to be used for storing plots
     """
-    pair_name = pair.replace("/", "_")
-    file_name = 'freqtrade-plot-' + pair_name + '-' + timeframe + '.html'
+    pair_s = pair_to_filename(pair)
+    file_name = 'freqtrade-plot-' + pair_s + '-' + timeframe + '.html'
 
     logger.info('Generate plot file for %s', pair)
 

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -159,6 +159,7 @@ def test_testdata_path(testdatadir) -> None:
     ("CMT@18/ETH", 'CMT_18_ETH'),
     ("LBTC:1022/SAI", 'LBTC_1022_SAI'),
     ("$PAC/BTC", '_PAC_BTC'),
+    ("ACC_OLD/BTC", 'ACC_OLD_BTC'),
 ])
 def test_pair_to_filename(pair, expected_result):
     pair_s = pair_to_filename(pair)
@@ -171,6 +172,7 @@ def test_pair_to_filename(pair, expected_result):
     ("ETHH20", 'freqtrade/hello/world/ETHH20-5m.json'),
     (".XBTBON2H", 'freqtrade/hello/world/_XBTBON2H-5m.json'),
     ("ETHUSD.d", 'freqtrade/hello/world/ETHUSD_d-5m.json'),
+    ("ACC_OLD/BTC", 'freqtrade/hello/world/ACC_OLD_BTC-5m.json'),
 ])
 def test_pair_data_filename(pair, expected_result):
     fn = pair_data_filename(Path('freqtrade/hello/world'), pair, '5m')
@@ -184,6 +186,7 @@ def test_pair_data_filename(pair, expected_result):
     ("ETHH20", 'freqtrade/hello/world/ETHH20-trades.json.gz'),
     (".XBTBON2H", 'freqtrade/hello/world/_XBTBON2H-trades.json.gz'),
     ("ETHUSD.d", 'freqtrade/hello/world/ETHUSD_d-trades.json.gz'),
+    ("ACC_OLD_BTC", 'freqtrade/hello/world/ACC_OLD_BTC-trades.json.gz'),
 ])
 def test_pair_trades_filename(pair, expected_result):
     fn = pair_trades_filename(Path('freqtrade/hello/world'), pair)

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -152,6 +152,13 @@ def test_testdata_path(testdatadir) -> None:
     ("ETHH20", 'ETHH20'),
     (".XBTBON2H", '_XBTBON2H'),
     ("ETHUSD.d", 'ETHUSD_d'),
+    ("ADA-0327", 'ADA_0327'),
+    ("BTC-USD-200110", 'BTC_USD_200110'),
+    ("F-AKRO/USDT", 'F_AKRO_USDT'),
+    ("LC+/ETH", 'LC__ETH'),
+    ("CMT@18/ETH", 'CMT_18_ETH'),
+    ("LBTC:1022/SAI", 'LBTC_1022_SAI'),
+    ("$PAC/BTC", '_PAC_BTC'),
 ])
 def test_pair_to_filename(pair, expected_result):
     pair_s = pair_to_filename(pair)


### PR DESCRIPTION
* Introduce `pair_to_filename()` function which maps them to `'_'` for pairname to be used in the filename.
* This is also for the name of the resulting html in plotting.

The 'bad' symbols can be seen as:
```
for e in `freqtrade list-exchanges -1`; do freqtrade list-markets --exchange $e -1 --all 2>/dev/null; done | tr -d '\na-zA-Z0-9/-'
```

Closes first part of #268 (mapping of the symbols in the pair names now located in a single function and only used in the filenames).

TODO:

* Pls review this part in persistence:
https://github.com/freqtrade/freqtrade/blob/3798f94d4c52fb0cf441d2d4e3c3f0218d9005a8/freqtrade/persistence.py#L129-L134
Should something be changed here taking into account that more than one `'_'` can appear in the pairname after mapping `'/'` to `'_'`? Is it really actual? (I have not found this mapping)

* Maybe `pair_to_filename()` should be moved into `misc.py` since it's not only about historical datafiles, but also used in plotting.
