### PR TITLE
trim dataframe by timerange if timerange is given

### DIFF
--- a/freqtrade/data/history/jsondatahandler.py
+++ b/freqtrade/data/history/jsondatahandler.py
@@ -77,6 +77,11 @@ class JsonDataHandler(IDataHandler):
                                        unit='ms',
                                        utc=True,
                                        infer_datetime_format=True)
+        if timerange:
+            start = to_datetime(timerange.startts, utc=True, unit='s')
+            stop = to_datetime(timerange.stopts, utc=True, unit='s')
+            pairdata = pairdata.loc[(pairdata['date'] >= start)
+                                    & (pairdata['date'] <= stop)]
         return pairdata
 
     def ohlcv_purge(self, pair: str, timeframe: str) -> bool:


### PR DESCRIPTION
## Summary
IDataHandler `_ohlcv_load` accepts `timerange` but `JsonDataHandler` doesn't use it...but the public `ohlcv_load` method does an `.empty` check. If you pass a timerange for a pair that does have data, just not for that timerange, that check is voided and you get an index exception..
some tests seem to give the timerange but expect a full df anyway so they break
