### PR TITLE
check that the strategy dataframe matches the one given by the bot

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -279,11 +279,12 @@ class IStrategy(ABC):
             dataframe = self._analyze_ticker_internal(dataframe, {'pair': pair})
             self.assert_df(dataframe, df_len, df_close, df_date)
         except ValueError as error:
-            logger.warning(
-                'Unable to analyze candle (OHLCV) data for pair %s: %s',
-                pair,
-                str(error)
-            )
+            logger.warning('Unable to analyze candle (OHLCV) data for pair %s: %s',
+                           pair, str(error))
+            return False, False
+        except DependencyException as error:
+            logger.warning("Unable to analyze candle (OHLCV) data for pair %s: %s",
+                           pair, str(error))
             return False, False
         except Exception as error:
             logger.exception(


### PR DESCRIPTION
## Summary
Save a few dataframe elements before calling the signals, to make sure they are
still there afterwards.
Also fetch the correct signals by date.

related to #2696 
## Quick changelog

- functions `preserve_df` and `assert_df` used around strategy calls to gauge dataframe validity
- locate the correct signals row by date instead of by index (which is kinda reduntant since with those checks it will raise an exception if the index does not match...

...the failing tests are...broken because they indeed pass a non matching dataframe..
these checks are done on each call...they are not heavy so...doesn't seem to hurt