### PR TITLE
increment limit to adjust to FTX defaults (1500 candles)

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,18 +1,20 @@
-from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS  # noqa: F401
-from freqtrade.exchange.exchange import Exchange  # noqa: F401
-from freqtrade.exchange.exchange import (get_exchange_bad_reason,  # noqa: F401
+# flake8: noqa: F401
+from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS
+from freqtrade.exchange.exchange import Exchange
+from freqtrade.exchange.exchange import (get_exchange_bad_reason,
                                          is_exchange_bad,
                                          is_exchange_known_ccxt,
                                          is_exchange_officially_supported,
                                          ccxt_exchanges,
                                          available_exchanges)
-from freqtrade.exchange.exchange import (timeframe_to_seconds,  # noqa: F401
+from freqtrade.exchange.exchange import (timeframe_to_seconds,
                                          timeframe_to_minutes,
                                          timeframe_to_msecs,
                                          timeframe_to_next_date,
                                          timeframe_to_prev_date)
-from freqtrade.exchange.exchange import (market_is_active,  # noqa: F401
+from freqtrade.exchange.exchange import (market_is_active,
                                          symbol_is_pair)
-from freqtrade.exchange.kraken import Kraken  # noqa: F401
-from freqtrade.exchange.binance import Binance  # noqa: F401
-from freqtrade.exchange.bibox import Bibox  # noqa: F401
+from freqtrade.exchange.kraken import Kraken
+from freqtrade.exchange.binance import Binance
+from freqtrade.exchange.bibox import Bibox
+from freqtrade.exchange.ftx import Ftx

--- a/freqtrade/exchange/ftx.py
+++ b/freqtrade/exchange/ftx.py
@@ -1,0 +1,14 @@
+""" FTX exchange subclass """
+import logging
+from typing import Dict
+
+from freqtrade.exchange import Exchange
+
+logger = logging.getLogger(__name__)
+
+
+class Ftx(Exchange):
+
+    _ft_has: Dict = {
+        "ohlcv_candle_limit": 1500,
+    }


### PR DESCRIPTION
## Summary
since ftx returns 1500 candles by default, we should adjust to this to avoid downloading the same data twice.

In combination with #2719 this would not be a problem for the final data (duplicate candles are dropped) - however the data is still downloaded 3 times - which is absolutely unnecessary.

Closes #2916
## Quick changelog

- Create FTX subclass to change setting of default candle return value