### PR TITLE
run-mode not correctly set when using --dry-run

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -167,10 +167,6 @@ class Configuration:
         if 'sd_notify' in self.args and self.args["sd_notify"]:
             config['internals'].update({'sd_notify': True})
 
-        self._args_to_config(config, argname='dry_run',
-                             logstring='Parameter --dry-run detected, '
-                             'overriding dry_run to: {} ...')
-
     def _process_datadir_options(self, config: Dict[str, Any]) -> None:
         """
         Extract information for sys.argv and load directory configurations
@@ -375,6 +371,10 @@ class Configuration:
                              logstring='Using "{}" to store trades data.')
 
     def _process_runmode(self, config: Dict[str, Any]) -> None:
+
+        self._args_to_config(config, argname='dry_run',
+                             logstring='Parameter --dry-run detected, '
+                             'overriding dry_run to: {} ...')
 
         if not self.runmode:
             # Handle real mode, infer dry/live from config

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -319,6 +319,7 @@ def test_load_dry_run(default_conf, mocker, config_value, expected, arglist) -> 
     validated_conf = configuration.load_config()
 
     assert validated_conf['dry_run'] is expected
+    assert validated_conf['runmode'] == (RunMode.DRY_RUN if expected else RunMode.LIVE)
 
 
 def test_load_custom_strategy(default_conf, mocker) -> None:


### PR DESCRIPTION
## Summary
run-mode not correctly set when using --dry-run

closes #2980
## Quick changelog

- Test reproducing this behaviour
- fix by reordering config parsing.

