### PR TITLE
Load ohlcv data as float

### DIFF
--- a/freqtrade/data/history/jsondatahandler.py
+++ b/freqtrade/data/history/jsondatahandler.py
@@ -69,7 +69,7 @@ class JsonDataHandler(IDataHandler):
         filename = self._pair_data_filename(self._datadir, pair, timeframe)
         if not filename.exists():
             return DataFrame(columns=self._columns)
-        pairdata = read_json(filename, orient='values')
+        pairdata = read_json(filename, orient='values', dtype='float64')
         pairdata.columns = self._columns
         pairdata['date'] = to_datetime(pairdata['date'],
                                        unit='ms',

--- a/freqtrade/data/history/jsondatahandler.py
+++ b/freqtrade/data/history/jsondatahandler.py
@@ -69,7 +69,9 @@ class JsonDataHandler(IDataHandler):
         filename = self._pair_data_filename(self._datadir, pair, timeframe)
         if not filename.exists():
             return DataFrame(columns=self._columns)
-        pairdata = read_json(filename, orient='values', dtype='float64')
+        pairdata = read_json(filename, orient='values',
+                             dtype={'open': 'float', 'high': 'float',
+                                    'low': 'float', 'close': 'float', 'volume': 'float'})
         pairdata.columns = self._columns
         pairdata['date'] = to_datetime(pairdata['date'],
                                        unit='ms',


### PR DESCRIPTION
## Summary
This replicates behaviour from `parse_ticker_dataframe()` - which however is not called for backtesting data since #2719, as we load the data directly as pandas dataframe, skipping the step of loading it as list, and then converting to dataframe.

closes #2948 
