### PR TITLE
Update wording in expectancy docs and add example

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -79,7 +79,7 @@ So lets say your Win rate is 28% and your Risk Reward Ratio is 5:
 Expectancy = (5 X 0.28) – 0.72 = 0.68
 ```
 
-Superficially, this means that on average you expect this strategy’s trades to return .68 times the size of your loses. This is important for two reasons: First, it may seem obvious, but you know right away that you have a positive return. Second, you now have a number you can compare to other candidate systems to make decisions about which ones you employ.
+Superficially, this means that on average you expect this strategy’s trades to return 1.68 times the size of your loses. Said another way, you can expect to win $1.68 for every $1 you lose. This is important for two reasons: First, it may seem obvious, but you know right away that you have a positive return. Second, you now have a number you can compare to other candidate systems to make decisions about which ones you employ.
 
 It is important to remember that any system with an expectancy greater than 0 is profitable using past data. The key is finding one that will be profitable in the future.
 


### PR DESCRIPTION
## Summary
This PR aims to improve the documentation of the Edge module by using more precise wording when describing expectancy.

## Quick changelog

-  Fix return rate in expectancy docs
-  Add example to make it more clear

## What's new?
The docs state that a strategy which returns .68 times as much as it loses is positive. But, if a strategy returns .68 times as much as it loses, then that means it loses 1.47 times as much as it returns and it is NOT a good strategy. 

One (off-topic) question, have you guys ever considered using the kelly criterion in order to determine stake size? The math is very similar to what already exists in this module. I believe that ideal position size according to the kelly criterion would be given by:

 (expectancy * available capital) / (risk reward ratio)

I think this could be normalized to avoid inadvertently placing 100% of your available capital on one bet. 

see:
https://www.investopedia.com/articles/trading/04/091504.asp (some imprecise wording)
and https://en.wikipedia.org/wiki/Kelly_criterion