### PR TITLE
[minor] have version-detection fall back to freqtrade_commit

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -25,7 +25,7 @@ if __version__ == 'develop':
     except Exception:
         # git not available, ignore
         try:
-            # Try Fallback to freqtrade_commit file (created by CI whild building docker image)
+            # Try Fallback to freqtrade_commit file (created by CI while building docker image)
             from pathlib import Path
             versionfile = Path('./freqtrade_commit')
             if versionfile.is_file():

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -24,4 +24,11 @@ if __version__ == 'develop':
         #     stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
     except Exception:
         # git not available, ignore
-        pass
+        try:
+            # Try Fallback to freqtrade_commit file (created by CI whild building docker image)
+            from pathlib import Path
+            versionfile = Path('./freqtrade_commit')
+            if versionfile.is_file():
+                __version__ = f"docker-{versionfile.read_text()[:8]}"
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
have version-detection fall back to `freqtrade_commit` - the file created in docker-ci.

this allows `freqtrade --version` to work for develop images in docker too.


to test: 
- create a file freqtrade_commit containing the current hash
- modify docker-compose.yml to include `- ".:/freqtrade/"` as volume (mounting the current directory into the container)
- run `docker-compose run --rm freqtrade --version`

