### PR TITLE
[minor] Test warnings with filter always on

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -73,6 +73,7 @@ def test__args_to_config(caplog):
     configuration = Configuration(args)
     config = {}
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         # No warnings ...
         configuration._args_to_config(config, argname="strategy_path", logstring="DeadBeef")
         assert len(w) == 0
@@ -82,6 +83,7 @@ def test__args_to_config(caplog):
     configuration = Configuration(args)
     config = {}
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         # Deprecation warnings!
         configuration._args_to_config(config, argname="strategy_path", logstring="DeadBeef",
                                       deprecated_msg="Going away soon!")


### PR DESCRIPTION
## Summary
Fix random test failure by always enabling warnings - otherwise it'll sometimes be disabled depending on the environment.
