### PR TITLE
Safe sell amount update wallet

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -902,15 +902,19 @@ class FreqtradeBot:
         :return: amount to sell
         :raise: DependencyException: if available balance is not within 2% of the available amount.
         """
+        # Update wallets to ensure amounts tied up in a stoploss is now free!
+        self.wallets.update()
+
         wallet_amount = self.wallets.get_free(pair.split('/')[0])
-        logger.info(f"Selling {pair} - Wallet: {wallet_amount} - Trade-amount: {amount}")
+        logger.debug(f"{pair} - Wallet: {wallet_amount} - Trade-amount: {amount}")
         if wallet_amount >= amount:
             return amount
         elif wallet_amount > amount * 0.98:
             logger.info(f"{pair} - Falling back to wallet-amount.")
             return wallet_amount
         else:
-            raise DependencyException("Not enough amount to sell.")
+            raise DependencyException(
+                f"Not enough amount to sell. Trade-amount: {amount}, Wallet: {wallet_amount}")
 
     def execute_sell(self, trade: Trade, limit: float, sell_reason: SellType) -> None:
         """

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -513,6 +513,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
         ),
         get_fee=fee,
     )
+    mocker.patch('freqtrade.wallets.Wallets.get_free', return_value=1000)
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2750,6 +2750,7 @@ def test__safe_sell_amount(default_conf, fee, caplog, mocker):
     amount = 95.33
     amount_wallet = 95.29
     mocker.patch('freqtrade.wallets.Wallets.get_free', MagicMock(return_value=amount_wallet))
+    wallet_update = mocker.patch('freqtrade.wallets.Wallets.update')
     trade = Trade(
         pair='LTC/ETH',
         amount=amount,
@@ -2762,11 +2763,15 @@ def test__safe_sell_amount(default_conf, fee, caplog, mocker):
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
 
+    wallet_update.reset_mock()
     assert freqtrade._safe_sell_amount(trade.pair, trade.amount) == amount_wallet
     assert log_has_re(r'.*Falling back to wallet-amount.', caplog)
+    assert wallet_update.call_count == 1
     caplog.clear()
+    wallet_update.reset_mock()
     assert freqtrade._safe_sell_amount(trade.pair, amount_wallet) == amount_wallet
     assert not log_has_re(r'.*Falling back to wallet-amount.', caplog)
+    assert wallet_update.call_count == 1
 
 
 def test__safe_sell_amount_error(default_conf, fee, caplog, mocker):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -97,8 +97,8 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
 
     # Only order for 3rd trade needs to be cancelled
     assert cancel_order_mock.call_count == 1
-    # Wallets should only be called once per sell cycle
-    assert wallets_mock.call_count == 1
+    # Wallets must be updated between stoploss cancellation and selling.
+    assert wallets_mock.call_count == 2
 
     trade = trades[0]
     assert trade.sell_reason == SellType.STOPLOSS_ON_EXCHANGE.value


### PR DESCRIPTION
## Summary
When using wallets.get_free() we need to ensure that the wallet is uptodate.
A stoploss on exchange is cancelled milliseconds before executing `_safe_sell_amount()` - so the amount on the exchange will not be free at that time.

This will also revert the log-message to debug - however show the amounts as part of the exception (that's where we really need them - when it fails, not when it works).

closes #2770 

