### PR TITLE
Remove hardcoded exchange parameters

### DIFF
--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -48,11 +48,6 @@ def validate_config_schema(conf: Dict[str, Any]) -> Dict[str, Any]:
         conf_schema['required'] = constants.SCHEMA_TRADE_REQUIRED
     else:
         conf_schema['required'] = constants.SCHEMA_MINIMAL_REQUIRED
-        # Dynamically allow empty stake-currency
-        # Since the minimal config specifies this too.
-        # It's not allowed for Dry-run or live modes
-        conf_schema['properties']['stake_currency']['enum'] += ['']  # type: ignore
-
     try:
         FreqtradeValidator(conf_schema).validate(conf)
         return conf

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -61,7 +61,7 @@ CONF_SCHEMA = {
     'properties': {
         'max_open_trades': {'type': ['integer', 'number'], 'minimum': -1},
         'ticker_interval': {'type': 'string'},
-        'stake_currency': {'type': 'string', 'enum': ['BTC', 'XBT', 'ETH', 'USDT', 'EUR', 'USD']},
+        'stake_currency': {'type': 'string'},
         'stake_amount': {
             'type': ['number', 'string'],
             'minimum': 0.0001,

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -33,12 +33,6 @@ USER_DATA_FILES = {
     'strategy_analysis_example.ipynb': 'notebooks',
 }
 
-TIMEFRAMES = [
-    '1m', '3m', '5m', '15m', '30m',
-    '1h', '2h', '4h', '6h', '8h', '12h',
-    '1d', '3d', '1w',
-]
-
 SUPPORTED_FIAT = [
     "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK",
     "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY",
@@ -66,7 +60,7 @@ CONF_SCHEMA = {
     'type': 'object',
     'properties': {
         'max_open_trades': {'type': ['integer', 'number'], 'minimum': -1},
-        'ticker_interval': {'type': 'string', 'enum': TIMEFRAMES},
+        'ticker_interval': {'type': 'string'},
         'stake_currency': {'type': 'string', 'enum': ['BTC', 'XBT', 'ETH', 'USDT', 'EUR', 'USD']},
         'stake_amount': {
             'type': ['number', 'string'],

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -216,7 +216,7 @@ class Exchange:
         Return a list of supported quote currencies
         """
         markets = self.markets
-        currencies = set([x['quote'] for _, x in markets.items()])
+        currencies = set([x.get('quote') for _, x in markets.items()])
         return list(currencies)
 
     def klines(self, pair_interval: Tuple[str, str], copy=True) -> DataFrame:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -216,8 +216,9 @@ class Exchange:
         Return a list of supported quote currencies
         """
         markets = self.markets
-        currencies = set([x.get('quote') for _, x in markets.items()])
-        return list(currencies)
+        currencies = list(set([x.get('quote') for _, x in markets.items()]))
+        currencies.sort()
+        return currencies
 
     def klines(self, pair_interval: Tuple[str, str], copy=True) -> DataFrame:
         if pair_interval in self._klines:
@@ -277,8 +278,8 @@ class Exchange:
         quote_currencies = self.get_quote_currencies()
         if stake_currency not in quote_currencies:
             raise OperationalException(
-                    f"{stake_currency} is not available as stake on {self.name}."
-                    f"Available currencies are: {','.join(quote_currencies)}")
+                    f"{stake_currency} is not available as stake on {self.name}. "
+                    f"Available currencies are: {', '.join(quote_currencies)}")
 
     def validate_pairs(self, pairs: List[str]) -> None:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -319,6 +319,10 @@ class Exchange:
             raise OperationalException(
                 f"Invalid ticker interval '{timeframe}'. This exchange supports: {self.timeframes}")
 
+        if timeframe_to_minutes(timeframe) < 1:
+            raise OperationalException(
+                f"Timeframes < 1m are currently not supported by Freqtrade.")
+
     def validate_ordertypes(self, order_types: Dict) -> None:
         """
         Checks if order-types configured in strategy/config are supported

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -216,9 +216,7 @@ class Exchange:
         Return a list of supported quote currencies
         """
         markets = self.markets
-        currencies = list(set([x.get('quote') for _, x in markets.items()]))
-        currencies.sort()
-        return currencies
+        return sorted(set([x['quote'] for _, x in markets.items()]))
 
     def klines(self, pair_interval: Tuple[str, str], copy=True) -> DataFrame:
         if pair_interval in self._klines:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -116,6 +116,7 @@ class Exchange:
             self._load_markets()
 
             # Check if all pairs are available
+            self.validate_stakecurrency(config['stake_currency'])
             self.validate_pairs(config['exchange']['pair_whitelist'])
             self.validate_ordertypes(config.get('order_types', {}))
             self.validate_order_time_in_force(config.get('order_time_in_force', {}))
@@ -210,6 +211,14 @@ class Exchange:
             markets = {k: v for k, v in markets.items() if market_is_active(v)}
         return markets
 
+    def get_quote_currencies(self) -> List[str]:
+        """
+        Return a list of supported quote currencies
+        """
+        markets = self.markets
+        currencies = set([x['quote'] for _, x in markets.items()])
+        return list(currencies)
+
     def klines(self, pair_interval: Tuple[str, str], copy=True) -> DataFrame:
         if pair_interval in self._klines:
             return self._klines[pair_interval].copy() if copy else self._klines[pair_interval]
@@ -259,11 +268,23 @@ class Exchange:
         except ccxt.BaseError:
             logger.exception("Could not reload markets.")
 
+    def validate_stakecurrency(self, stake_currency) -> None:
+        """
+        Checks stake-currency against available currencies on the exchange.
+        :param stake_currency: Stake-currency to validate
+        :raise: OperationalException if stake-currency is not available.
+        """
+        quote_currencies = self.get_quote_currencies()
+        if stake_currency not in quote_currencies:
+            raise OperationalException(
+                    f"{stake_currency} is not available as stake on {self.name}."
+                    f"Available currencies are: {','.join(quote_currencies)}")
+
     def validate_pairs(self, pairs: List[str]) -> None:
         """
         Checks if all given pairs are tradable on the current exchange.
-        Raises OperationalException if one pair is not available.
         :param pairs: list of pairs
+        :raise: OperationalException if one pair is not available
         :return: None
         """
 
@@ -319,7 +340,7 @@ class Exchange:
             raise OperationalException(
                 f"Invalid ticker interval '{timeframe}'. This exchange supports: {self.timeframes}")
 
-        if timeframe_to_minutes(timeframe) < 1:
+        if timeframe and timeframe_to_minutes(timeframe) < 1:
             raise OperationalException(
                 f"Timeframes < 1m are currently not supported by Freqtrade.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> No
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_ordertypes', MagicMock())
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.id', PropertyMock(return_value=id))
     mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value=id.title()))
     if mock_markets:


### PR DESCRIPTION
## Summary
We should not hardcode timeframes nor stake-currencies. THey vary by exchange, so we should use what the exchange gives us.

Closes #2757
closes #1861 

## Quick changelog

- Use timeframes from the exchange
- Use quote-currencies from the exchange
- Limit freqtrade to work on timeframes >1m (lower than that is very risky and does currently produce errors since we assume minute in certain places (for example when resampling). While these could be easily fixed, i don't think trading <1m with freqtrade is something that can be profitable.
- Remove some occurences of empty `MagicMock()` in `mocker.patch()` calls (it defaults to MagicMock() anyway).

