### PR TITLE
Better throttling

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -6,7 +6,6 @@ import logging
 import traceback
 from datetime import datetime
 from math import isclose
-from os import getpid
 from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -51,10 +50,6 @@ class FreqtradeBot:
 
         # Init objects
         self.config = config
-
-        self._heartbeat_msg = 0
-
-        self.heartbeat_interval = self.config.get('internals', {}).get('heartbeat_interval', 60)
 
         self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 
@@ -158,11 +153,6 @@ class FreqtradeBot:
         # Check and handle any timed out open orders
         self.check_handle_timedout()
         Trade.session.flush()
-
-        if (self.heartbeat_interval
-                and (arrow.utcnow().timestamp - self._heartbeat_msg > self.heartbeat_interval)):
-            logger.info(f"Bot heartbeat. PID={getpid()}")
-            self._heartbeat_msg = arrow.utcnow().timestamp
 
     def _refresh_whitelist(self, trades: List[Trade] = []) -> List[str]:
         """

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -7,7 +7,6 @@ import traceback
 from os import getpid
 from typing import Any, Callable, Dict, Optional
 
-import arrow
 import sdnotify
 
 from freqtrade import __version__, constants
@@ -34,8 +33,8 @@ class Worker:
         self._config = config
         self._init(False)
 
-        self.last_throttle_start_time: Optional[float] = None
-        self._heartbeat_msg = 0
+        self.last_throttle_start_time: float = 0
+        self._heartbeat_msg: float = 0
 
         # Tell systemd that we completed initialization phase
         if self._sd_notify:
@@ -100,10 +99,11 @@ class Worker:
 
             self._throttle(func=self._process_running, throttle_secs=self._throttle_secs)
 
-        if (self._heartbeat_interval
-                and (arrow.utcnow().timestamp - self._heartbeat_msg > self._heartbeat_interval)):
-            logger.info(f"Bot heartbeat. PID={getpid()}")
-            self._heartbeat_msg = arrow.utcnow().timestamp
+        if self._heartbeat_interval:
+            now = time.time()
+            if (now - self._heartbeat_msg) > self._heartbeat_interval:
+                logger.info(f"Bot heartbeat. PID={getpid()}")
+                self._heartbeat_msg = now
 
         return state
 

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -69,7 +69,7 @@ class Worker:
 
     def _worker(self, old_state: Optional[State]) -> State:
         """
-        Trading routine that must be run at each loop
+        The main routine that runs each throttling iteration and handles the states.
         :param old_state: the previous service state from the previous call
         :return: current service state
         """

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -109,14 +109,14 @@ class Worker:
         """
         start = time.time()
         result = func(*args, **kwargs)
+        logger.debug("========================================")
         end = time.time()
         duration = max(min_secs - (end - start), 0.0)
-        logger.debug('Throttling %s for %.2f seconds', func.__name__, duration)
+        logger.debug(f"Throttling {func.__name__} for {duration:.2f} seconds")
         time.sleep(duration)
         return result
 
     def _process(self) -> None:
-        logger.debug("========================================")
         try:
             self.freqtrade.process()
         except TemporaryError as error:

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -108,12 +108,13 @@ class Worker:
         :return: Any
         """
         start = time.time()
-        result = func(*args, **kwargs)
         logger.debug("========================================")
-        end = time.time()
-        duration = max(min_secs - (end - start), 0.0)
-        logger.debug(f"Throttling {func.__name__} for {duration:.2f} seconds")
-        time.sleep(duration)
+        result = func(*args, **kwargs)
+        time_passed = time.time() - start
+        sleep_duration = max(min_secs - time_passed, 0.0)
+        logger.debug(f"Throttling with '{func.__name__}()': sleep for {sleep_duration:.2f} s, "
+                     f"last iteration took {time_passed:.2f} s.")
+        time.sleep(sleep_duration)
         return result
 
     def _process_stopped(self) -> None:

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -26,7 +26,7 @@ class Worker:
         """
         Init all variables and objects the bot needs to work
         """
-        logger.info('Starting worker %s', __version__)
+        logger.info(f"Starting worker {__version__}")
 
         self._args = args
         self._config = config
@@ -77,7 +77,7 @@ class Worker:
         if state != old_state:
             self.freqtrade.notify_status(f'{state.name.lower()}')
 
-            logger.info('Changing state to: %s', state.name)
+            logger.info(f"Changing state to: {state.name}")
             if state == State.RUNNING:
                 self.freqtrade.startup()
 

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -83,6 +83,10 @@ class Worker:
             if state == State.RUNNING:
                 self.freqtrade.startup()
 
+            # Reset heartbeat timestamp to log the heartbeat message at
+            # first throttling iteration when the state changes
+            self._heartbeat_msg = 0
+
         if state == State.STOPPED:
             # Ping systemd watchdog before sleeping in the stopped state
             if self._sd_notify:

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -87,7 +87,7 @@ class Worker:
                 logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: STOPPED.")
                 self._sd_notify.notify("WATCHDOG=1\nSTATUS=State: STOPPED.")
 
-            time.sleep(throttle_secs)
+            self._throttle(func=self._process_stopped, min_secs=throttle_secs)
 
         elif state == State.RUNNING:
             # Ping systemd watchdog before throttling
@@ -95,7 +95,7 @@ class Worker:
                 logger.debug("sd_notify: WATCHDOG=1\\nSTATUS=State: RUNNING.")
                 self._sd_notify.notify("WATCHDOG=1\nSTATUS=State: RUNNING.")
 
-            self._throttle(func=self._process, min_secs=throttle_secs)
+            self._throttle(func=self._process_running, min_secs=throttle_secs)
 
         return state
 
@@ -116,7 +116,11 @@ class Worker:
         time.sleep(duration)
         return result
 
-    def _process(self) -> None:
+    def _process_stopped(self) -> None:
+        # Maybe do here something in the future...
+        pass
+
+    def _process_running(self) -> None:
         try:
             self.freqtrade.process()
         except TemporaryError as error:

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -32,6 +32,8 @@ class Worker:
         self._config = config
         self._init(False)
 
+        self.last_throttle_start_time: float = None
+
         # Tell systemd that we completed initialization phase
         if self._sd_notify:
             logger.debug("sd_notify: READY=1")
@@ -107,10 +109,10 @@ class Worker:
         :param min_secs: minimum execution time in seconds
         :return: Any
         """
-        start = time.time()
+        self.last_throttle_start_time = time.time()
         logger.debug("========================================")
         result = func(*args, **kwargs)
-        time_passed = time.time() - start
+        time_passed = time.time() - self.last_throttle_start_time
         sleep_duration = max(min_secs - time_passed, 0.0)
         logger.debug(f"Throttling with '{func.__name__}()': sleep for {sleep_duration:.2f} s, "
                      f"last iteration took {time_passed:.2f} s.")

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -102,7 +102,8 @@ class Worker:
         if self._heartbeat_interval:
             now = time.time()
             if (now - self._heartbeat_msg) > self._heartbeat_interval:
-                logger.info(f"Bot heartbeat. PID={getpid()}")
+                logger.info(f"Bot heartbeat. PID={getpid()}, "
+                            f"version='{__version__}', state='{state.name}'")
                 self._heartbeat_msg = now
 
         return state

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, PropertyMock
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.state import State
 from freqtrade.worker import Worker
-from tests.conftest import get_patched_worker, log_has
+from tests.conftest import get_patched_worker, log_has, log_has_re
 
 
 def test_worker_state(mocker, default_conf, markets) -> None:
@@ -38,15 +38,13 @@ def test_worker_running(mocker, default_conf, caplog) -> None:
 def test_worker_stopped(mocker, default_conf, caplog) -> None:
     mock_throttle = MagicMock()
     mocker.patch('freqtrade.worker.Worker._throttle', mock_throttle)
-    mock_sleep = mocker.patch('time.sleep', return_value=None)
 
     worker = get_patched_worker(mocker, default_conf)
     worker.freqtrade.state = State.STOPPED
     state = worker._worker(old_state=State.RUNNING)
     assert state is State.STOPPED
     assert log_has('Changing state to: STOPPED', caplog)
-    assert mock_throttle.call_count == 0
-    assert mock_sleep.call_count == 1
+    assert mock_throttle.call_count == 1
 
 
 def test_throttle(mocker, default_conf, caplog) -> None:
@@ -57,14 +55,14 @@ def test_throttle(mocker, default_conf, caplog) -> None:
     worker = get_patched_worker(mocker, default_conf)
 
     start = time.time()
-    result = worker._throttle(throttled_func, min_secs=0.1)
+    result = worker._throttle(throttled_func, throttle_secs=0.1)
     end = time.time()
 
     assert result == 42
     assert end - start > 0.1
-    assert log_has('Throttling throttled_func for 0.10 seconds', caplog)
+    assert log_has_re(r"Throttling with 'throttled_func\(\)': sleep for 0\.10 s.*", caplog)
 
-    result = worker._throttle(throttled_func, min_secs=-1)
+    result = worker._throttle(throttled_func, throttle_secs=-1)
     assert result == 42
 
 
@@ -74,8 +72,54 @@ def test_throttle_with_assets(mocker, default_conf) -> None:
 
     worker = get_patched_worker(mocker, default_conf)
 
-    result = worker._throttle(throttled_func, min_secs=0.1, nb_assets=666)
+    result = worker._throttle(throttled_func, throttle_secs=0.1, nb_assets=666)
     assert result == 666
 
-    result = worker._throttle(throttled_func, min_secs=0.1)
+    result = worker._throttle(throttled_func, throttle_secs=0.1)
     assert result == -1
+
+
+def test_worker_heartbeat_running(default_conf, mocker, caplog):
+    message = r"Bot heartbeat\. PID=.*state='RUNNING'"
+
+    mock_throttle = MagicMock()
+    mocker.patch('freqtrade.worker.Worker._throttle', mock_throttle)
+    worker = get_patched_worker(mocker, default_conf)
+
+    worker.freqtrade.state = State.RUNNING
+    worker._worker(old_state=State.STOPPED)
+    assert log_has_re(message, caplog)
+
+    caplog.clear()
+    # Message is not shown before interval is up
+    worker._worker(old_state=State.RUNNING)
+    assert not log_has_re(message, caplog)
+
+    caplog.clear()
+    # Set clock - 70 seconds
+    worker._heartbeat_msg -= 70
+    worker._worker(old_state=State.RUNNING)
+    assert log_has_re(message, caplog)
+
+
+def test_worker_heartbeat_stopped(default_conf, mocker, caplog):
+    message = r"Bot heartbeat\. PID=.*state='STOPPED'"
+
+    mock_throttle = MagicMock()
+    mocker.patch('freqtrade.worker.Worker._throttle', mock_throttle)
+    worker = get_patched_worker(mocker, default_conf)
+
+    worker.freqtrade.state = State.STOPPED
+    worker._worker(old_state=State.RUNNING)
+    assert log_has_re(message, caplog)
+
+    caplog.clear()
+    # Message is not shown before interval is up
+    worker._worker(old_state=State.STOPPED)
+    assert not log_has_re(message, caplog)
+
+    caplog.clear()
+    # Set clock - 70 seconds
+    worker._heartbeat_msg -= 70
+    worker._worker(old_state=State.STOPPED)
+    assert log_has_re(message, caplog)


### PR DESCRIPTION
Preparation for (part of) #2885 

Split from the upcoming rest to have it observable, for easy review.

* Worker now throttles (with an empty function) in the STOPPED state as well, instead of explicit sleep, this allows to print same diagnostics messages in the stopped state as well.
* Better throttling: the "====..." divider (at debug level) is printed before the working function, to efficiently separate startup messages in the log from the messages of the first throttling iteration
* The heartbeat message moved from FreqtradeBot into Worker and issued at the stopped state as well.
* The heartbeat message now contains the state, to see something when the bot was stopped.
* The heartbeat message now contains the version of the bot. I added this for us to see the version from the logs posted by users, which forget to fill the new issue form. However, I do not like it actually, the version info can be removed from the heartbeat message.

The overall look of the new heartbeat message:
```
...
2020-02-23 00:32:03,654 - freqtrade.exchange.exchange - INFO - Using Exchange "Binance"
2020-02-23 00:32:04,485 - freqtrade.resolvers.exchange_resolver - INFO - Using resolved exchange 'Binance'...
2020-02-23 00:32:04,505 - freqtrade.wallets - INFO - Wallets synced.
2020-02-23 00:32:04,508 - freqtrade.resolvers.iresolver - INFO - Using resolved pairlist StaticPairList from '/home/user/freqtrade-wrk/github-hroff-1902/freqtrade/freqtrade/pairlist/StaticPairList.py'...
2020-02-23 00:32:04,508 - freqtrade.rpc.rpc_manager - INFO - Enabling rpc.api_server
2020-02-23 00:32:04,611 - freqtrade.rpc.api_server - INFO - Starting HTTP Server at 127.0.0.1:8080
2020-02-23 00:32:04,612 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'running'}
2020-02-23 00:32:04,612 - freqtrade.rpc.api_server - INFO - Starting Local Rest Server.
2020-02-23 00:32:04,612 - freqtrade.worker - INFO - Changing state to: RUNNING
2020-02-23 00:32:04,613 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': warning, 'status': 'Dry run is enabled. All trades are simulated.'}
2020-02-23 00:32:04,613 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': custom, 'status': "*Exchange:* `binance`\n*Stake per trade:* `0.05 BTC`\n*Minimum ROI:* `{'60': 0.01, '30': 0.02, '0': 0.04}`\n*Stoploss:* `-0.1`\n*Ticker Interval:* `1m`\n*Strategy:* `SampleStrategy`"}
2020-02-23 00:32:04,613 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': "Searching for BTC pairs to buy and sell based on [{'StaticPairList': 'StaticPairList'}]"}
2020-02-23 00:32:09,622 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='RUNNING'
2020-02-23 00:33:09,681 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='RUNNING'
2020-02-23 00:34:09,743 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='RUNNING'
```
then `/stop` command:
```
2020-02-23 00:34:55,791 - werkzeug - INFO - 127.0.0.1 - - [23/Feb/2020 00:34:55] "POST /api/v1/stop HTTP/1.1" 200 -
2020-02-23 00:34:59,786 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'stopped'}
2020-02-23 00:34:59,786 - freqtrade.worker - INFO - Changing state to: STOPPED
2020-02-23 00:35:04,791 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='STOPPED'
2020-02-23 00:36:04,846 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='STOPPED'
```
then `/reload_conf`:
```
2020-02-23 00:36:10,487 - werkzeug - INFO - 127.0.0.1 - - [23/Feb/2020 00:36:10] "POST /api/v1/reload_conf HTTP/1.1" 200 -
2020-02-23 00:36:14,853 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'reload_conf'}
2020-02-23 00:36:14,853 - freqtrade.worker - INFO - Changing state to: RELOAD_CONF
2020-02-23 00:36:14,854 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='RELOAD_CONF'
2020-02-23 00:36:14,854 - freqtrade.freqtradebot - INFO - Cleaning up modules ...
...
2020-02-23 00:36:15,027 - freqtrade.exchange.exchange - INFO - Using Exchange "Binance"
2020-02-23 00:36:15,915 - freqtrade.resolvers.exchange_resolver - INFO - Using resolved exchange 'Binance'...
2020-02-23 00:36:15,924 - freqtrade.wallets - INFO - Wallets synced.
2020-02-23 00:36:15,927 - freqtrade.resolvers.iresolver - INFO - Using resolved pairlist StaticPairList from '/home/user/freqtrade-wrk/github-hroff-1902/freqtrade/freqtrade/pairlist/StaticPairList.py'...
2020-02-23 00:36:15,927 - freqtrade.rpc.rpc_manager - INFO - Enabling rpc.api_server
2020-02-23 00:36:15,939 - freqtrade.rpc.api_server - INFO - Starting HTTP Server at 127.0.0.1:8080
2020-02-23 00:36:15,939 - freqtrade.rpc.api_server - INFO - Starting Local Rest Server.
2020-02-23 00:36:15,940 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'config reloaded'}
2020-02-23 00:36:15,940 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'running'}
2020-02-23 00:36:15,940 - freqtrade.worker - INFO - Changing state to: RUNNING
2020-02-23 00:36:15,940 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': warning, 'status': 'Dry run is enabled. All trades are simulated.'}
2020-02-23 00:36:15,940 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': custom, 'status': "*Exchange:* `binance`\n*Stake per trade:* `0.05 BTC`\n*Minimum ROI:* `{'60': 0.01, '30': 0.02, '0': 0.04}`\n*Stoploss:* `-0.1`\n*Ticker Interval:* `1m`\n*Strategy:* `SampleStrategy`"}
2020-02-23 00:36:15,940 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': "Searching for BTC pairs to buy and sell based on [{'StaticPairList': 'StaticPairList'}]"}
2020-02-23 00:36:20,945 - freqtrade.worker - INFO - Bot heartbeat. PID=22502, version='develop-ca8e52dc', state='RUNNING'
^C2020-02-23 00:36:33,455 - freqtrade.commands.trade_commands - INFO - SIGINT received, aborting ...
2020-02-23 00:36:33,456 - freqtrade.commands.trade_commands - INFO - worker found ... calling exit
2020-02-23 00:36:33,456 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': status, 'status': 'process died'}
2020-02-23 00:36:33,456 - freqtrade.freqtradebot - INFO - Cleaning up modules ...
2020-02-23 00:36:33,456 - freqtrade.rpc.rpc_manager - INFO - Cleaning up rpc modules ...
2020-02-23 00:36:33,456 - freqtrade.rpc.api_server - INFO - Stopping API Server
2020-02-23 00:36:33,465 - freqtrade.rpc.api_server - INFO - Local Rest Server started.
```