### PR TITLE
Max drawdown in plot-profit

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -196,6 +196,7 @@ The first graph is good to get a grip of how the overall market progresses.
 
 The second graph will show if your algorithm works or doesn't.
 Perhaps you want an algorithm that steadily makes small profits, or one that acts less often, but makes big swings.
+This graph will also highlight the start (and end) of the Max drawdown period.
 
 The third graph can be useful to spot outliers, events in pairs that cause profit spikes.
 

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -3,7 +3,7 @@ Helpers when analyzing backtest data
 """
 import logging
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Union, Tuple
 
 import numpy as np
 import pandas as pd
@@ -188,3 +188,23 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     # FFill to get continuous
     df[col_name] = df[col_name].ffill()
     return df
+
+
+def calculate_max_drawdown(trades: pd.DataFrame) -> Tuple[float, pd.Timestamp, pd.Timestamp]:
+    """
+    Calculate max drawdown and the corresponding close dates
+    :param trades: DataFrame containing trades (requires columns close_time and profitperc)
+    :return: Tuple (float, highdate, lowdate) with absolute max drawdown, high and low time
+    :raise: ValueError if trade-dataframe was found empty.
+    """
+    if len(trades) == 0:
+        raise ValueError("Trade dataframe empty")
+    profit_results = trades.sort_values('close_time')
+    max_drawdown_df = pd.DataFrame()
+    max_drawdown_df['cumulative'] = profit_results['profitperc'].cumsum()
+    max_drawdown_df['high_value'] = max_drawdown_df['cumulative'].cummax()
+    max_drawdown_df['drawdown'] = max_drawdown_df['cumulative'] - max_drawdown_df['high_value']
+    high_date = profit_results.loc[max_drawdown_df['high_value'].idxmax(), 'close_time']
+    low_date = profit_results.loc[max_drawdown_df['drawdown'].idxmin(), 'close_time']
+
+    return abs(min(max_drawdown_df['drawdown'])), high_date, low_date

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -198,7 +198,7 @@ def calculate_max_drawdown(trades: pd.DataFrame) -> Tuple[float, pd.Timestamp, p
     :raise: ValueError if trade-dataframe was found empty.
     """
     if len(trades) == 0:
-        raise ValueError("Trade dataframe empty")
+        raise ValueError("Trade dataframe empty.")
     profit_results = trades.sort_values('close_time')
     max_drawdown_df = pd.DataFrame()
     max_drawdown_df['cumulative'] = profit_results['profitperc'].cumsum()

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -190,7 +190,7 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     return df
 
 
-def calculate_max_drawdown(trades: pd.DataFrame, date_col: str = 'close_time',
+def calculate_max_drawdown(trades: pd.DataFrame, *, date_col: str = 'close_time',
                            value_col: str = 'profitperc'
                            ) -> Tuple[float, pd.Timestamp, pd.Timestamp]:
     """

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -190,21 +190,26 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     return df
 
 
-def calculate_max_drawdown(trades: pd.DataFrame) -> Tuple[float, pd.Timestamp, pd.Timestamp]:
+def calculate_max_drawdown(trades: pd.DataFrame, date_col: str = 'close_time',
+                           value_col: str = 'profitperc'
+                           ) -> Tuple[float, pd.Timestamp, pd.Timestamp]:
     """
     Calculate max drawdown and the corresponding close dates
     :param trades: DataFrame containing trades (requires columns close_time and profitperc)
+    :param date_col: Column in DataFrame to use for dates (defaults to 'close_time')
+    :param value_col: Column in DataFrame to use for values (defaults to 'profitperc')
     :return: Tuple (float, highdate, lowdate) with absolute max drawdown, high and low time
     :raise: ValueError if trade-dataframe was found empty.
     """
     if len(trades) == 0:
         raise ValueError("Trade dataframe empty.")
-    profit_results = trades.sort_values('close_time')
+    profit_results = trades.sort_values(date_col)
     max_drawdown_df = pd.DataFrame()
-    max_drawdown_df['cumulative'] = profit_results['profitperc'].cumsum()
+    max_drawdown_df['cumulative'] = profit_results[value_col].cumsum()
     max_drawdown_df['high_value'] = max_drawdown_df['cumulative'].cummax()
     max_drawdown_df['drawdown'] = max_drawdown_df['cumulative'] - max_drawdown_df['high_value']
-    high_date = profit_results.loc[max_drawdown_df['high_value'].idxmax(), 'close_time']
-    low_date = profit_results.loc[max_drawdown_df['drawdown'].idxmin(), 'close_time']
+
+    high_date = profit_results.loc[max_drawdown_df['high_value'].idxmax(), date_col]
+    low_date = profit_results.loc[max_drawdown_df['drawdown'].idxmin(), date_col]
 
     return abs(min(max_drawdown_df['drawdown'])), high_date, low_date

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -126,8 +126,8 @@ def add_max_drawdown(fig, row, trades: pd.DataFrame, df_comb: pd.DataFrame) -> m
                 df_comb.loc[lowdate, 'cum_profit'],
             ],
             mode='markers',
-            name='Max Drawdown',
-            text=f"Max drawdown {max_drawdown}",
+            name=f"Max drawdown {max_drawdown:.2f}%",
+            text=f"Max drawdown {max_drawdown:.2f}%",
             marker=dict(
                 symbol='square-open',
                 size=9,

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from freqtrade.configuration import TimeRange
-from freqtrade.data.btanalysis import (combine_tickers_with_mean,
+from freqtrade.data.btanalysis import (calculate_max_drawdown,
+                                       combine_tickers_with_mean,
                                        create_cum_profit,
                                        extract_trades_of_period, load_trades)
 from freqtrade.data.converter import trim_dataframe
@@ -108,6 +109,36 @@ def add_profit(fig, row, data: pd.DataFrame, column: str, name: str) -> make_sub
     )
     fig.add_trace(profit, row, 1)
 
+    return fig
+
+
+def add_max_drawdown(fig, row, trades: pd.DataFrame, df_comb: pd.DataFrame) -> make_subplots:
+    """
+    Add scatter points indicating max drawdown
+    """
+    try:
+        max_drawdown, highdate, lowdate = calculate_max_drawdown(trades)
+
+        drawdown = go.Scatter(
+            x=[highdate, lowdate],
+            y=[
+                df_comb.loc[highdate, 'cum_profit'],
+                df_comb.loc[lowdate, 'cum_profit'],
+            ],
+            mode='markers',
+            name='Max Drawdown',
+            text=f"Max drawdown {max_drawdown}",
+            marker=dict(
+                symbol='square-open',
+                size=9,
+                line=dict(width=2),
+                color='green'
+
+            )
+        )
+        fig.add_trace(drawdown, row, 1)
+    except ValueError:
+        logger.warning("No trades found - not plotting max drawdown.")
     return fig
 
 
@@ -364,6 +395,7 @@ def generate_profit_graph(pairs: str, tickers: Dict[str, pd.DataFrame],
 
     fig.add_trace(avgclose, 1, 1)
     fig = add_profit(fig, 2, df_comb, 'cum_profit', 'Profit')
+    fig = add_max_drawdown(fig, 2, trades, df_comb)
 
     for pair in pairs:
         profit_col = f'cum_profit_{pair}'


### PR DESCRIPTION
## Summary
Adds additional markets for max drawdown period in the profit plot.
The function (`calculate_max_drawdown()`) is intended to be reused for other areas of the bot as well (backtesting -> #1908, Risk management -> #2968).


## Quick changelog

- Add new markets showing max-drawdown period
- New function calculationg max drawdown (including start and end dates).

## What's new?

Max drawdown visualized

![2020-03-03-202044_1901x943_scrot](https://user-images.githubusercontent.com/5024695/75811460-c16a5f80-5d8c-11ea-9dc9-86066b9ea1a3.png)
