### PR TITLE
[minor] Improve exception handling on critical errors

### DIFF
--- a/freqtrade/commands/trade_commands.py
+++ b/freqtrade/commands/trade_commands.py
@@ -18,6 +18,9 @@ def start_trading(args: Dict[str, Any]) -> int:
     try:
         worker = Worker(args)
         worker.run()
+    except Exception as e:
+        logger.error(str(e))
+        logger.exception("Fatal exception!")
     except KeyboardInterrupt:
         logger.info('SIGINT received, aborting ...')
     finally:

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -32,7 +32,7 @@ def test_setup_utils_configuration():
     assert config['exchange']['secret'] == ''
 
 
-def test_start_trading_fail(mocker):
+def test_start_trading_fail(mocker, caplog):
 
     mocker.patch("freqtrade.worker.Worker.run", MagicMock(side_effect=OperationalException))
 
@@ -43,16 +43,15 @@ def test_start_trading_fail(mocker):
         'trade',
         '-c', 'config.json.example'
     ]
-    with pytest.raises(OperationalException):
-        start_trading(get_args(args))
+    start_trading(get_args(args))
     assert exitmock.call_count == 1
 
     exitmock.reset_mock()
-
+    caplog.clear()
     mocker.patch("freqtrade.worker.Worker.__init__", MagicMock(side_effect=OperationalException))
-    with pytest.raises(OperationalException):
-        start_trading(get_args(args))
+    start_trading(get_args(args))
     assert exitmock.call_count == 0
+    assert log_has('Fatal exception!', caplog)
 
 
 def test_list_exchanges(capsys):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,6 +115,28 @@ def test_main_operational_exception(mocker, default_conf, caplog) -> None:
     assert log_has('Oh snap!', caplog)
 
 
+def test_main_operational_exception1(mocker, default_conf, caplog) -> None:
+    patch_exchange(mocker)
+    mocker.patch(
+        'freqtrade.commands.list_commands.available_exchanges',
+        MagicMock(side_effect=ValueError('Oh snap!'))
+    )
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    args = ['list-exchanges']
+
+    # Test Main + the KeyboardInterrupt exception
+    with pytest.raises(SystemExit):
+        main(args)
+
+    assert log_has('Fatal exception!', caplog)
+    assert not log_has_re(r'SIGINT.*', caplog)
+    mocker.patch(
+        'freqtrade.commands.list_commands.available_exchanges',
+        MagicMock(side_effect=KeyboardInterrupt)
+    )
+
+
 def test_main_reload_conf(mocker, default_conf, caplog) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.cleanup', MagicMock())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,6 +135,10 @@ def test_main_operational_exception1(mocker, default_conf, caplog) -> None:
         'freqtrade.commands.list_commands.available_exchanges',
         MagicMock(side_effect=KeyboardInterrupt)
     )
+    with pytest.raises(SystemExit):
+        main(args)
+
+    assert log_has_re(r'SIGINT.*', caplog)
 
 
 def test_main_reload_conf(mocker, default_conf, caplog) -> None:


### PR DESCRIPTION
## Summary
As identified in #3268, logging does not properly print the stacktrace for certain errors.

This happens because the except / finally handler "swallows" the exception and does not bubble it further.

Catching all errors in the trade_command module will solve this issue (no other command uses a finally handler).
