### PR TITLE
Add pair to exception messages in exchange module

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -736,10 +736,11 @@ class Exchange:
                 f'Exchange {self._api.name} does not support fetching historical candlestick data.'
                 f'Message: {e}') from e
         except (ccxt.NetworkError, ccxt.ExchangeError) as e:
-            raise TemporaryError(f'Could not load ticker history due to {e.__class__.__name__}. '
-                                 f'Message: {e}') from e
+            raise TemporaryError(f'Could not load ticker history for pair {pair} due to '
+                                 f'{e.__class__.__name__}. Message: {e}') from e
         except ccxt.BaseError as e:
-            raise OperationalException(f'Could not fetch ticker data. Msg: {e}') from e
+            raise OperationalException(f'Could not fetch ticker data for pair {pair}. '
+                                       f'Msg: {e}') from e
 
     @retrier_async
     async def _async_fetch_trades(self, pair: str,


### PR DESCRIPTION
Helps localizing #2774:
```
2020-02-03 17:16:45,439 - freqtrade.exchange.common - WARNING - _async_get_candle_history() returned exception: "Could not load ticker history for pair NXT/BTC due to BadSymbol. Message: bittrex {"success":false,"message":"RESTRICTED_MARKET","result":null,"explanation":null}"
```

Without this it's impossible to get which pair is problematic.
