### PR TITLE
Minor: Add filterwarning for DeprecationWarning in test

### DIFF
--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -649,6 +649,7 @@ def test_backtest_start_timerange(default_conf, mocker, caplog, testdatadir):
         assert log_has(line, caplog)
 
 
+@pytest.mark.filterwarnings("ignore:deprecated")
 def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
 
     patch_exchange(mocker)


### PR DESCRIPTION
Suppress DeprecationWarning from a test unit which uses LegacyStrategy.
