### PR TITLE
Fix SharpeHyperOptLossDaily

### DIFF
--- a/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sharpe_daily.py
@@ -39,7 +39,8 @@ class SharpeHyperOptLossDaily(IHyperOptLoss):
             results['profit_percent'] - slippage_per_trade_ratio
 
         # create the index within the min_date and end max_date
-        t_index = date_range(start=min_date, end=max_date, freq=resample_freq)
+        t_index = date_range(start=min_date, end=max_date, freq=resample_freq,
+                             normalize=True)
 
         sum_daily = (
             results.resample(resample_freq, on='close_time').agg(


### PR DESCRIPTION
Calculations of SharpeHyperOptLossDaily fails in some conditions due to non-normalized index.

Reindex then (I wonder why it fails on non-normalized index!..) fills the aggregated column with NaNs and loss function therefore returns the '-20' bad value for all epochs.

The behavior depends on current local time and on the timerange passed to hyperopt.

Thanks to @yazeed for pointing out on the conditions when this happens.
(data with --days 500, 1h timeframe, local time is not about midnight, timerange is omitted or just before the date of first downloaded candle)
