### PR TITLE
[minor] Show forcebuy status so it's visible before calling forcebuy.

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -104,6 +104,7 @@ class RPC:
             'ticker_interval': config['ticker_interval'],
             'exchange': config['exchange']['name'],
             'strategy': config['strategy'],
+            'forcebuy_enabled': self._freqtrade.config.get('forcebuy_enable', False),
             'state': str(self._freqtrade.state)
         }
         return val

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -104,7 +104,7 @@ class RPC:
             'ticker_interval': config['ticker_interval'],
             'exchange': config['exchange']['name'],
             'strategy': config['strategy'],
-            'forcebuy_enabled': self._freqtrade.config.get('forcebuy_enable', False),
+            'forcebuy_enabled': config.get('forcebuy_enable', False),
             'state': str(self._freqtrade.state)
         }
         return val


### PR DESCRIPTION
## Summary
Show forcebuy status so it's visible before calling forcebuy.

Otherwise we need to call /forcebuy to know if it's available (via API...).
