### PR TITLE
Humanize show-trades error when no database is specified

### DIFF
--- a/freqtrade/commands/list_commands.py
+++ b/freqtrade/commands/list_commands.py
@@ -206,6 +206,11 @@ def start_show_trades(args: Dict[str, Any]) -> None:
     from freqtrade.persistence import init, Trade
     import json
     config = setup_utils_configuration(args, RunMode.UTIL_NO_EXCHANGE)
+
+    if 'db_url' not in config:
+        raise OperationalException("--db-url is required for this command.")
+
+    logger.info(f'Using DB: "{config["db_url"]}"')
     init(config['db_url'], clean_open_orders=False)
     tfilter = []
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1077,3 +1077,11 @@ def test_show_trades(mocker, fee, capsys, caplog):
     assert '"trade_id": 1' in captured.out
     assert '"trade_id": 2' in captured.out
     assert '"trade_id": 3' not in captured.out
+    args = [
+        "show-trades",
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+
+    with pytest.raises(OperationalException, match=r"--db-url is required for this command."):
+        start_show_trades(pargs)


### PR DESCRIPTION
## Summary
Humanize show-trades error when no database is specified

database url (db_url) can be specified in either configuration or explicitly.
Fallback to Default url's is intentionally NOT supported - as it would create the database if it doesn't exist - and just from this command it's not clear if it's a dry-run database or a production database.

Closes #3261