### PR TITLE
Added Telegram command "logs [n]"

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -208,7 +208,7 @@ class Telegram(RPC):
                  self._send_msg(str(e))
 
         try:
-            location = '/freqtrade/user_data/logs'
+            location = '../../user_data/logs'
             for filename in os.listdir(location):
                 if filename == 'freqtrade.log':
                     f  = open(os.path.join(location, 'freqtrade.log'), "r")


### PR DESCRIPTION
## Summary
Telegram command to check last [n] entries of the logs.

## Quick changelog

- freqtrade/freqtrade/rpc/telegram.py
    - `import os` added to access the logs on the filesystem,
    - Added _logs function, 
    - command handler, 
    - and command explanation on the "/help" message.

## What's new?
Checking the current status of the bot can be useful while being afk. This command enables to check the logfile from the Telegram bot; the text formatting may be not smartphone friendly, but it helped me in more than one occasion.

Posting in case it is useful for anyone else.
