### PR TITLE
[PoC] [WiP] Allow backtest exporting of candlestick data as well as trade data

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -382,6 +382,7 @@ class Backtesting:
         data, timerange = self.load_bt_data()
 
         all_results = {}
+        preprocessed_data = {}
         for strat in self.strategylist:
             logger.info("Running backtesting for Strategy %s", strat.get_strategy_name())
             self._set_strategy(strat)
@@ -398,6 +399,10 @@ class Backtesting:
                 'Backtesting with data from %s up to %s (%s days)..',
                 min_date.isoformat(), max_date.isoformat(), (max_date - min_date).days
             )
+
+            # Store reprocessed data for later use in export
+            preprocessed_data[self.strategy.get_strategy_name()] = preprocessed
+
             # Execute backtest and print results
             all_results[self.strategy.get_strategy_name()] = self.backtest(
                 processed=preprocessed,
@@ -409,6 +414,6 @@ class Backtesting:
             )
 
         if self.config.get('export', False):
-            store_backtest_result(self.config['exportfilename'], all_results)
+            store_backtest_result(self.config, preprocessed_data, all_results)
         # Show backtest results
         show_backtest_results(self.config, data, all_results)


### PR DESCRIPTION
## Summary
Allow backtest exporting of candlestick data as well as trades using `--export all`

## Quick changelog

- allows for exporting of candlestick data and trades using `--export all`

## What's new?

You were already able to export a list backtest trades as json using `--export trades`. This PR enables the user to use `--export all` to export a json object that looks like this:

```
{
  'ETH/BTC': {
    trades: [ [Object] ],
    candles: [
      [Object], [Object], [Object], 
      ... 8475 more items
    ]
  },
  'LTC/BTC': {
    trades: [ [Object], [Object], [Object] ],
    candles: [
      [Object], [Object], [Object], 
      ... 8475 more items
    ]
  }, ...
}
```
The change keeps backwards compatibility by using the exact same function for exporting trades whenever `--export` is used without `all`.