### PR TITLE
Improve handling for buy order cancels

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -20,6 +20,7 @@ from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
 from freqtrade.exceptions import DependencyException, InvalidOrderException
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
+from freqtrade.misc import safe_value_fallback
 from freqtrade.pairlist.pairlistmanager import PairListManager
 from freqtrade.persistence import Trade
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
@@ -892,18 +893,23 @@ class FreqtradeBot:
         """
         if order['status'] != 'canceled':
             reason = "cancelled due to timeout"
-            corder = self.exchange.cancel_order(trade.open_order_id, trade.pair)
-            # Some exchanges don't return a dict here.
-            if not isinstance(corder, dict):
+            try:
+                corder = self.exchange.cancel_order(trade.open_order_id, trade.pair)
+                # Some exchanges don't return a dict here.
+                if not isinstance(corder, dict):
+                    corder = {}
+                logger.info('Buy order %s for %s.', reason, trade)
+            except InvalidOrderException:
                 corder = {}
-            logger.info('Buy order %s for %s.', reason, trade)
+                logger.exception(
+                    f"Could not cancel buy order {trade.open_order_id} for pair {trade.pair}")
         else:
             # Order was cancelled already, so we can reuse the existing dict
             corder = order
             reason = "cancelled on exchange"
             logger.info('Buy order %s for %s.', reason, trade)
 
-        if corder.get('remaining', order['remaining']) == order['amount']:
+        if safe_value_fallback(corder, order, 'remaining', 'remaining') == order['amount']:
             logger.info('Buy order removed from database %s', trade)
             # if trade is not partially completed, just delete the trade
             Trade.session.delete(trade)
@@ -915,7 +921,8 @@ class FreqtradeBot:
         # cancel_order may not contain the full order dict, so we need to fallback
         # to the order dict aquired before cancelling.
         # we need to fall back to the values from order if corder does not contain these keys.
-        trade.amount = order['amount'] - corder.get('remaining', order['remaining'])
+        trade.amount = order['amount'] - safe_value_fallback(corder, order,
+                                                             'remaining', 'remaining')
         trade.stake_amount = trade.amount * trade.open_rate
         # verify if fees were taken from amount to avoid problems during selling
         try:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -904,6 +904,7 @@ class FreqtradeBot:
             logger.info('Buy order %s for %s.', reason, trade)
 
         if corder.get('remaining', order['remaining']) == order['amount']:
+            logger.info('Buy order removed from database %s', trade)
             # if trade is not partially completed, just delete the trade
             Trade.session.delete(trade)
             Trade.session.flush()

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -910,7 +910,7 @@ class FreqtradeBot:
             logger.info('Buy order %s for %s.', reason, trade)
 
         if safe_value_fallback(corder, order, 'remaining', 'remaining') == order['amount']:
-            logger.info('Buy order removed from database %s', trade)
+            logger.info('Buy order fully cancelled. Removing %s from database.', trade)
             # if trade is not partially completed, just delete the trade
             Trade.session.delete(trade)
             Trade.session.flush()

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -134,6 +134,21 @@ def round_dict(d, n):
     return {k: (round(v, n) if isinstance(v, float) else v) for k, v in d.items()}
 
 
+def safe_value_fallback(dict1: dict, dict2: dict, key1: str, key2: str, default_value=None):
+    """
+    Search a value in dict1, return this if it's not None.
+    Fall back to dict2 - return key2 from dict2 if it's not None.
+    Else falls back to None.
+
+    """
+    if key1 in dict1 and dict1[key1] is not None:
+        return dict1[key1]
+    else:
+        if key2 in dict2 and dict2[key2] is not None:
+            return dict2[key2]
+    return default_value
+
+
 def plural(num: float, singular: str, plural: str = None) -> str:
     return singular if (num == 1 or num == -1) else plural or singular + 's'
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,7 +9,7 @@ import pytest
 from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.misc import (datesarray_to_datetimearray, file_dump_json,
                             file_load_json, format_ms_time, pair_to_filename,
-                            plural, shorten_date)
+                            plural, safe_value_fallback, shorten_date)
 
 
 def test_shorten_date() -> None:
@@ -91,6 +91,19 @@ def test_format_ms_time() -> None:
     # Date 2017-12-13 08:02:01
     date_in_epoch_ms = 1513152121000
     assert format_ms_time(date_in_epoch_ms) == res.astimezone(None).strftime('%Y-%m-%dT%H:%M:%S')
+
+
+def test_safe_value_fallback():
+    dict1 = {'keya': None, 'keyb': 2, 'keyc': 5}
+    dict2 = {'keya': 20, 'keyb': None, 'keyc': 6}
+    assert safe_value_fallback(dict1, dict2, 'keya', 'keya') == 20
+    assert safe_value_fallback(dict2, dict1, 'keya', 'keya') == 20
+
+    assert safe_value_fallback(dict1, dict2, 'keyb', 'keyb') == 2
+    assert safe_value_fallback(dict2, dict1, 'keyb', 'keyb') == 2
+
+    assert safe_value_fallback(dict1, dict2, 'keyc', 'keyc') == 5
+    assert safe_value_fallback(dict2, dict1, 'keyc', 'keyc') == 6
 
 
 def test_plural() -> None:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -94,8 +94,8 @@ def test_format_ms_time() -> None:
 
 
 def test_safe_value_fallback():
-    dict1 = {'keya': None, 'keyb': 2, 'keyc': 5}
-    dict2 = {'keya': 20, 'keyb': None, 'keyc': 6}
+    dict1 = {'keya': None, 'keyb': 2, 'keyc': 5, 'keyd': None}
+    dict2 = {'keya': 20, 'keyb': None, 'keyc': 6, 'keyd': None}
     assert safe_value_fallback(dict1, dict2, 'keya', 'keya') == 20
     assert safe_value_fallback(dict2, dict1, 'keya', 'keya') == 20
 
@@ -104,6 +104,14 @@ def test_safe_value_fallback():
 
     assert safe_value_fallback(dict1, dict2, 'keyc', 'keyc') == 5
     assert safe_value_fallback(dict2, dict1, 'keyc', 'keyc') == 6
+
+    assert safe_value_fallback(dict1, dict2, 'keyd', 'keyd') is None
+    assert safe_value_fallback(dict2, dict1, 'keyd', 'keyd') is None
+    assert safe_value_fallback(dict2, dict1, 'keyd', 'keyd', 1234) == 1234
+
+    assert safe_value_fallback(dict1, dict2, 'keyNo', 'keyNo') is None
+    assert safe_value_fallback(dict2, dict1, 'keyNo', 'keyNo') is None
+    assert safe_value_fallback(dict2, dict1, 'keyNo', 'keyNo', 1234) == 1234
 
 
 def test_plural() -> None:


### PR DESCRIPTION
## Summary
Improve logging to enable checking (via logs) which branch is taken when cancelling a buy order.
Also fixes #3130 - an exception caused by the cancel-order ['remaining'] field to be None (instead of not being present).

## Quick changelog

- Add logging statement for full buy order cancel
- Logging for the "partial" branch is available.
- Add `safe_value_fallback()` - a function to safely get a value out of 2 dictionaries where keys could exist, or be empty
- use safe_value_fallback to get remaining - the failing key
- Correctly catch InvalidOrderException should it occur from cancel_order (could happen if the order is filled that moment).