### PR TITLE
/status table quick fix

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -168,9 +168,9 @@ class RPC:
                         profit_str += f" ({fiat_profit:.2f})"
                 trades_list.append([
                     trade.id,
-                    trade.pair + ['', '*'][trade.open_order_id is not None
-                                           and trade.close_rate_requested is None]
-                               + ['', '**'][trade.close_rate_requested is not None],
+                    trade.pair + ('*' if (trade.open_order_id is not None
+                                          and trade.close_rate_requested is None) else '')
+                               + ('**' if (trade.close_rate_requested is not None) else ''),
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
                     profit_str
                 ])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -168,9 +168,9 @@ class RPC:
                         profit_str += f" ({fiat_profit:.2f})"
                 trades_list.append([
                     trade.id,
-                    trade.pair + '*' if (trade.open_order_id is not None
-                                         and trade.close_rate_requested is None) else ''
-                               + '**' if (trade.close_rate_requested is not None) else '',
+                    trade.pair + ['', '*'][trade.open_order_id is not None
+                                           and trade.close_rate_requested is None]
+                               + ['', '**'][trade.close_rate_requested is not None],
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
                     profit_str
                 ])


### PR DESCRIPTION
So, after testing develop branch for a bit, I noticed /status table wasn't returning pairs as expected:

![Screenshot 2020-02-15 20 31 40](https://user-images.githubusercontent.com/191483/74594340-91edf000-5035-11ea-8540-1f3d06194562.png)

So, I looked into the code merged from #2887 and apparently the problem lied here:

```
                    trade.pair + '*' if (trade.open_order_id is not None
                                         and trade.close_rate_requested is None) else ''
                               + '**' if (trade.close_rate_requested is not None) else '',
```

However, trying the previous code format I had actually works, no idea why though.

```
                    trade.pair + ['', '*'][trade.open_order_id is not None
                                           and trade.close_rate_requested is None]
                               + ['', '**'][trade.close_rate_requested is not None],

```

This is a PR to propose a right fix for it (if you still don't want to use my code as it doesn't have great at readability), though, it starts with proposing my code format as a quick fix for it.

Thanks.