### PR TITLE
Cleanup in pairlistmanager

### DIFF
--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -1,5 +1,5 @@
 """
-PairList base class
+PairList Handler base class
 """
 import logging
 from abc import ABC, abstractmethod, abstractproperty
@@ -21,10 +21,10 @@ class IPairList(ABC):
                  pairlist_pos: int) -> None:
         """
         :param exchange: Exchange instance
-        :param pairlistmanager: Instanciating Pairlist manager
+        :param pairlistmanager: Instantiated Pairlist manager
         :param config: Global bot configuration
-        :param pairlistconfig: Configuration for this pairlist - can be empty.
-        :param pairlist_pos: Position of the filter in the pairlist-filter-list
+        :param pairlistconfig: Configuration for this Pairlist Handler - can be empty.
+        :param pairlist_pos: Position of the Pairlist Handler in the chain
         """
         self._exchange = exchange
         self._pairlistmanager = pairlistmanager
@@ -93,10 +93,10 @@ class IPairList(ABC):
         """
         Verify and remove items from pairlist - returning a filtered pairlist.
         Logs a warning or info depending on `aswarning`.
-        Pairlists explicitly using this method shall use `aswarning=False`!
+        Pairlist Handlers explicitly using this method shall use `aswarning=False`!
         :param pairlist: Pairlist to validate
         :param blacklist: Blacklist to validate pairlist against
-        :param aswarning: Log message as Warning or info
+        :param aswarning: Log message as Warning or Info
         :return: pairlist - blacklisted pairs
         """
         for pair in deepcopy(pairlist):

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -10,8 +10,6 @@ from freqtrade.pairlist.pairlistmanager import PairListManager
 from freqtrade.resolvers import PairListResolver
 from tests.conftest import get_patched_freqtradebot, log_has, log_has_re
 
-# whitelist, blacklist
-
 
 @pytest.fixture(scope="function")
 def whitelist_conf(default_conf):
@@ -55,7 +53,7 @@ def test_log_on_refresh(mocker, static_pl_conf, markets, tickers):
     freqtrade = get_patched_freqtradebot(mocker, static_pl_conf)
     logmock = MagicMock()
     # Assign starting whitelist
-    pl = freqtrade.pairlists._pairlists[0]
+    pl = freqtrade.pairlists._pairlist_handlers[0]
     pl.log_on_refresh(logmock, 'Hello world')
     assert logmock.call_count == 1
     pl.log_on_refresh(logmock, 'Hello world')
@@ -290,7 +288,8 @@ def test__whitelist_for_active_markets(mocker, whitelist_conf, markets, pairlist
     caplog.clear()
 
     # Assign starting whitelist
-    new_whitelist = freqtrade.pairlists._pairlists[0]._whitelist_for_active_markets(whitelist)
+    pairlist_handler = freqtrade.pairlists._pairlist_handlers[0]
+    new_whitelist = pairlist_handler._whitelist_for_active_markets(whitelist)
 
     assert set(new_whitelist) == set(['ETH/BTC', 'TKN/BTC'])
     assert log_message in caplog.text
@@ -313,17 +312,17 @@ def test_volumepairlist_caching(mocker, markets, whitelist_conf, tickers):
                           get_tickers=tickers
                           )
     freqtrade = get_patched_freqtradebot(mocker, whitelist_conf)
-    assert freqtrade.pairlists._pairlists[0]._last_refresh == 0
+    assert freqtrade.pairlists._pairlist_handlers[0]._last_refresh == 0
     assert tickers.call_count == 0
     freqtrade.pairlists.refresh_pairlist()
     assert tickers.call_count == 1
 
-    assert freqtrade.pairlists._pairlists[0]._last_refresh != 0
-    lrf = freqtrade.pairlists._pairlists[0]._last_refresh
+    assert freqtrade.pairlists._pairlist_handlers[0]._last_refresh != 0
+    lrf = freqtrade.pairlists._pairlist_handlers[0]._last_refresh
     freqtrade.pairlists.refresh_pairlist()
     assert tickers.call_count == 1
     # Time should not be updated.
-    assert freqtrade.pairlists._pairlists[0]._last_refresh == lrf
+    assert freqtrade.pairlists._pairlist_handlers[0]._last_refresh == lrf
 
 
 def test_pairlistmanager_no_pairlist(mocker, markets, whitelist_conf, caplog):
@@ -332,5 +331,5 @@ def test_pairlistmanager_no_pairlist(mocker, markets, whitelist_conf, caplog):
     whitelist_conf['pairlists'] = []
 
     with pytest.raises(OperationalException,
-                       match=r"No Pairlist defined!"):
+                       match=r"No Pairlist Handlers defined"):
         get_patched_freqtradebot(mocker, whitelist_conf)


### PR DESCRIPTION
...and partly in IPairList.

Just to make it clear, where pairlists (instances if IPairList) and pairlists (lists of pairs) are used. 😉 
The term Pairlist Handler is used for instances of IPairList, as in the updated part of the documentation.

Neither the name of IPairList class, nor the name of the parameters of the methods of this class were touched at this attempt, to keep the PR light.
