### PR TITLE
Hyperopt: fix number of CPU cores, jobs and total epochs

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -558,7 +558,8 @@ class Hyperopt:
         cpus = cpu_count()
         logger.info(f"Found {cpus} CPU cores. Let's make them scream!")
         config_jobs = self.config.get('hyperopt_jobs', -1)
-        if self.total_epochs < cpus and (config_jobs > self.total_epochs or config_jobs < 0):
+        if (config_jobs < 0 and (cpus + config_jobs + 1) > self.total_epochs) \
+           or (config_jobs > 0 and config_jobs > self.total_epochs):
             config_jobs = self.total_epochs
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -572,15 +572,15 @@ class Hyperopt:
                 logger.info(f'Effective number of parallel workers used: {jobs}')
                 EVALS = ceil(self.total_epochs / jobs)
                 for i in range(EVALS):
-                    asked = self.opt.ask(n_points=jobs)
+                    # Correct the number of epochs to be processed for the last
+                    # iteration (should not exceed self.total_epochs in total)
+                    n_rest = (i + 1) * jobs - self.total_epochs
+                    current_jobs = jobs - n_rest if n_rest > 0 else jobs
+
+                    asked = self.opt.ask(n_points=current_jobs)
                     f_val = self.run_optimizer_parallel(parallel, asked, i)
                     self.opt.tell(asked, [v['loss'] for v in f_val])
                     self.fix_optimizer_models_list()
-
-                    # Correct the number of epochs to handled for the last
-                    # iteration (should not exceed self.total_epochs)
-                    n_rest = (i + 1) * jobs - self.total_epochs
-                    current_jobs = jobs - n_rest if n_rest > 0 else jobs
 
                     for j in range(current_jobs):
                         # Use human-friendly indexes here (starting from 1)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -9,7 +9,7 @@ import logging
 import random
 import sys
 import warnings
-from math import ceil, floor
+from math import ceil
 from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
@@ -578,11 +578,13 @@ class Hyperopt:
                     f_val = self.run_optimizer_parallel(parallel, asked, i)
                     self.opt.tell(asked, [v['loss'] for v in f_val])
                     self.fix_optimizer_models_list()
-                    for j in range(jobs):
+                    if (i * jobs + jobs) > self.total_epochs:
+                        current_jobs = jobs - ((i * jobs + jobs) - self.total_epochs)
+                    else:
+                        current_jobs = jobs
+                    for j in range(current_jobs):
                         # Use human-friendly indexes here (starting from 1)
                         current = i * jobs + j + 1
-                        if current > self.total_epochs:
-                            continue
                         val = f_val[j]
                         val['current_epoch'] = current
                         val['is_initial_point'] = current <= INITIAL_POINTS

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -557,6 +557,8 @@ class Hyperopt:
         cpus = cpu_count()
         logger.info(f"Found {cpus} CPU cores. Let's make them scream!")
         config_jobs = self.config.get('hyperopt_jobs', -1)
+        if self.total_epochs < cpus:
+            config_jobs = self.total_epochs
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 
         self.dimensions: List[Dimension] = self.hyperopt_space()

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -9,6 +9,7 @@ import logging
 import random
 import sys
 import warnings
+from math import ceil, floor
 from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
@@ -571,7 +572,7 @@ class Hyperopt:
             with Parallel(n_jobs=config_jobs) as parallel:
                 jobs = parallel._effective_n_jobs()
                 logger.info(f'Effective number of parallel workers used: {jobs}')
-                EVALS = max(self.total_epochs // jobs, 1)
+                EVALS = ceil(self.total_epochs / jobs)
                 for i in range(EVALS):
                     asked = self.opt.ask(n_points=jobs)
                     f_val = self.run_optimizer_parallel(parallel, asked, i)
@@ -580,6 +581,8 @@ class Hyperopt:
                     for j in range(jobs):
                         # Use human-friendly indexes here (starting from 1)
                         current = i * jobs + j + 1
+                        if current > self.total_epochs:
+                            continue
                         val = f_val[j]
                         val['current_epoch'] = current
                         val['is_initial_point'] = current <= INITIAL_POINTS

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -557,7 +557,7 @@ class Hyperopt:
         cpus = cpu_count()
         logger.info(f"Found {cpus} CPU cores. Let's make them scream!")
         config_jobs = self.config.get('hyperopt_jobs', -1)
-        if self.total_epochs < cpus:
+        if self.total_epochs < cpus and (config_jobs > self.total_epochs or config_jobs < 0):
             config_jobs = self.total_epochs
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -582,10 +582,9 @@ class Hyperopt:
                     self.opt.tell(asked, [v['loss'] for v in f_val])
                     self.fix_optimizer_models_list()
 
-                    for j in range(current_jobs):
+                    for j, val in enumerate(f_val):
                         # Use human-friendly indexes here (starting from 1)
                         current = i * jobs + j + 1
-                        val = f_val[j]
                         val['current_epoch'] = current
                         val['is_initial_point'] = current <= INITIAL_POINTS
                         logger.debug(f"Optimizer epoch evaluated: {val}")

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -576,10 +576,12 @@ class Hyperopt:
                     f_val = self.run_optimizer_parallel(parallel, asked, i)
                     self.opt.tell(asked, [v['loss'] for v in f_val])
                     self.fix_optimizer_models_list()
-                    if (i * jobs + jobs) > self.total_epochs:
-                        current_jobs = jobs - ((i * jobs + jobs) - self.total_epochs)
-                    else:
-                        current_jobs = jobs
+
+                    # Correct the number of epochs to handled for the last
+                    # iteration (should not exceed self.total_epochs)
+                    n_rest = (i + 1) * jobs - self.total_epochs
+                    current_jobs = jobs - n_rest if n_rest > 0 else jobs
+
                     for j in range(current_jobs):
                         # Use human-friendly indexes here (starting from 1)
                         current = i * jobs + j + 1

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -558,10 +558,6 @@ class Hyperopt:
         cpus = cpu_count()
         logger.info(f"Found {cpus} CPU cores. Let's make them scream!")
         config_jobs = self.config.get('hyperopt_jobs', -1)
-        if (config_jobs < 0 and (cpus + config_jobs + 1) > self.total_epochs) \
-           or (config_jobs > 0 and config_jobs > self.total_epochs):
-            config_jobs = self.total_epochs
-            logger.info("Job count invalid will correct")
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 
         self.dimensions: List[Dimension] = self.hyperopt_space()

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -561,6 +561,7 @@ class Hyperopt:
         if (config_jobs < 0 and (cpus + config_jobs + 1) > self.total_epochs) \
            or (config_jobs > 0 and config_jobs > self.total_epochs):
             config_jobs = self.total_epochs
+            logger.info("Job count invalid will correct")
         logger.info(f'Number of parallel jobs set as: {config_jobs}')
 
         self.dimensions: List[Dimension] = self.hyperopt_space()


### PR DESCRIPTION
## Summary
Hyperopt fix when specifying total epochs less than amount of CPU cores.

PEP8 = yes

## Quick changelog

- Hyperopt.py, aligning total epochs and cpu core config

## What's new?
Aligning the parameters when less epochs are specified will avoid the situation below:
```
Parameter --epochs detected ... Will run Hyperopt with for 1 epochs ...
Parameter -j/--job-workers detected: -1
- INFO - Effective number of parallel workers used: 8
+--------+---------+----------+--------------+----------------+----------+----------------+-------------+
|   Best |   Epoch |   Trades |   Avg profit |   Total profit |   Profit |   Avg duration |   Objective |
|--------+---------+----------+--------------+----------------+----------+----------------+-------------|
|      * |     1/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|      * |     2/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|   Best |     3/1 |        3 |        0.46% | 0.00008214 BTC |    1.37% |          18.3m |     1.87778 |
2020-02-29 23:17:00,051 - freqtrade.optimize.hyperopt - INFO - Saving 3 epochs.
|      * |     4/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|      * |     5/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|      * |     6/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|      * |     7/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
|      * |     8/1 |        0 |          nan | 0.00000000 BTC |    0.00% |            nan |      100000 |
2020-02-29 23:17:00,109 - freqtrade.optimize.hyperopt - INFO - Saving 8 epochs.
```