### PR TITLE
Allow derived strategies

### DIFF
--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -4,6 +4,34 @@ This page explains some advanced Hyperopt topics that may require higher
 coding skills and Python knowledge than creation of an ordinal hyperoptimization
 class.
 
+## Derived hyperopt classes
+
+Custom hyperop classes can be derived in the same way [it can be done for strategies](strategy-customization.md#derived-strategies).
+
+Applying to hyperoptimization, as an example, you may override how dimensions are defined in your optimization hyperspace:
+
+```
+class MyAwesomeHyperOpt(IHyperOpt):
+    ...
+    # Uses default stoploss dimension
+
+class MyAwesomeHyperOpt2(MyAwesomeHyperOpt):
+    @staticmethod
+    def stoploss_space() -> List[Dimension]:
+        # Override boundaries for stoploss
+        return [
+            Real(-0.33, -0.01, name='stoploss'),
+        ]
+```
+
+and then quickly switch between hyperopt classes, running optimization process with hyperopt class you need in each particular case:
+
+```
+$ freqtrade hyperopt --hyperopt MyAwesomeHyperOpt ...
+or
+$ freqtrade hyperopt --hyperopt MyAwesomeHyperOpt2 ...
+```
+
 ## Creating and using a custom loss function
 
 To use a custom loss function class, make sure that the function `hyperopt_loss_function` is defined in your custom hyperopt loss class.

--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -10,7 +10,7 @@ Custom hyperop classes can be derived in the same way [it can be done for strate
 
 Applying to hyperoptimization, as an example, you may override how dimensions are defined in your optimization hyperspace:
 
-```
+```python
 class MyAwesomeHyperOpt(IHyperOpt):
     ...
     # Uses default stoploss dimension

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -532,6 +532,27 @@ If you want to use a strategy from a different directory you can pass `--strateg
 freqtrade trade --strategy AwesomeStrategy --strategy-path /some/directory
 ```
 
+### Derived strategies
+
+The strategies can be derived from other strategies. This avoids duplication of your custom strategy code. You can use this technique to override small parts of your main strategy, leaving the rest untouched:
+
+```
+class MyAwesomeStrategy(IStrategy):
+    ...
+    stoploss = 0.13
+    trailing_stop = False
+    # All other attributes and methods are here as they
+    # should be in any custom strategy...
+    ...
+
+class MyAwesomeStrategy2(MyAwesomeStrategy):
+    # Override something
+    stoploss = 0.08
+    trailing_stop = True
+```
+
+Both attributes and methods may be overriden, altering behavior of the original strategy in a way you need. The strategy classes may be located in the same module (python file with the source code of your strategy) or in different modules (different python files). In the latter case you need to properly import the strategy class you derive the new one from.
+
 ### Common mistakes when developing strategies
 
 Backtesting analyzes the whole time-range at once for performance reasons. Because of this, strategy authors need to make sure that strategies do not look-ahead into the future.

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -551,7 +551,7 @@ class MyAwesomeStrategy2(MyAwesomeStrategy):
     trailing_stop = True
 ```
 
-Both attributes and methods may be overriden, altering behavior of the original strategy in a way you need. The strategy classes may be located in the same module (python file with the source code of your strategy) or in different modules (different python files). In the latter case you need to properly import the strategy class you derive the new one from.
+Both attributes and methods may be overriden, altering behavior of the original strategy in a way you need.
 
 ### Common mistakes when developing strategies
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -536,7 +536,7 @@ freqtrade trade --strategy AwesomeStrategy --strategy-path /some/directory
 
 The strategies can be derived from other strategies. This avoids duplication of your custom strategy code. You can use this technique to override small parts of your main strategy, leaving the rest untouched:
 
-```
+``` python
 class MyAwesomeStrategy(IStrategy):
     ...
     stoploss = 0.13

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -61,7 +61,8 @@ class IResolver:
 
         valid_objects_gen = (
             obj for name, obj in inspect.getmembers(module, inspect.isclass)
-            if (object_name is None or object_name == name) and cls.object_type in obj.__bases__
+            if ((object_name is None or object_name == name) and
+                issubclass(obj, cls.object_type) and obj is not cls.object_type)
         )
         return valid_objects_gen
 


### PR DESCRIPTION
...like this:

```
class SampleStrategy2(SampleStrategy):
    # Override something
    trailing_stop = True
    # Methods can also be overridden if we need this
```

`list-strategies` also works:
```
$ freqtrade list-strategies
...
| name               | location                |
|:-------------------|:------------------------|
| SampleStrategy     | sample_strategy.py      |
| SampleStrategy2    | sample_strategy.py      |
```

P.S. Same should work for hyperopt classes. Can be very useful, since you can simply redefine the `indicator_space()` method(s), for example with different range for dimension(s), leaving the rest intact.
