### PR TITLE
Better handling and description of asterisk in Hyperopt output

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -6,9 +6,7 @@ algorithms included in the `scikit-optimize` package to accomplish this. The
 search will burn all your CPU cores, make your laptop sound like a fighter jet
 and still take a long time.
 
-In general, the search for best parameters starts with a few random combinations and then uses Bayesian search with a
-ML regressor algorithm (currently ExtraTreesRegressor) to quickly find a combination of parameters in the search hyperspace
-that minimizes the value of the [loss function](#loss-functions).
+In general, the search for best parameters starts with a few random combinations (see [below](#reproducible-results) for more details) and then uses Bayesian search with a ML regressor algorithm (currently ExtraTreesRegressor) to quickly find a combination of parameters in the search hyperspace that minimizes the value of the [loss function](#loss-functions).
 
 Hyperopt requires historic data to be available, just as backtesting does.
 To learn how to get data for the pairs and exchange you're interested in, head over to the [Data Downloading](data-download.md) section of the documentation.
@@ -311,7 +309,7 @@ You can also enable position stacking in the configuration file by explicitly se
 
 ### Reproducible results
 
-The search for optimal parameters starts with a few (currently 30) random combinations in the hyperspace of parameters, random Hyperopt epochs. These random epochs are marked with a leading asterisk sign at the Hyperopt output.
+The search for optimal parameters starts with a few (currently 30) random combinations in the hyperspace of parameters, random Hyperopt epochs. These random epochs are marked with an asterisk character (`*`) in the first column in the Hyperopt output.
 
 The initial state for generation of these random values (random state) is controlled by the value of the `--random-state` command line option. You can set it to some arbitrary value of your choice to obtain reproducible results.
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -304,8 +304,9 @@ class Hyperopt:
         trials.columns = ['Best', 'Epoch', 'Trades', 'Avg profit', 'Total profit',
                           'Profit', 'Avg duration', 'Objective', 'is_initial_point', 'is_best']
         trials['is_profit'] = False
-        trials.loc[trials['is_initial_point'], 'Best'] = '*'
+        trials.loc[trials['is_initial_point'], 'Best'] = '*     '
         trials.loc[trials['is_best'], 'Best'] = 'Best'
+        trials.loc[trials['is_initial_point'] & trials['is_best'], 'Best'] = '* Best'
         trials.loc[trials['Total profit'] > 0, 'is_profit'] = True
         trials['Trades'] = trials['Trades'].astype(str)
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -397,6 +397,7 @@ class Hyperopt:
         trials['is_profit'] = False
         trials.loc[trials['is_initial_point'], 'Best'] = '*'
         trials.loc[trials['is_best'], 'Best'] = 'Best'
+        trials.loc[trials['is_initial_point'] & trials['is_best'], 'Best'] = '* Best'
         trials.loc[trials['Total profit'] > 0, 'is_profit'] = True
         trials['Epoch'] = trials['Epoch'].astype(str)
         trials['Trades'] = trials['Trades'].astype(str)


### PR DESCRIPTION
* Fixes printing of asterisk (`*`) for initial random points (currently it's not printed for epochs marked as Best)
* The docs is slightly adjusted to document it, fixes #3065 

Current output:
```
+--------+---------+----------+--------------+------------------------------+----------------+-------------+
|   Best |   Epoch |   Trades |   Avg profit |                       Profit |   Avg duration |   Objective |
|--------+---------+----------+--------------+------------------------------+----------------+-------------|
|   Best |    1/50 |       63 |       -3.75% | -472.35727170 BTC (-235.94%) |     12,617.1 m |     2.44816 |
|   Best |    2/50 |      114 |       -1.20% | -274.30359399 BTC (-137.01%) |      5,760.0 m |      2.2858 |                                 
|   Best |    3/50 |       72 |        0.30% |   43.86067071 BTC   (21.91%) |      8,740.0 m |     -0.1685 |
|      * |    4/50 |       64 |       -0.97% | -124.88441910 BTC  (-62.38%) |     11,137.5 m |     0.74543 |                                 
|      * |    5/50 |       59 |       -4.25% | -502.01224276 BTC (-250.76%) |     13,326.1 m |     2.77929 |
|      * |    6/50 |       41 |       -4.29% | -351.84769615 BTC (-175.75%) |     22,723.9 m |     1.74674 |                                 
|      * |    7/50 |       35 |       -4.81% | -337.05428969 BTC (-168.36%) |     27,442.3 m |      1.7915 |
|      * |    8/50 |       43 |       -2.64% | -226.97343886 BTC (-113.37%) |     22,001.9 m |     1.26894 |                                 
|      * |    9/50 |       61 |       -2.38% | -290.95285159 BTC (-145.33%) |     12,889.2 m |     1.37578 |
|      * |   10/50 |       32 |       -5.96% | -381.87203347 BTC (-190.75%) |     30,375.0 m |     1.74034 |                                 
|      * |   11/50 |       37 |       -4.56% | -337.49435298 BTC (-168.58%) |     25,725.4 m |     1.80914 |
|      * |   12/50 |       43 |       -3.89% | -335.01568058 BTC (-167.34%) |     20,394.4 m |     1.65778 |                                 
|      * |   13/50 |      161 |       -1.14% | -367.50275334 BTC (-183.57%) |      1,601.0 m |     3.50851 |
|      * |   14/50 |      138 |       -1.49% | -410.68627668 BTC (-205.14%) |      4,100.9 m |     4.21782 |                                 
|      * |   15/50 |       32 |       -6.15% | -393.76975007 BTC (-196.69%) |     32,445.0 m |     1.87057 |
|      * |   16/50 |      163 |       -1.08% | -351.43117613 BTC (-175.54%) |      1,563.7 m |     3.52809 |
|   Best |   17/50 |      194 |        0.46% |  177.51488725 BTC   (88.67%) |        645.8 m |    -2.09119 |                                 
|      * |   18/50 |       53 |       -3.82% | -405.50914435 BTC (-202.55%) |     15,758.5 m |     2.00331 |                                 
|      * |   19/50 |       58 |       -3.05% | -353.63876138 BTC (-176.64%) |     13,580.7 m |     1.73411 |
|      * |   20/50 |       36 |       -2.32% | -167.51778408 BTC  (-83.68%) |     25,080.0 m |     0.76924 |                                 
|      * |   21/50 |      205 |        0.38% |  157.30166663 BTC   (78.57%) |        428.5 m |    -1.96652 |
|      * |   22/50 |       87 |       -1.64% | -285.00490229 BTC (-142.36%) |      7,001.4 m |     1.90633 |                                 
|      * |   23/50 |       40 |       -4.03% | -322.85848943 BTC (-161.27%) |     24,120.0 m |     1.64738 |
|      * |   24/50 |       83 |       -2.55% | -423.69111822 BTC (-211.63%) |      7,130.6 m |     2.88041 |
|      * |   25/50 |       97 |        0.35% |   68.38123491 BTC   (34.16%) |      6,101.4 m |      -0.395 |                                 
|      * |   26/50 |       41 |       -2.19% | -179.92749505 BTC  (-89.87%) |     22,126.8 m |     1.07731 |                                 
|      * |   27/50 |       37 |       -2.32% | -171.95006197 BTC  (-85.89%) |     24,674.6 m |     0.97755 |
|   Best |   28/50 |      232 |        0.78% |  364.19108794 BTC  (181.91%) |        223.4 m |    -6.94003 |                                 
|      * |   29/50 |       51 |       -2.82% | -288.20499481 BTC (-143.96%) |     16,404.7 m |     1.39079 |
|      * |   30/50 |       51 |       -4.10% | -418.74206753 BTC (-209.16%) |     17,138.8 m |     2.00807 |                                 
|        |   31/50 |      121 |       -1.72% | -417.07796102 BTC (-208.33%) |      3,594.0 m |     3.22762 |
|   Best |   32/50 |      232 |        1.15% |  536.19687015 BTC  (267.83%) |        223.4 m |     -10.738 |
|        |   33/50 |      225 |        0.63% |  284.25180920 BTC  (141.98%) |        262.4 m |    -4.39462 |                                 
|        |   34/50 |      228 |        1.03% |  468.64121600 BTC  (234.09%) |        252.6 m |    -8.93842 |                                 
|   Best |   35/50 |      239 |        1.60% |  764.48857639 BTC  (381.86%) |        120.5 m |    -21.0969 |
|   Best |   36/50 |      240 |        1.64% |  786.72226582 BTC  (392.97%) |        108.0 m |    -22.3696 |                                 
|        |   37/50 |      241 |        1.45% |  701.40638676 BTC  (350.35%) |        107.6 m |    -19.1468 |                                 
|   Best |   38/50 |      242 |        1.67% |  810.70052270 BTC  (404.95%) |        101.2 m |    -22.7755 |                                 
|        |   39/50 |      238 |        0.96% |  457.00634995 BTC  (228.27%) |        163.4 m |     -11.479 |                                 
|        |   40/50 |      246 |        1.24% |  612.56690075 BTC  (305.98%) |         70.2 m |    -18.0911 |
|        |   41/50 |      246 |        1.46% |  717.71039356 BTC  (358.50%) |         70.2 m |    -21.0078 |
|   Best |   42/50 |      246 |        1.67% |  820.01066377 BTC  (409.60%) |         70.2 m |    -24.2175 |                                 
|        |   43/50 |      242 |        1.63% |  789.22765559 BTC  (394.22%) |         95.2 m |    -22.5776 |
|        |   44/50 |      246 |        1.64% |  809.57912045 BTC  (404.39%) |         70.2 m |     -24.111 |                                 
|        |   45/50 |      241 |        1.62% |  780.27135697 BTC  (389.75%) |        107.6 m |    -21.0649 |
|   Best |   46/50 |      245 |        1.73% |  850.81482268 BTC  (424.98%) |         76.4 m |    -24.6374 |                                 
|        |   47/50 |      235 |        1.08% |  510.16946803 BTC  (254.83%) |        220.6 m |    -10.9355 |                                 
|        |   48/50 |      238 |        1.47% |  698.33513917 BTC  (348.82%) |        163.4 m |    -16.8413 |
|        |   49/50 |      241 |        1.58% |  764.14444638 BTC  (381.69%) |        107.6 m |    -20.1885 |
|        |   50/50 |      241 |        1.55% |  750.03181860 BTC  (374.64%) |        107.6 m |     -20.954 |                                 
```

New output:
```
+--------+---------+----------+--------------+------------------------------+----------------+-------------+
|   Best |   Epoch |   Trades |   Avg profit |                       Profit |   Avg duration |   Objective |
|--------+---------+----------+--------------+------------------------------+----------------+-------------|
| * Best |    1/50 |       63 |       -3.75% | -472.35727170 BTC (-235.94%) |     12,617.1 m |     2.44816 |
| * Best |    2/50 |      114 |       -1.20% | -274.30359399 BTC (-137.01%) |      5,760.0 m |      2.2858 |                                 
| * Best |    3/50 |       72 |        0.30% |   43.86067071 BTC   (21.91%) |      8,740.0 m |     -0.1685 |
| *      |    4/50 |       64 |       -0.97% | -124.88441910 BTC  (-62.38%) |     11,137.5 m |     0.74543 |                                 
| *      |    5/50 |       59 |       -4.25% | -502.01224276 BTC (-250.76%) |     13,326.1 m |     2.77929 |
| *      |    6/50 |       41 |       -4.29% | -351.84769615 BTC (-175.75%) |     22,723.9 m |     1.74674 |                                 
| *      |    7/50 |       35 |       -4.81% | -337.05428969 BTC (-168.36%) |     27,442.3 m |      1.7915 |
| *      |    8/50 |       43 |       -2.64% | -226.97343886 BTC (-113.37%) |     22,001.9 m |     1.26894 |                                 
| *      |    9/50 |       61 |       -2.38% | -290.95285159 BTC (-145.33%) |     12,889.2 m |     1.37578 |
| *      |   10/50 |       32 |       -5.96% | -381.87203347 BTC (-190.75%) |     30,375.0 m |     1.74034 |                                 
| *      |   11/50 |       37 |       -4.56% | -337.49435298 BTC (-168.58%) |     25,725.4 m |     1.80914 |
| *      |   12/50 |       43 |       -3.89% | -335.01568058 BTC (-167.34%) |     20,394.4 m |     1.65778 |
| *      |   13/50 |      161 |       -1.14% | -367.50275334 BTC (-183.57%) |      1,601.0 m |     3.50851 |                                 
| *      |   14/50 |      138 |       -1.49% | -410.68627668 BTC (-205.14%) |      4,100.9 m |     4.21782 |                                 
| *      |   15/50 |       32 |       -6.15% | -393.76975007 BTC (-196.69%) |     32,445.0 m |     1.87057 |
| *      |   16/50 |      163 |       -1.08% | -351.43117613 BTC (-175.54%) |      1,563.7 m |     3.52809 |                                 
| * Best |   17/50 |      194 |        0.46% |  177.51488725 BTC   (88.67%) |        645.8 m |    -2.09119 |
| *      |   18/50 |       53 |       -3.82% | -405.50914435 BTC (-202.55%) |     15,758.5 m |     2.00331 |                                 
| *      |   19/50 |       58 |       -3.05% | -353.63876138 BTC (-176.64%) |     13,580.7 m |     1.73411 |
| *      |   20/50 |       36 |       -2.32% | -167.51778408 BTC  (-83.68%) |     25,080.0 m |     0.76924 |                                 
| *      |   21/50 |      205 |        0.38% |  157.30166663 BTC   (78.57%) |        428.5 m |    -1.96652 |
| *      |   22/50 |       87 |       -1.64% | -285.00490229 BTC (-142.36%) |      7,001.4 m |     1.90633 |                                 
| *      |   23/50 |       40 |       -4.03% | -322.85848943 BTC (-161.27%) |     24,120.0 m |     1.64738 |
| *      |   24/50 |       83 |       -2.55% | -423.69111822 BTC (-211.63%) |      7,130.6 m |     2.88041 |                                 
| *      |   25/50 |       97 |        0.35% |   68.38123491 BTC   (34.16%) |      6,101.4 m |      -0.395 |
| *      |   26/50 |       41 |       -2.19% | -179.92749505 BTC  (-89.87%) |     22,126.8 m |     1.07731 |                                 
| *      |   27/50 |       37 |       -2.32% | -171.95006197 BTC  (-85.89%) |     24,674.6 m |     0.97755 |
| * Best |   28/50 |      232 |        0.78% |  364.19108794 BTC  (181.91%) |        223.4 m |    -6.94003 |                                 
| *      |   29/50 |       51 |       -2.82% | -288.20499481 BTC (-143.96%) |     16,404.7 m |     1.39079 |
| *      |   30/50 |       51 |       -4.10% | -418.74206753 BTC (-209.16%) |     17,138.8 m |     2.00807 |                                 
|        |   31/50 |      121 |       -1.72% | -417.07796102 BTC (-208.33%) |      3,594.0 m |     3.22762 |
|   Best |   32/50 |      232 |        1.15% |  536.19687015 BTC  (267.83%) |        223.4 m |     -10.738 |
|        |   33/50 |      225 |        0.63% |  284.25180920 BTC  (141.98%) |        262.4 m |    -4.39462 |                                 
|        |   34/50 |      228 |        1.03% |  468.64121600 BTC  (234.09%) |        252.6 m |    -8.93842 |                                 
|   Best |   35/50 |      239 |        1.60% |  764.48857639 BTC  (381.86%) |        120.5 m |    -21.0969 |
|   Best |   36/50 |      240 |        1.64% |  786.72226582 BTC  (392.97%) |        108.0 m |    -22.3696 |                                 
|        |   37/50 |      241 |        1.45% |  701.40638676 BTC  (350.35%) |        107.6 m |    -19.1468 |                                 
|   Best |   38/50 |      242 |        1.67% |  810.70052270 BTC  (404.95%) |        101.2 m |    -22.7755 |                                 
|        |   39/50 |      238 |        0.96% |  457.00634995 BTC  (228.27%) |        163.4 m |     -11.479 |                                 
|        |   40/50 |      246 |        1.24% |  612.56690075 BTC  (305.98%) |         70.2 m |    -18.0911 |
|        |   41/50 |      246 |        1.46% |  717.71039356 BTC  (358.50%) |         70.2 m |    -21.0078 |
|   Best |   42/50 |      246 |        1.67% |  820.01066377 BTC  (409.60%) |         70.2 m |    -24.2175 |                                 
|        |   43/50 |      242 |        1.63% |  789.22765559 BTC  (394.22%) |         95.2 m |    -22.5776 |                                 
|        |   44/50 |      246 |        1.64% |  809.57912045 BTC  (404.39%) |         70.2 m |     -24.111 |
|        |   45/50 |      241 |        1.62% |  780.27135697 BTC  (389.75%) |        107.6 m |    -21.0649 |                                 
|   Best |   46/50 |      245 |        1.73% |  850.81482268 BTC  (424.98%) |         76.4 m |    -24.6374 |                                 
|        |   47/50 |      235 |        1.08% |  510.16946803 BTC  (254.83%) |        220.6 m |    -10.9355 |                                 
|        |   48/50 |      238 |        1.47% |  698.33513917 BTC  (348.82%) |        163.4 m |    -16.8413 |
|        |   49/50 |      241 |        1.58% |  764.14444638 BTC  (381.69%) |        107.6 m |    -20.1885 |                                 
|        |   50/50 |      241 |        1.55% |  750.03181860 BTC  (374.64%) |        107.6 m |     -20.954 |                                 
```

Q: Maybe a better title of the first column (instead of current 'Best') should be used. Maybe the empty title is better.
