### PR TITLE
Fix mypy type errors in tests

### DIFF
--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -370,7 +370,7 @@ def test_load_partial_missing(testdatadir, caplog) -> None:
 
 def test_init(default_conf, mocker) -> None:
     assert {} == load_data(
-        datadir='',
+        datadir=Path(''),
         pairs=[],
         timeframe=default_conf['ticker_interval']
     )
@@ -379,13 +379,13 @@ def test_init(default_conf, mocker) -> None:
 def test_init_with_refresh(default_conf, mocker) -> None:
     exchange = get_patched_exchange(mocker, default_conf)
     refresh_data(
-        datadir='',
+        datadir=Path(''),
         pairs=[],
         timeframe=default_conf['ticker_interval'],
         exchange=exchange
     )
     assert {} == load_data(
-        datadir='',
+        datadir=Path(''),
         pairs=[],
         timeframe=default_conf['ticker_interval']
     )

--- a/tests/optimize/__init__.py
+++ b/tests/optimize/__init__.py
@@ -23,7 +23,7 @@ class BTContainer(NamedTuple):
     """
     Minimal BacktestContainer defining Backtest inputs and results.
     """
-    data: List[float]
+    data: List[List[float]]
     stop_loss: float
     roi: Dict[str, float]
     trades: List[BTrade]

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -287,8 +287,8 @@ def test_start(mocker, fee, default_conf, caplog) -> None:
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
     ]
-    args = get_args(args)
-    start_backtesting(args)
+    pargs = get_args(args)
+    start_backtesting(pargs)
     assert log_has('Starting freqtrade in Backtesting mode', caplog)
     assert start_mock.call_count == 1
 

--- a/tests/optimize/test_edge_cli.py
+++ b/tests/optimize/test_edge_cli.py
@@ -82,8 +82,8 @@ def test_start(mocker, fee, edge_conf, caplog) -> None:
         '--config', 'config.json',
         '--strategy', 'DefaultStrategy',
     ]
-    args = get_args(args)
-    start_edge(args)
+    pargs = get_args(args)
+    start_edge(pargs)
     assert log_has('Starting freqtrade in Edge mode', caplog)
     assert start_mock.call_count == 1
 

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -2,6 +2,7 @@
 import locale
 from datetime import datetime
 from pathlib import Path
+from typing import Dict, List
 from unittest.mock import MagicMock, PropertyMock
 
 import pandas as pd
@@ -9,7 +10,8 @@ import pytest
 from arrow import Arrow
 from filelock import Timeout
 
-from freqtrade.commands.optimize_commands import setup_optimize_configuration, start_hyperopt
+from freqtrade.commands.optimize_commands import (setup_optimize_configuration,
+                                                  start_hyperopt)
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.data.history import load_tickerdata_file
 from freqtrade.exceptions import OperationalException
@@ -54,7 +56,7 @@ def hyperopt_results():
 
 
 # Functions for recurrent object patching
-def create_trials(mocker, hyperopt, testdatadir) -> None:
+def create_trials(mocker, hyperopt, testdatadir) -> List[Dict]:
     """
     When creating trials, mock the hyperopt Trials so that *by default*
       - we don't create any pickle'd files in the filesystem
@@ -228,10 +230,10 @@ def test_start_not_installed(mocker, default_conf, caplog, import_fails) -> None
         '--hyperopt', 'DefaultHyperOpt',
         '--epochs', '5'
     ]
-    args = get_args(args)
+    pargs = get_args(args)
 
     with pytest.raises(OperationalException, match=r"Please ensure that the hyperopt dependencies"):
-        start_hyperopt(args)
+        start_hyperopt(pargs)
 
 
 def test_start(mocker, default_conf, caplog) -> None:
@@ -246,8 +248,8 @@ def test_start(mocker, default_conf, caplog) -> None:
         '--hyperopt', 'DefaultHyperOpt',
         '--epochs', '5'
     ]
-    args = get_args(args)
-    start_hyperopt(args)
+    pargs = get_args(args)
+    start_hyperopt(pargs)
 
     assert log_has('Starting freqtrade in Hyperopt mode', caplog)
     assert start_mock.call_count == 1
@@ -269,9 +271,9 @@ def test_start_no_data(mocker, default_conf, caplog) -> None:
         '--hyperopt', 'DefaultHyperOpt',
         '--epochs', '5'
     ]
-    args = get_args(args)
+    pargs = get_args(args)
     with pytest.raises(OperationalException, match='No data found. Terminating.'):
-        start_hyperopt(args)
+        start_hyperopt(pargs)
 
 
 def test_start_filelock(mocker, default_conf, caplog) -> None:
@@ -286,8 +288,8 @@ def test_start_filelock(mocker, default_conf, caplog) -> None:
         '--hyperopt', 'DefaultHyperOpt',
         '--epochs', '5'
     ]
-    args = get_args(args)
-    start_hyperopt(args)
+    pargs = get_args(args)
+    start_hyperopt(pargs)
     assert log_has("Another running instance of freqtrade Hyperopt detected.", caplog)
 
 


### PR DESCRIPTION
## Summary
As pointed out in #2894 - mypy for tests is not running correctly.

This does fix about half of the errors (reducing the errors from >200 to 95).

Now the problem with many of the remaining errors is that it's "cannot assign to a method".
For tests however, that's a perfectly valid scenario - where we want to monkey-patch a method for a 
specific run (that's why this was disabled in the first place).

To test this, remove the whole section of `[mypy-tests.*] ` in `setup.cfg`.

## Quick changelog

- Fix a few code type errors in tests
