### PR TITLE
Allow Stake currency empty when using download-data

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -332,7 +332,8 @@ class Exchange:
                 logger.warning(f"Pair {pair} is restricted for some users on this exchange."
                                f"Please check if you are impacted by this restriction "
                                f"on the exchange and eventually remove {pair} from your whitelist.")
-            if not self.get_pair_quote_currency(pair) == self._config['stake_currency']:
+            if (self._config['stake_currency'] and
+                    not self.get_pair_quote_currency(pair) == self._config['stake_currency']):
                 invalid_pairs.append(pair)
         if invalid_pairs:
             raise OperationalException(

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -333,7 +333,7 @@ class Exchange:
                                f"Please check if you are impacted by this restriction "
                                f"on the exchange and eventually remove {pair} from your whitelist.")
             if (self._config['stake_currency'] and
-                    not self.get_pair_quote_currency(pair) == self._config['stake_currency']):
+                    self.get_pair_quote_currency(pair) != self._config['stake_currency']):
                 invalid_pairs.append(pair)
         if invalid_pairs:
             raise OperationalException(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -511,6 +511,22 @@ def test_validate_pairs_stakecompatibility(default_conf, mocker, caplog):
     Exchange(default_conf)
 
 
+def test_validate_pairs_stakecompatibility_downloaddata(default_conf, mocker, caplog):
+    api_mock = MagicMock()
+    default_conf['stake_currency'] = ''
+    type(api_mock).markets = PropertyMock(return_value={
+        'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
+        'XRP/BTC': {'quote': 'BTC'}, 'NEO/BTC': {'quote': 'BTC'},
+        'HELLO-WORLD': {'quote': 'BTC'},
+    })
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
+    mocker.patch('freqtrade.exchange.Exchange._load_async_markets')
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
+
+    Exchange(default_conf)
+
+
 def test_validate_pairs_stakecompatibility_fail(default_conf, mocker, caplog):
     default_conf['exchange']['pair_whitelist'].append('HELLO-WORLD')
     api_mock = MagicMock()


### PR DESCRIPTION
## Summary
Fixes a bug mentioned on slack, where running download-data without stake-currency did fail again (reintroduced in #2973).


## Quick changelog

- Test + fix allowing empty stake-currency

