### PR TITLE
Wins/draws/losses/median profit in hyperopt output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -118,7 +118,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -175,7 +175,7 @@ jobs:
   docs_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Documentation syntax
       run: |
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'release') && github.repository == 'freqtrade/freqtrade'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.1-slim-buster
+FROM python:3.8.2-slim-buster
 
 RUN apt-get update \
     && apt-get -y install curl build-essential libssl-dev \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ hesitate to read the source code and understand the mechanism of this bot.
 ## Exchange marketplaces supported
 
 - [X] [Bittrex](https://bittrex.com/)
-- [X] [Binance](https://www.binance.com/) ([*Note for binance users](#a-note-on-binance))
+- [X] [Binance](https://www.binance.com/) ([*Note for binance users](docs/exchanges.md#blacklists))
+- [X] [Kraken](https://kraken.com/)
 - [ ] [113 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
 
 ## Documentation

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -275,7 +275,7 @@ Check the corresponding [Data Downloading](data-download.md) section for more de
 ## Hyperopt commands
 
 To optimize your strategy, you can use hyperopt parameter hyperoptimization
-to find optimal parameter values for your stategy.
+to find optimal parameter values for your strategy.
 
 ```
 usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
@@ -323,7 +323,7 @@ optional arguments:
   --print-all           Print all results, not only the best ones.
   --no-color            Disable colorization of hyperopt results. May be
                         useful if you are redirecting output to a file.
-  --print-json          Print best result detailization in JSON format.
+  --print-json          Print best results in JSON format.
   -j JOBS, --job-workers JOBS
                         The number of concurrently running jobs for
                         hyperoptimization (hyperopt worker processes). If -1
@@ -341,10 +341,11 @@ optional arguments:
                         class (IHyperOptLoss). Different functions can
                         generate completely different results, since the
                         target for optimization is different. Built-in
-                        Hyperopt-loss-functions are: DefaultHyperOptLoss,
-                        OnlyProfitHyperOptLoss, SharpeHyperOptLoss,
-                        SharpeHyperOptLossDaily.(default:
-                        `DefaultHyperOptLoss`).
+                        Hyperopt-loss-functions are:
+                        DefaultHyperOptLoss, OnlyProfitHyperOptLoss,
+                        SharpeHyperOptLoss, SharpeHyperOptLossDaily,
+                        SortinoHyperOptLoss, SortinoHyperOptLossDaily.
+                        (default: `DefaultHyperOptLoss`).
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,15 +370,17 @@ The possible values are: `gtc` (default), `fok` or `ioc`.
 
 Freqtrade is based on [CCXT library](https://github.com/ccxt/ccxt) that supports over 100 cryptocurrency
 exchange markets and trading APIs. The complete up-to-date list can be found in the
-[CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python). However, the bot was tested
-with only Bittrex and Binance.
-
-The bot was tested with the following exchanges:
+[CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python).
+ However, the bot was tested by the development team with only Bittrex, Binance and Kraken,
+ so the these are the only officially supported exhanges:
 
 - [Bittrex](https://bittrex.com/): "bittrex"
 - [Binance](https://www.binance.com/): "binance"
+- [Kraken](https://kraken.com/): "kraken"
 
 Feel free to test other exchanges and submit your PR to improve the bot.
+
+Some exchanges require special configuration, which can be found on the [Exchange-specific Notes](exchanges.md) documentation page.
 
 #### Sample exchange configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,7 +340,7 @@ This is most of the time the default time in force. It means the order will rema
 on exchange till it is canceled by user. It can be fully or partially fulfilled.
 If partially fulfilled, the remaining will stay on the exchange till cancelled.
 
-**FOK (Full Or Kill):**
+**FOK (Fill Or Kill):**
 
 It means if the order is not executed immediately AND fully then it is canceled by the exchange.
 
@@ -531,6 +531,12 @@ It uses configuration from `exchange.pair_whitelist` and `exchange.pair_blacklis
 `VolumePairList` considers outputs of previous pairlists unless  it's the first configured pairlist, it does not consider `pair_whitelist`, but selects the top assets from all available markets (with matching stake-currency) on the exchange.
 
 `refresh_period` allows setting the period (in seconds), at which the pairlist will be refreshed. Defaults to 1800s (30 minutes).
+
+`VolumePairList` is based on the ticker data, as reported by the ccxt library:
+
+* The `bidVolume` is the volume (amount) of current best bid in the orderbook.
+* The `askVolume` is the volume (amount) of current best ask in the orderbook.
+* The `quoteVolume` is the amount of quote (stake) currency traded (bought or sold) in last 24 hours.
 
 ```json
 "pairlists": [{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -626,6 +626,11 @@ In production mode, the bot will engage your money. Be careful, since a wrong
 strategy can lose all your money. Be aware of what you are doing when
 you run it in production mode.
 
+### Setup your exchange account
+
+You will need to create API Keys (usually you get `key` and `secret`, some exchanges require an additional `password`) from the Exchange website and you'll need to insert this into the appropriate fields in the configuration or when asked by the `freqtrade new-config` command.
+API Keys are usually only required for live trading (trading for real money, bot running in "production mode", executing real orders on the exchange) and are not required for the bot running in dry-run (trade simulation) mode. When you setup the bot in dry-run mode, you may fill these fields with empty values.
+
 ### To switch your bot in production mode
 
 **Edit your `config.json`  file.**
@@ -646,9 +651,6 @@ you run it in production mode.
         ...
 }
 ```
-
-!!! Note
-    If you have an exchange API key yet, [see our tutorial](installation.md#setup-your-exchange-account).
 
 You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -234,7 +234,7 @@ git checkout -b new_release <commitid>
 
 Determine if crucial bugfixes have been made between this commit and the current state, and eventually cherry-pick these.
 
-* Edit `freqtrade/__init__.py` and add the version matching the current date (for example `2019.7` for July 2019). Minor versions can be `2019.7-1` should we need to do a second release that month.
+* Edit `freqtrade/__init__.py` and add the version matching the current date (for example `2019.7` for July 2019). Minor versions can be `2019.7.1` should we need to do a second release that month. Version numbers must follow allowed versions from PEP0440 to avoid failures pushing to pypi.
 * Commit this part
 * push that branch to the remote and create a PR against the master branch
 
@@ -267,11 +267,6 @@ Once the PR against master is merged (best right after merging):
 * Use the version-number specified as tag.
 * Use "master" as reference (this step comes after the above PR is merged).
 * Use the above changelog as release comment (as codeblock)
-
-### After-release
-
-* Update version in develop by postfixing that with `-dev` (`2019.6 -> 2019.6-dev`).
-* Create a PR against develop to update that branch.
 
 ## Releases
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -62,6 +62,11 @@ res = [ f"{x['MarketCurrency']}/{x['BaseCurrency']}" for x in ct.publicGetMarket
 print(res)
 ```
 
+## All exchanges
+
+Should you experience constant errors with Nonce (like `InvalidNonce`), it is best to regenerate the API keys. Resetting Nonce is difficult and it's usually easier to regenerate the API keys.
+
+
 ## Random notes for other exchanges
 
 * The Ocean (exchange id: `theocean`) exchange uses Web3 functionality and requires `web3` python package to be installed:

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -31,9 +31,9 @@ This will create a new hyperopt file from a template, which will be located unde
 Depending on the space you want to optimize, only some of the below are required:
 
 * fill `buy_strategy_generator` - for buy signal optimization
-* fill `indicator_space` - for buy signal optimzation
+* fill `indicator_space` - for buy signal optimization
 * fill `sell_strategy_generator` - for sell signal optimization
-* fill `sell_indicator_space` - for sell signal optimzation
+* fill `sell_indicator_space` - for sell signal optimization
 
 !!! Note
     `populate_indicators` needs to create all indicators any of thee spaces may use, otherwise hyperopt will not work.
@@ -81,11 +81,11 @@ There are two places you need to change in your hyperopt file to add a new buy h
 There you have two different types of indicators: 1. `guards` and 2. `triggers`.
 
 1. Guards are conditions like "never buy if ADX < 10", or never buy if current price is over EMA10.
-2. Triggers are ones that actually trigger buy in specific moment, like "buy when EMA5 crosses over EMA10" or "buy when close price touches lower bollinger band".
+2. Triggers are ones that actually trigger buy in specific moment, like "buy when EMA5 crosses over EMA10" or "buy when close price touches lower Bollinger band".
 
 Hyperoptimization will, for each eval round, pick one trigger and possibly
 multiple guards. The constructed strategy will be something like
-"*buy exactly when close price touches lower bollinger band, BUT only if
+"*buy exactly when close price touches lower Bollinger band, BUT only if
 ADX > 10*".
 
 If you have updated the buy strategy, i.e. changed the contents of
@@ -172,7 +172,7 @@ So let's write the buy strategy using these values:
 Hyperopting will now call this `populate_buy_trend` as many times you ask it (`epochs`)
 with different value combinations. It will then use the given historical data and make
 buys based on the buy signals generated with the above function and based on the results
-it will end with telling you which paramter combination produced the best profits.
+it will end with telling you which parameter combination produced the best profits.
 
 The above setup expects to find ADX, RSI and Bollinger Bands in the populated indicators.
 When you want to test an indicator that isn't used by the bot currently, remember to
@@ -191,8 +191,10 @@ Currently, the following loss functions are builtin:
 
 * `DefaultHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function)
 * `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
-* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on the trade returns)
-* `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on daily trade returns)
+* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on trade returns relative to standard deviation)
+* `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on **daily** trade returns relative to standard deviation)
+* `SortinoHyperOptLoss` (optimizes Sortino Ratio calculated on trade returns relative to **downside** standard deviation)
+* `SortinoHyperOptLossDaily` (optimizes Sortino Ratio calculated on **daily** trade returns relative to **downside** standard deviation)
 
 Creation of a custom loss function is covered in the [Advanced Hyperopt](advanced-hyperopt.md) part of the documentation.
 
@@ -272,7 +274,7 @@ In some situations, you may need to run Hyperopt (and Backtesting) with the
 By default, hyperopt emulates the behavior of the Freqtrade Live Run/Dry Run, where only one
 open trade is allowed for every traded pair. The total number of trades open for all pairs
 is also limited by the `max_open_trades` setting. During Hyperopt/Backtesting this may lead to
-some potential trades to be hidden (or masked) by previosly open trades.
+some potential trades to be hidden (or masked) by previously open trades.
 
 The `--eps`/`--enable-position-stacking` argument allows emulation of buying the same pair multiple times,
 while `--dmmp`/`--disable-max-market-positions` disables applying `max_open_trades`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 This page explains how to prepare your environment for running the bot.
 
+Please consider using the prebuilt [docker images](docker.md) to get started quickly while trying out freqtrade evaluating how it operates.
+
 ## Prerequisite
 
 ### Requirements
@@ -14,15 +16,7 @@ Click each one for install guide:
 * [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
 * [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html) (install instructions below)
 
-### API keys
-
-Before running your bot in production you will need to setup few
-external API. In production mode, the bot will require valid Exchange API
-credentials. We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot) (optional but recommended).
-
-### Setup your exchange account
-
-You will need to create API Keys (Usually you get `key` and `secret`) from the Exchange website and insert this into the appropriate fields in the configuration or when asked by the installation script.
+ We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot), which is optional but recommended.
 
 ## Quick start
 
@@ -65,11 +59,11 @@ usage:
 
 ** --install **
 
-With this option, the script will install everything you need to run the bot:
+With this option, the script will install the bot and most dependencies:
+You will need to have git and python3.6+ installed beforehand for this to work.
 
 * Mandatory software as: `ta-lib`
-* Setup your virtualenv
-* Configure your `config.json` file
+* Setup your virtualenv under `.env/`
 
 This option is a combination of installation tasks, `--reset` and `--config`.
 
@@ -83,7 +77,7 @@ This option will hard reset your branch (only if you are on either `master` or `
 
 ** --config **
 
-Use this option to configure the `config.json` configuration file. The script will interactively ask you questions to setup your bot and create your `config.json`.
+DEPRECATED - use `freqtrade new-config -c config.json` instead.
 
 ------
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -249,6 +249,23 @@ minimal_roi = {
 
 While technically not completely disabled, this would sell once the trade reaches 10000% Profit.
 
+To use times based on candle duration (ticker_interval or timeframe), the following snippet can be handy.
+This will allow you to change the ticket_interval for the strategy, and ROI times will still be set as candles (e.g. after 3 candles ...)
+
+``` python
+from freqtrade.exchange import timeframe_to_minutes
+
+class AwesomeStrategy(IStrategy):
+
+    ticker_interval = "1d"
+    ticker_interval_mins = timeframe_to_minutes(ticker_interval)
+    minimal_roi = {
+        "0": 0.05,                             # 5% for the first 3 candles
+        str(ticker_interval_mins * 3)): 0.02,  # 2% after 3 candles
+        str(ticker_interval_mins * 6)): 0.01,  # 1% After 6 candles
+    }
+```
+
 ### Stoploss
 
 Setting a stoploss is highly recommended to protect your capital from strong moves against you.

--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -121,7 +121,6 @@ from freqtrade.data.btanalysis import analyze_trade_parallelism
 # Analyze the above
 parallel_trades = analyze_trade_parallelism(trades, '5m')
 
-
 parallel_trades.plot()
 ```
 
@@ -134,11 +133,14 @@ Freqtrade offers interactive plotting capabilities based on plotly.
 from freqtrade.plot.plotting import  generate_candlestick_graph
 # Limit graph period to keep plotly quick and reactive
 
+# Filter trades to one pair
+trades_red = trades.loc[trades['pair'] == pair]
+
 data_red = data['2019-06-01':'2019-06-10']
 # Generate candlestick graph
 graph = generate_candlestick_graph(pair=pair,
                                    data=data_red,
-                                   trades=trades,
+                                   trades=trades_red,
                                    indicators1=['sma20', 'ema50', 'ema55'],
                                    indicators2=['rsi', 'macd', 'macdsignal', 'macdhist']
                                   )

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -257,7 +257,8 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify the class name of the hyperopt loss function class (IHyperOptLoss). '
         'Different functions can generate completely different results, '
         'since the target for optimization is different. Built-in Hyperopt-loss-functions are: '
-        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss, SharpeHyperOptLossDaily.'
+        'DefaultHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss, SharpeHyperOptLossDaily, '
+        'SortinoHyperOptLoss, SortinoHyperOptLossDaily.'
         '(default: `%(default)s`).',
         metavar='NAME',
         default=constants.DEFAULT_HYPEROPT_LOSS,

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -97,10 +97,10 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
 
     if n > trials_epochs:
         raise OperationalException(
-                f"The index of the epoch to show should be less than {trials_epochs + 1}.")
+            f"The index of the epoch to show should be less than {trials_epochs + 1}.")
     if n < -trials_epochs:
         raise OperationalException(
-                f"The index of the epoch to show should be greater than {-trials_epochs - 1}.")
+            f"The index of the epoch to show should be greater than {-trials_epochs - 1}.")
 
     # Translate epoch index from human-readable format to pythonic
     if n > 0:
@@ -122,52 +122,52 @@ def _hyperopt_filter_trials(trials: List, filteroptions: dict) -> List:
         trials = [x for x in trials if x['results_metrics']['profit'] > 0]
     if filteroptions['filter_min_trades'] > 0:
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['trade_count'] > filteroptions['filter_min_trades']
-                 ]
+            x for x in trials
+            if x['results_metrics']['trade_count'] > filteroptions['filter_min_trades']
+        ]
     if filteroptions['filter_max_trades'] > 0:
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['trade_count'] < filteroptions['filter_max_trades']
-                 ]
+            x for x in trials
+            if x['results_metrics']['trade_count'] < filteroptions['filter_max_trades']
+        ]
     if filteroptions['filter_min_avg_time'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['duration'] > filteroptions['filter_min_avg_time']
-                 ]
+            x for x in trials
+            if x['results_metrics']['duration'] > filteroptions['filter_min_avg_time']
+        ]
     if filteroptions['filter_max_avg_time'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['duration'] < filteroptions['filter_max_avg_time']
-                 ]
+            x for x in trials
+            if x['results_metrics']['duration'] < filteroptions['filter_max_avg_time']
+        ]
     if filteroptions['filter_min_avg_profit'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['avg_profit']
-                    > filteroptions['filter_min_avg_profit']
-                 ]
+            x for x in trials
+            if x['results_metrics']['avg_profit']
+            > filteroptions['filter_min_avg_profit']
+        ]
     if filteroptions['filter_max_avg_profit'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['avg_profit']
-                    < filteroptions['filter_max_avg_profit']
-                 ]
+            x for x in trials
+            if x['results_metrics']['avg_profit']
+            < filteroptions['filter_max_avg_profit']
+        ]
     if filteroptions['filter_min_total_profit'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['profit'] > filteroptions['filter_min_total_profit']
-                 ]
+            x for x in trials
+            if x['results_metrics']['profit'] > filteroptions['filter_min_total_profit']
+        ]
     if filteroptions['filter_max_total_profit'] is not None:
         trials = [x for x in trials if x['results_metrics']['trade_count'] > 0]
         trials = [
-                    x for x in trials
-                    if x['results_metrics']['profit'] < filteroptions['filter_max_total_profit']
-                 ]
+            x for x in trials
+            if x['results_metrics']['profit'] < filteroptions['filter_max_total_profit']
+        ]
 
     logger.info(f"{len(trials)} " +
                 ("best " if filteroptions['only_best'] else "") +

--- a/freqtrade/commands/list_commands.py
+++ b/freqtrade/commands/list_commands.py
@@ -58,7 +58,7 @@ def _print_objs_tabular(objs: List, print_colorized: bool) -> None:
                    else yellow + "DUPLICATE NAME" + reset)
     } for s in objs]
 
-    print(tabulate(objss_to_print, headers='keys', tablefmt='pipe'))
+    print(tabulate(objss_to_print, headers='keys', tablefmt='psql', stralign='right'))
 
 
 def start_list_strategies(args: Dict[str, Any]) -> None:
@@ -192,7 +192,7 @@ def start_list_markets(args: Dict[str, Any], pairs_only: bool = False) -> None:
             else:
                 # print data as a table, with the human-readable summary
                 print(f"{summary_str}:")
-                print(tabulate(tabular_data, headers='keys', tablefmt='pipe'))
+                print(tabulate(tabular_data, headers='keys', tablefmt='psql', stralign='right'))
         elif not (args.get('print_one_column', False) or
                   args.get('list_pairs_print_json', False) or
                   args.get('print_csv', False)):

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -150,15 +150,3 @@ def _validate_whitelist(conf: Dict[str, Any]) -> None:
         if (pl.get('method') == 'StaticPairList'
                 and not conf.get('exchange', {}).get('pair_whitelist')):
             raise OperationalException("StaticPairList requires pair_whitelist to be set.")
-
-        if pl.get('method') == 'StaticPairList':
-            stake = conf['stake_currency']
-            invalid_pairs = []
-            for pair in conf['exchange'].get('pair_whitelist'):
-                if not pair.endswith(f'/{stake}'):
-                    invalid_pairs.append(pair)
-
-            if invalid_pairs:
-                raise OperationalException(
-                    f"Stake-currency '{stake}' not compatible with pair-whitelist. "
-                    f"Please remove the following pairs: {invalid_pairs}")

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -96,6 +96,8 @@ class Configuration:
         # Keep a copy of the original configuration file
         config['original_config'] = deepcopy(config)
 
+        self._process_logging_options(config)
+
         self._process_runmode(config)
 
         self._process_common_options(config)
@@ -145,8 +147,6 @@ class Configuration:
         logger.info(f'Using DB: "{config["db_url"]}"')
 
     def _process_common_options(self, config: Dict[str, Any]) -> None:
-
-        self._process_logging_options(config)
 
         # Set strategy if not specified in config and or if it's non default
         if self.args.get("strategy") or not config.get('strategy'):
@@ -379,7 +379,7 @@ class Configuration:
         if not self.runmode:
             # Handle real mode, infer dry/live from config
             self.runmode = RunMode.DRY_RUN if config.get('dry_run', True) else RunMode.LIVE
-            logger.info(f"Runmode set to {self.runmode}.")
+            logger.info(f"Runmode set to {self.runmode.value}.")
 
         config.update({'runmode': self.runmode})
 

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -167,10 +167,6 @@ class Configuration:
         if 'sd_notify' in self.args and self.args["sd_notify"]:
             config['internals'].update({'sd_notify': True})
 
-        self._args_to_config(config, argname='dry_run',
-                             logstring='Parameter --dry-run detected, '
-                             'overriding dry_run to: {} ...')
-
     def _process_datadir_options(self, config: Dict[str, Any]) -> None:
         """
         Extract information for sys.argv and load directory configurations
@@ -375,6 +371,10 @@ class Configuration:
                              logstring='Using "{}" to store trades data.')
 
     def _process_runmode(self, config: Dict[str, Any]) -> None:
+
+        self._args_to_config(config, argname='dry_run',
+                             logstring='Parameter --dry-run detected, '
+                             'overriding dry_run to: {} ...')
 
         if not self.runmode:
             # Handle real mode, infer dry/live from config

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -251,7 +251,6 @@ CONF_SCHEMA = {
                     'type': 'array',
                     'items': {
                         'type': 'string',
-                        'pattern': '^[0-9A-Z]+/[0-9A-Z]+$'
                     },
                     'uniqueItems': True
                 },
@@ -259,7 +258,6 @@ CONF_SCHEMA = {
                     'type': 'array',
                     'items': {
                         'type': 'string',
-                        'pattern': '^[0-9A-Z]+/[0-9A-Z]+$'
                     },
                     'uniqueItems': True
                 },

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1023,7 +1023,7 @@ def is_exchange_known_ccxt(exchange_name: str, ccxt_module: CcxtModuleType = Non
 
 
 def is_exchange_officially_supported(exchange_name: str) -> bool:
-    return exchange_name in ['bittrex', 'binance']
+    return exchange_name in ['bittrex', 'binance', 'kraken']
 
 
 def ccxt_exchanges(ccxt_module: CcxtModuleType = None) -> List[str]:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -332,7 +332,8 @@ class Exchange:
                 logger.warning(f"Pair {pair} is restricted for some users on this exchange."
                                f"Please check if you are impacted by this restriction "
                                f"on the exchange and eventually remove {pair} from your whitelist.")
-            if not self.get_pair_quote_currency(pair) == self._config['stake_currency']:
+            if (self._config['stake_currency'] and
+                    self.get_pair_quote_currency(pair) != self._config['stake_currency']):
                 invalid_pairs.append(pair)
         if invalid_pairs:
             raise OperationalException(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -423,28 +423,37 @@ class Backtesting:
                                             strategy if len(self.strategylist) > 1 else None)
 
             print(f"Result for strategy {strategy}")
-            print(' BACKTESTING REPORT '.center(133, '='))
-            print(generate_text_table(data,
-                                      stake_currency=self.config['stake_currency'],
-                                      max_open_trades=self.config['max_open_trades'],
-                                      results=results))
+            table = generate_text_table(data, stake_currency=self.config['stake_currency'],
+                                        max_open_trades=self.config['max_open_trades'],
+                                        results=results)
+            if isinstance(table, str):
+                print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
+            print(table)
 
-            print(' SELL REASON STATS '.center(133, '='))
-            print(generate_text_table_sell_reason(data,
-                                                  stake_currency=self.config['stake_currency'],
-                                                  max_open_trades=self.config['max_open_trades'],
-                                                  results=results))
+            table = generate_text_table_sell_reason(data,
+                                                    stake_currency=self.config['stake_currency'],
+                                                    max_open_trades=self.config['max_open_trades'],
+                                                    results=results)
+            if isinstance(table, str):
+                print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
+            print(table)
 
-            print(' LEFT OPEN TRADES REPORT '.center(133, '='))
-            print(generate_text_table(data,
-                                      stake_currency=self.config['stake_currency'],
-                                      max_open_trades=self.config['max_open_trades'],
-                                      results=results.loc[results.open_at_end], skip_nan=True))
+            table = generate_text_table(data,
+                                        stake_currency=self.config['stake_currency'],
+                                        max_open_trades=self.config['max_open_trades'],
+                                        results=results.loc[results.open_at_end], skip_nan=True)
+            if isinstance(table, str):
+                print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))
+            print(table)
+            if isinstance(table, str):
+                print('=' * len(table.splitlines()[0]))
             print()
         if len(all_results) > 1:
             # Print Strategy summary table
-            print(' STRATEGY SUMMARY '.center(133, '='))
-            print(generate_text_table_strategy(self.config['stake_currency'],
-                                               self.config['max_open_trades'],
-                                               all_results=all_results))
+            table = generate_text_table_strategy(self.config['stake_currency'],
+                                                 self.config['max_open_trades'],
+                                                 all_results=all_results)
+            print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
+            print(table)
+            print('=' * len(table.splitlines()[0]))
             print('\nFor more details, please look at the detail tables above')

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -460,7 +460,7 @@ class Hyperopt:
             'total_profit': total_profit,
         }
 
-        def _calculate_results_metrics(self, backtesting_results: DataFrame) -> Dict:
+    def _calculate_results_metrics(self, backtesting_results: DataFrame) -> Dict:
         return {
             'trade_count': len(backtesting_results.index),
             'wins': len(backtesting_results[backtesting_results.profit_percent > 0]),

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -460,10 +460,14 @@ class Hyperopt:
             'total_profit': total_profit,
         }
 
-    def _calculate_results_metrics(self, backtesting_results: DataFrame) -> Dict:
+        def _calculate_results_metrics(self, backtesting_results: DataFrame) -> Dict:
         return {
             'trade_count': len(backtesting_results.index),
+            'wins': len(backtesting_results[backtesting_results.profit_percent > 0]),
+            'draws': len(backtesting_results[backtesting_results.profit_percent == 0]),
+            'losses': len(backtesting_results[backtesting_results.profit_percent < 0]),
             'avg_profit': backtesting_results.profit_percent.mean() * 100.0,
+            'median_profit': backtesting_results.profit_percent.median() * 100.0,
             'total_profit': backtesting_results.profit_abs.sum(),
             'profit': backtesting_results.profit_percent.sum() * 100.0,
             'duration': backtesting_results.trade_duration.mean(),
@@ -475,7 +479,11 @@ class Hyperopt:
         """
         stake_cur = self.config['stake_currency']
         return (f"{results_metrics['trade_count']:6d} trades. "
+                f"{results_metrics['wins']:6d} wins. "
+                f"{results_metrics['draws']:6d} draws. "
+                f"{results_metrics['losses']:6d} losses. "
                 f"Avg profit {results_metrics['avg_profit']: 6.2f}%. "
+                f"Median profit {results_metrics['median_profit']: 6.2f}%. "
                 f"Total profit {results_metrics['total_profit']: 11.8f} {stake_cur} "
                 f"({results_metrics['profit']: 7.2f}\N{GREEK CAPITAL LETTER SIGMA}%). "
                 f"Avg duration {results_metrics['duration']:5.1f} min."

--- a/freqtrade/optimize/hyperopt_loss_sortino.py
+++ b/freqtrade/optimize/hyperopt_loss_sortino.py
@@ -1,0 +1,49 @@
+"""
+SortinoHyperOptLoss
+
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
+from datetime import datetime
+
+from pandas import DataFrame
+import numpy as np
+
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+class SortinoHyperOptLoss(IHyperOptLoss):
+    """
+    Defines the loss function for hyperopt.
+
+    This implementation uses the Sortino Ratio calculation.
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               *args, **kwargs) -> float:
+        """
+        Objective function, returns smaller number for more optimal results.
+
+        Uses Sortino Ratio calculation.
+        """
+        total_profit = results["profit_percent"]
+        days_period = (max_date - min_date).days
+
+        # adding slippage of 0.1% per trade
+        total_profit = total_profit - 0.0005
+        expected_returns_mean = total_profit.sum() / days_period
+
+        results['downside_returns'] = 0
+        results.loc[total_profit < 0, 'downside_returns'] = results['profit_percent']
+        down_stdev = np.std(results['downside_returns'])
+
+        if np.std(total_profit) != 0.0:
+            sortino_ratio = expected_returns_mean / down_stdev * np.sqrt(365)
+        else:
+            # Define high (negative) sortino ratio to be clear that this is NOT optimal.
+            sortino_ratio = -20.
+
+        # print(expected_returns_mean, down_stdev, sortino_ratio)
+        return -sortino_ratio

--- a/freqtrade/optimize/hyperopt_loss_sortino_daily.py
+++ b/freqtrade/optimize/hyperopt_loss_sortino_daily.py
@@ -1,0 +1,70 @@
+"""
+SortinoHyperOptLossDaily
+
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
+import math
+from datetime import datetime
+
+from pandas import DataFrame, date_range
+
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+class SortinoHyperOptLossDaily(IHyperOptLoss):
+    """
+    Defines the loss function for hyperopt.
+
+    This implementation uses the Sortino Ratio calculation.
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               *args, **kwargs) -> float:
+        """
+        Objective function, returns smaller number for more optimal results.
+
+        Uses Sortino Ratio calculation.
+
+        Sortino Ratio calculated as described in
+        http://www.redrockcapital.com/Sortino__A__Sharper__Ratio_Red_Rock_Capital.pdf
+        """
+        resample_freq = '1D'
+        slippage_per_trade_ratio = 0.0005
+        days_in_year = 365
+        minimum_acceptable_return = 0.0
+
+        # apply slippage per trade to profit_percent
+        results.loc[:, 'profit_percent_after_slippage'] = \
+            results['profit_percent'] - slippage_per_trade_ratio
+
+        # create the index within the min_date and end max_date
+        t_index = date_range(start=min_date, end=max_date, freq=resample_freq,
+                             normalize=True)
+
+        sum_daily = (
+            results.resample(resample_freq, on='close_time').agg(
+                {"profit_percent_after_slippage": sum}).reindex(t_index).fillna(0)
+        )
+
+        total_profit = sum_daily["profit_percent_after_slippage"] - minimum_acceptable_return
+        expected_returns_mean = total_profit.mean()
+
+        sum_daily['downside_returns'] = 0
+        sum_daily.loc[total_profit < 0, 'downside_returns'] = total_profit
+        total_downside = sum_daily['downside_returns']
+        # Here total_downside contains min(0, P - MAR) values,
+        # where P = sum_daily["profit_percent_after_slippage"]
+        down_stdev = math.sqrt((total_downside**2).sum() / len(total_downside))
+
+        if (down_stdev != 0.):
+            sortino_ratio = expected_returns_mean / down_stdev * math.sqrt(days_in_year)
+        else:
+            # Define high (negative) sortino ratio to be clear that this is NOT optimal.
+            sortino_ratio = -20.
+
+        # print(t_index, sum_daily, total_profit)
+        # print(minimum_acceptable_return, expected_returns_mean, down_stdev, sortino_ratio)
+        return -sortino_ratio

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -66,7 +66,7 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
     ])
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore
 
 
 def generate_text_table_sell_reason(
@@ -112,7 +112,7 @@ def generate_text_table_sell_reason(
                 profit_percent_tot,
             ]
         )
-    return tabulate(tabular_data, headers=headers, tablefmt="pipe")
+    return tabulate(tabular_data, headers=headers, tablefmt="orgtbl", stralign="right")
 
 
 def generate_text_table_strategy(stake_currency: str, max_open_trades: str,
@@ -146,7 +146,7 @@ def generate_text_table_strategy(stake_currency: str, max_open_trades: str,
         ])
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore
 
 
 def generate_edge_table(results: dict) -> str:
@@ -172,4 +172,4 @@ def generate_edge_table(results: dict) -> str:
 
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore

--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -99,7 +99,8 @@ class IPairList(ABC):
                 logger.warning(f"Pair {pair} is not compatible with exchange "
                                f"{self._exchange.name}. Removing it from whitelist..")
                 continue
-            if not pair.endswith(self._config['stake_currency']):
+
+            if self._exchange.get_pair_quote_currency(pair) != self._config['stake_currency']:
                 logger.warning(f"Pair {pair} is not compatible with your stake currency "
                                f"{self._config['stake_currency']}. Removing it from whitelist..")
                 continue

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -91,9 +91,9 @@ class VolumePairList(IPairList):
 
         if self._pairlist_pos == 0:
             # If VolumePairList is the first in the list, use fresh pairlist
-            # check length so that we make sure that '/' is actually in the string
+            # Check if pair quote currency equals to the stake currency.
             filtered_tickers = [v for k, v in tickers.items()
-                                if (len(k.split('/')) == 2 and k.split('/')[1] == base_currency
+                                if (self._exchange.get_pair_quote_currency(k) == base_currency
                                     and v[key] is not None)]
         else:
             # If other pairlist is in front, use the incomming pairlist.

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -460,9 +460,9 @@ class RPC:
         if self._freqtrade.state != State.RUNNING:
             raise RPCException('trader is not running')
 
-        # Check pair is in stake currency
+        # Check if pair quote currency equals to the stake currency.
         stake_currency = self._freqtrade.config.get('stake_currency')
-        if not pair.endswith(stake_currency):
+        if not self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency:
             raise RPCException(
                 f'Wrong pair selected. Please pairs with stake {stake_currency} pairs only')
         # check if valid pair
@@ -517,7 +517,7 @@ class RPC:
         if add:
             stake_currency = self._freqtrade.config.get('stake_currency')
             for pair in add:
-                if (pair.endswith(stake_currency)
+                if (self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency
                         and pair not in self._freqtrade.pairlists.blacklist):
                     self._freqtrade.pairlists.blacklist.append(pair)
 

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -190,7 +190,6 @@
     "# Analyze the above\n",
     "parallel_trades = analyze_trade_parallelism(trades, '5m')\n",
     "\n",
-    "\n",
     "parallel_trades.plot()"
    ]
   },
@@ -212,11 +211,14 @@
     "from freqtrade.plot.plotting import  generate_candlestick_graph\n",
     "# Limit graph period to keep plotly quick and reactive\n",
     "\n",
+    "# Filter trades to one pair\n",
+    "trades_red = trades.loc[trades['pair'] == pair]\n",
+    "\n",
     "data_red = data['2019-06-01':'2019-06-10']\n",
     "# Generate candlestick graph\n",
     "graph = generate_candlestick_graph(pair=pair,\n",
     "                                   data=data_red,\n",
-    "                                   trades=trades,\n",
+    "                                   trades=trades_red,\n",
     "                                   indicators1=['sma20', 'ema50', 'ema55'],\n",
     "                                   indicators2=['rsi', 'macd', 'macdsignal', 'macdhist']\n",
     "                                  )\n",

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -74,7 +74,7 @@ class Wallets:
         )
 
         for trade in open_trades:
-            curr = trade.pair.split('/')[0]
+            curr = self._exchange.get_pair_base_currency(trade.pair)
             _wallets[curr] = Wallet(
                 curr,
                 trade.amount,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Freqtrade
 nav:
-    - About: index.md
-    - Installation: installation.md
+    - Home: index.md
     - Installation Docker: docker.md
+    - Installation: installation.md
     - Configuration: configuration.md
     - Strategy Customization: strategy-customization.md
     - Stoploss: stoploss.md

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -447,11 +447,9 @@ def test_create_datadir_failed(caplog):
 
 
 def test_create_datadir(caplog, mocker):
-    # Ensure that caplog is empty before starting ...
-    # Should prevent random failures.
-    caplog.clear()
-    # Added assert here to analyze random test-failures ...
-    assert len(caplog.record_tuples) == 0
+
+    # Capture caplog length here trying to avoid random test failure
+    len_caplog_before = len(caplog.record_tuples)
 
     cud = mocker.patch("freqtrade.commands.deploy_commands.create_userdata_dir", MagicMock())
     csf = mocker.patch("freqtrade.commands.deploy_commands.copy_sample_files", MagicMock())
@@ -464,7 +462,7 @@ def test_create_datadir(caplog, mocker):
 
     assert cud.call_count == 1
     assert csf.call_count == 1
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == len_caplog_before
 
 
 def test_start_new_strategy(mocker, caplog):

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -217,8 +217,9 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 9 active markets: "
-            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, NEO/BTC, TKN/BTC, XLTCUSDT, XRP/BTC.\n"
+    assert ("Exchange Bittrex has 10 active markets: "
+            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/ETH, LTC/USD, NEO/BTC, "
+            "TKN/BTC, XLTCUSDT, XRP/BTC.\n"
             in captured.out)
 
     patch_exchange(mocker, api_mock=api_mock, id="binance")
@@ -231,7 +232,7 @@ def test_list_markets(mocker, markets, capsys):
     pargs['config'] = None
     start_list_markets(pargs, False)
     captured = capsys.readouterr()
-    assert re.match("\nExchange Binance has 9 active markets:\n",
+    assert re.match("\nExchange Binance has 10 active markets:\n",
                     captured.out)
 
     patch_exchange(mocker, api_mock=api_mock, id="bittrex")
@@ -243,8 +244,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 11 markets: "
-            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, LTC/USDT, NEO/BTC, "
+    assert ("Exchange Bittrex has 12 markets: "
+            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/ETH, LTC/USD, LTC/USDT, NEO/BTC, "
             "TKN/BTC, XLTCUSDT, XRP/BTC.\n"
             in captured.out)
 
@@ -256,8 +257,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), True)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 8 active pairs: "
-            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, NEO/BTC, TKN/BTC, XRP/BTC.\n"
+    assert ("Exchange Bittrex has 9 active pairs: "
+            "BLK/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/ETH, LTC/USD, NEO/BTC, TKN/BTC, XRP/BTC.\n"
             in captured.out)
 
     # Test list-pairs subcommand with --all: all pairs
@@ -268,8 +269,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), True)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 10 pairs: "
-            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, LTC/USDT, NEO/BTC, "
+    assert ("Exchange Bittrex has 11 pairs: "
+            "BLK/BTC, BTT/BTC, ETH/BTC, ETH/USDT, LTC/BTC, LTC/ETH, LTC/USD, LTC/USDT, NEO/BTC, "
             "TKN/BTC, XRP/BTC.\n"
             in captured.out)
 
@@ -282,8 +283,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 5 active markets with ETH, LTC as base currencies: "
-            "ETH/BTC, ETH/USDT, LTC/BTC, LTC/USD, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 6 active markets with ETH, LTC as base currencies: "
+            "ETH/BTC, ETH/USDT, LTC/BTC, LTC/ETH, LTC/USD, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, base=LTC
@@ -295,8 +296,8 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 3 active markets with LTC as base currency: "
-            "LTC/BTC, LTC/USD, XLTCUSDT.\n"
+    assert ("Exchange Bittrex has 4 active markets with LTC as base currency: "
+            "LTC/BTC, LTC/ETH, LTC/USD, XLTCUSDT.\n"
             in captured.out)
 
     # active markets, quote=USDT, USD
@@ -384,7 +385,7 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ("Exchange Bittrex has 9 active markets:\n"
+    assert ("Exchange Bittrex has 10 active markets:\n"
             in captured.out)
 
     # Test tabular output, no markets found
@@ -407,7 +408,7 @@ def test_list_markets(mocker, markets, capsys):
     ]
     start_list_markets(get_args(args), False)
     captured = capsys.readouterr()
-    assert ('["BLK/BTC","ETH/BTC","ETH/USDT","LTC/BTC","LTC/USD","NEO/BTC",'
+    assert ('["BLK/BTC","ETH/BTC","ETH/USDT","LTC/BTC","LTC/ETH","LTC/USD","NEO/BTC",'
             '"TKN/BTC","XLTCUSDT","XRP/BTC"]'
             in captured.out)
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -781,6 +781,20 @@ def test_hyperopt_list(mocker, capsys, hyperopt_results):
                          " 11/12", " 12/12"])
     args = [
         "hyperopt-list",
+        "--profitable"
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    start_hyperopt_list(pargs)
+    captured = capsys.readouterr()
+    assert all(x in captured.out
+               for x in [" 2/12", " 10/12", "Best result:", "Buy hyperspace params",
+                         "Sell hyperspace params", "ROI table", "Stoploss"])
+    assert all(x not in captured.out
+               for x in [" 1/12", " 3/12", " 4/12", " 5/12", " 6/12", " 7/12", " 8/12", " 9/12",
+                         " 11/12", " 12/12"])
+    args = [
+        "hyperopt-list",
         "--no-details",
         "--no-color",
         "--min-trades", "20"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -575,7 +575,34 @@ def get_markets():
                 }
             },
             'info': {},
-        }
+        },
+        'LTC/ETH': {
+            'id': 'LTCETH',
+            'symbol': 'LTC/ETH',
+            'base': 'LTC',
+            'quote': 'ETH',
+            'active': True,
+            'precision': {
+                'base': 8,
+                'quote': 8,
+                'amount': 3,
+                'price': 5
+            },
+            'limits': {
+                'amount': {
+                    'min': 0.001,
+                    'max': 10000000.0
+                },
+                'price': {
+                    'min': 1e-05,
+                    'max': 1000.0
+                },
+                'cost': {
+                    'min': 0.01,
+                    'max': None
+                }
+            },
+        },
     }
 
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -511,6 +511,22 @@ def test_validate_pairs_stakecompatibility(default_conf, mocker, caplog):
     Exchange(default_conf)
 
 
+def test_validate_pairs_stakecompatibility_downloaddata(default_conf, mocker, caplog):
+    api_mock = MagicMock()
+    default_conf['stake_currency'] = ''
+    type(api_mock).markets = PropertyMock(return_value={
+        'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC'}, 'NEO/BTC': {'quote': 'BTC'},
+        'HELLO-WORLD': {'quote': 'BTC'},
+    })
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
+    mocker.patch('freqtrade.exchange.Exchange._load_async_markets')
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
+
+    Exchange(default_conf)
+
+
 def test_validate_pairs_stakecompatibility_fail(default_conf, mocker, caplog):
     default_conf['exchange']['pair_whitelist'].append('HELLO-WORLD')
     api_mock = MagicMock()

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -400,13 +400,40 @@ def test_validate_stake_currency_error(default_conf, mocker, caplog):
 def test_get_quote_currencies(default_conf, mocker):
     ex = get_patched_exchange(mocker, default_conf)
 
-    assert set(ex.get_quote_currencies()) == set(['USD', 'BTC', 'USDT'])
+    assert set(ex.get_quote_currencies()) == set(['USD', 'ETH', 'BTC', 'USDT'])
+
+
+@pytest.mark.parametrize('pair,expected', [
+    ('XRP/BTC', 'BTC'),
+    ('LTC/USD', 'USD'),
+    ('ETH/USDT', 'USDT'),
+    ('XLTCUSDT', 'USDT'),
+    ('XRP/NOCURRENCY', ''),
+])
+def test_get_pair_quote_currency(default_conf, mocker, pair, expected):
+    ex = get_patched_exchange(mocker, default_conf)
+    assert ex.get_pair_quote_currency(pair) == expected
+
+
+@pytest.mark.parametrize('pair,expected', [
+    ('XRP/BTC', 'XRP'),
+    ('LTC/USD', 'LTC'),
+    ('ETH/USDT', 'ETH'),
+    ('XLTCUSDT', 'LTC'),
+    ('XRP/NOCURRENCY', ''),
+])
+def test_get_pair_base_currency(default_conf, mocker, pair, expected):
+    ex = get_patched_exchange(mocker, default_conf)
+    assert ex.get_pair_base_currency(pair) == expected
 
 
 def test_validate_pairs(default_conf, mocker):  # test exchange.validate_pairs directly
     api_mock = MagicMock()
     type(api_mock).markets = PropertyMock(return_value={
-        'ETH/BTC': {}, 'LTC/BTC': {}, 'XRP/BTC': {}, 'NEO/BTC': {}
+        'ETH/BTC': {'quote': 'BTC'},
+        'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC'},
+        'NEO/BTC': {'quote': 'BTC'},
     })
     id_mock = PropertyMock(return_value='test_exchange')
     type(api_mock).id = id_mock
@@ -454,9 +481,9 @@ def test_validate_pairs_exception(default_conf, mocker, caplog):
 def test_validate_pairs_restricted(default_conf, mocker, caplog):
     api_mock = MagicMock()
     type(api_mock).markets = PropertyMock(return_value={
-        'ETH/BTC': {}, 'LTC/BTC': {},
-        'XRP/BTC': {'info': {'IsRestricted': True}},
-        'NEO/BTC': {'info': 'TestString'},  # info can also be a string ...
+        'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC', 'info': {'IsRestricted': True}},
+        'NEO/BTC': {'quote': 'BTC', 'info': 'TestString'},  # info can also be a string ...
     })
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
@@ -467,6 +494,38 @@ def test_validate_pairs_restricted(default_conf, mocker, caplog):
     assert log_has(f"Pair XRP/BTC is restricted for some users on this exchange."
                    f"Please check if you are impacted by this restriction "
                    f"on the exchange and eventually remove XRP/BTC from your whitelist.", caplog)
+
+
+def test_validate_pairs_stakecompatibility(default_conf, mocker, caplog):
+    api_mock = MagicMock()
+    type(api_mock).markets = PropertyMock(return_value={
+        'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC'}, 'NEO/BTC': {'quote': 'BTC'},
+        'HELLO-WORLD': {'quote': 'BTC'},
+    })
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
+    mocker.patch('freqtrade.exchange.Exchange._load_async_markets')
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
+
+    Exchange(default_conf)
+
+
+def test_validate_pairs_stakecompatibility_fail(default_conf, mocker, caplog):
+    default_conf['exchange']['pair_whitelist'].append('HELLO-WORLD')
+    api_mock = MagicMock()
+    type(api_mock).markets = PropertyMock(return_value={
+        'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC'}, 'NEO/BTC': {'quote': 'BTC'},
+        'HELLO-WORLD': {'quote': 'USDT'},
+    })
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
+    mocker.patch('freqtrade.exchange.Exchange._load_async_markets')
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
+
+    with pytest.raises(OperationalException, match=r"Stake-currency 'BTC' not compatible with.*"):
+        Exchange(default_conf)
 
 
 @pytest.mark.parametrize("timeframe", [
@@ -1819,6 +1878,7 @@ def test_get_valid_pair_combination(default_conf, mocker, markets):
         # 'ETH/BTC':  'active': True
         # 'ETH/USDT': 'active': True
         # 'LTC/BTC':  'active': False
+        # 'LTC/ETH':  'active': True
         # 'LTC/USD':  'active': True
         # 'LTC/USDT': 'active': True
         # 'NEO/BTC':  'active': False
@@ -1827,26 +1887,26 @@ def test_get_valid_pair_combination(default_conf, mocker, markets):
         # 'XRP/BTC':  'active': False
         # all markets
         ([], [], False, False,
-         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD',
+         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/ETH', 'LTC/USD',
           'LTC/USDT', 'NEO/BTC', 'TKN/BTC', 'XLTCUSDT', 'XRP/BTC']),
         # active markets
         ([], [], False, True,
-         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'NEO/BTC',
+         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/ETH', 'LTC/USD', 'NEO/BTC',
           'TKN/BTC', 'XLTCUSDT', 'XRP/BTC']),
         # all pairs
         ([], [], True, False,
-         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD',
+         ['BLK/BTC', 'BTT/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/ETH', 'LTC/USD',
           'LTC/USDT', 'NEO/BTC', 'TKN/BTC', 'XRP/BTC']),
         # active pairs
         ([], [], True, True,
-         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'NEO/BTC',
+         ['BLK/BTC', 'ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/ETH', 'LTC/USD', 'NEO/BTC',
           'TKN/BTC', 'XRP/BTC']),
         # all markets, base=ETH, LTC
         (['ETH', 'LTC'], [], False, False,
-         ['ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/USD', 'LTC/USDT', 'XLTCUSDT']),
+         ['ETH/BTC', 'ETH/USDT', 'LTC/BTC', 'LTC/ETH', 'LTC/USD', 'LTC/USDT', 'XLTCUSDT']),
         # all markets, base=LTC
         (['LTC'], [], False, False,
-         ['LTC/BTC', 'LTC/USD', 'LTC/USDT', 'XLTCUSDT']),
+         ['LTC/BTC', 'LTC/ETH', 'LTC/USD', 'LTC/USDT', 'XLTCUSDT']),
         # all markets, quote=USDT
         ([], ['USDT'], False, False,
          ['ETH/USDT', 'LTC/USDT', 'XLTCUSDT']),

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -369,6 +369,42 @@ def test_sharpe_loss_daily_prefers_higher_profits(default_conf, hyperopt_results
     assert under > correct
 
 
+def test_sortino_loss_prefers_higher_profits(default_conf, hyperopt_results) -> None:
+    results_over = hyperopt_results.copy()
+    results_over['profit_percent'] = hyperopt_results['profit_percent'] * 2
+    results_under = hyperopt_results.copy()
+    results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
+
+    default_conf.update({'hyperopt_loss': 'SortinoHyperOptLoss'})
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
+    correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
+                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),
+                                     datetime(2019, 1, 1), datetime(2019, 5, 1))
+    under = hl.hyperopt_loss_function(results_under, len(hyperopt_results),
+                                      datetime(2019, 1, 1), datetime(2019, 5, 1))
+    assert over < correct
+    assert under > correct
+
+
+def test_sortino_loss_daily_prefers_higher_profits(default_conf, hyperopt_results) -> None:
+    results_over = hyperopt_results.copy()
+    results_over['profit_percent'] = hyperopt_results['profit_percent'] * 2
+    results_under = hyperopt_results.copy()
+    results_under['profit_percent'] = hyperopt_results['profit_percent'] / 2
+
+    default_conf.update({'hyperopt_loss': 'SortinoHyperOptLossDaily'})
+    hl = HyperOptLossResolver.load_hyperoptloss(default_conf)
+    correct = hl.hyperopt_loss_function(hyperopt_results, len(hyperopt_results),
+                                        datetime(2019, 1, 1), datetime(2019, 5, 1))
+    over = hl.hyperopt_loss_function(results_over, len(hyperopt_results),
+                                     datetime(2019, 1, 1), datetime(2019, 5, 1))
+    under = hl.hyperopt_loss_function(results_under, len(hyperopt_results),
+                                      datetime(2019, 1, 1), datetime(2019, 5, 1))
+    assert over < correct
+    assert under > correct
+
+
 def test_onlyprofit_loss_prefers_higher_profits(default_conf, hyperopt_results) -> None:
     results_over = hyperopt_results.copy()
     results_over['profit_percent'] = hyperopt_results['profit_percent'] * 2

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -706,8 +706,10 @@ def test_generate_optimizer(mocker, default_conf) -> None:
     }
     response_expected = {
         'loss': 1.9840569076926293,
-        'results_explanation': ('     1 trades. Avg profit   2.31%. Total profit  0.00023300 BTC '
-                                '(   2.31\N{GREEK CAPITAL LETTER SIGMA}%). Avg duration 100.0 min.'
+        'results_explanation': ('     1 trades.      1 wins.      0 draws.      0 losses. '
+                                'Avg profit   2.31%. Median profit   2.31%. Total profit  '
+                                '0.00023300 BTC (   2.31\N{GREEK CAPITAL LETTER SIGMA}%). '
+                                'Avg duration 100.0 min.'
                                 ).encode(locale.getpreferredencoding(), 'replace').decode('utf-8'),
         'params_details': {'buy': {'adx-enabled': False,
                                    'adx-value': 0,
@@ -738,10 +740,14 @@ def test_generate_optimizer(mocker, default_conf) -> None:
                                         'trailing_stop_positive_offset': 0.07}},
         'params_dict': optimizer_param,
         'results_metrics': {'avg_profit': 2.3117,
+                            'draws': 0,
                             'duration': 100.0,
+                            'losses': 0,
+                            'median_profit': 2.3117,
                             'profit': 2.3117,
                             'total_profit': 0.000233,
-                            'trade_count': 1},
+                            'trade_count': 1,
+                            'wins': 1},
         'total_profit': 0.00023300
     }
 

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -22,14 +22,14 @@ def test_generate_text_table(default_conf, mocker):
     )
 
     result_str = (
-        '| Pair    |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |'
-        '   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |\n'
-        '|:--------|-------:|---------------:|---------------:|-----------------:|'
-        '---------------:|:---------------|-------:|--------:|---------:|\n'
+        '|    Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |'
+        '   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |\n'
+        '|---------+--------+----------------+----------------+------------------+'
+        '----------------+----------------+--------+---------+----------|\n'
         '| ETH/BTC |      2 |          15.00 |          30.00 |       0.60000000 |'
-        '          15.00 | 0:20:00        |      2 |       0 |        0 |\n'
-        '| TOTAL   |      2 |          15.00 |          30.00 |       0.60000000 |'
-        '          15.00 | 0:20:00        |      2 |       0 |        0 |'
+        '          15.00 |        0:20:00 |      2 |       0 |        0 |\n'
+        '|   TOTAL |      2 |          15.00 |          30.00 |       0.60000000 |'
+        '          15.00 |        0:20:00 |      2 |       0 |        0 |'
     )
     assert generate_text_table(data={'ETH/BTC': {}},
                                stake_currency='BTC', max_open_trades=2,
@@ -52,13 +52,13 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
     )
 
     result_str = (
-        '| Sell Reason   |   Sells |   Wins |   Draws |   Losses |'
+        '|   Sell Reason |   Sells |   Wins |   Draws |   Losses |'
         '   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |\n'
-        '|:--------------|--------:|-------:|--------:|---------:|'
-        '---------------:|---------------:|-----------------:|---------------:|\n'
-        '| roi           |       2 |      2 |       0 |        0 |'
+        '|---------------+---------+--------+---------+----------+'
+        '----------------+----------------+------------------+----------------|\n'
+        '|           roi |       2 |      2 |       0 |        0 |'
         '             15 |             30 |              0.6 |             15 |\n'
-        '| stop_loss     |       1 |      0 |       0 |        1 |'
+        '|     stop_loss |       1 |      0 |       0 |        1 |'
         '            -10 |            -10 |             -0.2 |             -5 |'
     )
     assert generate_text_table_sell_reason(
@@ -95,14 +95,14 @@ def test_generate_text_table_strategy(default_conf, mocker):
     )
 
     result_str = (
-        '| Strategy      |   Buys |   Avg Profit % |   Cum Profit % |   Tot'
-        ' Profit BTC |   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |\n'
-        '|:--------------|-------:|---------------:|---------------:|------'
-        '-----------:|---------------:|:---------------|-------:|--------:|---------:|\n'
-        '| TestStrategy1 |      3 |          20.00 |          60.00 |      '
-        ' 1.10000000 |          30.00 | 0:17:00        |      3 |       0 |        0 |\n'
-        '| TestStrategy2 |      3 |          30.00 |          90.00 |      '
-        ' 1.30000000 |          45.00 | 0:20:00        |      3 |       0 |        0 |'
+        '|      Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot'
+        ' Profit BTC |   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |\n'
+        '|---------------+--------+----------------+----------------+------------------+'
+        '----------------+----------------+--------+---------+----------|\n'
+        '| TestStrategy1 |      3 |          20.00 |          60.00 |       1.10000000 |'
+        '          30.00 |        0:17:00 |      3 |       0 |        0 |\n'
+        '| TestStrategy2 |      3 |          30.00 |          90.00 |       1.30000000 |'
+        '          45.00 |        0:20:00 |      3 |       0 |        0 |'
     )
     assert generate_text_table_strategy('BTC', 2, all_results=results) == result_str
 
@@ -111,8 +111,7 @@ def test_generate_edge_table(edge_conf, mocker):
 
     results = {}
     results['ETH/BTC'] = PairInfo(-0.01, 0.60, 2, 1, 3, 10, 60)
-
-    assert generate_edge_table(results).count(':|') == 7
+    assert generate_edge_table(results).count('+') == 7
     assert generate_edge_table(results).count('| ETH/BTC |') == 1
     assert generate_edge_table(results).count(
         '|   Risk Reward Ratio |   Required Risk Reward |   Expectancy |') == 1

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -681,7 +681,7 @@ def test_rpcforcebuy(mocker, default_conf, ticker, fee, limit_buy_order) -> None
 
     # Test buy pair not with stakes
     with pytest.raises(RPCException, match=r'Wrong pair selected. Please pairs with stake.*'):
-        rpc._rpc_forcebuy('XRP/ETH', 0.0001)
+        rpc._rpc_forcebuy('LTC/ETH', 0.0001)
     pair = 'XRP/BTC'
 
     # Test not buying

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -34,13 +34,6 @@ def all_conf():
     return conf
 
 
-def test_load_config_invalid_pair(default_conf) -> None:
-    default_conf['exchange']['pair_whitelist'].append('ETH-BTC')
-
-    with pytest.raises(ValidationError, match=r'.*does not match.*'):
-        validate_config_schema(default_conf)
-
-
 def test_load_config_missing_attributes(default_conf) -> None:
     conf = deepcopy(default_conf)
     conf.pop('exchange')
@@ -809,12 +802,6 @@ def test_validate_whitelist(default_conf):
     del conf['exchange']['pair_whitelist']
 
     validate_config_consistency(conf)
-
-    conf = deepcopy(default_conf)
-    conf['stake_currency'] = 'USDT'
-    with pytest.raises(OperationalException,
-                       match=r"Stake-currency 'USDT' not compatible with pair-whitelist.*"):
-        validate_config_consistency(conf)
 
 
 def test_load_config_test_comments() -> None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -319,6 +319,7 @@ def test_load_dry_run(default_conf, mocker, config_value, expected, arglist) -> 
     validated_conf = configuration.load_config()
 
     assert validated_conf['dry_run'] is expected
+    assert validated_conf['runmode'] == (RunMode.DRY_RUN if expected else RunMode.LIVE)
 
 
 def test_load_custom_strategy(default_conf, mocker) -> None:

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2200,6 +2200,7 @@ def test_handle_timedout_limit_buy(mocker, default_conf, limit_buy_order) -> Non
 
     Trade.session = MagicMock()
     trade = MagicMock()
+    trade.pair = 'LTC/ETH'
     limit_buy_order['remaining'] = limit_buy_order['amount']
     assert freqtrade.handle_timedout_limit_buy(trade, limit_buy_order)
     assert cancel_order_mock.call_count == 1
@@ -2223,6 +2224,7 @@ def test_handle_timedout_limit_buy_corder_empty(mocker, default_conf, limit_buy_
 
     Trade.session = MagicMock()
     trade = MagicMock()
+    trade.pair = 'LTC/ETH'
     limit_buy_order['remaining'] = limit_buy_order['amount']
     assert freqtrade.handle_timedout_limit_buy(trade, limit_buy_order)
     assert cancel_order_mock.call_count == 1


### PR DESCRIPTION
This PR suggests a couple of additional info to the hyperopt output (wins/draws/losses, and median profit which kinda shows if your avg profit is skewed due to lucky trades in that epoch, it's a simple way to detect outlier trades in an epoch), it should support #2943 if that PR is merged into develop.

Let me know your thoughts.

Will work on the tests once thoughts are finalized into this.