### PR TITLE
Reorder subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ For any other type of installation please refer to [Installation doc](https://ww
 
 ```
 usage: freqtrade [-h] [-V]
-                 {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
+                 {trade,create-userdir,new-config,new-hyperopt,new-strategy,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
                  ...
 
 Free, open source crypto trading bot
 
 positional arguments:
-  {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
+  {trade,create-userdir,new-config,new-hyperopt,new-strategy,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
     trade               Trade module.
     create-userdir      Create user-data directory.
     new-config          Create new config

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ positional arguments:
     trade               Trade module.
     create-userdir      Create user-data directory.
     new-config          Create new config
-    new-strategy        Create new strategy
     new-hyperopt        Create new hyperopt
+    new-strategy        Create new strategy
     download-data       Download backtesting data.
     convert-data        Convert candle (OHLCV) data from one format to another.
     convert-trade-data  Convert trade data from one format to another.

--- a/README.md
+++ b/README.md
@@ -68,40 +68,42 @@ For any other type of installation please refer to [Installation doc](https://ww
 ### Bot commands
 
 ```
-usage: freqtrade [-h] [-v] [--logfile FILE] [--version] [-c PATH] [-d PATH]
-                 [-s NAME] [--strategy-path PATH] [--dynamic-whitelist [INT]]
-                 [--db-url PATH] [--sd-notify]
-                 {backtesting,edge,hyperopt} ...
+usage: freqtrade [-h] [-V]
+                 {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
+                 ...
 
 Free, open source crypto trading bot
 
 positional arguments:
-  {backtesting,edge,hyperopt}
+  {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
+    trade               Trade module.
+    create-userdir      Create user-data directory.
+    new-config          Create new config
+    new-strategy        Create new strategy
+    new-hyperopt        Create new hyperopt
+    download-data       Download backtesting data.
+    convert-data        Convert candle (OHLCV) data from one format to another.
+    convert-trade-data  Convert trade data from one format to another.
     backtesting         Backtesting module.
     edge                Edge module.
     hyperopt            Hyperopt module.
+    hyperopt-list       List Hyperopt results
+    hyperopt-show       Show details of Hyperopt results
+    list-exchanges      Print available exchanges.
+    list-hyperopts      Print available hyperopt classes.
+    list-markets        Print markets on exchange.
+    list-pairs          Print pairs on exchange.
+    list-strategies     Print available strategies.
+    list-timeframes     Print available ticker intervals (timeframes) for the exchange.
+    show-trades         Show trades.
+    test-pairlist       Test your pairlist configuration.
+    plot-dataframe      Plot candles with indicators.
+    plot-profit         Generate plot showing profits.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
-  --logfile FILE        Log to the file specified
-  --version             show program's version number and exit
-  -c PATH, --config PATH
-                        Specify configuration file (default: None). Multiple
-                        --config options may be used.
-  -d PATH, --datadir PATH
-                        Path to backtest data.
-  -s NAME, --strategy NAME
-                        Specify strategy class name (default:
-                        DefaultStrategy).
-  --strategy-path PATH  Specify additional strategy lookup path.
-  --dynamic-whitelist [INT]
-                        Dynamically generate and update whitelist based on 24h
-                        BaseVolume (default: 20). DEPRECATED.
-  --db-url PATH         Override trades database URL, this is useful if
-                        dry_run is enabled or in custom deployments (default:
-                        None).
-  --sd-notify           Notify systemd service manager.
+  -V, --version         show program's version number and exit
+
 ```
 
 ### Telegram RPC commands

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -206,6 +206,33 @@ class Arguments:
         build_hyperopt_cmd.set_defaults(func=start_new_hyperopt)
         self._build_args(optionlist=ARGS_BUILD_HYPEROPT, parser=build_hyperopt_cmd)
 
+        # Add download-data subcommand
+        download_data_cmd = subparsers.add_parser(
+            'download-data',
+            help='Download backtesting data.',
+            parents=[_common_parser],
+        )
+        download_data_cmd.set_defaults(func=start_download_data)
+        self._build_args(optionlist=ARGS_DOWNLOAD_DATA, parser=download_data_cmd)
+
+        # Add convert-data subcommand
+        convert_data_cmd = subparsers.add_parser(
+            'convert-data',
+            help='Convert candle (OHLCV) data from one format to another.',
+            parents=[_common_parser],
+        )
+        convert_data_cmd.set_defaults(func=partial(start_convert_data, ohlcv=True))
+        self._build_args(optionlist=ARGS_CONVERT_DATA_OHLCV, parser=convert_data_cmd)
+
+        # Add convert-trade-data subcommand
+        convert_trade_data_cmd = subparsers.add_parser(
+            'convert-trade-data',
+            help='Convert trade data from one format to another.',
+            parents=[_common_parser],
+        )
+        convert_trade_data_cmd.set_defaults(func=partial(start_convert_data, ohlcv=False))
+        self._build_args(optionlist=ARGS_CONVERT_DATA, parser=convert_trade_data_cmd)
+
         # Add backtesting subcommand
         backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.',
                                                 parents=[_common_parser, _strategy_parser])
@@ -217,6 +244,31 @@ class Arguments:
                                          parents=[_common_parser, _strategy_parser])
         edge_cmd.set_defaults(func=start_edge)
         self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
+
+        # Add hyperopt subcommand
+        hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.',
+                                             parents=[_common_parser, _strategy_parser],
+                                             )
+        hyperopt_cmd.set_defaults(func=start_hyperopt)
+        self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
+
+        # Add hyperopt-list subcommand
+        hyperopt_list_cmd = subparsers.add_parser(
+            'hyperopt-list',
+            help='List Hyperopt results',
+            parents=[_common_parser],
+        )
+        hyperopt_list_cmd.set_defaults(func=start_hyperopt_list)
+        self._build_args(optionlist=ARGS_HYPEROPT_LIST, parser=hyperopt_list_cmd)
+
+        # Add hyperopt-show subcommand
+        hyperopt_show_cmd = subparsers.add_parser(
+            'hyperopt-show',
+            help='Show details of Hyperopt results',
+            parents=[_common_parser],
+        )
+        hyperopt_show_cmd.set_defaults(func=start_hyperopt_show)
+        self._build_args(optionlist=ARGS_HYPEROPT_SHOW, parser=hyperopt_show_cmd)
 
         # Add list-strategies subcommand
         list_strategies_cmd = subparsers.add_parser(
@@ -289,33 +341,6 @@ class Arguments:
         show_trades.set_defaults(func=start_show_trades)
         self._build_args(optionlist=ARGS_SHOW_TRADES, parser=show_trades)
 
-        # Add download-data subcommand
-        download_data_cmd = subparsers.add_parser(
-            'download-data',
-            help='Download backtesting data.',
-            parents=[_common_parser],
-        )
-        download_data_cmd.set_defaults(func=start_download_data)
-        self._build_args(optionlist=ARGS_DOWNLOAD_DATA, parser=download_data_cmd)
-
-        # Add convert-data subcommand
-        convert_data_cmd = subparsers.add_parser(
-            'convert-data',
-            help='Convert candle (OHLCV) data from one format to another.',
-            parents=[_common_parser],
-        )
-        convert_data_cmd.set_defaults(func=partial(start_convert_data, ohlcv=True))
-        self._build_args(optionlist=ARGS_CONVERT_DATA_OHLCV, parser=convert_data_cmd)
-
-        # Add convert-trade-data subcommand
-        convert_trade_data_cmd = subparsers.add_parser(
-            'convert-trade-data',
-            help='Convert trade data from one format to another.',
-            parents=[_common_parser],
-        )
-        convert_trade_data_cmd.set_defaults(func=partial(start_convert_data, ohlcv=False))
-        self._build_args(optionlist=ARGS_CONVERT_DATA, parser=convert_trade_data_cmd)
-
         # Add Plotting subcommand
         plot_dataframe_cmd = subparsers.add_parser(
             'plot-dataframe',
@@ -333,28 +358,3 @@ class Arguments:
         )
         plot_profit_cmd.set_defaults(func=start_plot_profit)
         self._build_args(optionlist=ARGS_PLOT_PROFIT, parser=plot_profit_cmd)
-
-        # Add hyperopt subcommand
-        hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.',
-                                             parents=[_common_parser, _strategy_parser],
-                                             )
-        hyperopt_cmd.set_defaults(func=start_hyperopt)
-        self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
-
-        # Add hyperopt-list subcommand
-        hyperopt_list_cmd = subparsers.add_parser(
-            'hyperopt-list',
-            help='List Hyperopt results',
-            parents=[_common_parser],
-        )
-        hyperopt_list_cmd.set_defaults(func=start_hyperopt_list)
-        self._build_args(optionlist=ARGS_HYPEROPT_LIST, parser=hyperopt_list_cmd)
-
-        # Add hyperopt-show subcommand
-        hyperopt_show_cmd = subparsers.add_parser(
-            'hyperopt-show',
-            help='Show details of Hyperopt results',
-            parents=[_common_parser],
-        )
-        hyperopt_show_cmd.set_defaults(func=start_hyperopt_show)
-        self._build_args(optionlist=ARGS_HYPEROPT_SHOW, parser=hyperopt_show_cmd)

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -181,25 +181,6 @@ class Arguments:
         trade_cmd.set_defaults(func=start_trading)
         self._build_args(optionlist=ARGS_TRADE, parser=trade_cmd)
 
-        # Add backtesting subcommand
-        backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.',
-                                                parents=[_common_parser, _strategy_parser])
-        backtesting_cmd.set_defaults(func=start_backtesting)
-        self._build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
-
-        # Add edge subcommand
-        edge_cmd = subparsers.add_parser('edge', help='Edge module.',
-                                         parents=[_common_parser, _strategy_parser])
-        edge_cmd.set_defaults(func=start_edge)
-        self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
-
-        # Add hyperopt subcommand
-        hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.',
-                                             parents=[_common_parser, _strategy_parser],
-                                             )
-        hyperopt_cmd.set_defaults(func=start_hyperopt)
-        self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
-
         # add create-userdir subcommand
         create_userdir_cmd = subparsers.add_parser('create-userdir',
                                                    help="Create user-data directory.",
@@ -224,6 +205,18 @@ class Arguments:
                                                    help="Create new hyperopt")
         build_hyperopt_cmd.set_defaults(func=start_new_hyperopt)
         self._build_args(optionlist=ARGS_BUILD_HYPEROPT, parser=build_hyperopt_cmd)
+
+        # Add backtesting subcommand
+        backtesting_cmd = subparsers.add_parser('backtesting', help='Backtesting module.',
+                                                parents=[_common_parser, _strategy_parser])
+        backtesting_cmd.set_defaults(func=start_backtesting)
+        self._build_args(optionlist=ARGS_BACKTEST, parser=backtesting_cmd)
+
+        # Add edge subcommand
+        edge_cmd = subparsers.add_parser('edge', help='Edge module.',
+                                         parents=[_common_parser, _strategy_parser])
+        edge_cmd.set_defaults(func=start_edge)
+        self._build_args(optionlist=ARGS_EDGE, parser=edge_cmd)
 
         # Add list-strategies subcommand
         list_strategies_cmd = subparsers.add_parser(
@@ -287,6 +280,15 @@ class Arguments:
         test_pairlist_cmd.set_defaults(func=start_test_pairlist)
         self._build_args(optionlist=ARGS_TEST_PAIRLIST, parser=test_pairlist_cmd)
 
+        # Add show-trades subcommand
+        show_trades = subparsers.add_parser(
+            'show-trades',
+            help='Show trades.',
+            parents=[_common_parser],
+        )
+        show_trades.set_defaults(func=start_show_trades)
+        self._build_args(optionlist=ARGS_SHOW_TRADES, parser=show_trades)
+
         # Add download-data subcommand
         download_data_cmd = subparsers.add_parser(
             'download-data',
@@ -332,14 +334,12 @@ class Arguments:
         plot_profit_cmd.set_defaults(func=start_plot_profit)
         self._build_args(optionlist=ARGS_PLOT_PROFIT, parser=plot_profit_cmd)
 
-        # Add show-trades subcommand
-        show_trades = subparsers.add_parser(
-            'show-trades',
-            help='Show trades.',
-            parents=[_common_parser],
-        )
-        show_trades.set_defaults(func=start_show_trades)
-        self._build_args(optionlist=ARGS_SHOW_TRADES, parser=show_trades)
+        # Add hyperopt subcommand
+        hyperopt_cmd = subparsers.add_parser('hyperopt', help='Hyperopt module.',
+                                             parents=[_common_parser, _strategy_parser],
+                                             )
+        hyperopt_cmd.set_defaults(func=start_hyperopt)
+        self._build_args(optionlist=ARGS_HYPEROPT, parser=hyperopt_cmd)
 
         # Add hyperopt-list subcommand
         hyperopt_list_cmd = subparsers.add_parser(

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -194,17 +194,17 @@ class Arguments:
         build_config_cmd.set_defaults(func=start_new_config)
         self._build_args(optionlist=ARGS_BUILD_CONFIG, parser=build_config_cmd)
 
-        # add new-strategy subcommand
-        build_strategy_cmd = subparsers.add_parser('new-strategy',
-                                                   help="Create new strategy")
-        build_strategy_cmd.set_defaults(func=start_new_strategy)
-        self._build_args(optionlist=ARGS_BUILD_STRATEGY, parser=build_strategy_cmd)
-
         # add new-hyperopt subcommand
         build_hyperopt_cmd = subparsers.add_parser('new-hyperopt',
                                                    help="Create new hyperopt")
         build_hyperopt_cmd.set_defaults(func=start_new_hyperopt)
         self._build_args(optionlist=ARGS_BUILD_HYPEROPT, parser=build_hyperopt_cmd)
+
+        # add new-strategy subcommand
+        build_strategy_cmd = subparsers.add_parser('new-strategy',
+                                                   help="Create new strategy")
+        build_strategy_cmd.set_defaults(func=start_new_strategy)
+        self._build_args(optionlist=ARGS_BUILD_STRATEGY, parser=build_strategy_cmd)
 
         # Add download-data subcommand
         download_data_cmd = subparsers.add_parser(

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -270,24 +270,6 @@ class Arguments:
         hyperopt_show_cmd.set_defaults(func=start_hyperopt_show)
         self._build_args(optionlist=ARGS_HYPEROPT_SHOW, parser=hyperopt_show_cmd)
 
-        # Add list-strategies subcommand
-        list_strategies_cmd = subparsers.add_parser(
-            'list-strategies',
-            help='Print available strategies.',
-            parents=[_common_parser],
-        )
-        list_strategies_cmd.set_defaults(func=start_list_strategies)
-        self._build_args(optionlist=ARGS_LIST_STRATEGIES, parser=list_strategies_cmd)
-
-        # Add list-hyperopts subcommand
-        list_hyperopts_cmd = subparsers.add_parser(
-            'list-hyperopts',
-            help='Print available hyperopt classes.',
-            parents=[_common_parser],
-        )
-        list_hyperopts_cmd.set_defaults(func=start_list_hyperopts)
-        self._build_args(optionlist=ARGS_LIST_HYPEROPTS, parser=list_hyperopts_cmd)
-
         # Add list-exchanges subcommand
         list_exchanges_cmd = subparsers.add_parser(
             'list-exchanges',
@@ -297,14 +279,14 @@ class Arguments:
         list_exchanges_cmd.set_defaults(func=start_list_exchanges)
         self._build_args(optionlist=ARGS_LIST_EXCHANGES, parser=list_exchanges_cmd)
 
-        # Add list-timeframes subcommand
-        list_timeframes_cmd = subparsers.add_parser(
-            'list-timeframes',
-            help='Print available ticker intervals (timeframes) for the exchange.',
+        # Add list-hyperopts subcommand
+        list_hyperopts_cmd = subparsers.add_parser(
+            'list-hyperopts',
+            help='Print available hyperopt classes.',
             parents=[_common_parser],
         )
-        list_timeframes_cmd.set_defaults(func=start_list_timeframes)
-        self._build_args(optionlist=ARGS_LIST_TIMEFRAMES, parser=list_timeframes_cmd)
+        list_hyperopts_cmd.set_defaults(func=start_list_hyperopts)
+        self._build_args(optionlist=ARGS_LIST_HYPEROPTS, parser=list_hyperopts_cmd)
 
         # Add list-markets subcommand
         list_markets_cmd = subparsers.add_parser(
@@ -324,13 +306,23 @@ class Arguments:
         list_pairs_cmd.set_defaults(func=partial(start_list_markets, pairs_only=True))
         self._build_args(optionlist=ARGS_LIST_PAIRS, parser=list_pairs_cmd)
 
-        # Add test-pairlist subcommand
-        test_pairlist_cmd = subparsers.add_parser(
-            'test-pairlist',
-            help='Test your pairlist configuration.',
+        # Add list-strategies subcommand
+        list_strategies_cmd = subparsers.add_parser(
+            'list-strategies',
+            help='Print available strategies.',
+            parents=[_common_parser],
         )
-        test_pairlist_cmd.set_defaults(func=start_test_pairlist)
-        self._build_args(optionlist=ARGS_TEST_PAIRLIST, parser=test_pairlist_cmd)
+        list_strategies_cmd.set_defaults(func=start_list_strategies)
+        self._build_args(optionlist=ARGS_LIST_STRATEGIES, parser=list_strategies_cmd)
+
+        # Add list-timeframes subcommand
+        list_timeframes_cmd = subparsers.add_parser(
+            'list-timeframes',
+            help='Print available ticker intervals (timeframes) for the exchange.',
+            parents=[_common_parser],
+        )
+        list_timeframes_cmd.set_defaults(func=start_list_timeframes)
+        self._build_args(optionlist=ARGS_LIST_TIMEFRAMES, parser=list_timeframes_cmd)
 
         # Add show-trades subcommand
         show_trades = subparsers.add_parser(
@@ -340,6 +332,14 @@ class Arguments:
         )
         show_trades.set_defaults(func=start_show_trades)
         self._build_args(optionlist=ARGS_SHOW_TRADES, parser=show_trades)
+
+        # Add test-pairlist subcommand
+        test_pairlist_cmd = subparsers.add_parser(
+            'test-pairlist',
+            help='Test your pairlist configuration.',
+        )
+        test_pairlist_cmd.set_defaults(func=start_test_pairlist)
+        self._build_args(optionlist=ARGS_TEST_PAIRLIST, parser=test_pairlist_cmd)
 
         # Add Plotting subcommand
         plot_dataframe_cmd = subparsers.add_parser(


### PR DESCRIPTION
## Summary
Reorder subcommands so they have "some" sense when running `freqtrade --help`.

Now i've tried to
a) combine them how they belong together (backtesting/optimize commands, new commands)
b) order them alphabetically where the above doesn't make sense

now we can argue about the trade command. I've left it in "first place" for now as the "important" commmand - but maybe the sequence should be by workflow?
(optimize - then trade) ... 



*note* i only reordered the commands - didn't type one character (might simplify reviews ...)

## Quick changelog
Old:
```
usage: freqtrade [-h] [-V]
                 {trade,backtesting,edge,hyperopt,create-userdir,new-config,new-strategy,new-hyperopt,list-strategies,list-hyperopts,list-exchanges,list-timeframes,list-markets,list-pairs,test-pairlist,download-data,convert-data,convert-trade-data,plot-dataframe,plot-profit,show-trades,hyperopt-list,hyperopt-show}
                 ...

Free, open source crypto trading bot

positional arguments:
  {trade,backtesting,edge,hyperopt,create-userdir,new-config,new-strategy,new-hyperopt,list-strategies,list-hyperopts,list-exchanges,list-timeframes,list-markets,list-pairs,test-pairlist,download-data,convert-data,convert-trade-data,plot-dataframe,plot-profit,show-trades,hyperopt-list,hyperopt-show}
    trade               Trade module.
    backtesting         Backtesting module.
    edge                Edge module.
    hyperopt            Hyperopt module.
    create-userdir      Create user-data directory.
    new-config          Create new config
    new-strategy        Create new strategy
    new-hyperopt        Create new hyperopt
    list-strategies     Print available strategies.
    list-hyperopts      Print available hyperopt classes.
    list-exchanges      Print available exchanges.
    list-timeframes     Print available ticker intervals (timeframes) for the exchange.
    list-markets        Print markets on exchange.
    list-pairs          Print pairs on exchange.
    test-pairlist       Test your pairlist configuration.
    download-data       Download backtesting data.
    convert-data        Convert candle (OHLCV) data from one format to another.
    convert-trade-data  Convert trade data from one format to another.
    plot-dataframe      Plot candles with indicators.
    plot-profit         Generate plot showing profits.
    show-trades         Show trades.
    hyperopt-list       List Hyperopt results
    hyperopt-show       Show details of Hyperopt results

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit

```

Now:

```
usage: freqtrade [-h] [-V]
                 {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
                 ...

Free, open source crypto trading bot

positional arguments:
  {trade,create-userdir,new-config,new-strategy,new-hyperopt,download-data,convert-data,convert-trade-data,backtesting,edge,hyperopt,hyperopt-list,hyperopt-show,list-exchanges,list-hyperopts,list-markets,list-pairs,list-strategies,list-timeframes,show-trades,test-pairlist,plot-dataframe,plot-profit}
    trade               Trade module.
    create-userdir      Create user-data directory.
    new-config          Create new config
    new-hyperopt        Create new hyperopt
    new-strategy        Create new strategy
    download-data       Download backtesting data.
    convert-data        Convert candle (OHLCV) data from one format to another.
    convert-trade-data  Convert trade data from one format to another.
    backtesting         Backtesting module.
    edge                Edge module.
    hyperopt            Hyperopt module.
    hyperopt-list       List Hyperopt results
    hyperopt-show       Show details of Hyperopt results
    list-exchanges      Print available exchanges.
    list-hyperopts      Print available hyperopt classes.
    list-markets        Print markets on exchange.
    list-pairs          Print pairs on exchange.
    list-strategies     Print available strategies.
    list-timeframes     Print available ticker intervals (timeframes) for the exchange.
    show-trades         Show trades.
    test-pairlist       Test your pairlist configuration.
    plot-dataframe      Plot candles with indicators.
    plot-profit         Generate plot showing profits.

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit

```
