### PR TITLE
Fix failing stoploss CI test

### DIFF
--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1145,11 +1145,11 @@ def test_handle_stoploss_on_exchange(mocker, default_conf, fee, caplog,
     # Should not create new order
     trade.stoploss_order_id = None
     trade.is_open = False
-    stoploss_limit.reset_mock()
+    stoploss.reset_mock()
     mocker.patch('freqtrade.exchange.Exchange.get_order')
-    mocker.patch('freqtrade.exchange.Exchange.stoploss_limit', stoploss_limit)
+    mocker.patch('freqtrade.exchange.Exchange.stoploss', stoploss)
     assert freqtrade.handle_stoploss_on_exchange(trade) is False
-    assert stoploss_limit.call_count == 0
+    assert stoploss.call_count == 0
 
 
 def test_handle_sle_cancel_cant_recreate(mocker, default_conf, fee, caplog,


### PR DESCRIPTION
## Summary
Fix test error introduced in combination of #2799 and #2779 - by having "colliding" but not breaking commit overlaps


## Quick changelog

- Rename mock to how it should really be called.