### PR TITLE
Rename fetch_ticker() in Exchange

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -619,7 +619,7 @@ class Exchange:
             raise OperationalException(e) from e
 
     @retrier
-    def fetch_ticker(self, pair: str) -> dict:
+    def get_ticker(self, pair: str) -> dict:
         try:
             if pair not in self._api.markets or not self._api.markets[pair].get('active'):
                 raise DependencyException(f"Pair {pair} not available")

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -263,7 +263,7 @@ class FreqtradeBot:
             used_rate = order_book_rate
         else:
             logger.info(f"Using Last {bid_strategy['price_side'].capitalize()} / Last Price")
-            ticker = self.exchange.fetch_ticker(pair)
+            ticker = self.exchange.get_ticker(pair)
             ticker_rate = ticker[bid_strategy['price_side']]
             if ticker['last'] and ticker_rate > ticker['last']:
                 balance = self.config['bid_strategy']['ask_last_balance']
@@ -638,7 +638,7 @@ class FreqtradeBot:
         """
         Get sell rate - either using ticker bid or first bid based on orderbook
         The orderbook portion is only used for rpc messaging, which would otherwise fail
-        for BitMex (has no bid/ask in fetch_ticker)
+        for BitMex (has no bid/ask in get_ticker)
         or remain static in any other case since it's not updating.
         :param pair: Pair to get rate for
         :param refresh: allow cached data
@@ -660,7 +660,7 @@ class FreqtradeBot:
             rate = next(self._order_book_gen(pair, f"{ask_strategy['price_side']}s"))
 
         else:
-            rate = self.exchange.fetch_ticker(pair)[ask_strategy['price_side']]
+            rate = self.exchange.get_ticker(pair)[ask_strategy['price_side']]
         self._sell_rate_cache[pair] = rate
         return rate
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1187,7 +1187,7 @@ def test_get_tickers(default_conf, mocker, exchange_name):
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
-def test_fetch_ticker(default_conf, mocker, exchange_name):
+def test_get_ticker(default_conf, mocker, exchange_name):
     api_mock = MagicMock()
     tick = {
         'symbol': 'ETH/BTC',
@@ -1199,7 +1199,7 @@ def test_fetch_ticker(default_conf, mocker, exchange_name):
     api_mock.markets = {'ETH/BTC': {'active': True}}
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
     # retrieve original ticker
-    ticker = exchange.fetch_ticker(pair='ETH/BTC')
+    ticker = exchange.get_ticker(pair='ETH/BTC')
 
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
@@ -1216,22 +1216,22 @@ def test_fetch_ticker(default_conf, mocker, exchange_name):
 
     # if not caching the result we should get the same ticker
     # if not fetching a new result we should get the cached ticker
-    ticker = exchange.fetch_ticker(pair='ETH/BTC')
+    ticker = exchange.get_ticker(pair='ETH/BTC')
 
     assert api_mock.fetch_ticker.call_count == 1
     assert ticker['bid'] == 0.5
     assert ticker['ask'] == 1
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
-                           "fetch_ticker", "fetch_ticker",
+                           "get_ticker", "fetch_ticker",
                            pair='ETH/BTC')
 
     api_mock.fetch_ticker = MagicMock(return_value={})
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
-    exchange.fetch_ticker(pair='ETH/BTC')
+    exchange.get_ticker(pair='ETH/BTC')
 
     with pytest.raises(DependencyException, match=r'Pair XRP/ETH not available'):
-        exchange.fetch_ticker(pair='XRP/ETH')
+        exchange.get_ticker(pair='XRP/ETH')
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -29,7 +29,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -126,7 +126,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -169,7 +169,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -247,7 +247,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -271,7 +271,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     # Update the ticker with a market going up
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up
+        get_ticker=ticker_sell_up
     )
     trade.update(limit_sell_order)
     trade.close_date = datetime.utcnow()
@@ -285,7 +285,7 @@ def test_rpc_trade_statistics(default_conf, ticker, ticker_sell_up, fee,
     # Update the ticker with a market going up
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up
+        get_ticker=ticker_sell_up
     )
     trade.update(limit_sell_order)
     trade.close_date = datetime.utcnow()
@@ -331,7 +331,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -350,7 +350,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, fee,
     # Update the ticker with a market going up
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up,
+        get_ticker=ticker_sell_up,
         get_fee=fee
     )
     trade.update(limit_sell_order)
@@ -483,7 +483,7 @@ def test_rpc_start(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock()
+        get_ticker=MagicMock()
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
@@ -504,7 +504,7 @@ def test_rpc_stop(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock()
+        get_ticker=MagicMock()
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
@@ -526,7 +526,7 @@ def test_rpc_stopbuy(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock()
+        get_ticker=MagicMock()
     )
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
@@ -546,7 +546,7 @@ def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     cancel_order_mock = MagicMock()
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         cancel_order=cancel_order_mock,
         get_order=MagicMock(
             return_value={
@@ -649,7 +649,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -682,7 +682,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -706,7 +706,7 @@ def test_rpcforcebuy(mocker, default_conf, ticker, fee, limit_buy_order) -> None
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         buy=buy_mm
     )

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -256,7 +256,7 @@ def test_api_count(botclient, mocker, ticker, fee, markets):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -293,7 +293,7 @@ def test_api_daily(botclient, mocker, ticker, fee, markets):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -333,7 +333,7 @@ def test_api_edge_disabled(botclient, mocker, ticker, fee, markets):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -348,7 +348,7 @@ def test_api_profit(botclient, mocker, ticker, fee, markets, limit_buy_order, li
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -438,7 +438,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )
@@ -594,7 +594,7 @@ def test_api_forcesell(botclient, mocker, ticker, fee, markets):
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_balances=MagicMock(return_value=ticker),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         markets=PropertyMock(return_value=markets)
     )

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -194,7 +194,7 @@ def test_status(default_conf, update, mocker, fee, ticker,) -> None:
 def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     msg_mock = MagicMock()
@@ -244,7 +244,7 @@ def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
 def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': 'mocked_order_id'}),
         get_fee=fee,
     )
@@ -297,7 +297,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     )
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     msg_mock = MagicMock()
@@ -364,7 +364,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
 def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker
+        get_ticker=ticker
     )
     msg_mock = MagicMock()
     mocker.patch.multiple(
@@ -402,7 +402,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     msg_mock = MagicMock()
@@ -434,7 +434,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     msg_mock.reset_mock()
 
     # Update the ticker with a market going up
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', ticker_sell_up)
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', ticker_sell_up)
     trade.update(limit_sell_order)
 
     trade.close_date = datetime.utcnow()
@@ -691,7 +691,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     patch_whitelist(mocker, default_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -706,7 +706,7 @@ def test_forcesell_handle(default_conf, update, ticker, fee,
     assert trade
 
     # Increase the price and sell it
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', ticker_sell_up)
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', ticker_sell_up)
 
     # /forcesell 1
     context = MagicMock()
@@ -746,7 +746,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
 
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
 
@@ -760,7 +760,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, fee,
     # Decrease the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_down
+        get_ticker=ticker_sell_down
     )
 
     trade = Trade.query.first()
@@ -803,7 +803,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None
     patch_whitelist(mocker, default_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     default_conf['max_open_trades'] = 4
@@ -954,7 +954,7 @@ def test_performance_handle(default_conf, update, ticker, fee,
     )
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
@@ -989,7 +989,7 @@ def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     )
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': 'mocked_order_id'}),
         get_fee=fee,
     )

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -156,7 +156,7 @@ def test_check_available_stake_amount(default_conf, ticker, mocker, fee, limit_b
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_balance=MagicMock(return_value=default_conf['stake_amount'] * 2),
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee
@@ -201,7 +201,7 @@ def test_get_trade_stake_amount_unlimited_amount(default_conf, ticker, balance_r
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee
     )
@@ -278,7 +278,7 @@ def test_edge_overrides_stoploss(limit_buy_order, fee, caplog, mocker, edge_conf
     buy_price = limit_buy_order['price']
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': buy_price * 0.79,
             'ask': buy_price * 0.79,
             'last': buy_price * 0.79
@@ -318,7 +318,7 @@ def test_edge_should_ignore_strategy_stoploss(limit_buy_order, fee,
     buy_price = limit_buy_order['price']
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': buy_price * 0.85,
             'ask': buy_price * 0.85,
             'last': buy_price * 0.85
@@ -350,7 +350,7 @@ def test_total_open_trades_stakes(mocker, default_conf, ticker,
     default_conf['max_open_trades'] = 2
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -513,7 +513,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order, fee, mocker) -> Non
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -547,7 +547,7 @@ def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order,
     patch_wallet(mocker, free=default_conf['stake_amount'] * 0.5)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -565,7 +565,7 @@ def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order,
     buy_mock = MagicMock(return_value={'id': limit_buy_order['id']})
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=buy_mock,
         get_fee=fee,
     )
@@ -585,7 +585,7 @@ def test_create_trade_too_small_stake_amount(default_conf, ticker, limit_buy_ord
     buy_mock = MagicMock(return_value={'id': limit_buy_order['id']})
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=buy_mock,
         get_fee=fee,
     )
@@ -604,7 +604,7 @@ def test_create_trade_limit_reached(default_conf, ticker, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_balance=MagicMock(return_value=default_conf['stake_amount']),
         get_fee=fee,
@@ -625,7 +625,7 @@ def test_enter_positions_no_pairs_left(default_conf, ticker, limit_buy_order, fe
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -648,7 +648,7 @@ def test_enter_positions_no_pairs_in_whitelist(default_conf, ticker, limit_buy_o
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -692,7 +692,7 @@ def test_create_trades_multiple_trades(default_conf, ticker, fee, mocker,
 
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': "12355555"}),
         get_fee=fee,
     )
@@ -713,7 +713,7 @@ def test_create_trades_preopen(default_conf, ticker, fee, mocker) -> None:
     default_conf['max_open_trades'] = 4
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': "12355555"}),
         get_fee=fee,
     )
@@ -740,7 +740,7 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_order=MagicMock(return_value=limit_buy_order),
         get_fee=fee,
@@ -774,7 +774,7 @@ def test_process_exchange_failures(default_conf, ticker, mocker) -> None:
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(side_effect=TemporaryError)
     )
     sleep_mock = mocker.patch('time.sleep', side_effect=lambda _: None)
@@ -791,7 +791,7 @@ def test_process_operational_exception(default_conf, ticker, mocker) -> None:
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(side_effect=OperationalException)
     )
     worker = Worker(args=None, config=default_conf)
@@ -809,7 +809,7 @@ def test_process_trade_handling(default_conf, ticker, limit_buy_order, fee, mock
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_order=MagicMock(return_value=limit_buy_order),
         get_fee=fee,
@@ -836,7 +836,7 @@ def test_process_trade_no_whitelist_pair(default_conf, ticker, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_order=MagicMock(return_value=limit_buy_order),
         get_fee=fee,
@@ -886,7 +886,7 @@ def test_process_informative_pairs_added(default_conf, ticker, mocker) -> None:
     refresh_mock = MagicMock()
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(side_effect=TemporaryError),
         refresh_latest_ohlcv=refresh_mock,
     )
@@ -935,7 +935,7 @@ def test_get_buy_rate(mocker, default_conf, caplog, side, ask, bid,
     default_conf['bid_strategy']['ask_last_balance'] = last_ab
     default_conf['bid_strategy']['price_side'] = side
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={'ask': ask, 'last': last, 'bid': bid}))
 
     assert freqtrade.get_buy_rate('ETH/BTC', True) == expected
@@ -964,7 +964,7 @@ def test_execute_buy(mocker, default_conf, fee, limit_buy_order) -> None:
     buy_mm = MagicMock(return_value={'id': limit_buy_order['id']})
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1073,7 +1073,7 @@ def test_handle_stoploss_on_exchange(mocker, default_conf, fee, caplog,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1184,7 +1184,7 @@ def test_handle_sle_cancel_cant_recreate(mocker, default_conf, fee, caplog,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1218,7 +1218,7 @@ def test_create_stoploss_order_invalid_order(mocker, default_conf, caplog, fee,
     sell_mock = MagicMock(return_value={'id': limit_sell_order['id']})
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1261,7 +1261,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
     patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1316,7 +1316,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
     assert freqtrade.handle_stoploss_on_exchange(trade) is False
 
     # price jumped 2x
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', MagicMock(return_value={
         'bid': 0.00002344,
         'ask': 0.00002346,
         'last': 0.00002344
@@ -1348,7 +1348,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee, caplog,
                                                 stop_price=0.00002346 * 0.95)
 
     # price fell below stoploss, so dry-run sells trade.
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', MagicMock(return_value={
         'bid': 0.00002144,
         'ask': 0.00002146,
         'last': 0.00002144
@@ -1364,7 +1364,7 @@ def test_handle_stoploss_on_exchange_trailing_error(mocker, default_conf, fee, c
 
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1437,7 +1437,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     edge_conf['exchange']['name'] = 'binance'
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1501,7 +1501,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     mocker.patch('freqtrade.exchange.Binance.stoploss', stoploss_order_mock)
 
     # price goes down 5%
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', MagicMock(return_value={
         'bid': 0.00001172 * 0.95,
         'ask': 0.00001173 * 0.95,
         'last': 0.00001172 * 0.95
@@ -1517,7 +1517,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     cancel_order_mock.assert_not_called()
 
     # price jumped 2x
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', MagicMock(return_value={
         'bid': 0.00002344,
         'ask': 0.00002346,
         'last': 0.00002344
@@ -1765,7 +1765,7 @@ def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, fee, mock
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -1805,7 +1805,7 @@ def test_handle_overlapping_signals(default_conf, ticker, limit_buy_order, fee, 
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -1858,7 +1858,7 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order,
     patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -1890,7 +1890,7 @@ def test_handle_trade_use_sell_signal(
     patch_RPCManager(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -1918,7 +1918,7 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -1948,7 +1948,7 @@ def test_check_handle_timedout_buy_usercustom(default_conf, ticker, limit_buy_or
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old),
         cancel_order=cancel_order_mock,
         get_fee=fee
@@ -1993,7 +1993,7 @@ def test_check_handle_timedout_buy(default_conf, ticker, limit_buy_order_old, op
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old),
         cancel_order_with_result=cancel_order_mock,
         get_fee=fee
@@ -2023,7 +2023,7 @@ def test_check_handle_cancelled_buy(default_conf, ticker, limit_buy_order_old, o
     limit_buy_order_old.update({"status": "canceled", 'filled': 0.0})
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old),
         cancel_order=cancel_order_mock,
         get_fee=fee
@@ -2050,7 +2050,7 @@ def test_check_handle_timedout_buy_exception(default_conf, ticker, limit_buy_ord
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         validate_pairs=MagicMock(),
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(side_effect=DependencyException),
         cancel_order=cancel_order_mock,
         get_fee=fee
@@ -2076,7 +2076,7 @@ def test_check_handle_timedout_sell_usercustom(default_conf, ticker, limit_sell_
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_sell_order_old),
         cancel_order=cancel_order_mock
     )
@@ -2120,7 +2120,7 @@ def test_check_handle_timedout_sell(default_conf, ticker, limit_sell_order_old, 
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_sell_order_old),
         cancel_order=cancel_order_mock
     )
@@ -2151,7 +2151,7 @@ def test_check_handle_cancelled_sell(default_conf, ticker, limit_sell_order_old,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_sell_order_old),
         cancel_order_with_result=cancel_order_mock
     )
@@ -2178,7 +2178,7 @@ def test_check_handle_timedout_partial(default_conf, ticker, limit_buy_order_old
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old_partial),
         cancel_order_with_result=cancel_order_mock
     )
@@ -2205,7 +2205,7 @@ def test_check_handle_timedout_partial_fee(default_conf, ticker, open_trade, cap
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old_partial),
         cancel_order_with_result=cancel_order_mock,
         get_trades_for_order=MagicMock(return_value=trades_for_order),
@@ -2242,7 +2242,7 @@ def test_check_handle_timedout_partial_except(default_conf, ticker, open_trade, 
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(return_value=limit_buy_order_old_partial),
         cancel_order_with_result=cancel_order_mock,
         get_trades_for_order=MagicMock(return_value=trades_for_order),
@@ -2286,7 +2286,7 @@ def test_check_handle_timedout_exception(default_conf, ticker, open_trade, mocke
     )
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_order=MagicMock(side_effect=requests.exceptions.RequestException('Oh snap')),
         cancel_order=cancel_order_mock
     )
@@ -2410,7 +2410,7 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, mocker) -> N
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     patch_whitelist(mocker, default_conf)
@@ -2426,7 +2426,7 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, mocker) -> N
     # Increase the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up
+        get_ticker=ticker_sell_up
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'], sell_reason=SellType.ROI)
@@ -2458,7 +2458,7 @@ def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, mocker) 
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     patch_whitelist(mocker, default_conf)
@@ -2474,7 +2474,7 @@ def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, mocker) 
     # Decrease the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_down
+        get_ticker=ticker_sell_down
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_down()['bid'],
@@ -2508,7 +2508,7 @@ def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fe
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     patch_whitelist(mocker, default_conf)
@@ -2524,7 +2524,7 @@ def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fe
     # Decrease the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_down
+        get_ticker=ticker_sell_down
     )
 
     default_conf['dry_run'] = True
@@ -2567,7 +2567,7 @@ def test_execute_sell_sloe_cancel_exception(mocker, default_conf, ticker, fee, c
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         sell=sellmock
     )
@@ -2604,7 +2604,7 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf, ticker, fee, ticke
     cancel_order = MagicMock(return_value=True)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         amount_to_precision=lambda s, x, y: y,
         price_to_precision=lambda s, x, y: y,
@@ -2629,7 +2629,7 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf, ticker, fee, ticke
     # Increase the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up
+        get_ticker=ticker_sell_up
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
@@ -2648,7 +2648,7 @@ def test_may_execute_sell_after_stoploss_on_exchange_hit(default_conf, ticker, f
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         amount_to_precision=lambda s, x, y: y,
         price_to_precision=lambda s, x, y: y,
@@ -2715,7 +2715,7 @@ def test_execute_sell_market_order(default_conf, ticker, fee,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     patch_whitelist(mocker, default_conf)
@@ -2731,7 +2731,7 @@ def test_execute_sell_market_order(default_conf, ticker, fee,
     # Increase the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_up
+        get_ticker=ticker_sell_up
     )
     freqtrade.config['order_types']['sell'] = 'market'
 
@@ -2769,7 +2769,7 @@ def test_sell_profit_only_enable_profit(default_conf, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00002172,
             'ask': 0.00002173,
             'last': 0.00002172
@@ -2801,7 +2801,7 @@ def test_sell_profit_only_disable_profit(default_conf, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00002172,
             'ask': 0.00002173,
             'last': 0.00002172
@@ -2831,7 +2831,7 @@ def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, fee, mocker
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00000172,
             'ask': 0.00000173,
             'last': 0.00000172
@@ -2860,7 +2860,7 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, fee, mocke
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.0000172,
             'ask': 0.0000173,
             'last': 0.0000172
@@ -2893,7 +2893,7 @@ def test_sell_not_enough_balance(default_conf, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00002172,
             'ask': 0.00002173,
             'last': 0.00002172
@@ -2975,7 +2975,7 @@ def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, mocker, caplo
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
     )
     freqtrade = FreqtradeBot(default_conf)
@@ -2990,7 +2990,7 @@ def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, mocker, caplo
     # Decrease the price and sell it
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker_sell_down
+        get_ticker=ticker_sell_down
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_down()['bid'],
@@ -3011,7 +3011,7 @@ def test_ignore_roi_if_buy_signal(default_conf, limit_buy_order, fee, mocker) ->
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.0000172,
             'ask': 0.0000173,
             'last': 0.0000172
@@ -3045,7 +3045,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) 
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001099,
             'ask': 0.00001099,
             'last': 0.00001099
@@ -3064,7 +3064,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) 
     assert freqtrade.handle_trade(trade) is False
 
     # Raise ticker above buy price
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': 0.00001099 * 1.5,
                      'ask': 0.00001099 * 1.5,
@@ -3075,7 +3075,7 @@ def test_trailing_stop_loss(default_conf, limit_buy_order, fee, caplog, mocker) 
     assert freqtrade.handle_trade(trade) is False
 
     # Price fell
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': 0.00001099 * 1.1,
                      'ask': 0.00001099 * 1.1,
@@ -3099,7 +3099,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': buy_price - 0.000001,
             'ask': buy_price - 0.000001,
             'last': buy_price - 0.000001
@@ -3123,7 +3123,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee,
     assert freqtrade.handle_trade(trade) is False
 
     # Raise ticker above buy price
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.000003,
                      'ask': buy_price + 0.000003,
@@ -3135,7 +3135,7 @@ def test_trailing_stop_loss_positive(default_conf, limit_buy_order, fee,
     assert log_has(f"ETH/BTC - Adjusting stoploss...", caplog)
     assert trade.stop_loss == 0.0000138501
 
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.000002,
                      'ask': buy_price + 0.000002,
@@ -3156,7 +3156,7 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': buy_price - 0.000001,
             'ask': buy_price - 0.000001,
             'last': buy_price - 0.000001
@@ -3180,7 +3180,7 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
     assert freqtrade.handle_trade(trade) is False
 
     # Raise ticker above buy price
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.000003,
                      'ask': buy_price + 0.000003,
@@ -3193,7 +3193,7 @@ def test_trailing_stop_loss_offset(default_conf, limit_buy_order, fee,
     assert log_has(f"ETH/BTC - Adjusting stoploss...", caplog)
     assert trade.stop_loss == 0.0000138501
 
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.000002,
                      'ask': buy_price + 0.000002,
@@ -3217,7 +3217,7 @@ def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': buy_price,
             'ask': buy_price,
             'last': buy_price
@@ -3244,7 +3244,7 @@ def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
     assert trade.stop_loss == 0.0000098910
 
     # Raise ticker above buy price
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.0000004,
                      'ask': buy_price + 0.0000004,
@@ -3258,7 +3258,7 @@ def test_tsl_only_offset_reached(default_conf, limit_buy_order, fee,
     assert trade.stop_loss == 0.0000098910
 
     # price rises above the offset (rises 12% when the offset is 5.5%)
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker',
                  MagicMock(return_value={
                      'bid': buy_price + 0.0000014,
                      'ask': buy_price + 0.0000014,
@@ -3278,7 +3278,7 @@ def test_disable_ignore_roi_if_buy_signal(default_conf, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00000172,
             'ask': 0.00000173,
             'last': 0.00000172
@@ -3615,7 +3615,7 @@ def test_order_book_depth_of_market(default_conf, ticker, limit_buy_order, fee, 
     mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -3652,7 +3652,7 @@ def test_order_book_depth_of_market_high_delta(default_conf, ticker, limit_buy_o
     mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )
@@ -3675,7 +3675,7 @@ def test_order_book_bid_strategy1(mocker, default_conf, order_book_l2) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_order_book=order_book_l2,
-        fetch_ticker=ticker_mock,
+        get_ticker=ticker_mock,
 
     )
     default_conf['exchange']['name'] = 'binance'
@@ -3699,7 +3699,7 @@ def test_order_book_bid_strategy2(mocker, default_conf, order_book_l2) -> None:
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         get_order_book=order_book_l2,
-        fetch_ticker=ticker_mock,
+        get_ticker=ticker_mock,
 
     )
     default_conf['exchange']['name'] = 'binance'
@@ -3749,7 +3749,7 @@ def test_order_book_ask_strategy(default_conf, limit_buy_order, limit_sell_order
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=MagicMock(return_value={
+        get_ticker=MagicMock(return_value={
             'bid': 0.00001172,
             'ask': 0.00001173,
             'last': 0.00001172
@@ -3788,7 +3788,7 @@ def test_order_book_ask_strategy(default_conf, limit_buy_order, limit_sell_order
 ])
 def test_get_sell_rate(default_conf, mocker, caplog, side, bid, ask, expected) -> None:
     default_conf['ask_strategy']['price_side'] = side
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'ask': ask, 'bid': bid})
+    mocker.patch('freqtrade.exchange.Exchange.get_ticker', return_value={'ask': ask, 'bid': bid})
     pair = "ETH/BTC"
 
     # Test regular mode
@@ -3862,7 +3862,7 @@ def test_sync_wallet_dry_run(mocker, default_conf, ticker, fee, limit_buy_order,
     patch_exchange(mocker)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
         get_fee=fee,
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,7 +56,7 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
     mocker.patch('freqtrade.exchange.Binance.stoploss', stoploss)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         amount_to_precision=lambda s, x, y: y,
         price_to_precision=lambda s, x, y: y,
@@ -135,7 +135,7 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
-        fetch_ticker=ticker,
+        get_ticker=ticker,
         get_fee=fee,
         amount_to_precision=lambda s, x, y: y,
         price_to_precision=lambda s, x, y: y,


### PR DESCRIPTION
...to get_ticker(). To be aligned with other Exchange methods, fetch_ticker is the only one with 'fetch' prefix used.

It also allows better search for ccxt api fetch_ticker/fetch_tickers methods in the code and tests.
