### PR TITLE
Fix stoploss recreated

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -689,8 +689,13 @@ class FreqtradeBot:
             self._notify_sell(trade, "stoploss")
             return True
 
+        if trade.open_order_id:
+            # Trade has an open Buy or Sell order, Stoploss-handling can't happen in this case
+            # as the Amount on the exchange is tied up in another trade.
+            return False
+
         # If buy order is fulfilled but there is no stoploss, we add a stoploss on exchange
-        if (not trade.open_order_id and not stoploss_order):
+        if (not stoploss_order):
 
             stoploss = self.edge.stoploss(pair=trade.pair) if self.edge else self.strategy.stoploss
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -689,9 +689,10 @@ class FreqtradeBot:
             self._notify_sell(trade, "stoploss")
             return True
 
-        if trade.open_order_id:
+        if trade.open_order_id or not trade.is_open:
             # Trade has an open Buy or Sell order, Stoploss-handling can't happen in this case
             # as the Amount on the exchange is tied up in another trade.
+            # The trade can be closed already (sell-order fill confirmation came in this iteration)
             return False
 
         # If buy order is fulfilled but there is no stoploss, we add a stoploss on exchange

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1165,7 +1165,7 @@ def test_handle_sle_cancel_cant_recreate(mocker, default_conf, fee, caplog,
     freqtrade.enter_positions()
     trade = Trade.query.first()
     trade.is_open = True
-    trade.open_order_id = '12345'
+    trade.open_order_id = None
     trade.stoploss_order_id = 100
     assert trade
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1141,6 +1141,16 @@ def test_handle_stoploss_on_exchange(mocker, default_conf, fee, caplog,
     freqtrade.handle_stoploss_on_exchange(trade)
     assert stoploss_limit.call_count == 1
 
+    # Sixth case: Closed Trade
+    # Should not create new order
+    trade.stoploss_order_id = None
+    trade.is_open = False
+    stoploss_limit.reset_mock()
+    mocker.patch('freqtrade.exchange.Exchange.get_order')
+    mocker.patch('freqtrade.exchange.Exchange.stoploss_limit', stoploss_limit)
+    assert freqtrade.handle_stoploss_on_exchange(trade) is False
+    assert stoploss_limit.call_count == 0
+
 
 def test_handle_sle_cancel_cant_recreate(mocker, default_conf, fee, caplog,
                                          limit_buy_order, limit_sell_order) -> None:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1127,6 +1127,7 @@ def test_handle_stoploss_on_exchange(mocker, default_conf, fee, caplog,
         'freqtrade.exchange.Exchange.stoploss_limit',
         side_effect=DependencyException()
     )
+    trade.is_open = True
     freqtrade.handle_stoploss_on_exchange(trade)
     assert log_has('Unable to place a stoploss order on exchange.', caplog)
     assert trade.stoploss_order_id is None


### PR DESCRIPTION
## Summary
Combined with the 2nd part of #2796 (Locking) - this will prevent stoploss orders from being recreated if a sell is currently in place (but not yet filled).

There are several protections in place at the moment - however in case of trailing stoploss it can happen that the bot places a regular sell limit order which is not filled immediately.
The next iteration will see that the stoploss is gone and try to recreate a stoploss order.

The other case (the one i hit):
Sell-order limit is placed (obviously, cancelling stoploss_on_exchnage).
The next iteration, the limit-order filling is confirmed (calls `trade.close()` - which sets `is_open=False` and `open_order_id=None`, causing that protection to fail.

is_open is verified in `handle_trade()` - but was missing here.

For me, it created a stoploss sell order on the exchange again - and since i had balance in that coin, the creation did not fail, and would have sold the "bought amount" a second time.


## Quick changelog

- Make sure we're not (re)creating stoploss orders on closed trades.