### PR TITLE
Minor: Replace NXT with XRP in config.json.example

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -44,7 +44,7 @@
             "DASH/BTC",
             "ZEC/BTC",
             "XLM/BTC",
-            "NXT/BTC",
+            "XRP/BTC",
             "TRX/BTC",
             "ADA/BTC",
             "XMR/BTC"


### PR DESCRIPTION
Resolves #2774 
(NXT on Bittrex is restricted in some regions for unknown reason)
