### PR TITLE
fix download-data validation problems

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -37,7 +37,7 @@ def start_download_data(args: Dict[str, Any]) -> None:
     pairs_not_available: List[str] = []
 
     # Init exchange
-    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config)
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
     try:
 
         if config.get('download_trades'):

--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -38,6 +38,11 @@ def start_download_data(args: Dict[str, Any]) -> None:
 
     # Init exchange
     exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
+    # Manual validations of relevant settings
+    exchange.validate_pairs(config['pairs'])
+    for timeframe in config['timeframes']:
+        exchange.validate_timeframes(timeframe)
+
     try:
 
         if config.get('download_trades'):


### PR DESCRIPTION
## Summary
download-data does not need exchange validation - as none of the validated fields are relevant for data-download.

Closes #2883
closes #2679 
