### PR TITLE
Fix bad bug in safe_sell_amount

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -903,7 +903,7 @@ class FreqtradeBot:
         :raise: DependencyException: if available balance is not within 2% of the available amount.
         """
         wallet_amount = self.wallets.get_free(pair.split('/')[0])
-        logger.debug(f"{pair} - Wallet: {wallet_amount} - Trade-amount: {amount}")
+        logger.info(f"Selling {pair} - Wallet: {wallet_amount} - Trade-amount: {amount}")
         if wallet_amount >= amount:
             return amount
         elif wallet_amount > amount * 0.98:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -904,7 +904,7 @@ class FreqtradeBot:
         """
         wallet_amount = self.wallets.get_free(pair.split('/')[0])
         logger.debug(f"{pair} - Wallet: {wallet_amount} - Trade-amount: {amount}")
-        if wallet_amount > amount:
+        if wallet_amount >= amount:
             return amount
         elif wallet_amount > amount * 0.98:
             logger.info(f"{pair} - Falling back to wallet-amount.")

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2764,6 +2764,9 @@ def test__safe_sell_amount(default_conf, fee, caplog, mocker):
 
     assert freqtrade._safe_sell_amount(trade.pair, trade.amount) == amount_wallet
     assert log_has_re(r'.*Falling back to wallet-amount.', caplog)
+    caplog.clear()
+    assert freqtrade._safe_sell_amount(trade.pair, amount_wallet) == amount_wallet
+    assert not log_has_re(r'.*Falling back to wallet-amount.', caplog)
 
 
 def test__safe_sell_amount_error(default_conf, fee, caplog, mocker):


### PR DESCRIPTION
## Summary
We MUST compare selling amount to wallet amount with >= (not >) - otherwise regular trades without "dust" are unable to be sold.

supports #2770

## Quick changelog

- Fix bug
- add test
