### PR TITLE
Fix pairlist caching

### DIFF
--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -55,13 +55,13 @@ class IPairList(ABC):
         """
 
         @cached(cache=self._log_cache)
-        def _log_on_refresh(logmethod, message: str):
+        def _log_on_refresh(message: str):
             logmethod(message)
 
         # Log as debug first
         logger.debug(message)
         # Call hidden function.
-        _log_on_refresh(logmethod, message)
+        _log_on_refresh(message)
 
     @abstractproperty
     def needstickers(self) -> bool:

--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -9,6 +9,8 @@ from abc import ABC, abstractmethod, abstractproperty
 from copy import deepcopy
 from typing import Any, Dict, List
 
+from cachetools import TTLCache, cached
+
 from freqtrade.exchange import market_is_active
 
 logger = logging.getLogger(__name__)
@@ -31,6 +33,9 @@ class IPairList(ABC):
         self._config = config
         self._pairlistconfig = pairlistconfig
         self._pairlist_pos = pairlist_pos
+        self.refresh_period = self._pairlistconfig.get('refresh_period', 1800)
+        self._last_refresh = 0
+        self._log_cache = TTLCache(maxsize=1024, ttl=self.refresh_period)
 
     @property
     def name(self) -> str:
@@ -39,6 +44,24 @@ class IPairList(ABC):
         -> no need to overwrite in subclasses
         """
         return self.__class__.__name__
+
+    def log_on_refresh(self, logmethod, message: str) -> None:
+        """
+        Logs message - not more often than "refresh_period" to avoid log spamming
+        Logs the log-message as debug as well to simplify debugging.
+        :param logmethod: Function that'll be called. Most likely `logger.info`.
+        :param message: String containing the message to be sent to the function.
+        :return: None.
+        """
+
+        @cached(cache=self._log_cache)
+        def _log_on_refresh(logmethod, message: str):
+            logmethod(message)
+
+        # Log as debug first
+        logger.debug(message)
+        # Call hidden function.
+        _log_on_refresh(logmethod, message)
 
     @abstractproperty
     def needstickers(self) -> bool:

--- a/freqtrade/pairlist/PrecisionFilter.py
+++ b/freqtrade/pairlist/PrecisionFilter.py
@@ -39,8 +39,9 @@ class PrecisionFilter(IPairList):
         stop_gap_price = self._exchange.price_to_precision(ticker["symbol"], stop_price * 0.99)
         logger.debug(f"{ticker['symbol']} - {sp} : {stop_gap_price}")
         if sp <= stop_gap_price:
-            logger.info(f"Removed {ticker['symbol']} from whitelist, "
-                        f"because stop price {sp} would be <= stop limit {stop_gap_price}")
+            self.log_on_refresh(logger.info,
+                                f"Removed {ticker['symbol']} from whitelist, "
+                                f"because stop price {sp} would be <= stop limit {stop_gap_price}")
             return False
         return True
 

--- a/freqtrade/pairlist/PriceFilter.py
+++ b/freqtrade/pairlist/PriceFilter.py
@@ -43,8 +43,8 @@ class PriceFilter(IPairList):
         compare = ticker['last'] + 1 / pow(10, precision)
         changeperc = (compare - ticker['last']) / ticker['last']
         if changeperc > self._low_price_ratio:
-            logger.info(f"Removed {ticker['symbol']} from whitelist, "
-                        f"because 1 unit is {changeperc * 100:.3f}%")
+            self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                             f"because 1 unit is {changeperc * 100:.3f}%")
             return False
         return True
 

--- a/freqtrade/pairlist/SpreadFilter.py
+++ b/freqtrade/pairlist/SpreadFilter.py
@@ -49,9 +49,9 @@ class SpreadFilter(IPairList):
             if 'bid' in ticker and 'ask' in ticker:
                 spread = 1 - ticker['bid'] / ticker['ask']
                 if not ticker or spread > self._max_spread_ratio:
-                    logger.info(f"Removed {ticker['symbol']} from whitelist, "
-                                f"because spread {spread * 100:.3f}% >"
-                                f"{self._max_spread_ratio * 100}%")
+                    self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                                     f"because spread {spread * 100:.3f}% >"
+                                                     f"{self._max_spread_ratio * 100}%")
                     pairlist.remove(p)
             else:
                 pairlist.remove(p)

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -46,6 +46,28 @@ def static_pl_conf(whitelist_conf):
     return whitelist_conf
 
 
+def test_log_on_refresh(mocker, static_pl_conf, markets, tickers):
+    mocker.patch.multiple('freqtrade.exchange.Exchange',
+                          markets=PropertyMock(return_value=markets),
+                          exchange_has=MagicMock(return_value=True),
+                          get_tickers=tickers
+                          )
+    freqtrade = get_patched_freqtradebot(mocker, static_pl_conf)
+    logmock = MagicMock()
+    # Assign starting whitelist
+    pl = freqtrade.pairlists._pairlists[0]
+    pl.log_on_refresh(logmock, 'Hello world')
+    assert logmock.call_count == 1
+    pl.log_on_refresh(logmock, 'Hello world')
+    assert logmock.call_count == 1
+    assert pl._log_cache.currsize == 1
+    assert ('Hello world',) in pl._log_cache._Cache__data
+
+    pl.log_on_refresh(logmock, 'Hello world2')
+    assert logmock.call_count == 2
+    assert pl._log_cache.currsize == 2
+
+
 def test_load_pairlist_noexist(mocker, markets, default_conf):
     bot = get_patched_freqtradebot(mocker, default_conf)
     mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(return_value=markets))


### PR DESCRIPTION
## Summary
Fix bug from #3166, where Volumepairlist doesn't filter correctly when StaticPairlist is first.
Also, implements "log-caching" to avoid log spamming.
Currently, the same logmessages from PairlistFilter are printed every few seconds in certain constellations (when using StaticPairlist first, for example).

closes #3166

## Quick changelog

- Don't log so frequently by using a TTL cache (only logs messages every 1800s - avoiding log spamming).
- Fix bug where Volumepairlist doesn't correctly filter pairs 
