### PR TITLE
Try fix random testfailure

### DIFF
--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -447,11 +447,9 @@ def test_create_datadir_failed(caplog):
 
 
 def test_create_datadir(caplog, mocker):
-    # Ensure that caplog is empty before starting ...
-    # Should prevent random failures.
-    caplog.clear()
-    # Added assert here to analyze random test-failures ...
-    assert len(caplog.record_tuples) == 0
+
+    # Capture caplog length here trying to avoid random test failure
+    len_caplog_before = len(caplog.record_tuples)
 
     cud = mocker.patch("freqtrade.commands.deploy_commands.create_userdata_dir", MagicMock())
     csf = mocker.patch("freqtrade.commands.deploy_commands.copy_sample_files", MagicMock())
@@ -464,7 +462,7 @@ def test_create_datadir(caplog, mocker):
 
     assert cud.call_count == 1
     assert csf.call_count == 1
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == len_caplog_before
 
 
 def test_start_new_strategy(mocker, caplog):


### PR DESCRIPTION
## Summary
Yet another another try to fix the random test failure we're seeing while checking caplog length.

