### PR TITLE
Fix typo in sell-reason table generation

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -70,7 +70,7 @@ def generate_text_table_sell_reason(data: Dict[str, Dict], results: DataFrame) -
     for reason, count in results['sell_reason'].value_counts().iteritems():
         result = results.loc[results['sell_reason'] == reason]
         profit = len(result[result['profit_abs'] >= 0])
-        loss = len(result[results['profit_abs'] < 0])
+        loss = len(result[result['profit_abs'] < 0])
         profit_mean = round(result['profit_percent'].mean() * 100.0, 2)
         tabular_data.append([reason.value, count, profit, loss, profit_mean])
     return tabulate(tabular_data, headers=headers, tablefmt="pipe")


### PR DESCRIPTION
## Summary
FIx a typo in sell_reason table generation that's causing a warning to be shown in the middle of the table.

Closes #2789 
