### PR TITLE
Fix/stoploss on exchange dryrun

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -389,9 +389,11 @@ class IStrategy(ABC):
                 trade.adjust_stop_loss(high or current_rate, stop_loss_value)
 
         # evaluate if the stoploss was hit if stoploss is not on exchange
+        # in Dry-Run, this handles stoploss logic as well, as the logic will not be different to
+        # regular stoploss handling.
         if ((self.stoploss is not None) and
             (trade.stop_loss >= current_rate) and
-                (not self.order_types.get('stoploss_on_exchange'))):
+                (not self.order_types.get('stoploss_on_exchange') or self.config['dry_run'])):
 
             sell_type = SellType.STOP_LOSS
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1318,6 +1318,14 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
                                                 rate=0.00002344 * 0.95 * 0.99,
                                                 stop_price=0.00002344 * 0.95)
 
+    # price fell below stoploss, so dry-run sells trade.
+    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
+        'bid': 0.00002144,
+        'ask': 0.00002146,
+        'last': 0.00002144
+    }))
+    assert freqtrade.handle_trade(trade) is True
+
 
 def test_handle_stoploss_on_exchange_trailing_error(mocker, default_conf, fee, caplog,
                                                     limit_buy_order, limit_sell_order) -> None:


### PR DESCRIPTION
## Summary
stoploss_on_exchange in combination with dry-run needs to emulate using a regular stoploss.

strangely enough, handling for this case is in place when determining the sell-rate - but not to trigger the stoploss sell itself - making the part below dead code without this new addition.

https://github.com/freqtrade/freqtrade/blob/eb6c7f8595e826ce7d9ff6413b5b6352c9a5382a/freqtrade/freqtradebot.py#L931-L935

Closes #2785

## Quick changelog

- Add test recreating the faulty behaviour
- Fix bug 

