### PR TITLE
GitHub actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - develop
       - github_actions_tests
     tags:
+    release:
+      types: [published]
   pull_request:
   schedule:
     - cron:  '0 5 * * 4'
@@ -191,14 +193,39 @@ jobs:
   deploy:
     needs: [ build, build_windows, docs_check ]
     runs-on: ubuntu-18.04
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'freqtrade/freqtrade'
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'release') && github.repository == 'freqtrade/freqtrade'
     steps:
     - uses: actions/checkout@v1
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
 
     - name: Extract branch name
       shell: bash
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: extract_branch
+
+    - name: Build distribution
+      run: |
+        pip install -U setuptools wheel
+        python setup.py sdist bdist_wheel
+
+    - name: Publish to PyPI (Test)
+      uses: pypa/gh-action-pypi-publish@master
+      if: (steps.extract_branch.outputs.branch == 'master' || github.event_name == 'release')
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_test_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      if: (steps.extract_branch.outputs.branch == 'master' || github.event_name == 'release')
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
 
     - name: Build and test and push docker image
       env:

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -6,18 +6,18 @@ if __version__ == 'develop':
     try:
         import subprocess
 
-        # __version__ = 'develop-' + subprocess.check_output(
-        #     ['git', 'log', '--format="%h"', '-n 1'],
-        # stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
+        __version__ = 'develop-' + subprocess.check_output(
+            ['git', 'log', '--format="%h"', '-n 1'],
+            stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
 
-        from datetime import datetime
-        last_release = subprocess.check_output(
-            ['git', 'tag']
-        ).decode('utf-8').split()[-1].split(".")
-        # Releases are in the format "2020.1" - we increment the latest version for dev.
-        prefix = f"{last_release[0]}.{int(last_release[1]) + 1}"
-        dev_version = int(datetime.now().timestamp() // 1000)
-        __version__ = f"{prefix}.dev{dev_version}"
+        # from datetime import datetime
+        # last_release = subprocess.check_output(
+        #     ['git', 'tag']
+        # ).decode('utf-8').split()[-1].split(".")
+        # # Releases are in the format "2020.1" - we increment the latest version for dev.
+        # prefix = f"{last_release[0]}.{int(last_release[1]) + 1}"
+        # dev_version = int(datetime.now().timestamp() // 1000)
+        # __version__ = f"{prefix}.dev{dev_version}"
 
         #  subprocess.check_output(
         #     ['git', 'log', '--format="%h"', '-n 1'],

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -5,9 +5,23 @@ if __version__ == 'develop':
 
     try:
         import subprocess
-        __version__ = 'develop-' + subprocess.check_output(
-            ['git', 'log', '--format="%h"', '-n 1'],
-            stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
+
+        # __version__ = 'develop-' + subprocess.check_output(
+        #     ['git', 'log', '--format="%h"', '-n 1'],
+        # stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
+
+        from datetime import datetime
+        last_release = subprocess.check_output(
+            ['git', 'tag']
+        ).decode('utf-8').split()[-1].split(".")
+        # Releases are in the format "2020.1" - we increment the latest version for dev.
+        prefix = f"{last_release[0]}.{int(last_release[1]) + 1}"
+        dev_version = int(datetime.now().timestamp() // 1000)
+        __version__ = f"{prefix}.dev{dev_version}"
+
+        #  subprocess.check_output(
+        #     ['git', 'log', '--format="%h"', '-n 1'],
+        #     stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
     except Exception:
         # git not available, ignore
         pass

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,4 +1,4 @@
-""" FreqTrade bot """
+""" Freqtrade bot """
 __version__ = 'develop'
 
 if __version__ == 'develop':


### PR DESCRIPTION
## Summary
this will add PyPi builds / uploads to the CI pipeline.

Solve part of the issue: #2112 

An successful workflow is available [here](https://github.com/freqtrade/freqtrade/runs/449795378?check_suite_focus=true) - i've since rebased this branch as i needed about 20 retries to get to that point.

## Quick changelog

- Run on release (hopefully - can only really test this when releasing)
- build pypi package
- upload pypi package


## Open points
- [ ] shall we publish development versions (maybe built nightly) from the develop branch? if yes - requires some form of the next point.

 - [ ] 1172c95 shows an alternative versioning scheme [testpypi](https://test.pypi.org/project/freqtrade/#history). example: `2020.2.dev1581916`.
  Our current versioning scheme for develop versions of develop-commit-hash (`develop-1172c95` is not [PEP440](https://www.python.org/dev/peps/pep-0440/#dvcs-based-version-labels) compliant as ordering is not reliably possible - and such releases can therefore not be uploaded to pypi.
  This commit attempts itself on an alternative Versioning scheme (visible on both test.pypi.org - as well as pypi.org (i'll delete that release after we've decided on this - but i had to test...). The huge drawback to it is that it's not 100% clear which commit the release came from right away - but considering that in the future most users may install via PYPI, it may be neglectible).
  now this point is completely dependant on the implementation of the prior point (publish test/develop versions to pypi) - as otherwise versions for develop may remain as they are.


## TODO 
- [ ] delete test-release from Production pypi @xmatthias 
