### PR TITLE
Add ShuffleFilter

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -19,7 +19,7 @@ ORDERBOOK_SIDES = ['ask', 'bid']
 ORDERTYPE_POSSIBILITIES = ['limit', 'market']
 ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
-                       'PrecisionFilter', 'PriceFilter', 'SpreadFilter']
+                       'PrecisionFilter', 'PriceFilter', 'ShuffleFilter', 'SpreadFilter']
 AVAILABLE_DATAHANDLERS = ['json', 'jsongz']
 DRY_RUN_WALLET = 1000
 MATH_CLOSE_PREC = 1e-14  # Precision used for float comparisons

--- a/freqtrade/pairlist/ShuffleFilter.py
+++ b/freqtrade/pairlist/ShuffleFilter.py
@@ -1,0 +1,50 @@
+"""
+Shuffle pair list filter
+"""
+import logging
+import random
+from typing import Dict, List
+
+from freqtrade.pairlist.IPairList import IPairList
+
+
+logger = logging.getLogger(__name__)
+
+
+class ShuffleFilter(IPairList):
+
+    def __init__(self, exchange, pairlistmanager, config, pairlistconfig: dict,
+                 pairlist_pos: int) -> None:
+        super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
+
+        self._seed = pairlistconfig.get('seed')
+        self._random = random.Random(self._seed)
+
+    @property
+    def needstickers(self) -> bool:
+        """
+        Boolean property defining if tickers are necessary.
+        If no Pairlist requries tickers, an empty List is passed
+        as tickers argument to filter_pairlist
+        """
+        return False
+
+    def short_desc(self) -> str:
+        """
+        Short whitelist method description - used for startup-messages
+        """
+        return (f"{self.name} - Shuffling pairs" +
+                (f", seed = {self._seed}." if self._seed is not None else "."))
+
+    def filter_pairlist(self, pairlist: List[str], tickers: Dict) -> List[str]:
+        """
+        Filters and sorts pairlist and returns the whitelist again.
+        Called on each bot iteration - please use internal caching if necessary
+        :param pairlist: pairlist to filter or sort
+        :param tickers: Tickers (from exchange.get_tickers()). May be cached.
+        :return: new whitelist
+        """
+        # Shuffle is done inplace
+        self._random.shuffle(pairlist)
+
+        return pairlist

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -244,7 +244,7 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, t
     whitelist = freqtrade.pairlists.whitelist
 
     assert isinstance(whitelist, list)
-    
+
     # Verify length of pairlist matches (used for ShuffleFilter without seed)
     if type(whitelist_result) is list:
         assert whitelist == whitelist_result

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -176,7 +176,7 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
       {"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
       {"method": "PrecisionFilter"},
       {"method": "PriceFilter", "low_price_ratio": 0.03},
-      {"method": "SpreadFilter", "max_spread": 0.005},
+      {"method": "SpreadFilter", "max_spread_ratio": 0.005},
       {"method": "ShuffleFilter"}],
      "ETH", []),
     # Precisionfilter and quote volume
@@ -211,7 +211,7 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
      "BTC", ['TKN/BTC', 'ETH/BTC']),
     # SpreadFilter
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
-      {"method": "SpreadFilter", "max_spread": 0.005}],
+      {"method": "SpreadFilter", "max_spread_ratio": 0.005}],
      "USDT", ['ETH/USDT']),
     # ShuffleFilter
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -157,15 +157,27 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
 
 
 @pytest.mark.parametrize("pairlists,base_currency,whitelist_result", [
+    # VolumePairList only
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"}],
-        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC', 'HOT/BTC']),
+     "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC', 'HOT/BTC']),
     # Different sorting depending on quote or bid volume
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "bidVolume"}],
-        "BTC",  ['HOT/BTC', 'FUEL/BTC', 'XRP/BTC', 'LTC/BTC', 'TKN/BTC']),
+     "BTC",  ['HOT/BTC', 'FUEL/BTC', 'XRP/BTC', 'LTC/BTC', 'TKN/BTC']),
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"}],
-        "USDT", ['ETH/USDT', 'NANO/USDT', 'ADAHALF/USDT']),
-    # No pair for ETH ...
+     "USDT", ['ETH/USDT', 'NANO/USDT', 'ADAHALF/USDT']),
+    # No pair for ETH, VolumePairList
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"}],
+     "ETH", []),
+    # No pair for ETH, StaticPairList
+    ([{"method": "StaticPairList"}],
+     "ETH", []),
+    # No pair for ETH, all handlers
+    ([{"method": "StaticPairList"},
+      {"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
+      {"method": "PrecisionFilter"},
+      {"method": "PriceFilter", "low_price_ratio": 0.03},
+      {"method": "SpreadFilter", "max_spread": 0.005},
+      {"method": "ShuffleFilter"}],
      "ETH", []),
     # Precisionfilter and quote volume
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
@@ -176,31 +188,43 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
     # PriceFilter and VolumePairList
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
       {"method": "PriceFilter", "low_price_ratio": 0.03}],
-        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
+     "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
     # PriceFilter and VolumePairList
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
       {"method": "PriceFilter", "low_price_ratio": 0.03}],
-        "USDT", ['ETH/USDT', 'NANO/USDT']),
+     "USDT", ['ETH/USDT', 'NANO/USDT']),
     # Hot is removed by precision_filter, Fuel by low_price_filter.
     ([{"method": "VolumePairList", "number_assets": 6, "sort_key": "quoteVolume"},
       {"method": "PrecisionFilter"},
-      {"method": "PriceFilter", "low_price_ratio": 0.02}
-      ], "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
+      {"method": "PriceFilter", "low_price_ratio": 0.02}],
+     "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC', 'XRP/BTC']),
     # HOT and XRP are removed because below 1250 quoteVolume
     ([{"method": "VolumePairList", "number_assets": 5,
        "sort_key": "quoteVolume", "min_value": 1250}],
-        "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']),
-    # StaticPairlist Only
-    ([{"method": "StaticPairList"},
-      ], "BTC", ['ETH/BTC', 'TKN/BTC']),
+     "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']),
+    # StaticPairlist only
+    ([{"method": "StaticPairList"}],
+     "BTC", ['ETH/BTC', 'TKN/BTC']),
     # Static Pairlist before VolumePairList - sorting changes
     ([{"method": "StaticPairList"},
-      {"method": "VolumePairList", "number_assets": 5, "sort_key": "bidVolume"},
-      ], "BTC", ['TKN/BTC', 'ETH/BTC']),
+      {"method": "VolumePairList", "number_assets": 5, "sort_key": "bidVolume"}],
+     "BTC", ['TKN/BTC', 'ETH/BTC']),
     # SpreadFilter
     ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
-      {"method": "SpreadFilter", "max_spread": 0.005}
-      ], "USDT", ['ETH/USDT']),
+      {"method": "SpreadFilter", "max_spread": 0.005}],
+     "USDT", ['ETH/USDT']),
+    # ShuffleFilter
+    ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
+      {"method": "ShuffleFilter", "seed": 77}],
+     "USDT", ['ETH/USDT', 'ADAHALF/USDT', 'NANO/USDT']),
+    # ShuffleFilter, other seed
+    ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
+      {"method": "ShuffleFilter", "seed": 42}],
+     "USDT", ['NANO/USDT', 'ETH/USDT', 'ADAHALF/USDT']),
+    # ShuffleFilter, no seed
+    ([{"method": "VolumePairList", "number_assets": 5, "sort_key": "quoteVolume"},
+      {"method": "ShuffleFilter"}],
+     "USDT", 3),
 ])
 def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, tickers,
                                       pairlists, base_currency, whitelist_result,
@@ -219,12 +243,16 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, t
     freqtrade.pairlists.refresh_pairlist()
     whitelist = freqtrade.pairlists.whitelist
 
-    assert whitelist == whitelist_result
+    if type(whitelist_result) is list:
+        assert whitelist == whitelist_result
+    else:
+        len(whitelist) == whitelist_result
+
     for pairlist in pairlists:
-        if pairlist['method'] == 'PrecisionFilter':
+        if pairlist['method'] == 'PrecisionFilter' and whitelist_result:
             assert log_has_re(r'^Removed .* from whitelist, because stop price .* '
                               r'would be <= stop limit.*', caplog)
-        if pairlist['method'] == 'PriceFilter':
+        if pairlist['method'] == 'PriceFilter' and whitelist_result:
             assert (log_has_re(r'^Removed .* from whitelist, because 1 unit is .*%$', caplog) or
                     log_has_re(r"^Removed .* from whitelist, because ticker\['last'\] is empty.*",
                                caplog))

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -243,6 +243,9 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, t
     freqtrade.pairlists.refresh_pairlist()
     whitelist = freqtrade.pairlists.whitelist
 
+    assert isinstance(whitelist, list)
+    
+    # Verify length of pairlist matches (used for ShuffleFilter without seed)
     if type(whitelist_result) is list:
         assert whitelist == whitelist_result
     else:


### PR DESCRIPTION
Adds Shuffling pairlist filter.
Replaces #2956 

Usage:
```
{"method": "ShuffleFilter"}
```
for reproducible results:
```
{"method": "ShuffleFilter", "seed": 42}
```

Also, some tests for other pairlists added/adjusted.

TODO: docs
