### PR TITLE
Fix fee usage in Edge

### DIFF
--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -242,10 +242,6 @@ class Edge:
         # All returned values are relative, they are defined as ratios.
         stake = 0.015
 
-        # Fee should be applied twice
-        open_fee = self.fee
-        close_fee = self.fee
-
         result['trade_duration'] = result['close_time'] - result['open_time']
 
         result['trade_duration'] = result['trade_duration'].map(
@@ -255,12 +251,12 @@ class Edge:
 
         # Buy Price
         result['buy_vol'] = stake / result['open_rate']  # How many target are we buying
-        result['buy_fee'] = stake * open_fee
+        result['buy_fee'] = stake * self.fee
         result['buy_spend'] = stake + result['buy_fee']  # How much we're spending
 
         # Sell price
         result['sell_sum'] = result['buy_vol'] * result['close_rate']
-        result['sell_fee'] = result['sell_sum'] * close_fee
+        result['sell_fee'] = result['sell_sum'] * self.fee
         result['sell_take'] = result['sell_sum'] - result['sell_fee']
 
         # profit_ratio

--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -238,20 +238,13 @@ class Edge:
         :param result Dataframe
         :return: result Dataframe
         """
-
-        # stake and fees
-        # stake = 0.015
-        # 0.05% is 0.0005
-        # fee = 0.001
-
-        # we set stake amount to an arbitrary amount.
-        # as it doesn't change the calculation.
-        # all returned values are relative.
-        # they are defined as ratios.
+        # We set stake amount to an arbitrary amount, as it doesn't change the calculation.
+        # All returned values are relative, they are defined as ratios.
         stake = 0.015
-        fee = self.fee
-        open_fee = fee / 2
-        close_fee = fee / 2
+
+        # Fee should be applied twice
+        open_fee = self.fee
+        close_fee = self.fee
 
         result['trade_duration'] = result['close_time'] - result['open_time']
 

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -335,12 +335,16 @@ def test_edge_init_error(mocker, edge_conf,):
         get_patched_freqtradebot(mocker, edge_conf)
 
 
-def test_process_expectancy(mocker, edge_conf):
+@pytest.mark.parametrize("fee,risk_reward_ratio,expectancy", [
+    (0.0005, 306.5384615384, 101.5128205128),
+    (0.001, 152.6923076923, 50.2307692308),
+])
+def test_process_expectancy(mocker, edge_conf, fee, risk_reward_ratio, expectancy):
     edge_conf['edge']['min_trade_number'] = 2
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
 
     def get_fee(*args, **kwargs):
-        return 0.001
+        return fee
 
     freqtrade.exchange.get_fee = get_fee
     edge = Edge(edge_conf, freqtrade.exchange, freqtrade.strategy)
@@ -394,9 +398,9 @@ def test_process_expectancy(mocker, edge_conf):
     assert 'TEST/BTC' in final
     assert final['TEST/BTC'].stoploss == -0.9
     assert round(final['TEST/BTC'].winrate, 10) == 0.3333333333
-    assert round(final['TEST/BTC'].risk_reward_ratio, 10) == 306.5384615384
+    assert round(final['TEST/BTC'].risk_reward_ratio, 10) == risk_reward_ratio
     assert round(final['TEST/BTC'].required_risk_reward, 10) == 2.0
-    assert round(final['TEST/BTC'].expectancy, 10) == 101.5128205128
+    assert round(final['TEST/BTC'].expectancy, 10) == expectancy
 
     # Pop last item so no trade is profitable
     trades.pop()


### PR DESCRIPTION
Edge should apply the value of fee twice, not a half of it for buy and sell.

As it's used in backtesting and as defined in the description of the `--fee` cli option:
"Specify fee ratio. Will be applied twice (on trade entry and exit)".

`Exchange.get_fee()`, which is used by Edge, also returns 0.001 for Binance, so it should be applied twice, not halved.

Expectancy and risk reward ratio decreased in the test, as it should be when we apply a higher fee.
Old data kept in the tests, but with halved fee value.
