### PR TITLE
Ftx cancel order

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -891,6 +891,9 @@ class FreqtradeBot:
         if order['status'] != 'canceled':
             reason = "cancelled due to timeout"
             corder = self.exchange.cancel_order(trade.open_order_id, trade.pair)
+            # Some exchanges don't return a dict here.
+            if not isinstance(corder, dict):
+                corder = {}
             logger.info('Buy order %s for %s.', reason, trade)
         else:
             # Order was cancelled already, so we can reuse the existing dict

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2228,10 +2228,16 @@ def test_handle_timedout_limit_buy(mocker, default_conf, limit_buy_order) -> Non
     assert cancel_order_mock.call_count == 1
 
 
-def test_handle_timedout_limit_buy_corder_empty(mocker, default_conf, limit_buy_order) -> None:
+@pytest.mark.parametrize('cancelorder', [
+    {},
+    'String Return value',
+    123
+])
+def test_handle_timedout_limit_buy_corder_empty(mocker, default_conf, limit_buy_order,
+                                                cancelorder) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
-    cancel_order_mock = MagicMock(return_value={})
+    cancel_order_mock = MagicMock(return_value=cancelorder)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         cancel_order=cancel_order_mock


### PR DESCRIPTION
## Summary
Apparently ccxt's `cancel_order()` function does not guarantee to return a dictionary, and in FTX's case returns `'Order queued for cancellation'`.

Therefore, we need to verify if the return-value is a dict, and eventually use an empty dict instead.

closes #3085
