### PR TITLE
Backtesting memory and dataframe

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -149,8 +149,8 @@ class Backtesting:
 
             # To avoid using data from future, we use buy/sell signals shifted
             # from the previous candle
-            df_analyzed.loc[:, 'buy'] = df_analyzed['buy'].shift(1)
-            df_analyzed.loc[:, 'sell'] = df_analyzed['sell'].shift(1)
+            df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
+            df_analyzed.loc[:, 'sell'] = df_analyzed.loc[:, 'sell'].shift(1)
 
             df_analyzed.drop(df_analyzed.head(1).index, inplace=True)
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -467,6 +467,9 @@ class IStrategy(ABC):
         """
         Creates a dataframe and populates indicators for given candle (OHLCV) data
         Used by optimize operations only, not during dry / live runs.
+        Using .copy() to get a fresh copy of the dataframe for every strategy run.
+        Has positive effects on memory usage for whatever reason - also when
+        using only one strategy.
         """
         return {pair: self.advise_indicators(pair_data.copy(), {'pair': pair})
                 for pair, pair_data in data.items()}

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -468,7 +468,7 @@ class IStrategy(ABC):
         Creates a dataframe and populates indicators for given candle (OHLCV) data
         Used by optimize operations only, not during dry / live runs.
         """
-        return {pair: self.advise_indicators(pair_data, {'pair': pair})
+        return {pair: self.advise_indicators(pair_data.copy(), {'pair': pair})
                 for pair, pair_data in data.items()}
 
     def advise_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -168,6 +168,19 @@ def test_ohlcvdata_to_dataframe(default_conf, testdatadir) -> None:
     assert len(processed['UNITTEST/BTC']) == 102  # partial candle was removed
 
 
+def test_ohlcvdata_to_dataframe_copy(mocker, default_conf, testdatadir) -> None:
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    strategy = StrategyResolver.load_strategy(default_conf)
+    aimock = mocker.patch('freqtrade.strategy.interface.IStrategy.advise_indicators')
+    timerange = TimeRange.parse_timerange('1510694220-1510700340')
+    data = load_data(testdatadir, '1m', ['UNITTEST/BTC'], timerange=timerange,
+                     fill_up_missing=True)
+    strategy.ohlcvdata_to_dataframe(data)
+    assert aimock.call_count == 1
+    # Ensure that a copy of the dataframe is passed to advice_indicators
+    assert aimock.call_args_list[0][0][0] is not data
+
+
 def test_min_roi_reached(default_conf, fee) -> None:
 
     # Use list to confirm sequence does not matter


### PR DESCRIPTION
## Summary
After thinking about this for a long time  (since November) - i'm finally ready with this.
It'll be a small change - but memory_profiling shows positive effects on memory usage, especially when using multiple strategies, but also for single strategy backtesting.

This will also remove the risk of having a strategy overwrite certain columns when using `--strategy-list` - which could happen if for example 'close' would be overwritten.

Now this change also applies to "single-strategy" backtesting - and i've been thinking about that for a long time, and making this optional (only apply to multi-strategy mode) would not be a problem, but memory-profiler shows that memory-consumption is reduced also in that case.

closes #3132

## Quick changelog

- Provide a fresh copy of the dataframe to each strategy

## Visual proof

Current develop branch for a single strategy - top memory usage around 325Mb

![mprof_develop](https://user-images.githubusercontent.com/5024695/78369241-2a7c0780-75c5-11ea-98cd-46f2114d64cd.png)

This branch (same parameters than above) - top memory usage 300Mb

![mprof_new](https://user-images.githubusercontent.com/5024695/78369258-31a31580-75c5-11ea-956e-634bacfb482b.png)
