### PR TITLE
Hyperopt - add default volume > 0 filter

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -159,6 +159,9 @@ So let's write the buy strategy using these values:
                         dataframe['macd'], dataframe['macdsignal']
                     ))
 
+            # Check that volume is not 0
+            conditions.append(dataframe['volume'] > 0)
+
             if conditions:
                 dataframe.loc[
                     reduce(lambda x, y: x & y, conditions),

--- a/freqtrade/templates/base_hyperopt.py.j2
+++ b/freqtrade/templates/base_hyperopt.py.j2
@@ -66,6 +66,9 @@ class {{ hyperopt }}(IHyperOpt):
                         dataframe['close'], dataframe['sar']
                     ))
 
+            # Check that the candle had volume
+            conditions.append(dataframe['volume'] > 0)
+
             if conditions:
                 dataframe.loc[
                     reduce(lambda x, y: x & y, conditions),
@@ -110,6 +113,9 @@ class {{ hyperopt }}(IHyperOpt):
                     conditions.append(qtpylib.crossed_above(
                         dataframe['sar'], dataframe['close']
                     ))
+
+            # Check that the candle had volume
+            conditions.append(dataframe['volume'] > 0)
 
             if conditions:
                 dataframe.loc[

--- a/freqtrade/templates/sample_hyperopt.py
+++ b/freqtrade/templates/sample_hyperopt.py
@@ -78,6 +78,9 @@ class SampleHyperOpt(IHyperOpt):
                         dataframe['close'], dataframe['sar']
                     ))
 
+            # Check that volume is not 0
+            conditions.append(dataframe['volume'] > 0)
+
             if conditions:
                 dataframe.loc[
                     reduce(lambda x, y: x & y, conditions),
@@ -137,6 +140,9 @@ class SampleHyperOpt(IHyperOpt):
                     conditions.append(qtpylib.crossed_above(
                         dataframe['sar'], dataframe['close']
                     ))
+
+            # Check that volume is not 0
+            conditions.append(dataframe['volume'] > 0)
 
             if conditions:
                 dataframe.loc[

--- a/freqtrade/templates/sample_hyperopt_advanced.py
+++ b/freqtrade/templates/sample_hyperopt_advanced.py
@@ -93,6 +93,9 @@ class AdvancedSampleHyperOpt(IHyperOpt):
                         dataframe['close'], dataframe['sar']
                     ))
 
+            # Check that volume is not 0
+            conditions.append(dataframe['volume'] > 0)
+
             if conditions:
                 dataframe.loc[
                     reduce(lambda x, y: x & y, conditions),
@@ -152,6 +155,9 @@ class AdvancedSampleHyperOpt(IHyperOpt):
                     conditions.append(qtpylib.crossed_above(
                         dataframe['sar'], dataframe['close']
                     ))
+
+            # Check that volume is not 0
+            conditions.append(dataframe['volume'] > 0)
 
             if conditions:
                 dataframe.loc[


### PR DESCRIPTION
## Summary
To have hyperopt aligned to regular strategy recommandations, hyperopt should include a condition to only use candles with volume.

If that's not done and the strategy is written according to specs, a volume>0 condition is included, leading to slightly different results between backtesting and hyperopt.

## Quick changelog

- Add condition to check for volume to all hyperopt condition samples.