### PR TITLE
added daily sharpe ratio hyperopt loss method, ty @djacky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-18.04, macos-latest ]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-stretch
+FROM python:3.8.1-slim-buster
 
 RUN apt-get update \
     && apt-get -y install curl build-essential libssl-dev \

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -3,7 +3,7 @@
 This page explains the different parameters of the bot and how to run it.
 
 !!! Note
-    If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
+If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
 ## Bot commands
 
@@ -337,8 +337,8 @@ optional arguments:
                         generate completely different results, since the
                         target for optimization is different. Built-in
                         Hyperopt-loss-functions are: DefaultHyperOptLoss,
-                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss (default:
-                        `DefaultHyperOptLoss`).
+                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss,
+                        SharpeHyperOptLossDaily (default: `DefaultHyperOptLoss`).
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -3,7 +3,7 @@
 This page explains the different parameters of the bot and how to run it.
 
 !!! Note
-If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
+    If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
 ## Bot commands
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -30,34 +30,34 @@ This will create a new hyperopt file from a template, which will be located unde
 
 Depending on the space you want to optimize, only some of the below are required:
 
-- fill `buy_strategy_generator` - for buy signal optimization
-- fill `indicator_space` - for buy signal optimzation
-- fill `sell_strategy_generator` - for sell signal optimization
-- fill `sell_indicator_space` - for sell signal optimzation
+* fill `buy_strategy_generator` - for buy signal optimization
+* fill `indicator_space` - for buy signal optimzation
+* fill `sell_strategy_generator` - for sell signal optimization
+* fill `sell_indicator_space` - for sell signal optimzation
 
 !!! Note
-`populate_indicators` needs to create all indicators any of thee spaces may use, otherwise hyperopt will not work.
+    `populate_indicators` needs to create all indicators any of thee spaces may use, otherwise hyperopt will not work.
 
 Optional - can also be loaded from a strategy:
 
-- copy `populate_indicators` from your strategy - otherwise default-strategy will be used
-- copy `populate_buy_trend` from your strategy - otherwise default-strategy will be used
-- copy `populate_sell_trend` from your strategy - otherwise default-strategy will be used
+* copy `populate_indicators` from your strategy - otherwise default-strategy will be used
+* copy `populate_buy_trend` from your strategy - otherwise default-strategy will be used
+* copy `populate_sell_trend` from your strategy - otherwise default-strategy will be used
 
 !!! Note
-Assuming the optional methods are not in your hyperopt file, please use `--strategy AweSomeStrategy` which contains these methods so hyperopt can use these methods instead.
+    Assuming the optional methods are not in your hyperopt file, please use `--strategy AweSomeStrategy` which contains these methods so hyperopt can use these methods instead.
 
 Rarely you may also need to override:
 
-- `roi_space` - for custom ROI optimization (if you need the ranges for the ROI parameters in the optimization hyperspace that differ from default)
-- `generate_roi_table` - for custom ROI optimization (if you need the ranges for the values in the ROI table that differ from default or the number of entries (steps) in the ROI table which differs from the default 4 steps)
-- `stoploss_space` - for custom stoploss optimization (if you need the range for the stoploss parameter in the optimization hyperspace that differs from default)
-- `trailing_space` - for custom trailing stop optimization (if you need the ranges for the trailing stop parameters in the optimization hyperspace that differ from default)
+* `roi_space` - for custom ROI optimization (if you need the ranges for the ROI parameters in the optimization hyperspace that differ from default)
+* `generate_roi_table` - for custom ROI optimization (if you need the ranges for the values in the ROI table that differ from default or the number of entries (steps) in the ROI table which differs from the default 4 steps)
+* `stoploss_space` - for custom stoploss optimization (if you need the range for the stoploss parameter in the optimization hyperspace that differs from default)
+* `trailing_space` - for custom trailing stop optimization (if you need the ranges for the trailing stop parameters in the optimization hyperspace that differ from default)
 
 !!! Tip "Quickly optimize ROI, stoploss and trailing stoploss"
-You can quickly optimize the spaces `roi`, `stoploss` and `trailing` without changing anything (i.e. without creation of a "complete" Hyperopt class with dimensions, parameters, triggers and guards, as described in this document) from the default hyperopt template by relying on your strategy to do most of the calculations.
+    You can quickly optimize the spaces `roi`, `stoploss` and `trailing` without changing anything (i.e. without creation of a "complete" Hyperopt class with dimensions, parameters, triggers and guards, as described in this document) from the default hyperopt template by relying on your strategy to do most of the calculations.
 
-    ``` python
+    ```python
     # Have a working strategy at hand.
     freqtrade new-hyperopt --hyperopt EmptyHyperopt
 
@@ -75,8 +75,8 @@ Copy the file `user_data/hyperopts/sample_hyperopt.py` into `user_data/hyperopts
 
 There are two places you need to change in your hyperopt file to add a new buy hyperopt for testing:
 
-- Inside `indicator_space()` - the parameters hyperopt shall be optimizing.
-- Inside `populate_buy_trend()` - applying the parameters.
+* Inside `indicator_space()` - the parameters hyperopt shall be optimizing.
+* Inside `populate_buy_trend()` - applying the parameters.
 
 There you have two different types of indicators: 1. `guards` and 2. `triggers`.
 
@@ -85,8 +85,8 @@ There you have two different types of indicators: 1. `guards` and 2. `triggers`.
 
 Hyperoptimization will, for each eval round, pick one trigger and possibly
 multiple guards. The constructed strategy will be something like
-"_buy exactly when close price touches lower bollinger band, BUT only if
-ADX > 10_".
+"*buy exactly when close price touches lower bollinger band, BUT only if
+ADX > 10*".
 
 If you have updated the buy strategy, i.e. changed the contents of
 `populate_buy_trend()` method, you have to update the `guards` and
@@ -97,8 +97,8 @@ If you have updated the buy strategy, i.e. changed the contents of
 Similar to the buy-signal above, sell-signals can also be optimized.
 Place the corresponding settings into the following methods
 
-- Inside `sell_indicator_space()` - the parameters hyperopt shall be optimizing.
-- Inside `populate_sell_trend()` - applying the parameters.
+* Inside `sell_indicator_space()` - the parameters hyperopt shall be optimizing.
+* Inside `populate_sell_trend()` - applying the parameters.
 
 The configuration and rules are the same than for buy signals.
 To avoid naming collisions in the search-space, please prefix all sell-spaces with `sell-`.
@@ -189,10 +189,10 @@ This class should be in its own file within the `user_data/hyperopts/` directory
 
 Currently, the following loss functions are builtin:
 
-- `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
-- `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
-- `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
-- `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on daily trade returns)
+* `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
+* `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
+* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
+* `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on daily trade returns)
 
 Creation of a custom loss function is covered in the [Advanced Hyperopt](advanced-hyperopt.md) part of the documentation.
 
@@ -215,10 +215,10 @@ running at least several thousand evaluations.
 The `--spaces all` option determines that all possible parameters should be optimized. Possibilities are listed below.
 
 !!! Note
-By default, hyperopt will erase previous results and start from scratch. Continuation can be archived by using `--continue`.
+    By default, hyperopt will erase previous results and start from scratch. Continuation can be archived by using `--continue`.
 
 !!! Warning
-When switching parameters or changing configuration options, make sure to not use the argument `--continue` so temporary results can be removed.
+    When switching parameters or changing configuration options, make sure to not use the argument `--continue` so temporary results can be removed.
 
 ### Execute Hyperopt with Different Ticker-Data Source
 
@@ -253,14 +253,14 @@ new buy strategy you have.
 
 Legal values are:
 
-- `all`: optimize everything
-- `buy`: just search for a new buy strategy
-- `sell`: just search for a new sell strategy
-- `roi`: just optimize the minimal profit table for your strategy
-- `stoploss`: search for the best stoploss value
-- `trailing`: search for the best trailing stop values
-- `default`: `all` except `trailing`
-- space-separated list of any of the above values for example `--spaces roi stoploss`
+* `all`: optimize everything
+* `buy`: just search for a new buy strategy
+* `sell`: just search for a new sell strategy
+* `roi`: just optimize the minimal profit table for your strategy
+* `stoploss`: search for the best stoploss value
+* `trailing`: search for the best trailing stop values
+* `default`: `all` except `trailing`
+* space-separated list of any of the above values for example `--spaces roi stoploss`
 
 The default Hyperopt Search Space, used when no `--space` command line option is specified, does not include the `trailing` hyperspace. We recommend you to run optimization for the `trailing` hyperspace separately, when the best parameters for other hyperspaces were found, validated and pasted into your custom strategy.
 
@@ -280,7 +280,7 @@ during Hyperopt/Backtesting (which is equal to setting `max_open_trades` to a ve
 number).
 
 !!! Note
-Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
+    Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
 
 You can also enable position stacking in the configuration file by explicitly setting
 `"position_stacking"=true`.

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -14,7 +14,7 @@ Hyperopt requires historic data to be available, just as backtesting does.
 To learn how to get data for the pairs and exchange you're interested in, head over to the [Data Downloading](data-download.md) section of the documentation.
 
 !!! Bug
-    Hyperopt can crash when used with only 1 CPU Core as found out in [Issue #1133](https://github.com/freqtrade/freqtrade/issues/1133)
+Hyperopt can crash when used with only 1 CPU Core as found out in [Issue #1133](https://github.com/freqtrade/freqtrade/issues/1133)
 
 ## Prepare Hyperopting
 
@@ -30,39 +30,39 @@ This will create a new hyperopt file from a template, which will be located unde
 
 Depending on the space you want to optimize, only some of the below are required:
 
-* fill `buy_strategy_generator` - for buy signal optimization
-* fill `indicator_space` - for buy signal optimzation
-* fill `sell_strategy_generator` - for sell signal optimization
-* fill `sell_indicator_space` - for sell signal optimzation
+- fill `buy_strategy_generator` - for buy signal optimization
+- fill `indicator_space` - for buy signal optimzation
+- fill `sell_strategy_generator` - for sell signal optimization
+- fill `sell_indicator_space` - for sell signal optimzation
 
 !!! Note
-    `populate_indicators` needs to create all indicators any of thee spaces may use, otherwise hyperopt will not work.
+`populate_indicators` needs to create all indicators any of thee spaces may use, otherwise hyperopt will not work.
 
 Optional - can also be loaded from a strategy:
 
-* copy `populate_indicators` from your strategy - otherwise default-strategy will be used
-* copy `populate_buy_trend` from your strategy - otherwise default-strategy will be used
-* copy `populate_sell_trend` from your strategy - otherwise default-strategy will be used
+- copy `populate_indicators` from your strategy - otherwise default-strategy will be used
+- copy `populate_buy_trend` from your strategy - otherwise default-strategy will be used
+- copy `populate_sell_trend` from your strategy - otherwise default-strategy will be used
 
 !!! Note
-    Assuming the optional methods are not in your hyperopt file, please use `--strategy AweSomeStrategy` which contains these methods so hyperopt can use these methods instead.
+Assuming the optional methods are not in your hyperopt file, please use `--strategy AweSomeStrategy` which contains these methods so hyperopt can use these methods instead.
 
 Rarely you may also need to override:
 
-* `roi_space` - for custom ROI optimization (if you need the ranges for the ROI parameters in the optimization hyperspace that differ from default)
-* `generate_roi_table` - for custom ROI optimization (if you need the ranges for the values in the ROI table that differ from default or the number of entries (steps) in the ROI table which differs from the default 4 steps)
-* `stoploss_space` - for custom stoploss optimization (if you need the range for the stoploss parameter in the optimization hyperspace that differs from default)
-* `trailing_space` - for custom trailing stop optimization (if you need the ranges for the trailing stop parameters in the optimization hyperspace that differ from default)
+- `roi_space` - for custom ROI optimization (if you need the ranges for the ROI parameters in the optimization hyperspace that differ from default)
+- `generate_roi_table` - for custom ROI optimization (if you need the ranges for the values in the ROI table that differ from default or the number of entries (steps) in the ROI table which differs from the default 4 steps)
+- `stoploss_space` - for custom stoploss optimization (if you need the range for the stoploss parameter in the optimization hyperspace that differs from default)
+- `trailing_space` - for custom trailing stop optimization (if you need the ranges for the trailing stop parameters in the optimization hyperspace that differ from default)
 
 !!! Tip "Quickly optimize ROI, stoploss and trailing stoploss"
-    You can quickly optimize the spaces `roi`, `stoploss` and `trailing` without changing anything (i.e. without creation of a "complete" Hyperopt class with dimensions, parameters, triggers and guards, as described in this document) from the default hyperopt template by relying on your strategy to do most of the calculations.
+You can quickly optimize the spaces `roi`, `stoploss` and `trailing` without changing anything (i.e. without creation of a "complete" Hyperopt class with dimensions, parameters, triggers and guards, as described in this document) from the default hyperopt template by relying on your strategy to do most of the calculations.
 
     ``` python
     # Have a working strategy at hand.
     freqtrade new-hyperopt --hyperopt EmptyHyperopt
 
     freqtrade hyperopt --hyperopt EmptyHyperopt --spaces roi stoploss trailing --strategy MyWorkingStrategy --config config.json -e 100
-    ``` 
+    ```
 
 ### 1. Install a Custom Hyperopt File
 
@@ -85,8 +85,8 @@ There you have two different types of indicators: 1. `guards` and 2. `triggers`.
 
 Hyperoptimization will, for each eval round, pick one trigger and possibly
 multiple guards. The constructed strategy will be something like
-"*buy exactly when close price touches lower bollinger band, BUT only if
-ADX > 10*".
+"_buy exactly when close price touches lower bollinger band, BUT only if
+ADX > 10_".
 
 If you have updated the buy strategy, i.e. changed the contents of
 `populate_buy_trend()` method, you have to update the `guards` and
@@ -97,8 +97,8 @@ If you have updated the buy strategy, i.e. changed the contents of
 Similar to the buy-signal above, sell-signals can also be optimized.
 Place the corresponding settings into the following methods
 
-* Inside `sell_indicator_space()` - the parameters hyperopt shall be optimizing.
-* Inside `populate_sell_trend()` - applying the parameters.
+- Inside `sell_indicator_space()` - the parameters hyperopt shall be optimizing.
+- Inside `populate_sell_trend()` - applying the parameters.
 
 The configuration and rules are the same than for buy signals.
 To avoid naming collisions in the search-space, please prefix all sell-spaces with `sell-`.
@@ -141,7 +141,7 @@ one we call `trigger` and use it to decide which buy trigger we want to use.
 
 So let's write the buy strategy using these values:
 
-``` python
+```python
         def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
             conditions = []
             # GUARDS AND TRENDS
@@ -189,9 +189,10 @@ This class should be in its own file within the `user_data/hyperopts/` directory
 
 Currently, the following loss functions are builtin:
 
-* `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
-* `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
-* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
+- `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
+- `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
+- `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
+- `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on daily trade returns)
 
 Creation of a custom loss function is covered in the [Advanced Hyperopt](advanced-hyperopt.md) part of the documentation.
 
@@ -206,7 +207,7 @@ We strongly recommend to use `screen` or `tmux` to prevent any connection loss.
 freqtrade hyperopt --config config.json --hyperopt <hyperoptname> -e 5000 --spaces all
 ```
 
-Use  `<hyperoptname>` as the name of the custom hyperopt used.
+Use `<hyperoptname>` as the name of the custom hyperopt used.
 
 The `-e` option will set how many evaluations hyperopt will do. We recommend
 running at least several thousand evaluations.
@@ -214,10 +215,10 @@ running at least several thousand evaluations.
 The `--spaces all` option determines that all possible parameters should be optimized. Possibilities are listed below.
 
 !!! Note
-    By default, hyperopt will erase previous results and start from scratch. Continuation can be archived by using `--continue`.
+By default, hyperopt will erase previous results and start from scratch. Continuation can be archived by using `--continue`.
 
 !!! Warning
-    When switching parameters or changing configuration options, make sure to not use the argument `--continue` so temporary results can be removed.
+When switching parameters or changing configuration options, make sure to not use the argument `--continue` so temporary results can be removed.
 
 ### Execute Hyperopt with Different Ticker-Data Source
 
@@ -252,36 +253,36 @@ new buy strategy you have.
 
 Legal values are:
 
-* `all`: optimize everything
-* `buy`: just search for a new buy strategy
-* `sell`: just search for a new sell strategy
-* `roi`: just optimize the minimal profit table for your strategy
-* `stoploss`: search for the best stoploss value
-* `trailing`: search for the best trailing stop values
-* `default`: `all` except `trailing`
-* space-separated list of any of the above values for example `--spaces roi stoploss`
+- `all`: optimize everything
+- `buy`: just search for a new buy strategy
+- `sell`: just search for a new sell strategy
+- `roi`: just optimize the minimal profit table for your strategy
+- `stoploss`: search for the best stoploss value
+- `trailing`: search for the best trailing stop values
+- `default`: `all` except `trailing`
+- space-separated list of any of the above values for example `--spaces roi stoploss`
 
 The default Hyperopt Search Space, used when no `--space` command line option is specified, does not include the `trailing` hyperspace. We recommend you to run optimization for the `trailing` hyperspace separately, when the best parameters for other hyperspaces were found, validated and pasted into your custom strategy.
 
 ### Position stacking and disabling max market positions
 
-In some situations, you may need to run Hyperopt (and Backtesting) with the 
+In some situations, you may need to run Hyperopt (and Backtesting) with the
 `--eps`/`--enable-position-staking` and `--dmmp`/`--disable-max-market-positions` arguments.
 
 By default, hyperopt emulates the behavior of the Freqtrade Live Run/Dry Run, where only one
-open trade is allowed for every traded pair. The total number of trades open for all pairs 
+open trade is allowed for every traded pair. The total number of trades open for all pairs
 is also limited by the `max_open_trades` setting. During Hyperopt/Backtesting this may lead to
 some potential trades to be hidden (or masked) by previosly open trades.
 
 The `--eps`/`--enable-position-stacking` argument allows emulation of buying the same pair multiple times,
-while `--dmmp`/`--disable-max-market-positions` disables applying `max_open_trades` 
+while `--dmmp`/`--disable-max-market-positions` disables applying `max_open_trades`
 during Hyperopt/Backtesting (which is equal to setting `max_open_trades` to a very high
 number).
 
 !!! Note
-    Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
+Dry/live runs will **NOT** use position stacking - therefore it does make sense to also validate the strategy without this as it's closer to reality.
 
-You can also enable position stacking in the configuration file by explicitly setting 
+You can also enable position stacking in the configuration file by explicitly setting
 `"position_stacking"=true`.
 
 ### Reproducible results
@@ -323,7 +324,7 @@ method, what those values match to.
 
 So for example you had `rsi-value: 29.0` so we would look at `rsi`-block, that translates to the following code block:
 
-``` python
+```python
 (dataframe['rsi'] < 29.0)
 ```
 
@@ -372,18 +373,19 @@ In order to use this best ROI table found by Hyperopt in backtesting and for liv
         118: 0
     }
 ```
+
 As stated in the comment, you can also use it as the value of the `minimal_roi` setting in the configuration file.
 
 #### Default ROI Search Space
 
 If you are optimizing ROI, Freqtrade creates the 'roi' optimization hyperspace for you -- it's the hyperspace of components for the ROI tables. By default, each ROI table generated by the Freqtrade consists of 4 rows (steps). Hyperopt implements adaptive ranges for ROI tables with ranges for values in the ROI steps that depend on the ticker_interval used. By default the values vary in the following ranges (for some of the most used ticker intervals, values are rounded to 5 digits after the decimal point):
 
-| # step | 1m |  | 5m |  | 1h |  | 1d |  |
-|---|---|---|---|---|---|---|---|---|
-| 1 | 0 | 0.01161...0.11992 | 0 | 0.03...0.31 | 0 | 0.06883...0.71124 | 0 | 0.12178...1.25835 |
-| 2 | 2...8 | 0.00774...0.04255 | 10...40 | 0.02...0.11 | 120...480 | 0.04589...0.25238 | 2880...11520 | 0.08118...0.44651 |
-| 3 | 4...20 | 0.00387...0.01547 | 20...100 | 0.01...0.04 | 240...1200 | 0.02294...0.09177 | 5760...28800 | 0.04059...0.16237 |
-| 4 | 6...44 | 0.0 | 30...220 | 0.0 | 360...2640 | 0.0 | 8640...63360 | 0.0 |
+| # step | 1m     |                   | 5m       |             | 1h         |                   | 1d           |                   |
+| ------ | ------ | ----------------- | -------- | ----------- | ---------- | ----------------- | ------------ | ----------------- |
+| 1      | 0      | 0.01161...0.11992 | 0        | 0.03...0.31 | 0          | 0.06883...0.71124 | 0            | 0.12178...1.25835 |
+| 2      | 2...8  | 0.00774...0.04255 | 10...40  | 0.02...0.11 | 120...480  | 0.04589...0.25238 | 2880...11520 | 0.08118...0.44651 |
+| 3      | 4...20 | 0.00387...0.01547 | 20...100 | 0.01...0.04 | 240...1200 | 0.02294...0.09177 | 5760...28800 | 0.04059...0.16237 |
+| 4      | 6...44 | 0.0               | 30...220 | 0.0         | 360...2640 | 0.0               | 8640...63360 | 0.0               |
 
 These ranges should be sufficient in most cases. The minutes in the steps (ROI dict keys) are scaled linearly depending on the ticker interval used. The ROI values in the steps (ROI dict values) are scaled logarithmically depending on the ticker interval used.
 
@@ -416,6 +418,7 @@ In order to use this best stoploss value found by Hyperopt in backtesting and fo
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.27996
 ```
+
 As stated in the comment, you can also use it as the value of the `stoploss` setting in the configuration file.
 
 #### Default Stoploss Search Space
@@ -452,6 +455,7 @@ In order to use these best trailing stop parameters found by Hyperopt in backtes
     trailing_stop_positive_offset = 0.06038
     trailing_only_offset_is_reached = True
 ```
+
 As stated in the comment, you can also use it as the values of the corresponding settings in the configuration file.
 
 #### Default Trailing Stop Search Space

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -14,7 +14,7 @@ Hyperopt requires historic data to be available, just as backtesting does.
 To learn how to get data for the pairs and exchange you're interested in, head over to the [Data Downloading](data-download.md) section of the documentation.
 
 !!! Bug
-Hyperopt can crash when used with only 1 CPU Core as found out in [Issue #1133](https://github.com/freqtrade/freqtrade/issues/1133)
+    Hyperopt can crash when used with only 1 CPU Core as found out in [Issue #1133](https://github.com/freqtrade/freqtrade/issues/1133)
 
 ## Prepare Hyperopting
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -256,7 +256,7 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify the class name of the hyperopt loss function class (IHyperOptLoss). '
         'Different functions can generate completely different results, '
         'since the target for optimization is different. Built-in Hyperopt-loss-functions are: '
-        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss.'
+        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss, SharpeHyperOptLossDaily.'
         '(default: `%(default)s`).',
         metavar='NAME',
         default=constants.DEFAULT_HYPEROPT_LOSS,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -404,12 +404,12 @@ class Backtesting:
             )
             # Execute backtest and print results
             all_results[self.strategy.get_strategy_name()] = self.backtest(
-                    processed=preprocessed,
-                    stake_amount=self.config['stake_amount'],
-                    start_date=min_date,
-                    end_date=max_date,
-                    max_open_trades=max_open_trades,
-                    position_stacking=position_stacking,
+                processed=preprocessed,
+                stake_amount=self.config['stake_amount'],
+                start_date=min_date,
+                end_date=max_date,
+                max_open_trades=max_open_trades,
+                position_stacking=position_stacking,
             )
 
         for strategy, results in all_results.items():
@@ -426,7 +426,10 @@ class Backtesting:
                                       results=results))
 
             print(' SELL REASON STATS '.center(133, '='))
-            print(generate_text_table_sell_reason(data, results))
+            print(generate_text_table_sell_reason(data,
+                                                  stake_currency=self.config['stake_currency'],
+                                                  max_open_trades=self.config['max_open_trades'],
+                                                  results=results))
 
             print(' LEFT OPEN TRADES REPORT '.center(133, '='))
             print(generate_text_table(data,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -59,6 +59,7 @@ class Hyperopt:
     hyperopt = Hyperopt(config)
     hyperopt.start()
     """
+
     def __init__(self, config: Dict[str, Any]) -> None:
         self.config = config
 
@@ -90,13 +91,13 @@ class Hyperopt:
         # Populate functions here (hasattr is slow so should not be run during "regular" operations)
         if hasattr(self.custom_hyperopt, 'populate_indicators'):
             self.backtesting.strategy.advise_indicators = \
-                    self.custom_hyperopt.populate_indicators  # type: ignore
+                self.custom_hyperopt.populate_indicators  # type: ignore
         if hasattr(self.custom_hyperopt, 'populate_buy_trend'):
             self.backtesting.strategy.advise_buy = \
-                    self.custom_hyperopt.populate_buy_trend  # type: ignore
+                self.custom_hyperopt.populate_buy_trend  # type: ignore
         if hasattr(self.custom_hyperopt, 'populate_sell_trend'):
             self.backtesting.strategy.advise_sell = \
-                    self.custom_hyperopt.populate_sell_trend  # type: ignore
+                self.custom_hyperopt.populate_sell_trend  # type: ignore
 
         # Use max_open_trades for hyperopt as well, except --disable-max-market-positions is set
         if self.config.get('use_max_market_positions', True):
@@ -345,15 +346,15 @@ class Hyperopt:
 
         if self.has_space('roi'):
             self.backtesting.strategy.minimal_roi = \
-                    self.custom_hyperopt.generate_roi_table(params_dict)
+                self.custom_hyperopt.generate_roi_table(params_dict)
 
         if self.has_space('buy'):
             self.backtesting.strategy.advise_buy = \
-                    self.custom_hyperopt.buy_strategy_generator(params_dict)
+                self.custom_hyperopt.buy_strategy_generator(params_dict)
 
         if self.has_space('sell'):
             self.backtesting.strategy.advise_sell = \
-                    self.custom_hyperopt.sell_strategy_generator(params_dict)
+                self.custom_hyperopt.sell_strategy_generator(params_dict)
 
         if self.has_space('stoploss'):
             self.backtesting.strategy.stoploss = params_dict['stoploss']
@@ -372,12 +373,12 @@ class Hyperopt:
         min_date, max_date = get_timerange(processed)
 
         backtesting_results = self.backtesting.backtest(
-                processed=processed,
-                stake_amount=self.config['stake_amount'],
-                start_date=min_date,
-                end_date=max_date,
-                max_open_trades=self.max_open_trades,
-                position_stacking=self.position_stacking,
+            processed=processed,
+            stake_amount=self.config['stake_amount'],
+            start_date=min_date,
+            end_date=max_date,
+            max_open_trades=self.max_open_trades,
+            position_stacking=self.position_stacking,
         )
         return self._get_results_dict(backtesting_results, min_date, max_date,
                                       params_dict, params_details)
@@ -469,8 +470,8 @@ class Hyperopt:
             trials = Hyperopt._read_trials(trials_file)
             if trials[0].get('is_best') is None:
                 raise OperationalException(
-                        "The file with Hyperopt results is incompatible with this version "
-                        "of Freqtrade and cannot be loaded.")
+                    "The file with Hyperopt results is incompatible with this version "
+                    "of Freqtrade and cannot be loaded.")
             logger.info(f"Loaded {len(trials)} previous evaluations from disk.")
         return trials
 

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -1,0 +1,69 @@
+"""
+SharpeHyperOptLoss
+
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
+from datetime import datetime
+
+from pandas import DataFrame
+import numpy as np
+
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+class SharpeHyperOptLossDaily(IHyperOptLoss):
+    """
+    Defines the loss function for hyperopt.
+
+    This implementation uses the Sharpe Ratio calculation.
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(
+        results: DataFrame,
+        trade_count: int,
+        min_date: datetime,
+        max_date: datetime,
+        *args,
+        **kwargs
+    ) -> float:
+        """
+        Objective function, returns smaller number for more optimal results.
+
+        Uses Sharpe Ratio calculation.
+        """
+        total_profit = results.profit_percent
+        # days_period = (max_date - min_date).days
+
+        # adding slippage of 0.1% per trade
+        total_profit = total_profit - 0.0005
+        # expected_yearly_return = total_profit.sum() / days_period
+
+        # if np.std(total_profit) != 0.0:
+        #     sharp_ratio = expected_yearly_return / np.std(total_profit) * np.sqrt(365)
+        # else:
+        #     # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
+        #     sharp_ratio = -20.0
+
+        # # print(expected_yearly_return, np.std(total_profit), sharp_ratio)
+        # return -sharp_ratio
+
+        sum_daily = (
+            results.resample("D", on="close_time").agg(
+                {"profit_percent": sum, "profit_abs": sum}
+            )
+            * 100.0
+        )
+
+        if np.std(total_profit) != 0.0:
+            sharp_ratio = (
+                sum_daily["profit_percent"].mean()
+                / sum_daily["profit_percent"].std()
+                * np.sqrt(365)
+            )
+        else:
+            # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
+            sharp_ratio = -20.0
+
+        return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -43,7 +43,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if (np.std(sum_daily.profit_percent) != 0.):
+        if (np.std(dataframe['profit_percent']) != 0.):
             sharp_ratio = (
                 sum_daily["profit_percent"].mean()
                 / np.std(sum_daily["profit_percent"])

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -29,16 +29,16 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         Uses Sharpe Ratio calculation.
         """
         # get profit_percent and apply slippage of 0.1% per trade
-        results.loc[:, 'profit_percent'] = results['profit_percent'] - 0.0005
+        results.loc[:, 'profit_percent_after_slippage'] = results['profit_percent'] - 0.0005
 
         sum_daily = (
             results.resample("D", on="close_time").agg(
-                {"profit_percent": sum}
+                {"profit_percent_after_slippage": sum}
             )
             * 100.0
         )
 
-        total_profit = sum_daily["profit_percent"]
+        total_profit = sum_daily["profit_percent_after_slippage"]
         expected_returns_mean = total_profit.mean()
         up_stdev = np.std(total_profit)
 

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -33,10 +33,8 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
 
         Uses Sharpe Ratio calculation.
         """
-        total_profit = results.profit_percent
-
-        # adding slippage of 0.1% per trade
-        total_profit = total_profit - 0.0005
+        # get profit_percent and apply slippage of 0.1% per trade
+        results.loc[:, 'profit_percent'] = results['profit_percent'] - 0.0005
 
         sum_daily = (
             results.resample("D", on="close_time").agg(

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -4,10 +4,10 @@ SharpeHyperOptLossDaily
 This module defines the alternative HyperOptLoss class which can be used for
 Hyperoptimization.
 """
+import math
 from datetime import datetime
 
 from pandas import DataFrame, date_range
-import numpy as np
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
@@ -35,7 +35,8 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         risk_free_rate = annual_risk_free_rate / days_in_year
 
         # apply slippage per trade to profit_percent
-        results.loc[:, 'profit_percent_after_slippage'] = results['profit_percent'] - slippage_per_trade_ratio
+        results.loc[:, 'profit_percent_after_slippage'] = \
+            results['profit_percent'] - slippage_per_trade_ratio
 
         # create the index within the min_date and end max_date
         t_index = date_range(start=min_date, end=max_date, freq=resample_freq)
@@ -50,11 +51,11 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         up_stdev = total_profit.std()
 
         if (up_stdev != 0.):
-            sharp_ratio = expected_returns_mean / up_stdev * np.sqrt(days_in_year)
+            sharp_ratio = expected_returns_mean / up_stdev * math.sqrt(days_in_year)
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
             sharp_ratio = -20.
 
-        #print(t_index, sum_daily, total_profit)
-        #print(risk_free_rate, expected_returns_mean, up_stdev, sharp_ratio)
+        # print(t_index, sum_daily, total_profit)
+        # print(risk_free_rate, expected_returns_mean, up_stdev, sharp_ratio)
         return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -40,7 +40,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
 
         sum_daily = (
             results.resample("D", on="close_time").agg(
-                {"profit_percent": sum, "profit_abs": sum}
+                {"profit_percent": sum}
             )
             * 100.0
         )

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -31,7 +31,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         resample_freq = '1D'
         slippage_per_trade_ratio = 0.0005
         days_in_year = 365
-        annual_risk_free_rate = 0.03
+        annual_risk_free_rate = 0.0
         risk_free_rate = annual_risk_free_rate / days_in_year
 
         # apply slippage per trade to profit_percent

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -40,11 +40,13 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
 
         total_profit = sum_daily["profit_percent"]
         expected_returns_mean = total_profit.mean()
+        up_stdev = np.std(total_profit)
 
         if (np.std(total_profit) != 0.):
-            sharp_ratio = expected_returns_mean / np.std(total_profit) * np.sqrt(365)
+            sharp_ratio = expected_returns_mean / up_stdev * np.sqrt(365)
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
             sharp_ratio = -20.
 
+        # print(expected_returns_mean, up_stdev, sharp_ratio)
         return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -43,14 +43,14 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if (np.std(dataframe['profit_percent']) != 0.):
-            sharp_ratio = (
+        if (np.std(sum_daily["profit_percent"] != 0.):
+            sharp_ratio=(
                 sum_daily["profit_percent"].mean()
                 / np.std(sum_daily["profit_percent"])
                 * np.sqrt(365)
             )
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-            sharp_ratio = -20.0
+            sharp_ratio=-20.0
 
         return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -34,20 +34,9 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         Uses Sharpe Ratio calculation.
         """
         total_profit = results.profit_percent
-        # days_period = (max_date - min_date).days
 
         # adding slippage of 0.1% per trade
         total_profit = total_profit - 0.0005
-        # expected_yearly_return = total_profit.sum() / days_period
-
-        # if np.std(total_profit) != 0.0:
-        #     sharp_ratio = expected_yearly_return / np.std(total_profit) * np.sqrt(365)
-        # else:
-        #     # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-        #     sharp_ratio = -20.0
-
-        # # print(expected_yearly_return, np.std(total_profit), sharp_ratio)
-        # return -sharp_ratio
 
         sum_daily = (
             results.resample("D", on="close_time").agg(

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -43,14 +43,14 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if (np.std(sum_daily["profit_percent"] != 0.):
-            sharp_ratio=(
+        if (np.std(sum_daily["profit_percent"]) != 0.):
+            sharp_ratio = (
                 sum_daily["profit_percent"].mean()
                 / np.std(sum_daily["profit_percent"])
                 * np.sqrt(365)
             )
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-            sharp_ratio=-20.0
+            sharp_ratio = -20.0
 
         return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -46,7 +46,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
         if (np.std(sum_daily.profit_percent) != 0.):
             sharp_ratio = (
                 sum_daily["profit_percent"].mean()
-                / sum_daily["profit_percent"].std()
+                / np.std(sum_daily["profit_percent"])
                 * np.sqrt(365)
             )
         else:

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -1,5 +1,5 @@
 """
-SharpeHyperOptLoss
+SharpeHyperOptLossDaily
 
 This module defines the alternative HyperOptLoss class which can be used for
 Hyperoptimization.
@@ -43,7 +43,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if np.std(results.profit_percent) != 0.0:
+        if (np.std(sum_daily.profit_percent) != 0.):
             sharp_ratio = (
                 sum_daily["profit_percent"].mean()
                 / sum_daily["profit_percent"].std()

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -43,7 +43,7 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if np.std(total_profit) != 0.0:
+        if np.std(results.profit_percent) != 0.0:
             sharp_ratio = (
                 sum_daily["profit_percent"].mean()
                 / sum_daily["profit_percent"].std()

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -43,12 +43,11 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             * 100.0
         )
 
-        if (np.std(sum_daily["profit_percent"]) != 0.):
-            sharp_ratio = (
-                sum_daily["profit_percent"].mean()
-                / np.std(sum_daily["profit_percent"])
-                * np.sqrt(365)
-            )
+        total_profit = sum_daily["profit_percent"]
+        expected_returns_mean = total_profit.mean()
+
+        if (np.std(total_profit) != 0.):
+            sharp_ratio = expected_returns_mean / np.std(total_profit) * np.sqrt(365)
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
             sharp_ratio = -20.0

--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -20,14 +20,9 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
     """
 
     @staticmethod
-    def hyperopt_loss_function(
-        results: DataFrame,
-        trade_count: int,
-        min_date: datetime,
-        max_date: datetime,
-        *args,
-        **kwargs
-    ) -> float:
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for more optimal results.
 
@@ -50,6 +45,6 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             sharp_ratio = expected_returns_mean / np.std(total_profit) * np.sqrt(365)
         else:
             # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-            sharp_ratio = -20.0
+            sharp_ratio = -20.
 
         return -sharp_ratio

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -19,9 +19,17 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
 
     floatfmt = ('s', 'd', '.2f', '.2f', '.8f', '.2f', 'd', '.1f', '.1f')
     tabular_data = []
-    headers = ['pair', 'buy count', 'avg profit %', 'cum profit %',
-               f'tot profit {stake_currency}', 'tot profit %', 'avg duration',
-               'profit', 'loss']
+    headers = [
+        'Pair',
+        'Buy Count',
+        'Avg Profit %',
+        'Cum Profit %',
+        f'Tot Profit {stake_currency}',
+        'Tot Profit %',
+        'Avg Duration',
+        'Wins',
+        'Losses'
+    ]
     for pair in data:
         result = results[results.pair == pair]
         if skip_nan and result.profit_abs.isnull().all():
@@ -58,7 +66,9 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
                     floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
 
 
-def generate_text_table_sell_reason(data: Dict[str, Dict], results: DataFrame) -> str:
+def generate_text_table_sell_reason(
+    data: Dict[str, Dict], stake_currency: str, max_open_trades: int, results: DataFrame
+) -> str:
     """
     Generate small table outlining Backtest results
     :param data: Dict of <pair: dataframe> containing data that was used during backtesting.
@@ -66,13 +76,36 @@ def generate_text_table_sell_reason(data: Dict[str, Dict], results: DataFrame) -
     :return: pretty printed table with tabulate as string
     """
     tabular_data = []
-    headers = ['Sell Reason', 'Count', 'Profit', 'Loss', 'Profit %']
+    headers = [
+        "Sell Reason",
+        "Sell Count",
+        "Wins",
+        "Losses",
+        "Avg Profit %",
+        "Cum Profit %",
+        f"Tot Profit {stake_currency}",
+        "Tot Profit %",
+    ]
     for reason, count in results['sell_reason'].value_counts().iteritems():
         result = results.loc[results['sell_reason'] == reason]
         profit = len(result[result['profit_abs'] >= 0])
         loss = len(result[result['profit_abs'] < 0])
         profit_mean = round(result['profit_percent'].mean() * 100.0, 2)
-        tabular_data.append([reason.value, count, profit, loss, profit_mean])
+        profit_sum = round(result["profit_percent"].sum() * 100.0, 2)
+        profit_tot = result['profit_abs'].sum()
+        profit_percent_tot = round(result['profit_percent'].sum() * 100.0 / max_open_trades, 2)
+        tabular_data.append(
+            [
+                reason.value,
+                count,
+                profit,
+                loss,
+                profit_mean,
+                profit_sum,
+                profit_tot,
+                profit_percent_tot,
+            ]
+        )
     return tabulate(tabular_data, headers=headers, tablefmt="pipe")
 
 

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -42,7 +42,13 @@ def hyperopt_results():
             'profit_percent': [-0.1, 0.2, 0.3],
             'profit_abs': [-0.2, 0.4, 0.6],
             'trade_duration': [10, 30, 10],
-            'sell_reason': [SellType.STOP_LOSS, SellType.ROI, SellType.ROI]
+            'sell_reason': [SellType.STOP_LOSS, SellType.ROI, SellType.ROI],
+            'close_time':
+            [
+                datetime(2019, 1, 1, 9, 26, 3, 478039),
+                datetime(2019, 2, 1, 9, 26, 3, 478039),
+                datetime(2019, 3, 1, 9, 26, 3, 478039)
+            ]
         }
     )
 
@@ -325,6 +331,24 @@ def test_sharpe_loss_prefers_higher_profits(default_conf, hyperopt_results) -> N
     results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
 
     default_conf.update({'hyperopt_loss': 'SharpeHyperOptLoss'})
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
+    correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
+                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),
+                                     datetime(2019, 1, 1), datetime(2019, 5, 1))
+    under = hl.hyperopt_loss_function(results_under, len(hyperopt_results),
+                                      datetime(2019, 1, 1), datetime(2019, 5, 1))
+    assert over < correct
+    assert under > correct
+
+
+def test_sharpe_loss_daily_prefers_higher_profits(default_conf, hyperopt_results) -> None:
+    results_over = hyperopt_results.copy()
+    results_over['profit_percent'] = hyperopt_results['profit_percent'] * 2
+    results_under = hyperopt_results.copy()
+    results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
+
+    default_conf.update({'hyperopt_loss': 'SharpeHyperOptLossDaily'})
     hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
     correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
                                         datetime(2019, 1, 1), datetime(2019, 5, 1))

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -21,14 +21,14 @@ def test_generate_text_table(default_conf, mocker):
     )
 
     result_str = (
-        '| pair    |   buy count |   avg profit % |   cum profit % |   '
-        'tot profit BTC |   tot profit % | avg duration   |   profit |   loss |\n'
-        '|:--------|------------:|---------------:|---------------:|'
-        '-----------------:|---------------:|:---------------|---------:|-------:|\n'
-        '| ETH/BTC |           2 |          15.00 |          30.00 |       '
-        '0.60000000 |          15.00 | 0:20:00        |        2 |      0 |\n'
-        '| TOTAL   |           2 |          15.00 |          30.00 |       '
-        '0.60000000 |          15.00 | 0:20:00        |        2 |      0 |'
+        '| Pair    |   Buy Count |   Avg Profit % |   Cum Profit % |   Tot Profit BTC '
+        '|   Tot Profit % | Avg Duration   |   Wins |   Losses |\n'
+        '|:--------|------------:|---------------:|---------------:|-----------------:'
+        '|---------------:|:---------------|-------:|---------:|\n'
+        '| ETH/BTC |           2 |          15.00 |          30.00 |       0.60000000 '
+        '|          15.00 | 0:20:00        |      2 |        0 |\n'
+        '| TOTAL   |           2 |          15.00 |          30.00 |       0.60000000 '
+        '|          15.00 | 0:20:00        |      2 |        0 |'
     )
     assert generate_text_table(data={'ETH/BTC': {}},
                                stake_currency='BTC', max_open_trades=2,
@@ -50,13 +50,19 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
     )
 
     result_str = (
-        '| Sell Reason   |   Count |   Profit |   Loss |   Profit % |\n'
-        '|:--------------|--------:|---------:|-------:|-----------:|\n'
-        '| roi           |       2 |        2 |      0 |         15 |\n'
-        '| stop_loss     |       1 |        0 |      1 |        -10 |'
+        '| Sell Reason   |   Sell Count |   Wins |   Losses |   Avg Profit % |'
+        '   Cum Profit % |   Tot Profit BTC |   Tot Profit % |\n'
+        '|:--------------|-------------:|-------:|---------:|---------------:|'
+        '---------------:|-----------------:|---------------:|\n'
+        '| roi           |            2 |      2 |        0 |             15 |'
+        '             30 |              0.6 |             15 |\n'
+        '| stop_loss     |            1 |      0 |        1 |            -10 |'
+        '            -10 |             -0.2 |             -5 |'
     )
     assert generate_text_table_sell_reason(
-        data={'ETH/BTC': {}}, results=results) == result_str
+        data={'ETH/BTC': {}},
+        stake_currency='BTC', max_open_trades=2,
+        results=results) == result_str
 
 
 def test_generate_text_table_strategy(default_conf, mocker):


### PR DESCRIPTION
Added the sharpe ratio hyperopt loss method which calculates sharpe ratio on a daily basis instead of yearly, as suggested by @djacky [here](https://github.com/freqtrade/freqtrade/issues/2727). On that thread, it was discussed how it can also be modified to work for smaller timeframes by users. 

I believe this hyper optimization loss method may help in eliminating bias due to having certain trades taking place in historical trends, when backtesting for the goal of having a strategy with consistent daily risk.

closes #2727 

~~Note: This requires having [freqtrade/technical](https://github.com/freqtrade/technical) installed in your freqtrade.~~