### PR TITLE
Add official support for Kraken

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ hesitate to read the source code and understand the mechanism of this bot.
 ## Exchange marketplaces supported
 
 - [X] [Bittrex](https://bittrex.com/)
-- [X] [Binance](https://www.binance.com/) ([*Note for binance users](#a-note-on-binance))
+- [X] [Binance](https://www.binance.com/) ([*Note for binance users](docs/exchanges.md#blacklists))
+- [X] [Kraken](https://kraken.com/)
 - [ ] [113 others to tests](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,10 +370,9 @@ The possible values are: `gtc` (default), `fok` or `ioc`.
 
 Freqtrade is based on [CCXT library](https://github.com/ccxt/ccxt) that supports over 100 cryptocurrency
 exchange markets and trading APIs. The complete up-to-date list can be found in the
-[CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python). However, the bot was tested
-with only Bittrex, Binance and Kraken.
-
-The bot was tested with the following exchanges:
+[CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python).
+ However, the bot was tested by the development team with only Bittrex, Binance and Kraken,
+ so the these are the only officially supported exhanges:
 
 - [Bittrex](https://bittrex.com/): "bittrex"
 - [Binance](https://www.binance.com/): "binance"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -371,14 +371,17 @@ The possible values are: `gtc` (default), `fok` or `ioc`.
 Freqtrade is based on [CCXT library](https://github.com/ccxt/ccxt) that supports over 100 cryptocurrency
 exchange markets and trading APIs. The complete up-to-date list can be found in the
 [CCXT repo homepage](https://github.com/ccxt/ccxt/tree/master/python). However, the bot was tested
-with only Bittrex and Binance.
+with only Bittrex, Binance and Kraken.
 
 The bot was tested with the following exchanges:
 
 - [Bittrex](https://bittrex.com/): "bittrex"
 - [Binance](https://www.binance.com/): "binance"
+- [Kraken](https://kraken.com/): "kraken"
 
 Feel free to test other exchanges and submit your PR to improve the bot.
+
+Some exchanges require special configuration, which can be found on the [Exchange-specific Notes](exchanges.md) documentation page.
 
 #### Sample exchange configuration
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1023,7 +1023,7 @@ def is_exchange_known_ccxt(exchange_name: str, ccxt_module: CcxtModuleType = Non
 
 
 def is_exchange_officially_supported(exchange_name: str) -> bool:
-    return exchange_name in ['bittrex', 'binance']
+    return exchange_name in ['bittrex', 'binance', 'kraken']
 
 
 def ccxt_exchanges(ccxt_module: CcxtModuleType = None) -> List[str]:


### PR DESCRIPTION
## Summary
Secretly, kraken has been supported a while now.
We'll now 

## Quick changelog

- Add kraken to list of supported exchanges
- Fix link to binance BNB blacklist note
