### PR TITLE
[minor] Fix jupyter notebook example

### DIFF
--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -121,7 +121,6 @@ from freqtrade.data.btanalysis import analyze_trade_parallelism
 # Analyze the above
 parallel_trades = analyze_trade_parallelism(trades, '5m')
 
-
 parallel_trades.plot()
 ```
 
@@ -134,11 +133,14 @@ Freqtrade offers interactive plotting capabilities based on plotly.
 from freqtrade.plot.plotting import  generate_candlestick_graph
 # Limit graph period to keep plotly quick and reactive
 
+# Filter trades to one pair
+trades_red = trades.loc[trades['pair'] == pair]
+
 data_red = data['2019-06-01':'2019-06-10']
 # Generate candlestick graph
 graph = generate_candlestick_graph(pair=pair,
                                    data=data_red,
-                                   trades=trades,
+                                   trades=trades_red,
                                    indicators1=['sma20', 'ema50', 'ema55'],
                                    indicators2=['rsi', 'macd', 'macdsignal', 'macdhist']
                                   )

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -190,7 +190,6 @@
     "# Analyze the above\n",
     "parallel_trades = analyze_trade_parallelism(trades, '5m')\n",
     "\n",
-    "\n",
     "parallel_trades.plot()"
    ]
   },
@@ -212,11 +211,14 @@
     "from freqtrade.plot.plotting import  generate_candlestick_graph\n",
     "# Limit graph period to keep plotly quick and reactive\n",
     "\n",
+    "# Filter trades to one pair\n",
+    "trades_red = trades.loc[trades['pair'] == pair]\n",
+    "\n",
     "data_red = data['2019-06-01':'2019-06-10']\n",
     "# Generate candlestick graph\n",
     "graph = generate_candlestick_graph(pair=pair,\n",
     "                                   data=data_red,\n",
-    "                                   trades=trades,\n",
+    "                                   trades=trades_red,\n",
     "                                   indicators1=['sma20', 'ema50', 'ema55'],\n",
     "                                   indicators2=['rsi', 'macd', 'macdsignal', 'macdhist']\n",
     "                                  )\n",


### PR DESCRIPTION
## Summary

`generate_candlestick_graph()` needs a filtered pairlist, not a list
containing all pairs


Solve the issue: Posted on slack 

## Quick changelog

- Filter trades on pair before calling `generate_candlestick_graph()` in documentation and jupyter example.


**edit**
:tada: pr/issue #3000 ... can't say we've not been active anymore :laughing: 