### PR TITLE
Fix missed mock

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -665,11 +665,11 @@ def test_start_list_strategies(mocker, caplog, capsys):
     assert "DefaultStrategy" in captured.out
 
 
-def test_start_test_pairlist(mocker, caplog, markets, tickers, default_conf, capsys):
+def test_start_test_pairlist(mocker, caplog, tickers, default_conf, capsys):
+    patch_exchange(mocker, mock_markets=True)
     mocker.patch.multiple('freqtrade.exchange.Exchange',
-                          markets=PropertyMock(return_value=markets),
                           exchange_has=MagicMock(return_value=True),
-                          get_tickers=tickers
+                          get_tickers=tickers,
                           )
 
     default_conf['pairlists'] = [


### PR DESCRIPTION
## Summary
This test is missing a mock - causing a "real" ccxt object to be initialized.

I suspect that's causing the random test failure we see in `test_create_datadir()` - however since these failures seem to only happen in CI we'll have to test to be sure if this will really fix the issue for good.

