### PR TITLE
Fix typing circular dependency

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -3,6 +3,9 @@
 """
 bot constants
 """
+from typing import List, Tuple
+
+
 DEFAULT_CONFIG = 'config.json'
 DEFAULT_EXCHANGE = 'bittrex'
 PROCESS_THROTTLE_SECS = 5  # sec
@@ -329,3 +332,6 @@ CANCEL_REASON = {
     "ALL_CANCELLED": "cancelled (all unfilled and partially filled open orders cancelled)",
     "CANCELLED_ON_EXCHANGE": "cancelled on exchange",
 }
+
+# List of pairs with their timeframes
+ListPairsWithTimeframes = List[Tuple[str, str]]

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -13,7 +13,7 @@ from freqtrade.data.history import load_pair_history
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.exchange import Exchange
 from freqtrade.state import RunMode
-from freqtrade.typing import ListPairsWithTimeframes
+from freqtrade.constants import ListPairsWithTimeframes
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -23,7 +23,7 @@ from freqtrade.exceptions import (DependencyException, InvalidOrderException,
                                   OperationalException, TemporaryError)
 from freqtrade.exchange.common import BAD_EXCHANGES, retrier, retrier_async
 from freqtrade.misc import deep_merge_dicts, safe_value_fallback
-from freqtrade.typing import ListPairsWithTimeframes
+from freqtrade.constants import ListPairsWithTimeframes
 
 CcxtModuleType = Any
 

--- a/freqtrade/pairlist/pairlistmanager.py
+++ b/freqtrade/pairlist/pairlistmanager.py
@@ -10,7 +10,7 @@ from cachetools import TTLCache, cached
 from freqtrade.exceptions import OperationalException
 from freqtrade.pairlist.IPairList import IPairList
 from freqtrade.resolvers import PairListResolver
-from freqtrade.typing import ListPairsWithTimeframes
+from freqtrade.constants import ListPairsWithTimeframes
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -17,7 +17,7 @@ from freqtrade.exceptions import StrategyError
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.persistence import Trade
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
-from freqtrade.typing import ListPairsWithTimeframes
+from freqtrade.constants import ListPairsWithTimeframes
 from freqtrade.wallets import Wallets
 
 

--- a/freqtrade/typing.py
+++ b/freqtrade/typing.py
@@ -1,8 +1,0 @@
-"""
-Common Freqtrade types
-"""
-
-from typing import List, Tuple
-
-# List of pairs with their timeframes
-ListPairsWithTimeframes = List[Tuple[str, str]]


### PR DESCRIPTION
## Summary
As reported on slack (and anoyed myself just now)

we can't use a file called typing if we import from typing within it.

I've moved this to `constants.py` now ... in the end, that's what it is - a constant.

