### PR TITLE
API server - support JWT

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -120,6 +120,7 @@
         "enabled": false,
         "listen_ip_address": "127.0.0.1",
         "listen_port": 8080,
+        "jwt_secret_key": "somethingrandom",
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -208,7 +208,7 @@ whitelist
 !!! Note
     The below should be done in an application (a Freqtrade REST API client, which fetches info via API), and is not intended to be used on a regular basis.
 
-Freqtrade's REST API also offers JWT tokens.
+Freqtrade's REST API also offers JWT (JSON Web Tokens).
 You can login using the following command, and subsequently use the resulting access_token.
 
 ``` bash
@@ -216,7 +216,7 @@ You can login using the following command, and subsequently use the resulting ac
 {"access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiMmEwYmY0NWUtMjhmOS00YTUzLTlmNzItMmM5ZWVlYThkNzc2IiwiZXhwIjoxNTg5MTIwNTgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.qt6MAXYIa-l556OM7arBvYJ0SDI9J8bIk3_glDujF5g","refresh_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiZWQ1ZWI3YjAtYjMwMy00YzAyLTg2N2MtNWViMjIxNWQ2YTMxIiwiZXhwIjoxNTkxNzExNjgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJ0eXBlIjoicmVmcmVzaCJ9.d1AT_jYICyTAjD0fiQAr52rkRqtxCjUGEMwlNuuzgNQ"}
 
 > access_token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiMmEwYmY0NWUtMjhmOS00YTUzLTlmNzItMmM5ZWVlYThkNzc2IiwiZXhwIjoxNTg5MTIwNTgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.qt6MAXYIa-l556OM7arBvYJ0SDI9J8bIk3_glDujF5g"
-# Use tccess_token for authentication
+# Use access_token for authentication
 > curl -X GET --header "Authorization: Bearer ${access_token}" http://localhost:8080/api/v1/count
 
 ```

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -221,7 +221,7 @@ You can login using the following command, and subsequently use the resulting ac
 
 ```
 
-Since the access-token has a short timeout (15 min) - the refresh-token should be used to get a fresh access token:
+Since the access token has a short timeout (15 min) - the `token/refresh` request should be used periodically to get a fresh access token:
 
 ``` bash
 > curl -X POST --header "Authorization: Bearer ${refresh_token}"http://localhost:8080/api/v1/token/refresh

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -11,6 +11,7 @@ Sample configuration:
         "enabled": true,
         "listen_ip_address": "127.0.0.1",
         "listen_port": 8080,
+        "jwt_secret_key": "somethingrandom",
         "username": "Freqtrader",
         "password": "SuperSecret1!"
     },
@@ -29,7 +30,7 @@ This should return the response:
 {"status":"pong"}
 ```
 
-All other endpoints return sensitive info and require authentication, so are not available through a web browser.
+All other endpoints return sensitive info and require authentication and are therefore not available through a web browser.
 
 To generate a secure password, either use a password manager, or use the below code snipped.
 
@@ -37,6 +38,9 @@ To generate a secure password, either use a password manager, or use the below c
 import secrets
 secrets.token_hex()
 ```
+
+!!! Hint
+    Use the same method to also generate a JWT secret key (`jwt_secret_key`).
 
 ### Configuration with docker
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -202,3 +202,28 @@ whitelist
         Show the current whitelist
         :returns: json object
 ```
+
+## Advanced API usage using JWT tokens
+
+!!! Note
+    The below should be done in an application, and is not intended to be used on a regular basis.
+
+Freqtrade's REST API also offers JWT tokens.
+You can login using the following command, and subsequently use the resulting access_token.
+
+``` bash
+> curl -X POST --user Freqtrader http://localhost:8080/api/v1/token/login
+{"access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiMmEwYmY0NWUtMjhmOS00YTUzLTlmNzItMmM5ZWVlYThkNzc2IiwiZXhwIjoxNTg5MTIwNTgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.qt6MAXYIa-l556OM7arBvYJ0SDI9J8bIk3_glDujF5g","refresh_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiZWQ1ZWI3YjAtYjMwMy00YzAyLTg2N2MtNWViMjIxNWQ2YTMxIiwiZXhwIjoxNTkxNzExNjgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJ0eXBlIjoicmVmcmVzaCJ9.d1AT_jYICyTAjD0fiQAr52rkRqtxCjUGEMwlNuuzgNQ"}
+
+> access_token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk2ODEsIm5iZiI6MTU4OTExOTY4MSwianRpIjoiMmEwYmY0NWUtMjhmOS00YTUzLTlmNzItMmM5ZWVlYThkNzc2IiwiZXhwIjoxNTg5MTIwNTgxLCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.qt6MAXYIa-l556OM7arBvYJ0SDI9J8bIk3_glDujF5g"
+# Use tccess_token for authentication
+> curl -X GET --header "Authorization: Bearer ${access_token}" http://localhost:8080/api/v1/count
+
+```
+
+Since the access-token has a short timeout (15 min) - the refresh-token should be used to get a fresh access token:
+
+``` bash
+> curl -X POST --header "Authorization: Bearer ${refresh_token}"http://localhost:8080/api/v1/token/refresh
+{"access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk5NzQsIm5iZiI6MTU4OTExOTk3NCwianRpIjoiMDBjNTlhMWUtMjBmYS00ZTk0LTliZjAtNWQwNTg2MTdiZDIyIiwiZXhwIjoxNTg5MTIwODc0LCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.1seHlII3WprjjclY6DpRhen0rqdF4j6jbvxIhUFaSbs"}
+```

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -206,7 +206,7 @@ whitelist
 ## Advanced API usage using JWT tokens
 
 !!! Note
-    The below should be done in an application, and is not intended to be used on a regular basis.
+    The below should be done in an application (a Freqtrade REST API client, which fetches info via API), and is not intended to be used on a regular basis.
 
 Freqtrade's REST API also offers JWT tokens.
 You can login using the following command, and subsequently use the resulting access_token.

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -91,7 +91,8 @@ class ApiServer(RPC):
         self.app = Flask(__name__)
 
         # Setup the Flask-JWT-Extended extension
-        self.app.config['JWT_SECRET_KEY'] = 'super-secret'  # Change this!
+        self.app.config['JWT_SECRET_KEY'] = self._config['api_server'].get(
+            'jwt_secret_key', 'super-secret')
 
         self.jwt = JWTManager(self.app)
         self.app.json_encoder = ArrowJSONEncoder

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -45,8 +45,7 @@ def require_login(func: Callable[[Any, Any], Any]):
     def func_wrapper(obj, *args, **kwargs):
         verify_jwt_in_request_optional()
         auth = request.authorization
-        i = get_jwt_identity()
-        if i or auth and obj.check_auth(auth.username, auth.password):
+        if get_jwt_identity() or auth and obj.check_auth(auth.username, auth.password):
             return func(obj, *args, **kwargs)
         else:
             return jsonify({"error": "Unauthorized"}), 401

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -160,9 +160,9 @@ class ApiServer(RPC):
 
         # Actions to control the bot
         self.app.add_url_rule(f'{BASE_URI}/token/login', 'login',
-                              view_func=self._login, methods=['POST'])
+                              view_func=self._token_login, methods=['POST'])
         self.app.add_url_rule(f'{BASE_URI}/token/refresh', 'token_refresh',
-                              view_func=self._refresh_token, methods=['POST'])
+                              view_func=self._token_refresh, methods=['POST'])
         self.app.add_url_rule(f'{BASE_URI}/start', 'start',
                               view_func=self._start, methods=['POST'])
         self.app.add_url_rule(f'{BASE_URI}/stop', 'stop', view_func=self._stop, methods=['POST'])
@@ -216,7 +216,7 @@ class ApiServer(RPC):
 
     @require_login
     @rpc_catch_errors
-    def _login(self):
+    def _token_login(self):
         """
         Handler for /token/login
         Returns a JWT token
@@ -234,7 +234,7 @@ class ApiServer(RPC):
 
     @jwt_refresh_token_required
     @rpc_catch_errors
-    def _refresh_token(self):
+    def _token_refresh(self):
         """
         Handler for /token/refresh
         Returns a JWT token based on a JWT refresh token

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -25,6 +25,7 @@ sdnotify==0.3.2
 
 # Api server
 flask==1.1.2
+flask-jwt-extended==3.24.1
 
 # Support for colorized terminal output
 colorama==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if readme_file.is_file():
     readme_long = (Path(__file__).parent / "README.md").read_text()
 
 # Requirements used for submodules
-api = ['flask']
+api = ['flask', 'flask-jwt-extended']
 plot = ['plotly>=4.0']
 hyperopt = [
     'scipy',

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -150,6 +150,12 @@ def test_api__init__(default_conf, mocker):
     """
     Test __init__() method
     """
+    default_conf.update({"api_server": {"enabled": True,
+                                        "listen_ip_address": "127.0.0.1",
+                                        "listen_port": 8080,
+                                        "username": "TestUser",
+                                        "password": "testPass",
+                                        }})
     mocker.patch('freqtrade.rpc.telegram.Updater', MagicMock())
     mocker.patch('freqtrade.rpc.api_server.ApiServer.run', MagicMock())
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -94,6 +94,33 @@ def test_api_unauthorized(botclient):
     assert rc.json == {'error': 'Unauthorized'}
 
 
+def test_api_token_login(botclient):
+    ftbot, client = botclient
+    rc = client_post(client, f"{BASE_URI}/token/login")
+    assert_response(rc)
+    assert 'access_token' in rc.json
+    assert 'refresh_token' in rc.json
+
+    # test Authentication is working with JWT tokens too
+    rc = client.get(f"{BASE_URI}/count",
+                    content_type="application/json",
+                    headers={'Authorization': f'Bearer {rc.json["access_token"]}'})
+    assert_response(rc)
+
+
+def test_api_token_refresh(botclient):
+    ftbot, client = botclient
+    rc = client_post(client, f"{BASE_URI}/token/login")
+    assert_response(rc)
+    rc = client.post(f"{BASE_URI}/token/refresh",
+                     content_type="application/json",
+                     data=None,
+                     headers={'Authorization': f'Bearer {rc.json["refresh_token"]}'})
+    assert_response(rc)
+    assert 'access_token' in rc.json
+    assert 'refresh_token' not in rc.json
+
+
 def test_api_stop_workflow(botclient):
     ftbot, client = botclient
     assert ftbot.state == State.RUNNING


### PR DESCRIPTION
## Summary
In order to allow an UI to be more secure, the api server should support JWT (JSON Web Tokens), so the password isn't sent around in plaintext all the time.


## Quick changelog

- Support JWT 
- Support JWT refresh tokesn
- use `safe_str_cmp` to compare username/password.