### PR TITLE
Minor: Advise to use https method for git clone instead of ssh

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,7 +42,7 @@ The easiest way to install and run Freqtrade is to clone the bot GitHub reposito
 This can be achieved with the following commands:
 
 ```bash
-git clone git@github.com:freqtrade/freqtrade.git
+git clone https://github.com/freqtrade/freqtrade.git
 cd freqtrade
 git checkout master  # Optional, see (1)
 ./setup.sh --install


### PR DESCRIPTION
...because ssh can lead to permission denied error when no public key is installed, which can be frustrating for novices installing the bot following the docs.
