### PR TITLE
Adding --min-trades and --max-trades for hyperopt-list

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -416,7 +416,9 @@ usage: freqtrade hyperopt-list [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                                [--profitable] [--min-trades INT]
                                [--max-trades INT] [--min-avg-time FLOAT]
                                [--max-avg-time FLOAT] [--min-avg-profit FLOAT]
-                               [--min-total-profit FLOAT] [--no-color]
+                               [--max-avg-profit FLOAT]
+                               [--min-total-profit FLOAT]
+                               [--max-total-profit FLOAT] [--no-color]
                                [--print-json] [--no-details]
 
 optional arguments:
@@ -429,8 +431,12 @@ optional arguments:
   --max-avg-time FLOAT  Select epochs on under average time.
   --min-avg-profit FLOAT
                         Select epochs on above average profit.
+  --max-avg-profit FLOAT
+                        Select epochs on below average profit.
   --min-total-profit FLOAT
                         Select epochs on above total profit.
+  --max-total-profit FLOAT
+                        Select epochs on below total profit.
   --no-color            Disable colorization of hyperopt results. May be
                         useful if you are redirecting output to a file.
   --print-json          Print best result detailization in JSON format.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -413,7 +413,8 @@ You can list the hyperoptimization epochs the Hyperopt module evaluated previous
 ```
 usage: freqtrade hyperopt-list [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                                [-d PATH] [--userdir PATH] [--best]
-                               [--profitable] [--min-avg-time FLOAT]
+                               [--profitable] [--min-trades INT]
+                               [--max-trades INT] [--min-avg-time FLOAT]
                                [--max-avg-time FLOAT] [--min-avg-profit FLOAT]
                                [--min-total-profit FLOAT] [--no-color]
                                [--print-json] [--no-details]
@@ -422,6 +423,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --best                Select only best epochs.
   --profitable          Select only profitable epochs.
+  --min-trades INT      Select epochs with more than INT trades.
+  --max-trades INT      Select epochs with less than INT trades.
   --min-avg-time FLOAT  Select epochs on above average time.
   --max-avg-time FLOAT  Select epochs on under average time.
   --min-avg-profit FLOAT

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -64,7 +64,8 @@ ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
 ARGS_HYPEROPT_LIST = ["hyperopt_list_best", "hyperopt_list_profitable",
                       "hyperopt_list_min_trades", "hyperopt_list_max_trades",
                       "hyperopt_list_min_avg_time", "hyperopt_list_max_avg_time",
-                      "hyperopt_list_min_avg_profit", "hyperopt_list_min_total_profit",
+                      "hyperopt_list_min_avg_profit", "hyperopt_list_max_avg_profit",
+                      "hyperopt_list_min_total_profit", "hyperopt_list_max_total_profit",
                       "print_colorized", "print_json", "hyperopt_list_no_details"]
 
 ARGS_HYPEROPT_SHOW = ["hyperopt_list_best", "hyperopt_list_profitable", "hyperopt_show_index",

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -62,6 +62,7 @@ ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
                     "trade_source", "ticker_interval"]
 
 ARGS_HYPEROPT_LIST = ["hyperopt_list_best", "hyperopt_list_profitable",
+                      "hyperopt_list_min_trades", "hyperopt_list_max_trades",
                       "hyperopt_list_min_avg_time", "hyperopt_list_max_avg_time",
                       "hyperopt_list_min_avg_profit", "hyperopt_list_min_total_profit",
                       "print_colorized", "print_json", "hyperopt_list_no_details"]

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -428,9 +428,21 @@ AVAILABLE_CLI_OPTIONS = {
         type=float,
         metavar='FLOAT',
     ),
+    "hyperopt_list_max_avg_profit": Arg(
+        '--max-avg-profit',
+        help='Select epochs on below average profit.',
+        type=float,
+        metavar='FLOAT',
+    ),
     "hyperopt_list_min_total_profit": Arg(
         '--min-total-profit',
         help='Select epochs on above total profit.',
+        type=float,
+        metavar='FLOAT',
+    ),
+    "hyperopt_list_max_total_profit": Arg(
+        '--max-total-profit',
+        help='Select epochs on below total profit.',
         type=float,
         metavar='FLOAT',
     ),

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -401,13 +401,13 @@ AVAILABLE_CLI_OPTIONS = {
     "hyperopt_list_min_trades": Arg(
         '--min-trades',
         help='Select epochs with more than INT trades.',
-        type=check_int_nonzero,
+        type=check_int_positive,
         metavar='INT',
     ),
     "hyperopt_list_max_trades": Arg(
         '--max-trades',
         help='Select epochs with less than INT trades.',
-        type=check_int_nonzero,
+        type=check_int_positive,
         metavar='INT',
     ),
     "hyperopt_list_min_avg_time": Arg(

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -398,6 +398,18 @@ AVAILABLE_CLI_OPTIONS = {
         help='Select only best epochs.',
         action='store_true',
     ),
+    "hyperopt_list_min_trades": Arg(
+        '--min-trades',
+        help='Select epochs with more than INT trades.',
+        type=check_int_nonzero,
+        metavar='INT',
+    ),
+    "hyperopt_list_max_trades": Arg(
+        '--max-trades',
+        help='Select epochs with less than INT trades.',
+        type=check_int_nonzero,
+        metavar='INT',
+    ),
     "hyperopt_list_min_avg_time": Arg(
         '--min-avg-time',
         help='Select epochs on above average time.',

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -27,6 +27,8 @@ def start_hyperopt_list(args: Dict[str, Any]) -> None:
     filteroptions = {
         'only_best': config.get('hyperopt_list_best', False),
         'only_profitable': config.get('hyperopt_list_profitable', False),
+        'filter_min_trades': config.get('hyperopt_list_min_trades', 0),
+        'filter_max_trades': config.get('hyperopt_list_max_trades', 0),
         'filter_min_avg_time': config.get('hyperopt_list_min_avg_time', None),
         'filter_max_avg_time': config.get('hyperopt_list_max_avg_time', None),
         'filter_min_avg_profit': config.get('hyperopt_list_min_avg_profit', None),
@@ -74,6 +76,8 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
     filteroptions = {
         'only_best': config.get('hyperopt_list_best', False),
         'only_profitable': config.get('hyperopt_list_profitable', False),
+        'filter_min_trades': config.get('hyperopt_list_min_trades', 0),
+        'filter_max_trades': config.get('hyperopt_list_max_trades', 0),
         'filter_min_avg_time': config.get('hyperopt_list_min_avg_time', None),
         'filter_max_avg_time': config.get('hyperopt_list_max_avg_time', None),
         'filter_min_avg_profit': config.get('hyperopt_list_min_avg_profit', None),
@@ -119,6 +123,16 @@ def _hyperopt_filter_trials(trials: List, filteroptions: dict) -> List:
         trials = [x for x in trials if x['is_best']]
     if filteroptions['only_profitable']:
         trials = [x for x in trials if x['results_metrics']['profit'] > 0]
+    if filteroptions['filter_min_trades'] > 0:
+        trials = [
+                    x for x in trials
+                    if x['results_metrics']['trade_count'] > filteroptions['filter_min_trades']
+                 ]
+    if filteroptions['filter_max_trades'] > 0:
+        trials = [
+                    x for x in trials
+                    if x['results_metrics']['trade_count'] < filteroptions['filter_max_trades']
+                 ]
     if filteroptions['filter_min_avg_time'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -32,7 +32,9 @@ def start_hyperopt_list(args: Dict[str, Any]) -> None:
         'filter_min_avg_time': config.get('hyperopt_list_min_avg_time', None),
         'filter_max_avg_time': config.get('hyperopt_list_max_avg_time', None),
         'filter_min_avg_profit': config.get('hyperopt_list_min_avg_profit', None),
-        'filter_min_total_profit': config.get('hyperopt_list_min_total_profit', None)
+        'filter_max_avg_profit': config.get('hyperopt_list_max_avg_profit', None),
+        'filter_min_total_profit': config.get('hyperopt_list_min_total_profit', None),
+        'filter_max_total_profit': config.get('hyperopt_list_max_total_profit', None)
     }
 
     trials_file = (config['user_data_dir'] /
@@ -81,7 +83,9 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
         'filter_min_avg_time': config.get('hyperopt_list_min_avg_time', None),
         'filter_max_avg_time': config.get('hyperopt_list_max_avg_time', None),
         'filter_min_avg_profit': config.get('hyperopt_list_min_avg_profit', None),
-        'filter_min_total_profit': config.get('hyperopt_list_min_total_profit', None)
+        'filter_max_avg_profit': config.get('hyperopt_list_max_avg_profit', None),
+        'filter_min_total_profit': config.get('hyperopt_list_min_total_profit', None),
+        'filter_max_total_profit': config.get('hyperopt_list_max_total_profit', None)
     }
     no_header = config.get('hyperopt_show_no_header', False)
 
@@ -152,11 +156,24 @@ def _hyperopt_filter_trials(trials: List, filteroptions: dict) -> List:
                     if x['results_metrics']['avg_profit']
                     > filteroptions['filter_min_avg_profit']
                  ]
+    if filteroptions['filter_max_avg_profit'] is not None:
+        trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
+        trials = [
+                    x for x in trials
+                    if x['results_metrics']['avg_profit']
+                    < filteroptions['filter_max_avg_profit']
+                 ]
     if filteroptions['filter_min_total_profit'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
                     x for x in trials
                     if x['results_metrics']['profit'] > filteroptions['filter_min_total_profit']
+                 ]
+    if filteroptions['filter_max_total_profit'] is not None:
+        trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
+        trials = [
+                    x for x in trials
+                    if x['results_metrics']['profit'] < filteroptions['filter_max_total_profit']
                  ]
 
     logger.info(f"{len(trials)} " +

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -325,8 +325,14 @@ class Configuration:
         self._args_to_config(config, argname='hyperopt_list_min_avg_profit',
                              logstring='Parameter --min-avg-profit detected: {}')
 
+        self._args_to_config(config, argname='hyperopt_list_max_avg_profit',
+                             logstring='Parameter --max-avg-profit detected: {}')
+
         self._args_to_config(config, argname='hyperopt_list_min_total_profit',
                              logstring='Parameter --min-total-profit detected: {}')
+
+        self._args_to_config(config, argname='hyperopt_list_max_total_profit',
+                             logstring='Parameter --max-total-profit detected: {}')
 
         self._args_to_config(config, argname='hyperopt_list_no_details',
                              logstring='Parameter --no-details detected: {}')

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -310,6 +310,12 @@ class Configuration:
         self._args_to_config(config, argname='hyperopt_list_profitable',
                              logstring='Parameter --profitable detected: {}')
 
+        self._args_to_config(config, argname='hyperopt_list_min_trades',
+                             logstring='Parameter --min-trades detected: {}')
+
+        self._args_to_config(config, argname='hyperopt_list_max_trades',
+                             logstring='Parameter --max-trades detected: {}')
+
         self._args_to_config(config, argname='hyperopt_list_min_avg_time',
                              logstring='Parameter --min-avg-time detected: {}')
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -780,6 +780,35 @@ def test_hyperopt_list(mocker, capsys, hyperopt_results):
                          " 11/12", " 12/12"])
     args = [
         "hyperopt-list",
+        "--no-details",
+        "--no-color",
+        "--min-trades", "20"
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    start_hyperopt_list(pargs)
+    captured = capsys.readouterr()
+    assert all(x in captured.out
+               for x in [" 3/12", " 6/12", " 7/12", " 9/12", " 11/12"])
+    assert all(x not in captured.out
+               for x in [" 1/12", " 2/12", " 4/12", " 5/12", " 8/12", " 10/12", " 12/12"])
+    args = [
+        "hyperopt-list",
+        "--profitable",
+        "--no-details",
+        "--max-trades", "20"
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    start_hyperopt_list(pargs)
+    captured = capsys.readouterr()
+    assert all(x in captured.out
+               for x in [" 2/12", " 10/12"])
+    assert all(x not in captured.out
+               for x in [" 1/12", " 3/12", " 4/12", " 5/12", " 6/12", " 7/12", " 8/12", " 9/12",
+                         " 11/12", " 12/12"])
+    args = [
+        "hyperopt-list",
         "--profitable",
         "--no-details",
         "--min-avg-profit", "0.11"

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -825,6 +825,20 @@ def test_hyperopt_list(mocker, capsys, hyperopt_results):
     args = [
         "hyperopt-list",
         "--no-details",
+        "--max-avg-profit", "0.10"
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    start_hyperopt_list(pargs)
+    captured = capsys.readouterr()
+    assert all(x in captured.out
+               for x in [" 1/12", " 3/12", " 5/12", " 6/12", " 7/12", " 8/12", " 9/12",
+                         " 11/12"])
+    assert all(x not in captured.out
+               for x in [" 2/12", " 4/12", " 10/12", " 12/12"])
+    args = [
+        "hyperopt-list",
+        "--no-details",
         "--min-total-profit", "0.4"
     ]
     pargs = get_args(args)
@@ -836,6 +850,20 @@ def test_hyperopt_list(mocker, capsys, hyperopt_results):
     assert all(x not in captured.out
                for x in [" 1/12", " 2/12", " 3/12", " 4/12", " 5/12", " 6/12", " 7/12", " 8/12",
                          " 9/12", " 11/12", " 12/12"])
+    args = [
+        "hyperopt-list",
+        "--no-details",
+        "--max-total-profit", "0.4"
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    start_hyperopt_list(pargs)
+    captured = capsys.readouterr()
+    assert all(x in captured.out
+               for x in [" 1/12", " 2/12", " 3/12", " 5/12", " 6/12", " 7/12", " 8/12",
+                         " 9/12", " 11/12"])
+    assert all(x not in captured.out
+               for x in [" 4/12", " 10/12", " 12/12"])
     args = [
         "hyperopt-list",
         "--profitable",


### PR DESCRIPTION
## Summary
Adding more filter options for hyperopt-list to easier find what your looking for in larger runs

PEP8 = Yes
## Quick changelog
Adding two more filter options that can be used in combination to the other options in order to filter and search thru larger hyperopt runs.

- Adding filter options --max-trades and --min-trades
- Adding missing filter options --max-avg-profit and --max-total-profit
- Added additional tests for the new options

## What's new?
```
freqtrade hyperopt-list --max-avg-time 200 --min-trades 20 --max-avg-profit 0.29 --min-avg-profit 0.20 --max-total-profit 8
2020-02-11 21:01:47,383 - freqtrade.loggers - INFO - Verbosity set to 0
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Parameter --min-trades detected: 20
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Parameter --max-avg-time detected: 200.0
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Parameter --min-avg-profit detected: 0.2
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Parameter --max-avg-profit detected: 0.29
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Parameter --max-total-profit detected: 8.0
2020-02-11 21:01:47,383 - freqtrade.configuration.check_exchange - INFO - Checking exchange...
2020-02-11 21:01:47,383 - freqtrade.configuration.configuration - INFO - Using pairlist from configuration.
2020-02-11 21:01:47,383 - freqtrade.configuration.config_validation - INFO - Validating configuration ...
2020-02-11 21:01:47,574 - freqtrade.optimize.hyperopt - INFO - Loaded 1096 previous evaluations from disk.
2020-02-11 21:01:47,574 - freqtrade.commands.hyperopt_commands - INFO - 1 epochs found.
   602/1096:     29 trades. Avg profit   0.27%. Total profit  0.00046184 BTC (   7.69Σ%). Avg duration 189.8 min. Objective: 2.07836

Best result:

   602/1096:     29 trades. Avg profit   0.27%. Total profit  0.00046184 BTC (   7.69Σ%). Avg duration 189.8 min. Objective: 2.07836
```
