### PR TITLE
Use skopt model_queue_size instead of custom hack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ plot = ['plotly>=4.0']
 hyperopt = [
     'scipy',
     'scikit-learn',
-    'scikit-optimize',
+    'scikit-optimize>=0.7.4',
     'filelock',
     'joblib',
     'progressbar2',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ plot = ['plotly>=4.0']
 hyperopt = [
     'scipy',
     'scikit-learn',
-    'scikit-optimize>=0.7.4',
+    'scikit-optimize>=0.7.0',
     'filelock',
     'joblib',
     'progressbar2',


### PR DESCRIPTION
* Use optimizer's model_queue_size param (was introduced with model queue management PR in skopt v0.7.2, IIRC)
* Remove my custom hack I implemented before to do same (in a bit different approach) things
