### PR TITLE
[minor] Fix crash when no trades are found in plot-profit

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -194,7 +194,10 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     :param col_name: Column name that will be assigned the results
     :param timeframe: Timeframe used during the operations
     :return: Returns df with one additional column, col_name, containing the cumulative profit.
+    :raise: ValueError if trade-dataframe was found empty.
     """
+    if len(trades) == 0:
+        raise ValueError("Trade dataframe empty.")
     from freqtrade.exchange import timeframe_to_minutes
     timeframe_minutes = timeframe_to_minutes(timeframe)
     # Resample to timeframe to make sure trades match candles

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -10,8 +10,9 @@ from freqtrade.data.btanalysis import (calculate_max_drawdown,
                                        create_cum_profit,
                                        extract_trades_of_period, load_trades)
 from freqtrade.data.converter import trim_dataframe
-from freqtrade.exchange import timeframe_to_prev_date
 from freqtrade.data.history import load_data
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange import timeframe_to_prev_date
 from freqtrade.misc import pair_to_filename
 from freqtrade.resolvers import StrategyResolver
 
@@ -504,6 +505,9 @@ def plot_profit(config: Dict[str, Any]) -> None:
     trades = trades[(trades['pair'].isin(plot_elements["pairs"]))
                     & (~trades['close_time'].isnull())
                     ]
+    if len(trades) == 0:
+        raise OperationalException("No trades found, cannot generate Profit-plot without "
+                                   "trades from either Backtest result or database.")
 
     # Create an average close price of all the pairs that were involved.
     # this could be useful to gauge the overall market trend

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -178,6 +178,10 @@ def test_create_cum_profit1(testdatadir):
     assert cum_profits.iloc[0]['cum_profits'] == 0
     assert cum_profits.iloc[-1]['cum_profits'] == 0.0798005
 
+    with pytest.raises(ValueError, match='Trade dataframe empty.'):
+        create_cum_profit(df.set_index('date'), bt_data[bt_data["pair"] == 'NOTAPAIR'],
+                          "cum_profits", timeframe="5m")
+
 
 def test_calculate_max_drawdown(testdatadir):
     filename = testdatadir / "backtest-result_test.json"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -374,7 +374,7 @@ def test_start_plot_profit_error(mocker):
 def test_plot_profit(default_conf, mocker, testdatadir, caplog):
     default_conf['trade_source'] = 'file'
     default_conf["datadir"] = testdatadir
-    default_conf['exportfilename'] = testdatadir / "backtest-result_test.json"
+    default_conf['exportfilename'] = testdatadir / "backtest-result_test_nofile.json"
     default_conf['pairs'] = ["ETH/BTC", "LTC/BTC"]
 
     profit_mock = MagicMock()
@@ -384,6 +384,12 @@ def test_plot_profit(default_conf, mocker, testdatadir, caplog):
         generate_profit_graph=profit_mock,
         store_plot_file=store_mock
     )
+    with pytest.raises(OperationalException,
+                       match=r"No trades found, cannot generate Profit-plot.*"):
+        plot_profit(default_conf)
+
+    default_conf['exportfilename'] = testdatadir / "backtest-result_test.json"
+
     plot_profit(default_conf)
 
     # Plot-profit generates one combined plot


### PR DESCRIPTION
## Summary
Freqtrade should not crash - but instead show a "nice" warning about why it did not work.

closes #3342

## Quick changelog

- Check if trades are empty and don't run plot_profit
- Also verify the trade-dict within `create_cum_profit()`. This is not reachable from plot_profit anymore - but ensures we're not reintroduce this bug in other areas should create_cum_profit be reused someplace else.