### PR TITLE
Break the old binary file so users are forced to reinstall

### DIFF
--- a/bin/freqtrade
+++ b/bin/freqtrade
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import sys
-import warnings
+import logging
 
-from freqtrade.main import main
+logger = logging.getLogger(__name__)
 
-warnings.warn(
-    "Deprecated - To continue to run the bot like this, please run `pip install -e .` again.",
-    DeprecationWarning)
-main(sys.argv[1:])
+
+logger.error("DEPRECATED installation detected, please run `pip install -e .` again.")
+
+sys.exit(2)


### PR DESCRIPTION
## Summary

Break the old binary file so users are forced to reinstall.

We could also remove it assuming everyone did perform a "pip install ." again since July - however i'd like to leave it with the new message for one release - so really everyone is aware and is not hit by "could not find file".

This should not be relevant anymore - this binary has been deprecated
and is not being used by new installations since July 2019.

