### PR TITLE
Add cors support - needed for UI

### DIFF
--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict
 from arrow import Arrow
 from flask import Flask, jsonify, request
 from flask.json import JSONEncoder
+from flask_cors import CORS
 from flask_jwt_extended import (JWTManager, create_access_token,
                                 create_refresh_token, get_jwt_identity,
                                 jwt_refresh_token_required,
@@ -88,6 +89,7 @@ class ApiServer(RPC):
 
         self._config = freqtrade.config
         self.app = Flask(__name__)
+        self._cors = CORS(self.app, resources={r"/api/*": {"origins": "*"}})
 
         # Setup the Flask-JWT-Extended extension
         self.app.config['JWT_SECRET_KEY'] = self._config['api_server'].get(

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -26,6 +26,7 @@ sdnotify==0.3.2
 # Api server
 flask==1.1.2
 flask-jwt-extended==3.24.1
+flask-cors==3.0.8
 
 # Support for colorized terminal output
 colorama==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if readme_file.is_file():
     readme_long = (Path(__file__).parent / "README.md").read_text()
 
 # Requirements used for submodules
-api = ['flask', 'flask-jwt-extended']
+api = ['flask', 'flask-jwt-extended', 'flask-cors']
 plot = ['plotly>=4.0']
 hyperopt = [
     'scipy',

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -49,6 +49,7 @@ def client_get(client, url):
 def assert_response(response, expected_code=200):
     assert response.status_code == expected_code
     assert response.content_type == "application/json"
+    assert ('Access-Control-Allow-Origin', '*') in response.headers._list
 
 
 def test_api_not_found(botclient):


### PR DESCRIPTION
## Summary
Without this, cross origin requests are not possible as the CORS header is missing, limiting any UI to proxy requests through itself.