### PR TITLE
Edge test warning

### DIFF
--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -317,7 +317,7 @@ class Edge:
         }
 
         # Group by (pair and stoploss) by applying above aggregator
-        df = results.groupby(['pair', 'stoploss'])['profit_abs', 'trade_duration'].agg(
+        df = results.groupby(['pair', 'stoploss'])[['profit_abs', 'trade_duration']].agg(
             groupby_aggregator).reset_index(col_level=1)
 
         # Dropping level 0 as we don't need it

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -163,8 +163,8 @@ def test_edge_results(edge_conf, mocker, caplog, data) -> None:
     for c, trade in enumerate(data.trades):
         res = results.iloc[c]
         assert res.exit_type == trade.sell_reason
-        assert res.open_time == np.datetime64(_get_frame_time_from_offset(trade.open_tick))
-        assert res.close_time == np.datetime64(_get_frame_time_from_offset(trade.close_tick))
+        assert res.open_time == _get_frame_time_from_offset(trade.open_tick).replace(tzinfo=None)
+        assert res.close_time == _get_frame_time_from_offset(trade.close_tick).replace(tzinfo=None)
 
 
 def test_adjust(mocker, edge_conf):


### PR DESCRIPTION
## Summary
Fix deprecation warnings when running tests for edge (proactive, before it breaks with the next numpy update ...).


## Quick changelog

- use correct indexing of columns (2 columns = list)
- use different method to compare result times in test.