### PR TITLE
Remove state attribute from Worker class

### DIFF
--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -56,14 +56,6 @@ class Worker:
         self._sd_notify = sdnotify.SystemdNotifier() if \
             self._config.get('internals', {}).get('sd_notify', False) else None
 
-    @property
-    def state(self) -> State:
-        return self.freqtrade.state
-
-    @state.setter
-    def state(self, value: State) -> None:
-        self.freqtrade.state = value
-
     def run(self) -> None:
         state = None
         while True:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -797,10 +797,10 @@ def test_process_operational_exception(default_conf, ticker, mocker) -> None:
     worker = Worker(args=None, config=default_conf)
     patch_get_signal(worker.freqtrade)
 
-    assert worker.state == State.RUNNING
+    assert worker.freqtrade.state == State.RUNNING
 
     worker._process()
-    assert worker.state == State.STOPPED
+    assert worker.freqtrade.state == State.STOPPED
     assert 'OperationalException' in msg_mock.call_args_list[-1][0][0]['status']
 
 
@@ -3631,7 +3631,7 @@ def test_startup_state(default_conf, mocker):
                                 }
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
     worker = get_patched_worker(mocker, default_conf)
-    assert worker.state is State.RUNNING
+    assert worker.freqtrade.state is State.RUNNING
 
 
 def test_startup_trade_reinit(default_conf, edge_conf, mocker):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,11 +11,11 @@ from tests.conftest import get_patched_worker, log_has
 def test_worker_state(mocker, default_conf, markets) -> None:
     mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(return_value=markets))
     worker = get_patched_worker(mocker, default_conf)
-    assert worker.state is State.RUNNING
+    assert worker.freqtrade.state is State.RUNNING
 
     default_conf.pop('initial_state')
     worker = Worker(args=None, config=default_conf)
-    assert worker.state is State.STOPPED
+    assert worker.freqtrade.state is State.STOPPED
 
 
 def test_worker_running(mocker, default_conf, caplog) -> None:
@@ -41,7 +41,7 @@ def test_worker_stopped(mocker, default_conf, caplog) -> None:
     mock_sleep = mocker.patch('time.sleep', return_value=None)
 
     worker = get_patched_worker(mocker, default_conf)
-    worker.state = State.STOPPED
+    worker.freqtrade.state = State.STOPPED
     state = worker._worker(old_state=State.RUNNING)
     assert state is State.STOPPED
     assert log_has('Changing state to: STOPPED', caplog)


### PR DESCRIPTION
Small cleanup from the overall design point of view.

The `state` attr is currently only used in the tests. Which is probably wrong, because tests should interact with the code in the same way, as other parts.

Actually, `state: State` is not an attribute of worker from the design point of view: 1) worker is always running (throttling), even when the bot is in the stopped state; 2) assume we extend later the worker to operate with a couple or with a list of bots -- then the state of each bot should be handled separately. So it's an attribute of the bot instance, not of the worker itself.
