### PR TITLE
Docker log location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   freqtrade:
     image: freqtradeorg/freqtrade:master
+    # image: freqtradeorg/freqtrade:develop
     # Build step - only needed when additional dependencies are needed
     # build:
     #   context: .
@@ -14,7 +15,7 @@ services:
     # Default command used when running `docker compose up`
     command: >
       trade
-      --logfile /freqtrade/user_data/freqtrade.log
+      --logfile /freqtrade/user_data/logs/freqtrade.log
       --db-url sqlite:////freqtrade/user_data/tradesv3.sqlite
       --config /freqtrade/user_data/config.json
       --strategy SampleStrategy

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -37,30 +37,30 @@ as the watchdog.
 
 ## Advanced Logging
 
-On many Linux systems the bot can be configured to send its log messages to `syslog` or `journald` system services. Logging to a remote `syslog` server is also available on Windows. The special values for the `--logfilename` command line option can be used for this.
+On many Linux systems the bot can be configured to send its log messages to `syslog` or `journald` system services. Logging to a remote `syslog` server is also available on Windows. The special values for the `--logfile` command line option can be used for this.
 
 ### Logging to syslog
 
-To send Freqtrade log messages to a local or remote `syslog` service use the `--logfilename` command line option with the value in the following format:
+To send Freqtrade log messages to a local or remote `syslog` service use the `--logfile` command line option with the value in the following format:
 
-* `--logfilename syslog:<syslog_address>` -- send log messages to `syslog` service using the `<syslog_address>` as the syslog address.
+* `--logfile syslog:<syslog_address>` -- send log messages to `syslog` service using the `<syslog_address>` as the syslog address.
 
 The syslog address can be either a Unix domain socket (socket filename) or a UDP socket specification, consisting of IP address and UDP port, separated by the `:` character.
 
 So, the following are the examples of possible usages:
 
-* `--logfilename syslog:/dev/log` -- log to syslog (rsyslog) using the `/dev/log` socket, suitable for most systems.
-* `--logfilename syslog` -- same as above, the shortcut for `/dev/log`.
-* `--logfilename syslog:/var/run/syslog` -- log to syslog (rsyslog) using the `/var/run/syslog` socket. Use this on MacOS.
-* `--logfilename syslog:localhost:514` -- log to local syslog using UDP socket, if it listens on port 514.
-* `--logfilename syslog:<ip>:514` -- log to remote syslog at IP address and port 514. This may be used on Windows for remote logging to an external syslog server.
+* `--logfile syslog:/dev/log` -- log to syslog (rsyslog) using the `/dev/log` socket, suitable for most systems.
+* `--logfile syslog` -- same as above, the shortcut for `/dev/log`.
+* `--logfile syslog:/var/run/syslog` -- log to syslog (rsyslog) using the `/var/run/syslog` socket. Use this on MacOS.
+* `--logfile syslog:localhost:514` -- log to local syslog using UDP socket, if it listens on port 514.
+* `--logfile syslog:<ip>:514` -- log to remote syslog at IP address and port 514. This may be used on Windows for remote logging to an external syslog server.
 
 Log messages are send to `syslog` with the `user` facility. So you can see them with the following commands:
 
 * `tail -f /var/log/user`, or 
 * install a comprehensive graphical viewer (for instance, 'Log File Viewer' for Ubuntu).
 
-On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfilename syslog` or `--logfilename journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
+On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfile syslog` or `--logfile journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
 
 For `rsyslog` the messages from the bot can be redirected into a separate dedicated log file. To achieve this, add
 ```
@@ -78,9 +78,9 @@ $RepeatedMsgReduction on
 
 This needs the `systemd` python package installed as the dependency, which is not available on Windows. Hence, the whole journald logging functionality is not available for a bot running on Windows.
 
-To send Freqtrade log messages to `journald` system service use the `--logfilename` command line option with the value in the following format:
+To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
 
-* `--logfilename journald` -- send log messages to `journald`.
+* `--logfile journald` -- send log messages to `journald`.
 
 Log messages are send to `journald` with the `user` facility. So you can see them with the following commands:
 
@@ -89,4 +89,4 @@ Log messages are send to `journald` with the `user` facility. So you can see the
 
 There are many other options in the `journalctl` utility to filter the messages, see manual pages for this utility.
 
-On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfilename syslog` or `--logfilename journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
+On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfile syslog` or `--logfile journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -100,7 +100,7 @@ $ tail -f /path/to/mylogfile.log | grep 'something'
 ```
 from a separate terminal window.
 
-On Windows, the `--logfilename` option is also supported by Freqtrade and you can use the `findstr` command to search the log for the string of interest:
+On Windows, the `--logfile` option is also supported by Freqtrade and you can use the `findstr` command to search the log for the string of interest:
 ```
 > type \path\to\mylogfile.log | findstr "something"
 ```

--- a/freqtrade/configuration/directory_operations.py
+++ b/freqtrade/configuration/directory_operations.py
@@ -33,8 +33,8 @@ def create_userdata_dir(directory: str, create_dir: bool = False) -> Path:
     :param create_dir: Create directory if it does not exist.
     :return: Path object containing the directory
     """
-    sub_dirs = ["backtest_results", "data", "hyperopts", "hyperopt_results", "notebooks",
-                "plot", "strategies", ]
+    sub_dirs = ["backtest_results", "data", "hyperopts", "hyperopt_results", "logs",
+                "notebooks", "plot", "strategies", ]
     folder = Path(directory)
     if not folder.is_dir():
         if create_dir:

--- a/tests/test_directory_operations.py
+++ b/tests/test_directory_operations.py
@@ -25,7 +25,7 @@ def test_create_userdata_dir(mocker, default_conf, caplog) -> None:
     md = mocker.patch.object(Path, 'mkdir', MagicMock())
 
     x = create_userdata_dir('/tmp/bar', create_dir=True)
-    assert md.call_count == 8
+    assert md.call_count == 9
     assert md.call_args[1]['parents'] is False
     assert log_has(f'Created user-data directory: {Path("/tmp/bar")}', caplog)
     assert isinstance(x, Path)


### PR DESCRIPTION
## Summary
Default to creating a log folder in `user_data` - and have `docker-compose.yml` log there.

closes #3185
## Quick changelog

- fix typo in advanced logging documentation
- Log to user_data/logs/


## Future work
Default to log to a file in `user_data/logs` also for non-docker setups.
This is still in development / testing as it's not trivial to get this right without introducing a Memory leak.