### PR TITLE
Add template and jupyter files to release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.md
 include config.json.example
 recursive-include freqtrade *.py
+recursive-include freqtrade/templates/ *.j2 *.ipynb


### PR DESCRIPTION
## Summary
Non-python  files need to be included explicitly into a release distribution.

Closes #3078

## Quick changelog

- Add *.j2 and *.ipynb files from the templates directory.