### PR TITLE
Fix random test failure in hyperopt

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -665,7 +665,6 @@ class Hyperopt:
 
         self.dimensions: List[Dimension] = self.hyperopt_space()
         self.opt = self.get_optimizer(self.dimensions, config_jobs)
-
         try:
             with Parallel(n_jobs=config_jobs) as parallel:
                 jobs = parallel._effective_n_jobs()
@@ -693,7 +692,7 @@ class Hyperopt:
                         ' [', progressbar.ETA(), ', ', progressbar.Timer(), ']',
                     ]
                 with progressbar.ProgressBar(
-                         maxval=self.total_epochs, redirect_stdout=True, redirect_stderr=True,
+                         maxval=self.total_epochs, redirect_stdout=False, redirect_stderr=False,
                          widgets=widgets
                      ) as pbar:
                     EVALS = ceil(self.total_epochs / jobs)


### PR DESCRIPTION
## Summary
This fixes random test failures by not initializing stdout capturing twice.
Now i'm not certain why the failures only occur in windows CI - as with the same random number, i can get them to fail on linux just fine ... 

Visually i did not observe any difference between the 2 modes ... (probably because stdout/stderr is already captured).

progresbar however seems to have a problem with this double-capturing if it's initialized twice and raises an error.

https://github.com/WoLpH/python-progressbar/issues/225

## Quick changelog

- Fix random test failures

## Test values:
one of the random test-seeds:
(does not matter if it's running just for this file or for the whole testsuite).

```bash
pytest tests/optimize/test_hyperopt.py -v --random-order-seed=541257
```