### PR TITLE
Changed table style of backtesting and alignment of headers

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -423,28 +423,37 @@ class Backtesting:
                                             strategy if len(self.strategylist) > 1 else None)
 
             print(f"Result for strategy {strategy}")
-            print(' BACKTESTING REPORT '.center(133, '='))
-            print(generate_text_table(data,
-                                      stake_currency=self.config['stake_currency'],
-                                      max_open_trades=self.config['max_open_trades'],
-                                      results=results))
+            table = generate_text_table(data, stake_currency=self.config['stake_currency'],
+                                        max_open_trades=self.config['max_open_trades'],
+                                        results=results)
+            if isinstance(table, str):
+                print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
+            print(table)
 
-            print(' SELL REASON STATS '.center(133, '='))
-            print(generate_text_table_sell_reason(data,
-                                                  stake_currency=self.config['stake_currency'],
-                                                  max_open_trades=self.config['max_open_trades'],
-                                                  results=results))
+            table = generate_text_table_sell_reason(data,
+                                                    stake_currency=self.config['stake_currency'],
+                                                    max_open_trades=self.config['max_open_trades'],
+                                                    results=results)
+            if isinstance(table, str):
+                print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
+            print(table)
 
-            print(' LEFT OPEN TRADES REPORT '.center(133, '='))
-            print(generate_text_table(data,
-                                      stake_currency=self.config['stake_currency'],
-                                      max_open_trades=self.config['max_open_trades'],
-                                      results=results.loc[results.open_at_end], skip_nan=True))
+            table = generate_text_table(data,
+                                        stake_currency=self.config['stake_currency'],
+                                        max_open_trades=self.config['max_open_trades'],
+                                        results=results.loc[results.open_at_end], skip_nan=True)
+            if isinstance(table, str):
+                print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))
+            print(table)
+            if isinstance(table, str):
+                print('=' * len(table.splitlines()[0]))
             print()
         if len(all_results) > 1:
             # Print Strategy summary table
-            print(' STRATEGY SUMMARY '.center(133, '='))
-            print(generate_text_table_strategy(self.config['stake_currency'],
-                                               self.config['max_open_trades'],
-                                               all_results=all_results))
+            table = generate_text_table_strategy(self.config['stake_currency'],
+                                                 self.config['max_open_trades'],
+                                                 all_results=all_results)
+            print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
+            print(table)
+            print('=' * len(table.splitlines()[0]))
             print('\nFor more details, please look at the detail tables above')

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -66,7 +66,7 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
     ])
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore
 
 
 def generate_text_table_sell_reason(
@@ -112,7 +112,7 @@ def generate_text_table_sell_reason(
                 profit_percent_tot,
             ]
         )
-    return tabulate(tabular_data, headers=headers, tablefmt="pipe")
+    return tabulate(tabular_data, headers=headers, tablefmt="orgtbl", stralign="right")
 
 
 def generate_text_table_strategy(stake_currency: str, max_open_trades: str,
@@ -146,7 +146,7 @@ def generate_text_table_strategy(stake_currency: str, max_open_trades: str,
         ])
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore
 
 
 def generate_edge_table(results: dict) -> str:
@@ -172,4 +172,4 @@ def generate_edge_table(results: dict) -> str:
 
     # Ignore type as floatfmt does allow tuples but mypy does not know that
     return tabulate(tabular_data, headers=headers,
-                    floatfmt=floatfmt, tablefmt="pipe")  # type: ignore
+                    floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -22,14 +22,14 @@ def test_generate_text_table(default_conf, mocker):
     )
 
     result_str = (
-        '| Pair    |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |'
-        '   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |\n'
-        '|:--------|-------:|---------------:|---------------:|-----------------:|'
-        '---------------:|:---------------|-------:|--------:|---------:|\n'
+        '|    Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |'
+        '   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |\n'
+        '|---------+--------+----------------+----------------+------------------+'
+        '----------------+----------------+--------+---------+----------|\n'
         '| ETH/BTC |      2 |          15.00 |          30.00 |       0.60000000 |'
-        '          15.00 | 0:20:00        |      2 |       0 |        0 |\n'
-        '| TOTAL   |      2 |          15.00 |          30.00 |       0.60000000 |'
-        '          15.00 | 0:20:00        |      2 |       0 |        0 |'
+        '          15.00 |        0:20:00 |      2 |       0 |        0 |\n'
+        '|   TOTAL |      2 |          15.00 |          30.00 |       0.60000000 |'
+        '          15.00 |        0:20:00 |      2 |       0 |        0 |'
     )
     assert generate_text_table(data={'ETH/BTC': {}},
                                stake_currency='BTC', max_open_trades=2,
@@ -52,13 +52,13 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
     )
 
     result_str = (
-        '| Sell Reason   |   Sells |   Wins |   Draws |   Losses |'
+        '|   Sell Reason |   Sells |   Wins |   Draws |   Losses |'
         '   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |\n'
-        '|:--------------|--------:|-------:|--------:|---------:|'
-        '---------------:|---------------:|-----------------:|---------------:|\n'
-        '| roi           |       2 |      2 |       0 |        0 |'
+        '|---------------+---------+--------+---------+----------+'
+        '----------------+----------------+------------------+----------------|\n'
+        '|           roi |       2 |      2 |       0 |        0 |'
         '             15 |             30 |              0.6 |             15 |\n'
-        '| stop_loss     |       1 |      0 |       0 |        1 |'
+        '|     stop_loss |       1 |      0 |       0 |        1 |'
         '            -10 |            -10 |             -0.2 |             -5 |'
     )
     assert generate_text_table_sell_reason(
@@ -95,14 +95,14 @@ def test_generate_text_table_strategy(default_conf, mocker):
     )
 
     result_str = (
-        '| Strategy      |   Buys |   Avg Profit % |   Cum Profit % |   Tot'
-        ' Profit BTC |   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |\n'
-        '|:--------------|-------:|---------------:|---------------:|------'
-        '-----------:|---------------:|:---------------|-------:|--------:|---------:|\n'
-        '| TestStrategy1 |      3 |          20.00 |          60.00 |      '
-        ' 1.10000000 |          30.00 | 0:17:00        |      3 |       0 |        0 |\n'
-        '| TestStrategy2 |      3 |          30.00 |          90.00 |      '
-        ' 1.30000000 |          45.00 | 0:20:00        |      3 |       0 |        0 |'
+        '|      Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot'
+        ' Profit BTC |   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |\n'
+        '|---------------+--------+----------------+----------------+------------------+'
+        '----------------+----------------+--------+---------+----------|\n'
+        '| TestStrategy1 |      3 |          20.00 |          60.00 |       1.10000000 |'
+        '          30.00 |        0:17:00 |      3 |       0 |        0 |\n'
+        '| TestStrategy2 |      3 |          30.00 |          90.00 |       1.30000000 |'
+        '          45.00 |        0:20:00 |      3 |       0 |        0 |'
     )
     assert generate_text_table_strategy('BTC', 2, all_results=results) == result_str
 
@@ -111,8 +111,7 @@ def test_generate_edge_table(edge_conf, mocker):
 
     results = {}
     results['ETH/BTC'] = PairInfo(-0.01, 0.60, 2, 1, 3, 10, 60)
-
-    assert generate_edge_table(results).count(':|') == 7
+    assert generate_edge_table(results).count('+') == 7
     assert generate_edge_table(results).count('| ETH/BTC |') == 1
     assert generate_edge_table(results).count(
         '|   Risk Reward Ratio |   Required Risk Reward |   Expectancy |') == 1


### PR DESCRIPTION
Changed table style of backtesting to be same as for hyperopt-list
Aligned table headers so they match table size.

## Summary
PEP8 = Yes

## Quick changelog

- Changed table style
- Alignment of headers

## What's new?
Current:
```
========================================================= BACKTESTING REPORT ========================================================
| Pair     |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |
|:---------|-------:|---------------:|---------------:|-----------------:|---------------:|:---------------|-------:|--------:|---------:|
| ETH/BTC  |     32 |           0.42 |          13.56 |       0.00081463 |           4.52 | 5:50:00        |     32 |       0 |        0 |
| XRP/BTC  |      5 |           0.35 |           1.75 |       0.00010495 |           0.58 | 0:34:00        |      5 |       0 |        0 |
| BCH/BTC  |     11 |           0.13 |           1.42 |       0.00008512 |           0.47 | 1:47:00        |     10 |       0 |        1 |
| LINK/BTC |      0 |         nan    |           0.00 |       0.00000000 |           0.00 | 0:00           |      0 |       0 |        0 |
| LTC/BTC  |      9 |           0.95 |           8.55 |       0.00051331 |           2.85 | 0:08:00        |      9 |       0 |        0 |
| ETC/BTC  |      9 |          -0.74 |          -6.69 |      -0.00040194 |          -2.23 | 0:27:00        |      7 |       0 |        2 |
| LSK/BTC  |      9 |           0.68 |           6.12 |       0.00036783 |           2.04 | 0:17:00        |      9 |       0 |        0 |
| EOS/BTC  |      9 |           0.46 |           4.17 |       0.00025059 |           1.39 | 0:06:00        |      9 |       0 |        0 |
| XTZ/BTC  |      1 |           0.30 |           0.30 |       0.00001786 |           0.10 | 0:24:00        |      1 |       0 |        0 |
| DASH/BTC |      6 |           0.44 |           2.62 |       0.00015735 |           0.87 | 0:13:00        |      6 |       0 |        0 |
| ADA/BTC  |      0 |         nan    |           0.00 |       0.00000000 |           0.00 | 0:00           |      0 |       0 |        0 |
| TOTAL    |     91 |           0.35 |          31.80 |       0.00190970 |          10.60 | 2:25:00        |     88 |       0 |        3 |
========================================================= SELL REASON STATS =========================================================
| Sell Reason        |   Sells |   Wins |   Draws |   Losses |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |
|:-------------------|--------:|-------:|--------:|---------:|---------------:|---------------:|-----------------:|---------------:|
| trailing_stop_loss |      87 |     87 |       0 |        0 |           0.53 |          46.37 |        0.0027848 |          15.46 |
| stop_loss          |       3 |      0 |       0 |        3 |          -5.19 |         -15.57 |       -0.0009351 |          -5.19 |
| roi                |       1 |      1 |       0 |        0 |           1    |           1    |        6e-05     |           0.33 |
====================================================== LEFT OPEN TRADES REPORT ======================================================
| Pair   |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % | Avg Duration   |   Wins |   Draws |   Losses |
|:-------|-------:|---------------:|---------------:|-----------------:|---------------:|:---------------|-------:|--------:|---------:|
| TOTAL  |      0 |            nan |           0.00 |       0.00000000 |           0.00 | 0:00           |      0 |       0 |        0 |
```

New:
```
=========================================================== BACKTESTING REPORT ===========================================================
|     Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |
|----------+--------+----------------+----------------+------------------+----------------+----------------+--------+---------+----------|
|  ETH/BTC |     32 |           0.42 |          13.56 |       0.00081463 |           4.52 |        5:50:00 |     32 |       0 |        0 |
|  XRP/BTC |      5 |           0.35 |           1.75 |       0.00010495 |           0.58 |        0:34:00 |      5 |       0 |        0 |
|  BCH/BTC |     11 |           0.13 |           1.42 |       0.00008512 |           0.47 |        1:47:00 |     10 |       0 |        1 |
| LINK/BTC |      0 |         nan    |           0.00 |       0.00000000 |           0.00 |           0:00 |      0 |       0 |        0 |
|  LTC/BTC |      9 |           0.95 |           8.55 |       0.00051331 |           2.85 |        0:08:00 |      9 |       0 |        0 |
|  ETC/BTC |      9 |          -0.74 |          -6.69 |      -0.00040194 |          -2.23 |        0:27:00 |      7 |       0 |        2 |
|  LSK/BTC |      9 |           0.68 |           6.12 |       0.00036783 |           2.04 |        0:17:00 |      9 |       0 |        0 |
|  EOS/BTC |      9 |           0.46 |           4.17 |       0.00025059 |           1.39 |        0:06:00 |      9 |       0 |        0 |
|  XTZ/BTC |      1 |           0.30 |           0.30 |       0.00001786 |           0.10 |        0:24:00 |      1 |       0 |        0 |
| DASH/BTC |      6 |           0.44 |           2.62 |       0.00015735 |           0.87 |        0:13:00 |      6 |       0 |        0 |
|  ADA/BTC |      0 |         nan    |           0.00 |       0.00000000 |           0.00 |           0:00 |      0 |       0 |        0 |
|    TOTAL |     91 |           0.35 |          31.80 |       0.00190970 |          10.60 |        2:25:00 |     88 |       0 |        3 |
======================================================== SELL REASON STATS =========================================================
|        Sell Reason |   Sells |   Wins |   Draws |   Losses |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |
|--------------------+---------+--------+---------+----------+----------------+----------------+------------------+----------------|
| trailing_stop_loss |      87 |     87 |       0 |        0 |           0.53 |          46.37 |        0.0027848 |          15.46 |
|          stop_loss |       3 |      0 |       0 |        3 |          -5.19 |         -15.57 |       -0.0009351 |          -5.19 |
|                roi |       1 |      1 |       0 |        0 |           1    |           1    |        6e-05     |           0.33 |
======================================================= LEFT OPEN TRADES REPORT ========================================================
|   Pair |   Buys |   Avg Profit % |   Cum Profit % |   Tot Profit BTC |   Tot Profit % |   Avg Duration |   Wins |   Draws |   Losses |
|--------+--------+----------------+----------------+------------------+----------------+----------------+--------+---------+----------|
|  TOTAL |      0 |            nan |           0.00 |       0.00000000 |           0.00 |           0:00 |      0 |       0 |        0 |
========================================================================================================================================
```