### PR TITLE
Shuffle whitelisted pairs

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -11,6 +11,7 @@ from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple
 
 import arrow
+import random
 from requests.exceptions import RequestException
 
 from freqtrade import __version__, constants, persistence
@@ -221,6 +222,7 @@ class FreqtradeBot:
                 logger.info("No currency pair in active pair whitelist, "
                             "but checking to sell open trades.")
             else:
+                random.shuffle(whitelist)
                 # Create entity and execute trade for each pair from whitelist
                 for pair in whitelist:
                     try:


### PR DESCRIPTION
I noticed in backtesting results and in trading modes, that if you have a long list of pairs in your config file, that freqtrade seems to trade pairs in alphabetical order OR according to the order you have set them in your config file (still need to confirm this one yet), meaning that it seems to trade more the ones that come on top of the stack. This doesn't seem to me like the preferred behaviour, in the sense that most users do not take into account the order freqtrade scans their pairs.

I also wasn't sure if it's worth it to add a config flag to allow users to choose between shuffle or not, which is also a possibility, but I lean more towards having the shuffle as a default.

This PR suggests adding a simple random.shuffle on whitelisted pairs, without the config option.