### PR TITLE
Add dataframe_difference() helper function

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -188,3 +188,20 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     # FFill to get continuous
     df[col_name] = df[col_name].ffill()
     return df
+
+
+def dataframe_difference(df1: pd.DataFrame, df2: pd.DataFrame, which=None):
+    """
+    Find rows which are different between two DataFrames.
+    Taken with small adaptation from:
+    https://hackersandslackers.com/compare-rows-pandas-dataframes/
+    :param which: Allows to print 'left_only', 'right_only' or 'both' rows.
+    """
+    comparison_df = df1.merge(df2,
+                              indicator=True,
+                              how='outer')
+    if which is None:
+        diff_df = comparison_df[comparison_df['_merge'] != 'both']
+    else:
+        diff_df = comparison_df[comparison_df['_merge'] == which]
+    return diff_df


### PR DESCRIPTION
A helper function which allows to find differences between 2 dataframes.

For example, when used (for testing purposes) on a binance dataframe before fill up and after, it allows to see how the missing data were filled, finding the binance outage period, as expected:
```
                         date      open      high       low     close  volume      _merge
499 2020-02-19 11:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
500 2020-02-19 12:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
501 2020-02-19 12:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
502 2020-02-19 12:30:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
503 2020-02-19 12:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
504 2020-02-19 13:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
505 2020-02-19 13:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
506 2020-02-19 13:30:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
507 2020-02-19 13:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
508 2020-02-19 14:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
509 2020-02-19 14:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
510 2020-02-19 14:30:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
511 2020-02-19 14:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
512 2020-02-19 15:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
513 2020-02-19 15:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
514 2020-02-19 15:30:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
515 2020-02-19 15:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
516 2020-02-19 16:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
517 2020-02-19 16:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
518 2020-02-19 16:30:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
519 2020-02-19 16:45:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
520 2020-02-19 17:00:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
521 2020-02-19 17:15:00+00:00  0.027732  0.027732  0.027732  0.027732     0.0  right_only
2020-02-21 19:22:09,467 - freqtrade.data.converter - INFO - Missing data fillup for ETH/BTC: before: 499 - after: 522
```

* This can also be useful in the interactive environments, so placed in the `freqtrade.data.btanalysis` module. I can move it into (new) `freqtrade.data.misc` or `freqtrade.data.utils` module if this makes sense.
* @xmatthias pls add an example into ipynb example file if this makes sense...
* Docs? (is there place to mention this helper?)
