### PR TITLE
Fix implementation of rolling_max

### DIFF
--- a/freqtrade/vendor/qtpylib/indicators.py
+++ b/freqtrade/vendor/qtpylib/indicators.py
@@ -288,9 +288,9 @@ def rolling_min(series, window=14, min_periods=None):
 def rolling_max(series, window=14, min_periods=None):
     min_periods = window if min_periods is None else min_periods
     try:
-        return series.rolling(window=window, min_periods=min_periods).min()
+        return series.rolling(window=window, min_periods=min_periods).max()
     except Exception as e:  # noqa: F841
-        return pd.Series(series).rolling(window=window, min_periods=min_periods).min()
+        return pd.Series(series).rolling(window=window, min_periods=min_periods).max()
 
 
 # ---------------------------------------------


### PR DESCRIPTION
## Summary
Fixes the implementation of rolling_max to use rolling_max.

Identical to https://github.com/ranaroussi/qtpylib/pull/149

closes #2853
## Quick changelog

- use `max()` to calculate the maximum ...