### PR TITLE
Logging should be initialized first

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -96,6 +96,8 @@ class Configuration:
         # Keep a copy of the original configuration file
         config['original_config'] = deepcopy(config)
 
+        self._process_logging_options(config)
+
         self._process_runmode(config)
 
         self._process_common_options(config)
@@ -145,8 +147,6 @@ class Configuration:
         logger.info(f'Using DB: "{config["db_url"]}"')
 
     def _process_common_options(self, config: Dict[str, Any]) -> None:
-
-        self._process_logging_options(config)
 
         # Set strategy if not specified in config and or if it's non default
         if self.args.get("strategy") or not config.get('strategy'):
@@ -379,7 +379,7 @@ class Configuration:
         if not self.runmode:
             # Handle real mode, infer dry/live from config
             self.runmode = RunMode.DRY_RUN if config.get('dry_run', True) else RunMode.LIVE
-            logger.info(f"Runmode set to {self.runmode}.")
+            logger.info(f"Runmode set to {self.runmode.value}.")
 
         config.update({'runmode': self.runmode})
 


### PR DESCRIPTION
## Summary
While working on recreating #2980, i noticed that runmode should be shown in the logs but it's not because logging is initialized too late.

I think logging should be initialized first within config - so all log-messages are shown/logged correctly

## Quick changelog

- Change calling sequence within configuration for logging
- Fix output to be "nice"
