### PR TITLE
order_book_max - change example setting

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -23,7 +23,7 @@
     "ask_strategy":{
         "use_order_book": false,
         "order_book_min": 1,
-        "order_book_max": 9,
+        "order_book_max": 1,
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false

--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -23,7 +23,7 @@
     "ask_strategy":{
         "use_order_book": false,
         "order_book_min": 1,
-        "order_book_max": 9,
+        "order_book_max": 1,
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -38,7 +38,7 @@
         "price_side": "ask",
         "use_order_book": false,
         "order_book_min": 1,
-        "order_book_max": 9,
+        "order_book_max": 1,
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -23,7 +23,7 @@
     "ask_strategy":{
         "use_order_book": false,
         "order_book_min": 1,
-        "order_book_max": 9,
+        "order_book_max": 1,
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -537,7 +537,7 @@ The idea here is to place the sell order early, to be ahead in the queue.
 A fixed slot (mirroring `bid_strategy.order_book_top`) can be defined by setting `ask_strategy.order_book_min` and `ask_strategy.order_book_max` to the same number.
 
 !!! Warning "Orderbook and stoploss_on_exchange"
-    Using `ask_strategy.order_book_max` higher than 1 may increase the risk, since an eventual [stoploss on exchange](#understand-order_types) will be needed to be cancelled as soon as the order is placed.
+    Using `ask_strategy.order_book_max` higher than 1 will increase the risk, since an eventual [stoploss on exchange](#understand-order_types) will be needed to be cancelled as soon as the order is placed. Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (even without stoploss on exchange).
 
 #### Sell price without Orderbook enabled
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -541,7 +541,7 @@ A fixed slot (mirroring `bid_strategy.order_book_top`) can be defined by setting
     Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (with or without using stoploss_on_exchange).
 
 !!! Warning "Order_book_max > 1 in dry-run"
-    Using `ask_strategy.order_book_max` higher than 1 will result in improved dry-run results, since dry-run assumes orders to be filled almost instantly.
+    Using `ask_strategy.order_book_max` higher than 1 will result in improper dry-run results (significantly better than real orders executed on exchange), since dry-run assumes orders to be filled almost instantly.
     It is therefore advised to not use this setting for dry-runs.
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -536,8 +536,14 @@ The idea here is to place the sell order early, to be ahead in the queue.
 
 A fixed slot (mirroring `bid_strategy.order_book_top`) can be defined by setting `ask_strategy.order_book_min` and `ask_strategy.order_book_max` to the same number.
 
-!!! Warning "Orderbook and stoploss_on_exchange"
-    Using `ask_strategy.order_book_max` higher than 1 will increase the risk, since an eventual [stoploss on exchange](#understand-order_types) will be needed to be cancelled as soon as the order is placed. Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (even without stoploss on exchange).
+!!! Warning "Order_book_max > 1 - increased Risk!"
+    Using `ask_strategy.order_book_max` higher than 1 will increase the risk, since an eventual [stoploss on exchange](#understand-order_types) will be needed to be cancelled as soon as the order is placed.
+    Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (with or without using stoploss_on_exchange).
+
+!!! Warning "Order_book_max > 1 in dry-run"
+    Using `ask_strategy.order_book_max` higher than 1 will result in improved dry-run results, since dry-run assumes orders to be filled almost instantly.
+    It is therefore advised to not use this setting for dry-runs.
+
 
 #### Sell price without Orderbook enabled
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -536,9 +536,9 @@ The idea here is to place the sell order early, to be ahead in the queue.
 
 A fixed slot (mirroring `bid_strategy.order_book_top`) can be defined by setting `ask_strategy.order_book_min` and `ask_strategy.order_book_max` to the same number.
 
-!!! Warning "Order_book_max > 1 - increased Risk!"
-    Using `ask_strategy.order_book_max` higher than 1 will increase the risk, since an eventual [stoploss on exchange](#understand-order_types) will be needed to be cancelled as soon as the order is placed.
-    Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (with or without using stoploss_on_exchange).
+!!! Warning "Order_book_max > 1 - increased risks for stoplosses!"
+    Using `ask_strategy.order_book_max` higher than 1 will increase the risk the stoploss on exchange is cancelled too early, since an eventual [stoploss on exchange](#understand-order_types) will be cancelled as soon as the order is placed.
+    Also, the sell order will remain on the exchange for `unfilledtimeout.sell` (or until it's filled) - which can lead to missed stoplosses (with or without using stoploss on exchange).
 
 !!! Warning "Order_book_max > 1 in dry-run"
     Using `ask_strategy.order_book_max` higher than 1 will result in improper dry-run results (significantly better than real orders executed on exchange), since dry-run assumes orders to be filled almost instantly.

--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -24,7 +24,7 @@
         "price_side": "ask",
         "use_order_book": false,
         "order_book_min": 1,
-        "order_book_max": 9,
+        "order_book_max": 1,
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false


### PR DESCRIPTION
## Summary
order_book_max should be set to 1 in almost all cases, otherwise it can lead to misleading results in dry-runs - and may lead to missed stoplosses in real runs.

closes #3043

## Quick changelog

- Change default settings to 1
- update documentation with more clarity
