### PR TITLE
Move rpc send to be after db session add/flash

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -527,8 +527,6 @@ class FreqtradeBot:
             ticker_interval=timeframe_to_minutes(self.config['ticker_interval'])
         )
 
-        self._notify_buy(trade, order_type)
-
         # Update fees if order is closed
         if order_status == 'closed':
             self.update_trade_state(trade, order)
@@ -538,6 +536,8 @@ class FreqtradeBot:
 
         # Updating wallets
         self.wallets.update()
+
+        self._notify_buy(trade, order_type)
 
         return True
 


### PR DESCRIPTION
If telegram networking is blocked, then rpc send may hang for timeout. If the user then closes the bot, it may happen that the trade object has not been flushed to persistence properly.

It's better to have rpc call after session add/flush, just to be sure add/flush is made before blocking rpc call.
