### PR TITLE
refresh wallets on /balance call

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -306,6 +306,8 @@ class RPC:
         except (TemporaryError, DependencyException):
             raise RPCException('Error getting current tickers.')
 
+        self._freqtrade.wallets.update(require_update=False)
+
         for coin, balance in self._freqtrade.wallets.get_all_balances().items():
             if not balance.total:
                 continue

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -2,7 +2,10 @@
 """ Wallet """
 
 import logging
-from typing import Dict, NamedTuple, Any
+from typing import Any, Dict, NamedTuple
+
+import arrow
+
 from freqtrade.exchange import Exchange
 from freqtrade.persistence import Trade
 
@@ -24,7 +27,7 @@ class Wallets:
         self._exchange = exchange
         self._wallets: Dict[str, Wallet] = {}
         self.start_cap = config['dry_run_wallet']
-
+        self._last_wallet_refresh = 0
         self.update()
 
     def get_free(self, currency) -> float:
@@ -95,12 +98,21 @@ class Wallets:
                 balances[currency].get('total', None)
             )
 
-    def update(self) -> None:
-        if self._config['dry_run']:
-            self._update_dry()
-        else:
-            self._update_live()
-        logger.info('Wallets synced.')
+    def update(self, require_update: bool = True) -> None:
+        """
+        Updates wallets from the configured version.
+        By default, updates from the exchange.
+        Update-skipping should only be used for user-invoked /balance calls, since
+        for trading operations, the latest balance is needed.
+        :param require_update: Allow skipping an update if balances were recently refreshed
+        """
+        if (require_update or (self._last_wallet_refresh + 3600 < arrow.utcnow().timestamp)):
+            if self._config['dry_run']:
+                self._update_dry()
+            else:
+                self._update_live()
+            logger.info('Wallets synced.')
+            self._last_wallet_refresh = arrow.utcnow().timestamp
 
     def get_all_balances(self) -> Dict[str, Any]:
         return self._wallets

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -32,7 +32,7 @@ def test_sync_wallet_at_boot(mocker, default_conf):
     assert freqtrade.wallets._wallets['GAS'].used == 0.0
     assert freqtrade.wallets._wallets['GAS'].total == 0.260739
     assert freqtrade.wallets.get_free('BNT') == 1.0
-
+    assert freqtrade.wallets._last_wallet_refresh > 0
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value={
@@ -61,6 +61,11 @@ def test_sync_wallet_at_boot(mocker, default_conf):
     assert freqtrade.wallets.get_free('GAS') == 0.270739
     assert freqtrade.wallets.get_used('GAS') == 0.1
     assert freqtrade.wallets.get_total('GAS') == 0.260439
+    update_mock = mocker.patch('freqtrade.wallets.Wallets._update_live')
+    freqtrade.wallets.update(False)
+    assert update_mock.call_count == 0
+    freqtrade.wallets.update()
+    assert update_mock.call_count == 1
 
 
 def test_sync_wallet_missing_data(mocker, default_conf):


### PR DESCRIPTION
## Summary
Conditinoally refresh balances on /balance calls.
The configured value of 1h is not configurable (intentionally) as allowing this too often may result in exchange bans. wallets are refreshed before trading (buy / sell) actions to ensure we have the latest balance, so this applies only for `/balance` rpc calls.

Closes #2756

## Quick changelog

- Add conditinonal update possibility for wallets.update
- Call wallets.update() from /balance.