### PR TITLE
Update advanced hyperopt template

### DIFF
--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -207,7 +207,7 @@ class IHyperOpt(ABC):
             # so this intermediate parameter is used as the value of the difference between
             # them. The value of the 'trailing_stop_positive_offset' is constructed in the
             # generate_trailing_params() method.
-            # # This is similar to the hyperspace dimensions used for constructing the ROI tables.
+            # This is similar to the hyperspace dimensions used for constructing the ROI tables.
             Real(0.001, 0.1, name='trailing_stop_positive_offset_p1'),
 
             Categorical([True, False], name='trailing_only_offset_is_reached'),

--- a/freqtrade/templates/sample_hyperopt_advanced.py
+++ b/freqtrade/templates/sample_hyperopt_advanced.py
@@ -230,7 +230,7 @@ class AdvancedSampleHyperOpt(IHyperOpt):
         'stoploss' optimization hyperspace.
         """
         return [
-            Real(-0.5, -0.02, name='stoploss'),
+            Real(-0.35, -0.02, name='stoploss'),
         ]
 
     @staticmethod
@@ -249,8 +249,15 @@ class AdvancedSampleHyperOpt(IHyperOpt):
             # other 'trailing' hyperspace parameters.
             Categorical([True], name='trailing_stop'),
 
-            Real(0.02, 0.35, name='trailing_stop_positive'),
-            Real(0.01, 0.1, name='trailing_stop_positive_offset'),
+            Real(0.01, 0.35, name='trailing_stop_positive'),
+
+            # 'trailing_stop_positive_offset' should be greater than 'trailing_stop_positive',
+            # so this intermediate parameter is used as the value of the difference between
+            # them. The value of the 'trailing_stop_positive_offset' is constructed in the
+            # generate_trailing_params() method.
+            # This is similar to the hyperspace dimensions used for constructing the ROI tables.
+            Real(0.001, 0.1, name='trailing_stop_positive_offset_p1'),
+
             Categorical([True, False], name='trailing_only_offset_is_reached'),
         ]
 


### PR DESCRIPTION
Resolves #2859

* Align code of the trailing_space() method in advanced hyperopt sample to changes in dimensions made into hyperopt_interface
* Adjust the range of stoploss dimension to be same with default from hyperopt_interface
* Fix typo in the comment in hyperopt_interface
