### PR TITLE
Fix/precision rounding

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -41,7 +41,7 @@ class Binance(Exchange):
         """
         ordertype = "stop_loss_limit"
 
-        stop_price = self.symbol_price_prec(pair, stop_price)
+        stop_price = self.price_to_precision(pair, stop_price)
 
         # Ensure rate is less than stop price
         if stop_price <= rate:
@@ -57,9 +57,9 @@ class Binance(Exchange):
             params = self._params.copy()
             params.update({'stopPrice': stop_price})
 
-            amount = self.symbol_amount_prec(pair, amount)
+            amount = self.amount_to_precision(pair, amount)
 
-            rate = self.symbol_price_prec(pair, rate)
+            rate = self.price_to_precision(pair, rate)
 
             order = self._api.create_order(pair, ordertype, 'sell',
                                            amount, rate, params)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -14,8 +14,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import arrow
 import ccxt
 import ccxt.async_support as ccxt_async
-from ccxt.base.decimal_to_precision import (ROUND, ROUND_DOWN, ROUND_UP,
-                                            TRUNCATE, TICK_SIZE, decimal_to_precision)
+from ccxt.base.decimal_to_precision import (ROUND_DOWN, ROUND_UP, TICK_SIZE,
+                                            TRUNCATE, decimal_to_precision)
 from pandas import DataFrame
 
 from freqtrade.data.converter import parse_ticker_dataframe

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -188,6 +188,11 @@ class Exchange:
             self._load_markets()
         return self._api.markets
 
+    @property
+    def precisionMode(self) -> str:
+        """exchange ccxt precisionMode"""
+        return self._api.precisionMode
+
     def get_markets(self, base_currencies: List[str] = None, quote_currencies: List[str] = None,
                     pairs_only: bool = False, active_only: bool = False) -> Dict:
         """

--- a/freqtrade/pairlist/PrecisionFilter.py
+++ b/freqtrade/pairlist/PrecisionFilter.py
@@ -35,8 +35,8 @@ class PrecisionFilter(IPairList):
         """
         stop_price = ticker['ask'] * stoploss
         # Adjust stop-prices to precision
-        sp = self._exchange.symbol_price_prec(ticker["symbol"], stop_price)
-        stop_gap_price = self._exchange.symbol_price_prec(ticker["symbol"], stop_price * 0.99)
+        sp = self._exchange.price_to_precision(ticker["symbol"], stop_price)
+        stop_gap_price = self._exchange.price_to_precision(ticker["symbol"], stop_price * 0.99)
         logger.debug(f"{ticker['symbol']} - {sp} : {stop_gap_price}")
         if sp <= stop_gap_price:
             logger.info(f"Removed {ticker['symbol']} from whitelist, "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> No
     mocker.patch('freqtrade.exchange.Exchange.validate_ordertypes', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.id', PropertyMock(return_value=id))
     mocker.patch('freqtrade.exchange.Exchange.name', PropertyMock(return_value=id.title()))
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=2))
     if mock_markets:
         mocker.patch('freqtrade.exchange.Exchange.markets',
                      PropertyMock(return_value=get_markets()))

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -22,8 +22,8 @@ def test_stoploss_limit_order(default_conf, mocker):
     })
 
     default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
 
@@ -71,8 +71,8 @@ def test_stoploss_limit_order_dry_run(default_conf, mocker):
     api_mock = MagicMock()
     order_type = 'stop_loss_limit'
     default_conf['dry_run'] = True
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -173,7 +173,7 @@ def test_validate_order_time_in_force(default_conf, mocker, caplog):
     ex.validate_order_time_in_force(tif2)
 
 
-def test_symbol_amount_prec(default_conf, mocker):
+def test_amount_to_precision(default_conf, mocker):
     '''
     Test rounds down to 4 Decimal places
     '''
@@ -190,17 +190,17 @@ def test_symbol_amount_prec(default_conf, mocker):
 
     amount = 2.34559
     pair = 'ETH/BTC'
-    amount = exchange.symbol_amount_prec(pair, amount)
+    amount = exchange.amount_to_precision(pair, amount)
     assert amount == 2.3455
 
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'amount': 0.0001}}})
     mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=4))
     mocker.patch('freqtrade.exchange.Exchange.markets', markets)
-    amount = exchange.symbol_amount_prec(pair, amount)
+    amount = exchange.amount_to_precision(pair, amount)
     assert amount == 2.3455
 
 
-def test_symbol_price_prec(default_conf, mocker):
+def test_sprice_to_precision(default_conf, mocker):
     '''
     Test rounds up to 4 decimal places
     '''
@@ -212,14 +212,14 @@ def test_symbol_price_prec(default_conf, mocker):
 
     price = 2.34559
     pair = 'ETH/BTC'
-    price = exchange.symbol_price_prec(pair, price)
+    price = exchange.price_to_precision(pair, price)
     assert price == 2.3456
 
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'price': 0.0001}}})
     mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=4))
     mocker.patch('freqtrade.exchange.Exchange.markets', markets)
 
-    price = exchange.symbol_price_prec(pair, price)
+    price = exchange.price_to_precision(pair, price)
     assert price == 2.3456
 
 
@@ -615,8 +615,8 @@ def test_create_order(default_conf, mocker, side, ordertype, rate, marketprice, 
         }
     })
     default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
     order = exchange.create_order(
@@ -656,8 +656,8 @@ def test_buy_prod(default_conf, mocker, exchange_name):
         }
     })
     default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
     order = exchange.buy(pair='ETH/BTC', ordertype=order_type,
@@ -730,8 +730,8 @@ def test_buy_considers_time_in_force(default_conf, mocker, exchange_name):
         }
     })
     default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
     order_type = 'limit'
@@ -792,8 +792,8 @@ def test_sell_prod(default_conf, mocker, exchange_name):
     })
     default_conf['dry_run'] = False
 
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
     order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)
@@ -856,8 +856,8 @@ def test_sell_considers_time_in_force(default_conf, mocker, exchange_name):
     })
     api_mock.options = {}
     default_conf['dry_run'] = False
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
     order_type = 'limit'

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -220,9 +220,13 @@ def test_amount_to_precision(default_conf, mocker, amount, precision_mode, preci
     (2.34559, 4, 0.001, 2.346),
     (2.9999, 4, 0.001, 3.000),
     (2.9909, 4, 0.001, 2.991),
-    (2.9909, 4, 0.005, 2.99),
-    (2.9973, 4, 0.005, 2.995),
+    (2.9909, 4, 0.005, 2.995),
+    (2.9973, 4, 0.005, 3.0),
     (2.9977, 4, 0.005, 3.0),
+    (234.43, 4, 0.5, 234.5),
+    (234.53, 4, 0.5, 235.0),
+    (0.891534, 4, 0.0001, 0.8916),
+
 ])
 def test_price_to_precision(default_conf, mocker, price, precision_mode, precision, expected):
     '''
@@ -240,7 +244,7 @@ def test_price_to_precision(default_conf, mocker, price, precision_mode, precisi
                  PropertyMock(return_value=precision_mode))
 
     pair = 'ETH/BTC'
-    assert exchange.price_to_precision(pair, price) == expected
+    assert pytest.approx(exchange.price_to_precision(pair, price)) == expected
 
 
 def test_set_sandbox(default_conf, mocker):

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -181,10 +181,21 @@ def test_symbol_amount_prec(default_conf, mocker):
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'amount': 4}}})
 
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
+    # digits counting mode
+    # DECIMAL_PLACES = 2
+    # SIGNIFICANT_DIGITS = 3
+    # TICK_SIZE = 4
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=2))
     mocker.patch('freqtrade.exchange.Exchange.markets', markets)
 
     amount = 2.34559
     pair = 'ETH/BTC'
+    amount = exchange.symbol_amount_prec(pair, amount)
+    assert amount == 2.3455
+
+    markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'amount': 0.0001}}})
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=4))
+    mocker.patch('freqtrade.exchange.Exchange.markets', markets)
     amount = exchange.symbol_amount_prec(pair, amount)
     assert amount == 2.3455
 
@@ -197,9 +208,17 @@ def test_symbol_price_prec(default_conf, mocker):
 
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
     mocker.patch('freqtrade.exchange.Exchange.markets', markets)
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=2))
 
     price = 2.34559
     pair = 'ETH/BTC'
+    price = exchange.symbol_price_prec(pair, price)
+    assert price == 2.3456
+
+    markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'price': 0.0001}}})
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=4))
+    mocker.patch('freqtrade.exchange.Exchange.markets', markets)
+
     price = exchange.symbol_price_prec(pair, price)
     assert price == 2.3456
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -173,14 +173,22 @@ def test_validate_order_time_in_force(default_conf, mocker, caplog):
     ex.validate_order_time_in_force(tif2)
 
 
-@pytest.mark.parametrize("amount,precision,expected", [
-    (2.34559, 4, 2.3455),
-    (2.34559, 5, 2.34559),
-    (2.34559, 3, 2.345),
-    (2.9999, 3, 2.999),
-    (2.9909, 3, 2.990),
+@pytest.mark.parametrize("amount,precision_mode,precision,expected", [
+    (2.34559, 2, 4, 2.3455),
+    (2.34559, 2, 5, 2.34559),
+    (2.34559, 2, 3, 2.345),
+    (2.9999, 2, 3, 2.999),
+    (2.9909, 2, 3, 2.990),
+    # Tests for Tick-size
+    (2.34559, 4, 0.0001, 2.3455),
+    (2.34559, 4, 0.00001, 2.34559),
+    (2.34559, 4, 0.001, 2.345),
+    (2.9999, 4, 0.001, 2.999),
+    (2.9909, 4, 0.001, 2.990),
+    (2.9909, 4, 0.005, 2.990),
+    (2.9999, 4, 0.005, 2.995),
 ])
-def test_amount_to_precision_decimal_places(default_conf, mocker, amount, precision, expected):
+def test_amount_to_precision(default_conf, mocker, amount, precision_mode, precision, expected):
     '''
     Test rounds down
     '''
@@ -192,7 +200,8 @@ def test_amount_to_precision_decimal_places(default_conf, mocker, amount, precis
     # DECIMAL_PLACES = 2
     # SIGNIFICANT_DIGITS = 3
     # TICK_SIZE = 4
-    mocker.patch('freqtrade.exchange.Exchange.precisionMode', PropertyMock(return_value=2))
+    mocker.patch('freqtrade.exchange.Exchange.precisionMode',
+                 PropertyMock(return_value=precision_mode))
     mocker.patch('freqtrade.exchange.Exchange.markets', markets)
 
     pair = 'ETH/BTC'

--- a/tests/exchange/test_kraken.py
+++ b/tests/exchange/test_kraken.py
@@ -21,8 +21,8 @@ def test_buy_kraken_trading_agreement(default_conf, mocker):
     })
     default_conf['dry_run'] = False
 
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kraken")
 
     order = exchange.buy(pair='ETH/BTC', ordertype=order_type,
@@ -53,8 +53,8 @@ def test_sell_kraken_trading_agreement(default_conf, mocker):
     })
     default_conf['dry_run'] = False
 
-    mocker.patch('freqtrade.exchange.Exchange.symbol_amount_prec', lambda s, x, y: y)
-    mocker.patch('freqtrade.exchange.Exchange.symbol_price_prec', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.amount_to_precision', lambda s, x, y: y)
+    mocker.patch('freqtrade.exchange.Exchange.price_to_precision', lambda s, x, y: y)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kraken")
 
     order = exchange.sell(pair='ETH/BTC', ordertype=order_type, amount=1, rate=200)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2435,8 +2435,8 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf, ticker, fee, ticke
         'freqtrade.exchange.Exchange',
         fetch_ticker=ticker,
         get_fee=fee,
-        symbol_amount_prec=lambda s, x, y: y,
-        symbol_price_prec=lambda s, x, y: y,
+        amount_to_precision=lambda s, x, y: y,
+        price_to_precision=lambda s, x, y: y,
         stoploss_limit=stoploss_limit,
         cancel_order=cancel_order,
     )
@@ -2478,8 +2478,8 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf, ticker, f
         'freqtrade.exchange.Exchange',
         fetch_ticker=ticker,
         get_fee=fee,
-        symbol_amount_prec=lambda s, x, y: y,
-        symbol_price_prec=lambda s, x, y: y,
+        amount_to_precision=lambda s, x, y: y,
+        price_to_precision=lambda s, x, y: y,
     )
 
     stoploss_limit = MagicMock(return_value={

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -58,8 +58,8 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
         'freqtrade.exchange.Exchange',
         fetch_ticker=ticker,
         get_fee=fee,
-        symbol_amount_prec=lambda s, x, y: y,
-        symbol_price_prec=lambda s, x, y: y,
+        amount_to_precision=lambda s, x, y: y,
+        price_to_precision=lambda s, x, y: y,
         get_order=stoploss_order_mock,
         cancel_order=cancel_order_mock,
     )
@@ -137,8 +137,8 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
         'freqtrade.exchange.Exchange',
         fetch_ticker=ticker,
         get_fee=fee,
-        symbol_amount_prec=lambda s, x, y: y,
-        symbol_price_prec=lambda s, x, y: y,
+        amount_to_precision=lambda s, x, y: y,
+        price_to_precision=lambda s, x, y: y,
     )
 
     mocker.patch.multiple(


### PR DESCRIPTION
## Summary
CCXT does have multiple methods to handle precision. see https://github.com/ccxt/ccxt/issues/6364
Based on this - we should not implement these functions ourself, but rely on CCXT for doing so.

Closes #2759

## Quick changelog

- rename methods from `symbol_price_prec` to `price_to_precision` and `symbol_amount_prec` to `amount_to_prec`
- use ccxt's `decimal_to_precision()` for this calculation, which handles all the logic of using the correct method based on each exchange.

## Open / failing tests

Currently there are 2 tests failing.
This is because the old method always rounds price up (so 0.123 would become 0.13 instead of 0.12). 

Right now I'm now questioning this method - since i'm not convinced that's correct.

Now i remember we discussed this topic in the introduction PR #1083 - that amount should round down (truncate - especially important for sells - we can't round up as we'll never have "more" than we bought - even after fees are deduced).

Also in that PR: price should round up - however i don't really see the benefit in this - so additional opinions are highly apreciated.

The 2 tests which are failing show that the "correct" test did not properly cover this scenario - which we should do by testing a few "edge-cases" (or not test this as it's now part of CCXT code). 