### PR TITLE
Use non-deprectated parameter for progressbar

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -648,7 +648,7 @@ class Hyperopt:
                         ' [', progressbar.ETA(), ', ', progressbar.Timer(), ']',
                     ]
                 with progressbar.ProgressBar(
-                         maxval=self.total_epochs, redirect_stdout=False, redirect_stderr=False,
+                         max_value=self.total_epochs, redirect_stdout=False, redirect_stderr=False,
                          widgets=widgets
                      ) as pbar:
                     EVALS = ceil(self.total_epochs / jobs)


### PR DESCRIPTION
## Summary
Fix  deprecation message
```
 .../python3.8/site-packages/progressbar/bar.py:295: DeprecationWarning:
  
  The usage of `maxval` is deprecated, please use `max_value` instead

```
