### PR TITLE
Improve pairlist tests

### DIFF
--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -36,8 +36,8 @@ class VolumePairList(IPairList):
 
         if not self._exchange.exchange_has('fetchTickers'):
             raise OperationalException(
-                'Exchange does not support dynamic whitelist.'
-                'Please edit your config and restart the bot'
+                'Exchange does not support dynamic whitelist. '
+                'Please edit your config and restart the bot.'
             )
 
         if not self._validate_keys(self._sort_key):


### PR DESCRIPTION
* New unit test test_refresh_pairlist_dynamic_2 added -- it emulates expiring the cache, I thought there is a bug here (but it's actually okay)
* Exception text in VolumePairList corrected (missing space)
* The test_gen_pair_whitelist_not_supported (it catched and verified wrong exception)
