### PR TITLE
Add timeframe_to_minutes to ROI documentation

### DIFF
--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -260,8 +260,8 @@ class AwesomeStrategy(IStrategy):
     ticker_interval = '1d'
     ticker_interval_mins = timeframe_to_minutes(ticker_interval)
     minimal_roi = {
-        (ticker_interval_mins * 3): 0.02,  # After 3 candles
-        (ticker_interval_mins * 6): 0.01,  # After 6 candles
+        str(ticker_interval_mins * 3)): 0.02,  # After 3 candles
+        str(ticker_interval_mins * 6)): 0.01,  # After 6 candles
     }
 ```
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -249,8 +249,8 @@ minimal_roi = {
 
 While technically not completely disabled, this would sell once the trade reaches 10000% Profit.
 
-To use times based on candles, the following snippet can be handy.
-This will allow you to change the ticket_interval, and ROI will be set as candles (e.g. after 3 candles ...)
+To use times based on candle duration (ticker_interval or timeframe), the following snippet can be handy.
+This will allow you to change the ticket_interval for the strategy, and ROI times will still be set as candles (e.g. after 3 candles ...)
 
 ``` python
 from freqtrade.exchange import timeframe_to_minutes

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -257,11 +257,12 @@ from freqtrade.exchange import timeframe_to_minutes
 
 class AwesomeStrategy(IStrategy):
 
-    ticker_interval = '1d'
+    ticker_interval = "1d"
     ticker_interval_mins = timeframe_to_minutes(ticker_interval)
     minimal_roi = {
-        str(ticker_interval_mins * 3)): 0.02,  # After 3 candles
-        str(ticker_interval_mins * 6)): 0.01,  # After 6 candles
+        "0": 0.05,                             # 5% for the first 3 candles
+        str(ticker_interval_mins * 3)): 0.02,  # 2% after 3 candles
+        str(ticker_interval_mins * 6)): 0.01,  # 1% After 6 candles
     }
 ```
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -249,6 +249,22 @@ minimal_roi = {
 
 While technically not completely disabled, this would sell once the trade reaches 10000% Profit.
 
+To use times based on candles, the following snippet can be handy.
+This will allow you to change the ticket_interval, and ROI will be set as candles (e.g. after 3 candles ...)
+
+``` python
+from freqtrade.exchange import timeframe_to_minutes
+
+class AwesomeStrategy(IStrategy):
+
+    ticker_interval = '1d'
+    ticker_interval_mins = timeframe_to_minutes(ticker_interval)
+    minimal_roi = {
+        (ticker_interval_mins * 3): 0.02,  # After 3 candles
+        (ticker_interval_mins * 6): 0.01,  # After 6 candles
+    }
+```
+
 ### Stoploss
 
 Setting a stoploss is highly recommended to protect your capital from strong moves against you.


### PR DESCRIPTION
## Summary
sometimes using ROI based on candle can be useful (especially during strategy development when experimenting with different timeframes).

While easily possible, it's so far only been documented in a issue, but not in the documentation.

Closes #2463

## Quick changelog

- add sample for candle based ROI
