### PR TITLE
update wallets after forcesell

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -425,6 +425,7 @@ class RPC:
             for trade in Trade.get_open_trades():
                 _exec_forcesell(trade)
             Trade.session.flush()
+            self._freqtrade.wallets.update()
             return {'result': 'Created sell orders for all open trades.'}
 
         # Query for trade
@@ -437,6 +438,7 @@ class RPC:
 
         _exec_forcesell(trade)
         Trade.session.flush()
+        self._freqtrade.wallets.update()
         return {'result': f'Created sell order for trade {trade_id}.'}
 
     def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:


### PR DESCRIPTION
## Summary
Since forcesell calls `execute_sell()` we need to update wallets after this to avoid keeping the old wallet status until the next action happens. 
It's not a problem if the order doesn't fill immediately since `update_trade_state()` will update the state too - but it's a problem if the order does fill immediately, as then we close the trade.
In regular operations, wallets are updated after handling all "sellable" trades - but that's not the case with forcesell.

closes #2793

# Quick changelog

* call wallets.update when /forcesell is completed
* implement threading.lock object to avoid stoploss recreation when /forcesell is being used
