### PR TITLE
[minor] Add example notebook to gitignore again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ user_data/*
 !user_data/strategy/sample_strategy.py
 !user_data/notebooks
 user_data/notebooks/*
-!user_data/notebooks/*example.ipynb
 freqtrade-plot.html
 freqtrade-profit-plot.html
 


### PR DESCRIPTION
## Summary
Since the example notebooks have been moved to the templates folder, running `freqtrade new-datadir --userdir user_data` did result in a unclean git environment, showing `user_data/notebooks/strategy_analysis_example.ipynb` as uncommited file.
