### PR TITLE
[minor] Fix filename handling with --strategy-list

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -24,13 +24,14 @@ def store_backtest_result(recordfilename: Path, all_results: Dict[str, DataFrame
                    for index, t in results.iterrows()]
 
         if records:
+            filename = recordfilename
             if len(all_results) > 1:
                 # Inject strategy to filename
-                recordfilename = Path.joinpath(
+                filename = Path.joinpath(
                     recordfilename.parent,
                     f'{recordfilename.stem}-{strategy}').with_suffix(recordfilename.suffix)
-            logger.info(f'Dumping backtest results to {recordfilename}')
-            file_dump_json(recordfilename, records)
+            logger.info(f'Dumping backtest results to {filename}')
+            file_dump_json(filename, records)
 
 
 def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -160,10 +160,15 @@ def test_backtest_record(default_conf, fee, mocker):
     # reset test to test with strategy name
     names = []
     records = []
-    results['Strat'] = pd.DataFrame()
+    results['Strat'] = results['DefStrat']
+    results['Strat2'] = results['DefStrat']
     store_backtest_result(Path("backtest-result.json"), results)
     # Assert file_dump_json was only called once
-    assert names == [Path('backtest-result-DefStrat.json')]
+    assert names == [
+        Path('backtest-result-DefStrat.json'),
+        Path('backtest-result-Strat.json'),
+        Path('backtest-result-Strat2.json'),
+    ]
     records = records[0]
     # Ensure records are of correct type
     assert len(records) == 4

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -163,7 +163,6 @@ def test_backtest_record(default_conf, fee, mocker):
     results['Strat'] = results['DefStrat']
     results['Strat2'] = results['DefStrat']
     store_backtest_result(Path("backtest-result.json"), results)
-    # Assert file_dump_json was only called once
     assert names == [
         Path('backtest-result-DefStrat.json'),
         Path('backtest-result-Strat.json'),


### PR DESCRIPTION
## Summary
Filenames for exported fiels should not be increasing in length - but should be `filename-<strategy>.json` for all strategies, independently if it's the first or last strategy.

As reported on slack.