### PR TITLE
Backtest use pairlists

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -17,8 +17,12 @@ For details on downloading, please refer to the [Data Downloading](data-download
 
 The result of backtesting will confirm if your bot has better odds of making a profit than a loss.
 
-!!! Tip "Using dynamic pairlists for backtesting"
-    While using dynamic pairlists during backtesting is not possible, a dynamic pairlist using current data can be generated via the [`test-pairlist`](utils.md#test-pairlist) command, and needs to be specified as `"pair_whitelist"` attribute in the configuration.
+!!! Warning "Using dynamic pairlists for backtesting"
+    Using dynamic pairlists is possible, however it relies on the current market conditions - which will not reflect the historic status of the pairlist.
+    Also, when using pairlists other than StaticPairlist, reproducability of backtesting-results cannot be guaranteed.
+    Please read the [pairlists documentation](configuration.md#pairlists) for more information.
+
+    To achieve reproducible results, best generate a pairlist via the [`test-pairlist`](utils.md#test-pairlist) command and use that as static pairlist.
 
 ### Run a backtesting against the currencies listed in your config file
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -544,7 +544,6 @@ A fixed slot (mirroring `bid_strategy.order_book_top`) can be defined by setting
     Using `ask_strategy.order_book_max` higher than 1 will result in improper dry-run results (significantly better than real orders executed on exchange), since dry-run assumes orders to be filled almost instantly.
     It is therefore advised to not use this setting for dry-runs.
 
-
 #### Sell price without Orderbook enabled
 
 When not using orderbook (`ask_strategy.use_order_book=False`), the price at the `ask_strategy.price_side` side (defaults to `"ask"`) from the ticker will be used as the sell price.
@@ -622,6 +621,7 @@ Min price precision is 8 decimals. If price is 0.00000011 - one step would be 0.
 These pairs are dangerous since it may be impossible to place the desired stoploss - and often result in high losses.
 
 #### Spread Filter
+
 Removes pairs that have a difference between asks and bids above the specified ratio (default `0.005`).
 Example:
 If `DOGE/BTC` maximum bid is 0.00000026 and minimum ask is 0.00000027 the ratio is calculated as: `1 - bid/ask ~= 0.037` which is `> 0.005` 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -65,6 +65,9 @@ class Backtesting:
         self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
 
         self.pairlists = PairListManager(self.exchange, self.config)
+        if 'VolumePairList' in self.pairlists.name_list:
+            raise OperationalException("VolumePairList not allowed for backtesting.")
+
         self.pairlists.refresh_pairlist()
 
         if len(self.pairlists.whitelist) == 0:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -624,6 +624,7 @@ class Hyperopt:
 
         # We don't need exchange instance anymore while running hyperopt
         self.backtesting.exchange = None  # type: ignore
+        self.backtesting.pairlists = None  # type: ignore
 
         self.trials = self.load_previous_results(self.trials_file)
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -378,9 +378,7 @@ def test_backtesting_start_no_data(default_conf, mocker, caplog, testdatadir) ->
 
 
 def test_backtesting_no_pair_left(default_conf, mocker, caplog, testdatadir) -> None:
-    def get_timerange(input1):
-        return Arrow(2017, 11, 14, 21, 17), Arrow(2017, 11, 14, 22, 59)
-
+    mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
     mocker.patch('freqtrade.data.history.history_utils.load_pair_history',
                  MagicMock(return_value=pd.DataFrame()))
     mocker.patch('freqtrade.data.history.get_timerange', get_timerange)
@@ -395,6 +393,10 @@ def test_backtesting_no_pair_left(default_conf, mocker, caplog, testdatadir) -> 
     default_conf['timerange'] = '20180101-20180102'
 
     with pytest.raises(OperationalException, match='No pair in whitelist.'):
+        Backtesting(default_conf)
+
+    default_conf['pairlists'] = [{"method": "VolumePairList", "number_assets": 5}]
+    with pytest.raises(OperationalException, match='VolumePairList not allowed for backtesting.'):
         Backtesting(default_conf)
 
 


### PR DESCRIPTION
## Summary
Use pairlists for backtesting.
While i'm skeptical on using Volumepairlist for backtesting  since it will use the current 24h volume to select pairs (so pairs during dry-run would have been different), using the filters can make sense (especially once #2956 is in).

This also now respects the blacklist correctly - which was previously ignored by backtesting.

enables  #2956 (random pairlist) for backtesting

## Quick changelog

- Use pairlists for backtesting to respect blacklist.
 
## To discuss
- [ ]  maybe limit to `StaticPairlist` (and the filters) - since Volumepairlist can be misleading (it's not recalculated every 6 hours as it is in dry-run).