### PR TITLE
Backtest arguments instead of dictionary

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -279,7 +279,7 @@ class Backtesting:
             return bt_res
         return None
 
-    def backtest(self, processed: Dict, stake_amount: int,
+    def backtest(self, processed: Dict, stake_amount: float,
                  start_date, end_date,
                  max_open_trades: int = 0, position_stacking: bool = False) -> DataFrame:
         """
@@ -300,7 +300,7 @@ class Backtesting:
         logger.debug(f"Run backtest, stake_amount: {stake_amount}, "
                      f"start_date: {start_date}, end_date: {end_date}, "
                      f"max_open_trades: {max_open_trades}, position_stacking: {position_stacking}"
-        )
+                     )
         trades = []
         trade_count_lock: Dict = {}
 
@@ -405,7 +405,7 @@ class Backtesting:
             # Execute backtest and print results
             all_results[self.strategy.get_strategy_name()] = self.backtest(
                     processed=preprocessed,
-                    stake_amount=self.config.get('stake_amount'),
+                    stake_amount=self.config['stake_amount'],
                     start_date=min_date,
                     end_date=max_date,
                     max_open_trades=max_open_trades,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -372,14 +372,12 @@ class Hyperopt:
         min_date, max_date = get_timerange(processed)
 
         backtesting_results = self.backtesting.backtest(
-            {
-                'stake_amount': self.config['stake_amount'],
-                'processed': processed,
-                'max_open_trades': self.max_open_trades,
-                'position_stacking': self.position_stacking,
-                'start_date': min_date,
-                'end_date': max_date,
-            }
+                processed=processed,
+                stake_amount=self.config['stake_amount'],
+                start_date=min_date,
+                end_date=max_date,
+                max_open_trades=self.max_open_trades,
+                position_stacking=self.position_stacking,
         )
         return self._get_results_dict(backtesting_results, min_date, max_date,
                                       params_dict, params_details)

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -382,13 +382,11 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     data_processed = {pair: frame.copy()}
     min_date, max_date = get_timerange({pair: frame})
     results = backtesting.backtest(
-        {
-            'stake_amount': default_conf['stake_amount'],
-            'processed': data_processed,
-            'max_open_trades': 10,
-            'start_date': min_date,
-            'end_date': max_date,
-        }
+        processed=data_processed,
+        stake_amount=default_conf['stake_amount'],
+        start_date=min_date,
+        end_date=max_date,
+        max_open_trades=10,
     )
 
     assert len(results) == len(data.trades)


### PR DESCRIPTION
## Summary
Extract the first 2 commits from #2658. 
These do make absolute sense - and i need them "now" for some memory usage testing and optimizations i hope to get ...

## Quick changelog

- Backtesting should accept kwarguments, not a dictionary
