### PR TITLE
Do not instantiate directly DefaultStrategy in tests

### DIFF
--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -24,7 +24,7 @@ from freqtrade.data.history import (_download_pair_history,
                                     validate_backtest_data)
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.misc import file_dump_json
-from freqtrade.strategy.default_strategy import DefaultStrategy
+from freqtrade.resolvers import StrategyResolver
 from tests.conftest import (get_patched_exchange, log_has, log_has_re,
                             patch_exchange)
 
@@ -509,7 +509,9 @@ def test_file_dump_json_tofile(testdatadir) -> None:
 
 def test_get_timerange(default_conf, mocker, testdatadir) -> None:
     patch_exchange(mocker)
-    strategy = DefaultStrategy(default_conf)
+
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
 
     data = strategy.tickerdata_to_dataframe(
         load_data(
@@ -525,7 +527,9 @@ def test_get_timerange(default_conf, mocker, testdatadir) -> None:
 
 def test_validate_backtest_data_warn(default_conf, mocker, caplog, testdatadir) -> None:
     patch_exchange(mocker)
-    strategy = DefaultStrategy(default_conf)
+
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
 
     data = strategy.tickerdata_to_dataframe(
         load_data(
@@ -547,7 +551,9 @@ def test_validate_backtest_data_warn(default_conf, mocker, caplog, testdatadir) 
 
 def test_validate_backtest_data(default_conf, mocker, caplog, testdatadir) -> None:
     patch_exchange(mocker)
-    strategy = DefaultStrategy(default_conf)
+
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
 
     timerange = TimeRange('index', 'index', 200, 250)
     data = strategy.tickerdata_to_dataframe(

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -20,8 +20,8 @@ from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.optimize.backtesting import Backtesting
+from freqtrade.resolvers import StrategyResolver
 from freqtrade.state import RunMode
-from freqtrade.strategy.default_strategy import DefaultStrategy
 from freqtrade.strategy.interface import SellType
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
@@ -350,7 +350,9 @@ def test_tickerdata_to_dataframe_bt(default_conf, mocker, testdatadir) -> None:
     assert len(data['UNITTEST/BTC']) == 102
 
     # Load strategy to compare the result between Backtesting function and strategy are the same
-    strategy = DefaultStrategy(default_conf)
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+
     data2 = strategy.tickerdata_to_dataframe(tickerlist)
     assert data['UNITTEST/BTC'].equals(data2['UNITTEST/BTC'])
 

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -10,8 +10,9 @@ from freqtrade.configuration import TimeRange
 from freqtrade.data.converter import parse_ticker_dataframe
 from freqtrade.data.history import load_tickerdata_file
 from freqtrade.persistence import Trade
-from tests.conftest import get_patched_exchange, log_has
+from freqtrade.resolvers import StrategyResolver
 from freqtrade.strategy.default_strategy import DefaultStrategy
+from tests.conftest import get_patched_exchange, log_has
 
 # Avoid to reinit the same object again and again
 _STRATEGY = DefaultStrategy(config={})
@@ -104,7 +105,8 @@ def test_get_signal_handles_exceptions(mocker, default_conf):
 
 
 def test_tickerdata_to_dataframe(default_conf, testdatadir) -> None:
-    strategy = DefaultStrategy(default_conf)
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
 
     timerange = TimeRange.parse_timerange('1510694220-1510700340')
     tick = load_tickerdata_file(testdatadir, 'UNITTEST/BTC', '1m', timerange=timerange)
@@ -120,7 +122,8 @@ def test_min_roi_reached(default_conf, fee) -> None:
     min_roi_list = [{20: 0.05, 55: 0.01, 0: 0.1},
                     {0: 0.1, 20: 0.05, 55: 0.01}]
     for roi in min_roi_list:
-        strategy = DefaultStrategy(default_conf)
+        default_conf.update({'strategy': 'DefaultStrategy'})
+        strategy = StrategyResolver.load_strategy(default_conf)
         strategy.minimal_roi = roi
         trade = Trade(
             pair='ETH/BTC',
@@ -158,7 +161,8 @@ def test_min_roi_reached2(default_conf, fee) -> None:
                      },
                     ]
     for roi in min_roi_list:
-        strategy = DefaultStrategy(default_conf)
+        default_conf.update({'strategy': 'DefaultStrategy'})
+        strategy = StrategyResolver.load_strategy(default_conf)
         strategy.minimal_roi = roi
         trade = Trade(
             pair='ETH/BTC',
@@ -192,7 +196,8 @@ def test_min_roi_reached3(default_conf, fee) -> None:
                30: 0.05,
                55: 0.30,
                }
-    strategy = DefaultStrategy(default_conf)
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
     strategy.minimal_roi = min_roi
     trade = Trade(
             pair='ETH/BTC',
@@ -292,7 +297,8 @@ def test__analyze_ticker_internal_skip_analyze(ticker_history, mocker, caplog) -
 
 
 def test_is_pair_locked(default_conf):
-    strategy = DefaultStrategy(default_conf)
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
     # dict should be empty
     assert not strategy._pair_locked_until
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -19,7 +19,7 @@ from freqtrade.plot.plotting import (add_indicators, add_profit,
                                      generate_profit_graph, init_plotscript,
                                      load_and_plot_trades, plot_profit,
                                      plot_trades, store_plot_file)
-from freqtrade.strategy.default_strategy import DefaultStrategy
+from freqtrade.resolvers import StrategyResolver
 from tests.conftest import get_args, log_has, log_has_re
 
 
@@ -70,9 +70,11 @@ def test_add_indicators(default_conf, testdatadir, caplog):
     indicators1 = {"ema10": {}}
     indicators2 = {"macd": {"color": "red"}}
 
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+
     # Generate buy/sell signals and indicators
-    strat = DefaultStrategy(default_conf)
-    data = strat.analyze_ticker(data, {'pair': pair})
+    data = strategy.analyze_ticker(data, {'pair': pair})
     fig = generate_empty_figure()
 
     # Row 1
@@ -181,9 +183,11 @@ def test_generate_candlestick_graph_no_trades(default_conf, mocker, testdatadir)
     data = history.load_pair_history(pair=pair, timeframe='1m',
                                      datadir=testdatadir, timerange=timerange)
 
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+
     # Generate buy/sell signals and indicators
-    strat = DefaultStrategy(default_conf)
-    data = strat.analyze_ticker(data, {'pair': pair})
+    data = strategy.analyze_ticker(data, {'pair': pair})
 
     indicators1 = []
     indicators2 = []


### PR DESCRIPTION
...use `load_strategy()` instead, as in other places/tests. 

* This removes a few mypy errors in tests
* Can simplify removal of DefaultStrategy in the future, when (and if) this will be performed
* Not all appearances of `DefaultStrategy()` removed here -- some (with empty config dict) left to be managed separately
* Cosmetics in one of the tests: `strat` --> `strategy`, to have it aligned with the others
