### PR TITLE
Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-18.04, macos-latest ]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-stretch
+FROM python:3.8.1-slim-buster
 
 RUN apt-get update \
     && apt-get -y install curl build-essential libssl-dev \


### PR DESCRIPTION
## Summary
- Update Dockerfile to python3.8.
- Run CI against python 3.8 to ensure everything is working. 


(Note: i've been running with 3.8 since it came out without any issues).

