### PR TITLE
simplify installation documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -626,6 +626,11 @@ In production mode, the bot will engage your money. Be careful, since a wrong
 strategy can lose all your money. Be aware of what you are doing when
 you run it in production mode.
 
+### Setup your exchange account
+
+You will need to create API Keys (usually you get `key` and `secret`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
+API Keys are usually only required for real / production trading, but are not required for paper-trading / dry-run.
+
 ### To switch your bot in production mode
 
 **Edit your `config.json`  file.**
@@ -647,10 +652,13 @@ you run it in production mode.
 }
 ```
 
-!!! Note
-    If you have an exchange API key yet, [see our tutorial](installation.md#setup-your-exchange-account).
-
 You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
+
+### Setup your exchange account
+
+You will need to create API Keys (usually you get `key` and `secret`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
+API Keys are usually only required for real / production trading, but are not required for paper-trading / dry-run.
+
 
 ### Using proxy with Freqtrade
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -628,8 +628,8 @@ you run it in production mode.
 
 ### Setup your exchange account
 
-You will need to create API Keys (usually you get `key` and `secret`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
-API Keys are usually only required for real / production trading, but are not required for paper-trading / dry-run.
+You will need to create API Keys (usually you get `key` and `secret`, some exchanges require an additional `password`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the `freqtrade new-config` command.
+API Keys are usually only required for live trading (trading for real money, bot running in "production mode", executing real orders on the exchange) and are not required for the bot running in dry-run (trade simulation) mode. When you setup the bot in dry-run mode, you may fill these fields with empty values.
 
 ### To switch your bot in production mode
 
@@ -653,12 +653,6 @@ API Keys are usually only required for real / production trading, but are not re
 ```
 
 You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
-
-### Setup your exchange account
-
-You will need to create API Keys (usually you get `key` and `secret`, some exchanges supply it with `password`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
-API Keys are usually only required for live trade (trading for real money, bot running in the "production mode", executing real orders on the exchange) and are not required for the bot running in the dry-run (trade simulation) mode. When you setup the bot in the dry-run mode, you may fill these fields with empty values.
-
 
 ### Using proxy with Freqtrade
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -656,8 +656,8 @@ You should also make sure to read the [Exchanges](exchanges.md) section of the d
 
 ### Setup your exchange account
 
-You will need to create API Keys (usually you get `key` and `secret`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
-API Keys are usually only required for real / production trading, but are not required for paper-trading / dry-run.
+You will need to create API Keys (usually you get `key` and `secret`, some exchanges supply it with `password`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the installation script.
+API Keys are usually only required for live trade (trading for real money, bot running in the "production mode", executing real orders on the exchange) and are not required for the bot running in the dry-run (trade simulation) mode. When you setup the bot in the dry-run mode, you may fill these fields with empty values.
 
 
 ### Using proxy with Freqtrade

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,11 +65,11 @@ usage:
 
 ** --install **
 
-With this option, the script will install everything you need to run the bot:
+With this option, the script will install the bot and most dependencies:
+You will need to have git and python3.6+ installed beforehand for this to work.
 
 * Mandatory software as: `ta-lib`
-* Setup your virtualenv
-* Configure your `config.json` file
+* Setup your virtualenv under `.env/`
 
 This option is a combination of installation tasks, `--reset` and `--config`.
 
@@ -83,7 +83,7 @@ This option will hard reset your branch (only if you are on either `master` or `
 
 ** --config **
 
-Use this option to configure the `config.json` configuration file. The script will interactively ask you questions to setup your bot and create your `config.json`.
+DEPRECATED - use `freqtrade new-config -c config.json` instead.
 
 ------
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 This page explains how to prepare your environment for running the bot.
 
-Please consider using the prebuilt [docker images](docker.md) to get started quickly while trying out freqtrade.
+Please consider using the prebuilt [docker images](docker.md) to get started quickly while trying out freqtrade evaluating how it operates.
 
 ## Prerequisite
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 This page explains how to prepare your environment for running the bot.
 
+Please consider using the prebuilt [docker images](docker.md) to get started quickly while trying out freqtrade.
+
 ## Prerequisite
 
 ### Requirements
@@ -14,15 +16,7 @@ Click each one for install guide:
 * [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
 * [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html) (install instructions below)
 
-### API keys
-
-Before running your bot in production you will need to setup few
-external API. In production mode, the bot will require valid Exchange API
-credentials. We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot) (optional but recommended).
-
-### Setup your exchange account
-
-You will need to create API Keys (Usually you get `key` and `secret`) from the Exchange website and insert this into the appropriate fields in the configuration or when asked by the installation script.
+ We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot), which is optional but recommended.
 
 ## Quick start
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Freqtrade
 nav:
-    - About: index.md
-    - Installation: installation.md
+    - Home: index.md
     - Installation Docker: docker.md
+    - Installation: installation.md
     - Configuration: configuration.md
     - Strategy Customization: strategy-customization.md
     - Stoploss: stoploss.md


### PR DESCRIPTION
## Summary
This should simplify the installation documentation.
Docker should be the first option for new users (i think that's the easiest to get started with).
Also, Exchange keys are NOT part of the installation - users won't need them until the strategy is ready and backtested.

Closes #2498

## Quick changelog

- adjust easy-install script (i'll honestly not put too much work into this, as i see this method disappear hopefully soon)
- Reorder points to have docker installation come first on the documentation page
- api-keys should be part of the configuration - not part of the installation.