### PR TITLE
added missing word in hyperopt loss example

### DIFF
--- a/freqtrade/templates/sample_hyperopt_loss.py
+++ b/freqtrade/templates/sample_hyperopt_loss.py
@@ -27,7 +27,7 @@ class SampleHyperOptLoss(IHyperOptLoss):
     Defines the default loss function for hyperopt
     This is intended to give you some inspiration for your own loss function.
 
-    The Function needs to return a number (float) - which becomes for better backtest results.
+    The Function needs to return a number (float) - which becomes smaller for better backtest results.
     """
 
     @staticmethod

--- a/freqtrade/templates/sample_hyperopt_loss.py
+++ b/freqtrade/templates/sample_hyperopt_loss.py
@@ -27,7 +27,8 @@ class SampleHyperOptLoss(IHyperOptLoss):
     Defines the default loss function for hyperopt
     This is intended to give you some inspiration for your own loss function.
 
-    The Function needs to return a number (float) - which becomes smaller for better backtest results.
+    The Function needs to return a number (float) - which becomes smaller for better backtest
+    results.
     """
 
     @staticmethod


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
It's just one missing word I added
