### PR TITLE
Improve daily API format

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -186,7 +186,7 @@ class RPC:
 
     def _rpc_daily_profit(
             self, timescale: int,
-            stake_currency: str, fiat_display_currency: str) -> List[List[Any]]:
+            stake_currency: str, fiat_display_currency: str) -> Dict[str, Any]:
         today = datetime.utcnow().date()
         profit_days: Dict[date, Dict] = {}
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -206,28 +206,26 @@ class RPC:
                 'trades': len(trades)
             }
 
-        return [
-            [
-                key,
-                '{value:.8f} {symbol}'.format(
-                    value=float(value['amount']),
-                    symbol=stake_currency
-                ),
-                '{value:.3f} {symbol}'.format(
+        data = [
+            {
+                'date': key,
+                'abs_profit': f'{float(value["amount"]):.8f}',
+                'fiat_value': '{value:.3f}'.format(
                     value=self._fiat_converter.convert_amount(
                         value['amount'],
                         stake_currency,
                         fiat_display_currency
                     ) if self._fiat_converter else 0,
-                    symbol=fiat_display_currency
                 ),
-                '{value} trade{s}'.format(
-                    value=value['trades'],
-                    s='' if value['trades'] < 2 else 's'
-                ),
-            ]
+                'trade_count': f'{value["trades"]}',
+            }
             for key, value in profit_days.items()
         ]
+        return {
+            'stake_currency': stake_currency,
+            'fiat_display_currency': fiat_display_currency,
+            'data': data
+        }
 
     def _rpc_trade_history(self, limit: int) -> Dict:
         """ Returns the X last trades """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -276,14 +276,18 @@ class Telegram(RPC):
                 stake_cur,
                 fiat_disp_cur
             )
-            stats_tab = tabulate(stats,
-                                 headers=[
-                                     'Day',
-                                     f'Profit {stake_cur}',
-                                     f'Profit {fiat_disp_cur}',
-                                     f'Trades'
-                                 ],
-                                 tablefmt='simple')
+            stats_tab = tabulate(
+                [[day['date'],
+                  f"{day['abs_profit']} {stats['stake_currency']}",
+                  f"{day['fiat_value']} {stats['fiat_display_currency']}",
+                  f"{day['trade_count']} trades"] for day in stats['data']],
+                headers=[
+                    'Day',
+                    f'Profit {stake_cur}',
+                    f'Profit {fiat_disp_cur}',
+                    f'Trades',
+                ],
+                tablefmt='simple')
             message = f'<b>Daily Profit over the last {timescale} days</b>:\n<pre>{stats_tab}</pre>'
             self._send_msg(message, parse_mode=ParseMode.HTML)
         except RPCException as e:

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -203,16 +203,18 @@ def test_rpc_daily_profit(default_conf, update, ticker, fee,
     # Try valid data
     update.message.text = '/daily 2'
     days = rpc._rpc_daily_profit(7, stake_currency, fiat_display_currency)
-    assert len(days) == 7
-    for day in days:
+    assert len(days['data']) == 7
+    assert days['stake_currency'] == default_conf['stake_currency']
+    assert days['fiat_display_currency'] == default_conf['fiat_display_currency']
+    for day in days['data']:
         # [datetime.date(2018, 1, 11), '0.00000000 BTC', '0.000 USD']
-        assert (day[1] == '0.00000000 BTC' or
-                day[1] == '0.00006217 BTC')
+        assert (day['abs_profit'] == '0.00000000' or
+                day['abs_profit'] == '0.00006217')
 
-        assert (day[2] == '0.000 USD' or
-                day[2] == '0.767 USD')
+        assert (day['fiat_value'] == '0.000' or
+                day['fiat_value'] == '0.767')
     # ensure first day is current date
-    assert str(days[0][0]) == str(datetime.utcnow().date())
+    assert str(days['data'][0]['date']) == str(datetime.utcnow().date())
 
     # Try invalid data
     with pytest.raises(RPCException, match=r'.*must be an integer greater than 0*'):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -333,8 +333,10 @@ def test_api_daily(botclient, mocker, ticker, fee, markets):
     )
     rc = client_get(client, f"{BASE_URI}/daily")
     assert_response(rc)
-    assert len(rc.json) == 7
-    assert rc.json[0][0] == str(datetime.utcnow().date())
+    assert len(rc.json['data']) == 7
+    assert rc.json['stake_currency'] == 'BTC'
+    assert rc.json['fiat_display_currency'] == 'USD'
+    assert rc.json['data'][0]['date'] == str(datetime.utcnow().date())
 
 
 def test_api_trades(botclient, mocker, ticker, fee, markets):


### PR DESCRIPTION
## Summary
rpc should not format the output - but each RPC handler should do do this himself.
Telegram output is not changed (no change to test_telegram ...) - but the API now returns a list of objects, instead of a list of lists (where you need to guess which field means what).

This implicitly cleans up the return values for the API.
