### PR TITLE
Sell order cancel exception

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -949,8 +949,12 @@ class FreqtradeBot:
         if order['remaining'] == order['amount'] or order.get('filled') == 0.0:
             if not self.exchange.check_order_canceled_empty(order):
                 reason = "cancelled due to timeout"
-                # if trade is not partially completed, just delete the trade
-                self.exchange.cancel_order(trade.open_order_id, trade.pair)
+                try:
+                    # if trade is not partially completed, just delete the trade
+                    self.exchange.cancel_order(trade.open_order_id, trade.pair)
+                except InvalidOrderException:
+                    logger.exception(f"Could not cancel sell order {trade.open_order_id}")
+                    return 'error cancelling order'
                 logger.info('Sell order %s for %s.', reason, trade)
             else:
                 reason = "cancelled on exchange"

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2405,6 +2405,21 @@ def test_handle_timedout_limit_sell(mocker, default_conf) -> None:
     assert cancel_order_mock.call_count == 1
 
 
+def test_handle_timedout_limit_sell_cancel_exception(mocker, default_conf) -> None:
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    mocker.patch(
+        'freqtrade.exchange.Exchange.cancel_order', side_effect=InvalidOrderException())
+
+    freqtrade = FreqtradeBot(default_conf)
+
+    trade = MagicMock()
+    order = {'remaining': 1,
+             'amount': 1,
+             'status': "open"}
+    assert freqtrade.handle_timedout_limit_sell(trade, order) == 'error cancelling order'
+
+
 def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)


### PR DESCRIPTION
## Summary
Seems like one case of "cancel_order" exception was forgotten.
There is only one case where this can happen - which is if the order is fully filled between the `fetch_order()` call, and the `cancel_order()` call.

If this happens, then the next iteration will correctly close the trade.

Either way, this (in combination with #3269) will ensure that we're able to track errors correctly in the future should they arrise again (which i don't expect in this case though).

closes #3268

## Quick changelog

- Catch exception from cancel_order.