### PR TITLE
[minor] Remove defaultstrategy occurance from docs

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -144,10 +144,10 @@ It is recommended to use version control to keep track of changes to your strate
 ### How to use **--strategy**?
 
 This parameter will allow you to load your custom strategy class.
-Per default without `--strategy` or `-s` the bot will load the
-`SampleStrategy` installed by the `create-userdir` subcommand (usually `user_data/strategy/sample_strategy.py`).
+To test the bot installation, you can use the `SampleStrategy` installed by the `create-userdir` subcommand (usually `user_data/strategy/sample_strategy.py`).
 
 The bot will search your strategy file within `user_data/strategies`.
+To use other directories, please read the next section about `--strategy-path`.
 
 To load a strategy, simply pass the class name (e.g.: `CustomStrategy`) in this parameter.
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -145,9 +145,9 @@ It is recommended to use version control to keep track of changes to your strate
 
 This parameter will allow you to load your custom strategy class.
 Per default without `--strategy` or `-s` the bot will load the
-`DefaultStrategy` included with the bot (`freqtrade/strategy/default_strategy.py`).
+`SampleStrategy` installed by the `create-userdir` subcommand (usually `user_data/strategy/sample_strategy.py`).
 
-The bot will search your strategy file within `user_data/strategies` and `freqtrade/strategy`.
+The bot will search your strategy file within `user_data/strategies`.
 
 To load a strategy, simply pass the class name (e.g.: `CustomStrategy`) in this parameter.
 


### PR DESCRIPTION
## Summary
remove last occurance of default_strategy from the docs and replace it with SampleStrategy - as pointed out in #3120 
