### PR TITLE
Add tip on running order types for Bittrex

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -32,6 +32,10 @@ To download data for the Kraken exchange, using `--dl-trades` is mandatory, othe
 
 ## Bittrex
 
+### Order types
+
+Bittrex does not support market orders. If you have a message at the bot startup about this, you should change order type values set in your configuration and/or in the strategy from `"market"` to `"limit"`. See some more details on this [here in the FAQ](faw.md#im-getting-the-exchange-bittrex-does-not-support-market-orders-message-and-cannot-run-my-strategy).
+
 ### Restricted markets
 
 Bittrex split its exchange into US and International versions.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -34,7 +34,7 @@ To download data for the Kraken exchange, using `--dl-trades` is mandatory, othe
 
 ### Order types
 
-Bittrex does not support market orders. If you have a message at the bot startup about this, you should change order type values set in your configuration and/or in the strategy from `"market"` to `"limit"`. See some more details on this [here in the FAQ](faw.md#im-getting-the-exchange-bittrex-does-not-support-market-orders-message-and-cannot-run-my-strategy).
+Bittrex does not support market orders. If you have a message at the bot startup about this, you should change order type values set in your configuration and/or in the strategy from `"market"` to `"limit"`. See some more details on this [here in the FAQ](faq.md#im-getting-the-exchange-bittrex-does-not-support-market-orders-message-and-cannot-run-my-strategy).
 
 ### Restricted markets
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,7 @@ Read [the Bittrex section about restricted markets](exchanges.md#restricted-mark
 
 ### I'm getting the "Exchange Bittrex does not support market orders." message and cannot run my strategy
 
-As the message says, Bittrex does not support market orders and you have one of the [order types](configuration.md/#understand-order_types) set to "market". Probably your strategy was written for another exchanges in mind and sets "market" orders for "stoploss" orders, which is correct and preferable for most of other exchanges.
+As the message says, Bittrex does not support market orders and you have one of the [order types](configuration.md/#understand-order_types) set to "market". Probably your strategy was written with other exchanges in mind and sets "market" orders for "stoploss" orders, which is correct and preferable for most of the exchanges supporting market orders (but not for Bittrex).
 
 To fix it for Bittrex, redefine order types in the strategy to use "limit" instead of "market":
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,11 +45,23 @@ the tutorial [here|Testing-new-strategies-with-Hyperopt](bot-usage.md#hyperopt-c
 
 You can use the `/forcesell all` command from Telegram.
 
-### I get the message "RESTRICTED_MARKET"
+### I'm getting the "RESTRICTED_MARKET" message in the log
 
 Currently known to happen for US Bittrex users.  
 
 Read [the Bittrex section about restricted markets](exchanges.md#restricted-markets) for more information.
+
+### I'm getting the "Exchange Bittrex does not support market orders." message and cannot run my strategy
+
+As the message says, Bittrex does not support market orders and you have one of the [order types](configuration.md/#understand-order_types) set to "market". Probably your strategy was written for another exchanges in mind and sets "market" orders for "stoploss" orders, which is correct and preferable for most of other exchanges.
+
+To fix it for Bittrex, redefine order types in the configuration file (do this for all order types that are defined as "market" in your strategy):
+
+```
+"order_types": {
+    "stoploss": "limit",
+}
+```
 
 ### How do I search the bot logs for something?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,13 +55,17 @@ Read [the Bittrex section about restricted markets](exchanges.md#restricted-mark
 
 As the message says, Bittrex does not support market orders and you have one of the [order types](configuration.md/#understand-order_types) set to "market". Probably your strategy was written for another exchanges in mind and sets "market" orders for "stoploss" orders, which is correct and preferable for most of other exchanges.
 
-To fix it for Bittrex, redefine order types in the configuration file (do this for all order types that are defined as "market" in your strategy):
+To fix it for Bittrex, redefine order types in the strategy to use "limit" instead of "market":
 
 ```
-"order_types": {
-    "stoploss": "limit",
-}
+    order_types = {
+        ...
+        'stoploss': 'limit',
+        ...
+    }
 ```
+
+Same fix should be done in the configuration file, if order types are defined in your custom config rather than in the strategy.
 
 ### How do I search the bot logs for something?
 


### PR DESCRIPTION
"Fixes" running SampleStrategy on Bittrex (market order types) by adding a note in the FAQ.
