### PR TITLE
[minor] Increase cache for rate limit to avoid delays

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -54,8 +54,11 @@ class FreqtradeBot:
         # Init objects
         self.config = config
 
-        self._sell_rate_cache = TTLCache(maxsize=100, ttl=5)
-        self._buy_rate_cache = TTLCache(maxsize=100, ttl=5)
+        _process_throttle_secs = self.config['internals'].get('process_throttle_secs',
+                                                              constants.PROCESS_THROTTLE_SECS)
+        # Use 3x process_throttle_secs for caching to avoid delays in RPC methods.
+        self._sell_rate_cache = TTLCache(maxsize=100, ttl=_process_throttle_secs * 3)
+        self._buy_rate_cache = TTLCache(maxsize=100, ttl=_process_throttle_secs * 3)
 
         self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -54,11 +54,11 @@ class FreqtradeBot:
         # Init objects
         self.config = config
 
-        _process_throttle_secs = self.config['internals'].get('process_throttle_secs',
-                                                              constants.PROCESS_THROTTLE_SECS)
-        # Use 3x process_throttle_secs for caching to avoid delays in RPC methods.
-        self._sell_rate_cache = TTLCache(maxsize=100, ttl=_process_throttle_secs * 3)
-        self._buy_rate_cache = TTLCache(maxsize=100, ttl=_process_throttle_secs * 3)
+        # Cache values for 1800 to avoid frequent polling of the exchange for prices
+        # Caching only applies to RPC methods, so prices for open trades are still
+        # refreshed once every iteration.
+        self._sell_rate_cache = TTLCache(maxsize=100, ttl=1800)
+        self._buy_rate_cache = TTLCache(maxsize=100, ttl=1800)
 
         self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,7 +304,8 @@ def default_conf(testdatadir):
         "user_data_dir": Path("user_data"),
         "verbosity": 3,
         "strategy_path": str(Path(__file__).parent / "strategy" / "strats"),
-        "strategy": "DefaultStrategy"
+        "strategy": "DefaultStrategy",
+        "internals": {},
     }
     return configuration
 


### PR DESCRIPTION
##  Summary
Helps when calling `/status` or `/status table` frequently on slowish exchanges (kraken, i'm looking at you), and returns a result faster.

Has no practical impact on trading operations, as that will always refresh the rate - but for rpc methods, this has a huge impact on roundtrip time (and avoids unnecessary calls to the exchange, which can get us blocked on some exchanges).
