### PR TITLE
Refactor BTReport

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, Tuple, List, Any
+from typing import Dict, List, Any
 
 from pandas import DataFrame
 from tabulate import tabulate
@@ -59,7 +59,7 @@ def _generate_result_line(result: DataFrame, max_open_trades: int, first_column:
         'trades': len(result.index),
         'profit_mean': result.profit_percent.mean(),
         'profit_mean_pct': result.profit_percent.mean() * 100.0,
-        'profit_sum': result.profit_percent.sum() * 100.0,
+        'profit_sum': result.profit_percent.sum(),
         'profit_sum_pct': result.profit_percent.sum() * 100.0,
         'profit_total_abs': result.profit_abs.sum(),
         'profit_total_pct': result.profit_percent.sum() * 100.0 / max_open_trades,
@@ -78,8 +78,8 @@ def _generate_result_line(result: DataFrame, max_open_trades: int, first_column:
     }
 
 
-def _generate_pair_results(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,
-                           results: DataFrame, skip_nan: bool = False) -> List[Dict]:
+def generate_pair_results(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,
+                          results: DataFrame, skip_nan: bool = False) -> List[Dict]:
     """
     Generates and returns a list  for the given backtest data and the results dataframe
     :param data: Dict of <pair: dataframe> containing data that was used during backtesting.
@@ -161,7 +161,8 @@ def generate_sell_reason_stats(max_open_trades: int,
     return tabular_data
 
 
-def generate_text_table_sell_reason(sell_reason_stats: List[Dict[str, Any]], stake_currency: str) -> str:
+def generate_text_table_sell_reason(sell_reason_stats: List[Dict[str, Any]],
+                                    stake_currency: str) -> str:
     """
     Generate small table outlining Backtest results
     :param stake_currency: Stakecurrency used
@@ -257,9 +258,9 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
     for strategy, results in all_results.items():
 
         print(f"Result for strategy {strategy}")
-        pair_results = _generate_pair_results(btdata, stake_currency=config['stake_currency'],
-                                              max_open_trades=config['max_open_trades'],
-                                              results=results, skip_nan=False)
+        pair_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
+                                             max_open_trades=config['max_open_trades'],
+                                             results=results, skip_nan=False)
         table = generate_text_table(pair_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
@@ -274,10 +275,10 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
             print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        left_open_results = _generate_pair_results(btdata, stake_currency=config['stake_currency'],
-                                                   max_open_trades=config['max_open_trades'],
-                                                   results=results.loc[results['open_at_end']],
-                                                   skip_nan=True)
+        left_open_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
+                                                  max_open_trades=config['max_open_trades'],
+                                                  results=results.loc[results['open_at_end']],
+                                                  skip_nan=True)
         table = generate_text_table(left_open_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 from pandas import DataFrame
 from tabulate import tabulate

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -249,18 +249,22 @@ def generate_edge_table(results: dict) -> str:
 def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
                           all_results: Dict[str, DataFrame]):
     for strategy, results in all_results.items():
-
-        print(f"Result for strategy {strategy}")
         pair_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
                                              max_open_trades=config['max_open_trades'],
                                              results=results, skip_nan=False)
+        sell_reason_stats = generate_sell_reason_stats(max_open_trades=config['max_open_trades'],
+                                                       results=results)
+        left_open_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
+                                                  max_open_trades=config['max_open_trades'],
+                                                  results=results.loc[results['open_at_end']],
+                                                  skip_nan=True)
+        # Print results
+        print(f"Result for strategy {strategy}")
         table = generate_text_table(pair_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        sell_reason_stats = generate_sell_reason_stats(max_open_trades=config['max_open_trades'],
-                                                       results=results)
         table = generate_text_table_sell_reason(sell_reason_stats=sell_reason_stats,
                                                 stake_currency=config['stake_currency'],
                                                 )
@@ -268,10 +272,6 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
             print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        left_open_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
-                                                  max_open_trades=config['max_open_trades'],
-                                                  results=results.loc[results['open_at_end']],
-                                                  skip_nan=True)
         table = generate_text_table(left_open_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -104,8 +104,7 @@ def _generate_pair_results(data: Dict[str, Dict], stake_currency: str, max_open_
     return tabular_data
 
 
-def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,
-                        results: DataFrame, skip_nan: bool = False) -> str:
+def generate_text_table(pair_results: List[Dict[str, Any]], stake_currency: str) -> str:
     """
     Generates and returns a text table for the given backtest data and the results dataframe
     :param data: Dict of <pair: dataframe> containing data that was used during backtesting.
@@ -118,7 +117,6 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
 
     headers = _get_line_header('Pair', stake_currency)
     floatfmt = _get_line_floatfmt()
-    pair_results = _generate_pair_results(data, stake_currency, max_open_trades, results, skip_nan)
     output = [[
         t['key'], t['trades'], t['profit_mean_pct'], t['profit_sum_pct'], t['profit_total_abs'],
         t['profit_total_pct'], t['duration_avg'], t['wins'], t['draws'], t['losses']
@@ -259,9 +257,10 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
     for strategy, results in all_results.items():
 
         print(f"Result for strategy {strategy}")
-        table = generate_text_table(btdata, stake_currency=config['stake_currency'],
-                                    max_open_trades=config['max_open_trades'],
-                                    results=results)
+        pair_results = _generate_pair_results(btdata, stake_currency=config['stake_currency'],
+                                              max_open_trades=config['max_open_trades'],
+                                              results=results, skip_nan=False)
+        table = generate_text_table(pair_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)
@@ -275,10 +274,11 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
             print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        table = generate_text_table(btdata,
-                                    stake_currency=config['stake_currency'],
-                                    max_open_trades=config['max_open_trades'],
-                                    results=results.loc[results.open_at_end], skip_nan=True)
+        left_open_results = _generate_pair_results(btdata, stake_currency=config['stake_currency'],
+                                                   max_open_trades=config['max_open_trades'],
+                                                   results=results.loc[results['open_at_end']],
+                                                   skip_nan=True)
+        table = generate_text_table(left_open_results, stake_currency=config['stake_currency'])
         if isinstance(table, str):
             print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Any
 
 from pandas import DataFrame
 from tabulate import tabulate
@@ -112,11 +112,10 @@ def generate_text_table(data: Dict[str, Dict], stake_currency: str, max_open_tra
                     floatfmt=floatfmt, tablefmt="orgtbl", stralign="right")  # type: ignore
 
 
-def generate_sell_reason_stats(stake_currency: str, max_open_trades: int,
+def generate_sell_reason_stats(max_open_trades: int,
                                results: DataFrame) -> List[Dict]:
     """
     Generate small table outlining Backtest results
-    :param stake_currency: Stakecurrency used
     :param max_open_trades: Max_open_trades parameter
     :param results: Dataframe containing the backtest result for one strategy
     :return: List of Dicts containing the metrics per Sell reason
@@ -148,8 +147,7 @@ def generate_sell_reason_stats(stake_currency: str, max_open_trades: int,
     return tabular_data
 
 
-def generate_text_table_sell_reason(stake_currency: str,
-                                    max_open_trades: int, results: DataFrame) -> str:
+def generate_text_table_sell_reason(sell_reason_stats: Dict[str, Any], stake_currency: str) -> str:
     """
     Generate small table outlining Backtest results
     :param stake_currency: Stakecurrency used
@@ -168,7 +166,7 @@ def generate_text_table_sell_reason(stake_currency: str,
         f'Tot Profit {stake_currency}',
         'Tot Profit %',
     ]
-    sell_reason_stats = generate_sell_reason_stats(stake_currency, max_open_trades, results)
+
     output = [[
         t['sell_reason'], t['trades'], t['wins'], t['draws'], t['losses'],
         t['profit_mean_pct'], t['profit_sum_pct'], t['profit_total_abs'], t['profit_pct_total'],
@@ -249,9 +247,11 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
             print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        table = generate_text_table_sell_reason(stake_currency=config['stake_currency'],
-                                                max_open_trades=config['max_open_trades'],
-                                                results=results)
+        sell_reason_stats = generate_sell_reason_stats(max_open_trades=config['max_open_trades'],
+                                                       results=results)
+        table = generate_text_table_sell_reason(sell_reason_stats=sell_reason_stats,
+                                                stake_currency=config['stake_currency'],
+                                                )
         if isinstance(table, str):
             print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
         print(table)

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -78,7 +78,7 @@ def _generate_result_line(result: DataFrame, max_open_trades: int, first_column:
     }
 
 
-def generate_pair_results(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,
+def generate_pair_metrics(data: Dict[str, Dict], stake_currency: str, max_open_trades: int,
                           results: DataFrame, skip_nan: bool = False) -> List[Dict]:
     """
     Generates and returns a list  for the given backtest data and the results dataframe
@@ -184,7 +184,7 @@ def generate_text_table_sell_reason(sell_reason_stats: List[Dict[str, Any]],
     return tabulate(output, headers=headers, tablefmt="orgtbl", stralign="right")
 
 
-def generate_strategy_summary(stake_currency: str, max_open_trades: int,
+def generate_strategy_metrics(stake_currency: str, max_open_trades: int,
                               all_results: Dict) -> List[Dict]:
     """
     Generate summary per strategy
@@ -249,12 +249,12 @@ def generate_edge_table(results: dict) -> str:
 def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
                           all_results: Dict[str, DataFrame]):
     for strategy, results in all_results.items():
-        pair_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
+        pair_results = generate_pair_metrics(btdata, stake_currency=config['stake_currency'],
                                              max_open_trades=config['max_open_trades'],
                                              results=results, skip_nan=False)
         sell_reason_stats = generate_sell_reason_stats(max_open_trades=config['max_open_trades'],
                                                        results=results)
-        left_open_results = generate_pair_results(btdata, stake_currency=config['stake_currency'],
+        left_open_results = generate_pair_metrics(btdata, stake_currency=config['stake_currency'],
                                                   max_open_trades=config['max_open_trades'],
                                                   results=results.loc[results['open_at_end']],
                                                   skip_nan=True)
@@ -282,7 +282,7 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
 
     if len(all_results) > 1:
         # Print Strategy summary table
-        strategy_results = generate_strategy_summary(stake_currency=config['stake_currency'],
+        strategy_results = generate_strategy_metrics(stake_currency=config['stake_currency'],
                                                      max_open_trades=config['max_open_trades'],
                                                      all_results=all_results)
 

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -248,31 +248,34 @@ def generate_edge_table(results: dict) -> str:
 
 def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
                           all_results: Dict[str, DataFrame]):
+    stake_currency = config['stake_currency']
+    max_open_trades = config['max_open_trades']
+
     for strategy, results in all_results.items():
-        pair_results = generate_pair_metrics(btdata, stake_currency=config['stake_currency'],
-                                             max_open_trades=config['max_open_trades'],
+        pair_results = generate_pair_metrics(btdata, stake_currency=stake_currency,
+                                             max_open_trades=max_open_trades,
                                              results=results, skip_nan=False)
-        sell_reason_stats = generate_sell_reason_stats(max_open_trades=config['max_open_trades'],
+        sell_reason_stats = generate_sell_reason_stats(max_open_trades=max_open_trades,
                                                        results=results)
-        left_open_results = generate_pair_metrics(btdata, stake_currency=config['stake_currency'],
-                                                  max_open_trades=config['max_open_trades'],
+        left_open_results = generate_pair_metrics(btdata, stake_currency=stake_currency,
+                                                  max_open_trades=max_open_trades,
                                                   results=results.loc[results['open_at_end']],
                                                   skip_nan=True)
         # Print results
         print(f"Result for strategy {strategy}")
-        table = generate_text_table(pair_results, stake_currency=config['stake_currency'])
+        table = generate_text_table(pair_results, stake_currency=stake_currency)
         if isinstance(table, str):
             print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)
 
         table = generate_text_table_sell_reason(sell_reason_stats=sell_reason_stats,
-                                                stake_currency=config['stake_currency'],
+                                                stake_currency=stake_currency,
                                                 )
         if isinstance(table, str):
             print(' SELL REASON STATS '.center(len(table.splitlines()[0]), '='))
         print(table)
 
-        table = generate_text_table(left_open_results, stake_currency=config['stake_currency'])
+        table = generate_text_table(left_open_results, stake_currency=stake_currency)
         if isinstance(table, str):
             print(' LEFT OPEN TRADES REPORT '.center(len(table.splitlines()[0]), '='))
         print(table)
@@ -282,11 +285,11 @@ def show_backtest_results(config: Dict, btdata: Dict[str, DataFrame],
 
     if len(all_results) > 1:
         # Print Strategy summary table
-        strategy_results = generate_strategy_metrics(stake_currency=config['stake_currency'],
-                                                     max_open_trades=config['max_open_trades'],
+        strategy_results = generate_strategy_metrics(stake_currency=stake_currency,
+                                                     max_open_trades=max_open_trades,
                                                      all_results=all_results)
 
-        table = generate_text_table_strategy(strategy_results, config['stake_currency'])
+        table = generate_text_table_strategy(strategy_results, stake_currency)
         print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
         print(table)
         print('=' * len(table.splitlines()[0]))

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -665,9 +665,9 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
     mocker.patch.multiple('freqtrade.optimize.optimize_reports',
                           generate_text_table=gen_table_mock,
                           generate_text_table_strategy=gen_strattable_mock,
-                          generate_pair_results=MagicMock(),
+                          generate_pair_metrics=MagicMock(),
                           generate_sell_reason_stats=sell_reason_mock,
-                          generate_strategy_summary=gen_strat_summary,
+                          generate_strategy_metrics=gen_strat_summary,
                           )
     patched_configuration_load_config_file(mocker, default_conf)
 
@@ -712,3 +712,92 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
 
     for line in exists:
         assert log_has(line, caplog)
+
+
+@pytest.mark.filterwarnings("ignore:deprecated")
+def test_backtest_start_multi_strat_nomock(default_conf, mocker, caplog, testdatadir, capsys):
+
+    patch_exchange(mocker)
+    backtestmock = MagicMock(side_effect=[
+        pd.DataFrame({'pair': ['XRP/BTC', 'LTC/BTC'],
+                      'profit_percent': [0.0, 0.0],
+                      'profit_abs': [0.0, 0.0],
+                      'open_time': pd.to_datetime(['2018-01-29 18:40:00',
+                                                   '2018-01-30 03:30:00', ], utc=True
+                                                  ),
+                      'close_time': pd.to_datetime(['2018-01-29 20:45:00',
+                                                    '2018-01-30 05:35:00', ], utc=True),
+                      'open_index': [78, 184],
+                      'close_index': [125, 192],
+                      'trade_duration': [235, 40],
+                      'open_at_end': [False, False],
+                      'open_rate': [0.104445, 0.10302485],
+                      'close_rate': [0.104969, 0.103541],
+                      'sell_reason': [SellType.ROI, SellType.ROI]
+                      }),
+        pd.DataFrame({'pair': ['XRP/BTC', 'LTC/BTC', 'ETH/BTC'],
+                      'profit_percent': [0.03, 0.01, 0.1],
+                      'profit_abs': [0.01, 0.02, 0.2],
+                      'open_time': pd.to_datetime(['2018-01-29 18:40:00',
+                                                   '2018-01-30 03:30:00',
+                                                   '2018-01-30 05:30:00'], utc=True
+                                                  ),
+                      'close_time': pd.to_datetime(['2018-01-29 20:45:00',
+                                                    '2018-01-30 05:35:00',
+                                                    '2018-01-30 08:30:00'], utc=True),
+                      'open_index': [78, 184, 185],
+                      'close_index': [125, 224, 205],
+                      'trade_duration': [47, 40, 20],
+                      'open_at_end': [False, False, False],
+                      'open_rate': [0.104445, 0.10302485, 0.122541],
+                      'close_rate': [0.104969, 0.103541, 0.123541],
+                      'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
+                      }),
+    ])
+    mocker.patch('freqtrade.pairlist.pairlistmanager.PairListManager.whitelist',
+                 PropertyMock(return_value=['UNITTEST/BTC']))
+    mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', backtestmock)
+
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    args = [
+        'backtesting',
+        '--config', 'config.json',
+        '--datadir', str(testdatadir),
+        '--strategy-path', str(Path(__file__).parents[1] / 'strategy/strats'),
+        '--ticker-interval', '1m',
+        '--timerange', '1510694220-1510700340',
+        '--enable-position-stacking',
+        '--disable-max-market-positions',
+        '--strategy-list',
+        'DefaultStrategy',
+        'TestStrategyLegacy',
+    ]
+    args = get_args(args)
+    start_backtesting(args)
+
+    # check the logs, that will contain the backtest result
+    exists = [
+        'Parameter -i/--ticker-interval detected ... Using ticker_interval: 1m ...',
+        'Ignoring max_open_trades (--disable-max-market-positions was used) ...',
+        'Parameter --timerange detected: 1510694220-1510700340 ...',
+        f'Using data directory: {testdatadir} ...',
+        'Using stake_currency: BTC ...',
+        'Using stake_amount: 0.001 ...',
+        'Loading data from 2017-11-14T20:57:00+00:00 '
+        'up to 2017-11-14T22:58:00+00:00 (0 days)..',
+        'Backtesting with data from 2017-11-14T21:17:00+00:00 '
+        'up to 2017-11-14T22:58:00+00:00 (0 days)..',
+        'Parameter --enable-position-stacking detected ...',
+        'Running backtesting for Strategy DefaultStrategy',
+        'Running backtesting for Strategy TestStrategyLegacy',
+    ]
+
+    for line in exists:
+        assert log_has(line, caplog)
+
+    captured = capsys.readouterr()
+    assert 'BACKTESTING REPORT' in captured.out
+    assert 'SELL REASON STATS' in captured.out
+    assert 'LEFT OPEN TRADES REPORT' in captured.out
+    assert 'STRATEGY SUMMARY' in captured.out

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -658,10 +658,17 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
                  PropertyMock(return_value=['UNITTEST/BTC']))
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', backtestmock)
     gen_table_mock = MagicMock()
-    mocker.patch('freqtrade.optimize.optimize_reports.generate_text_table', gen_table_mock)
+    sell_reason_mock = MagicMock()
     gen_strattable_mock = MagicMock()
-    mocker.patch('freqtrade.optimize.optimize_reports.generate_text_table_strategy',
-                 gen_strattable_mock)
+    gen_strat_summary = MagicMock()
+
+    mocker.patch.multiple('freqtrade.optimize.optimize_reports',
+                          generate_text_table=gen_table_mock,
+                          generate_text_table_strategy=gen_strattable_mock,
+                          generate_pair_results=MagicMock(),
+                          generate_sell_reason_stats=sell_reason_mock,
+                          generate_strategy_summary=gen_strat_summary,
+                          )
     patched_configuration_load_config_file(mocker, default_conf)
 
     args = [
@@ -683,6 +690,8 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
     assert backtestmock.call_count == 2
     assert gen_table_mock.call_count == 4
     assert gen_strattable_mock.call_count == 1
+    assert sell_reason_mock.call_count == 2
+    assert gen_strat_summary.call_count == 1
 
     # check the logs, that will contain the backtest result
     exists = [

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -6,9 +6,9 @@ from arrow import Arrow
 
 from freqtrade.edge import PairInfo
 from freqtrade.optimize.optimize_reports import (
-    generate_edge_table, generate_sell_reason_stats, generate_text_table,
-    generate_text_table_sell_reason, generate_text_table_strategy,
-    store_backtest_result)
+    _generate_pair_results, generate_edge_table, generate_sell_reason_stats,
+    generate_text_table, generate_text_table_sell_reason,
+    generate_text_table_strategy, store_backtest_result)
 from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
 
@@ -37,9 +37,12 @@ def test_generate_text_table(default_conf, mocker):
         '|   TOTAL |      2 |          15.00 |          30.00 |       0.60000000 |'
         '          15.00 |        0:20:00 |      2 |       0 |        0 |'
     )
-    assert generate_text_table(data={'ETH/BTC': {}},
-                               stake_currency='BTC', max_open_trades=2,
-                               results=results) == result_str
+
+    pair_results = _generate_pair_results(data={'ETH/BTC': {}}, stake_currency='BTC',
+                                          max_open_trades=2,
+                                          results=results)
+    assert generate_text_table(pair_results,
+                               stake_currency='BTC') == result_str
 
 
 def test_generate_text_table_sell_reason(default_conf):

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 from arrow import Arrow
 
 from freqtrade.edge import PairInfo
 from freqtrade.optimize.optimize_reports import (
-    generate_edge_table, generate_text_table, generate_text_table_sell_reason,
-    generate_sell_reason_stats,
-    generate_text_table_strategy, store_backtest_result)
+    generate_edge_table, generate_sell_reason_stats, generate_text_table,
+    generate_text_table_sell_reason, generate_text_table_strategy,
+    store_backtest_result)
 from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
 
@@ -41,7 +42,7 @@ def test_generate_text_table(default_conf, mocker):
                                results=results) == result_str
 
 
-def test_generate_text_table_sell_reason(default_conf, mocker):
+def test_generate_text_table_sell_reason(default_conf):
 
     results = pd.DataFrame(
         {
@@ -71,6 +72,41 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
                                                    results=results)
     assert generate_text_table_sell_reason(sell_reason_stats=sell_reason_stats,
                                            stake_currency='BTC') == result_str
+
+
+def test_generate_sell_reason_stats(default_conf):
+
+    results = pd.DataFrame(
+        {
+            'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
+            'profit_percent': [0.1, 0.2, -0.1],
+            'profit_abs': [0.2, 0.4, -0.2],
+            'trade_duration': [10, 30, 10],
+            'wins': [2, 0, 0],
+            'draws': [0, 0, 0],
+            'losses': [0, 0, 1],
+            'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
+        }
+    )
+
+    sell_reason_stats = generate_sell_reason_stats(max_open_trades=2,
+                                                   results=results)
+    roi_result = sell_reason_stats[0]
+    assert roi_result['sell_reason'] == 'roi'
+    assert roi_result['trades'] == 2
+    assert pytest.approx(roi_result['profit_mean']) == 0.15
+    assert roi_result['profit_mean_pct'] == round(roi_result['profit_mean'] * 100, 2)
+    assert pytest.approx(roi_result['profit_mean']) == 0.15
+    assert roi_result['profit_mean_pct'] == round(roi_result['profit_mean'] * 100, 2)
+
+    stop_result = sell_reason_stats[1]
+
+    assert stop_result['sell_reason'] == 'stop_loss'
+    assert stop_result['trades'] == 1
+    assert pytest.approx(stop_result['profit_mean']) == -0.1
+    assert stop_result['profit_mean_pct'] == round(stop_result['profit_mean'] * 100, 2)
+    assert pytest.approx(stop_result['profit_mean']) == -0.1
+    assert stop_result['profit_mean_pct'] == round(stop_result['profit_mean'] * 100, 2)
 
 
 def test_generate_text_table_strategy(default_conf, mocker):

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -6,6 +6,7 @@ from arrow import Arrow
 from freqtrade.edge import PairInfo
 from freqtrade.optimize.optimize_reports import (
     generate_edge_table, generate_text_table, generate_text_table_sell_reason,
+    generate_sell_reason_stats,
     generate_text_table_strategy, store_backtest_result)
 from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
@@ -65,8 +66,11 @@ def test_generate_text_table_sell_reason(default_conf, mocker):
         '|     stop_loss |       1 |      0 |       0 |        1 |'
         '            -10 |            -10 |             -0.2 |             -5 |'
     )
-    assert generate_text_table_sell_reason(stake_currency='BTC', max_open_trades=2,
-                                           results=results) == result_str
+
+    sell_reason_stats = generate_sell_reason_stats(max_open_trades=2,
+                                                   results=results)
+    assert generate_text_table_sell_reason(sell_reason_stats=sell_reason_stats,
+                                           stake_currency='BTC') == result_str
 
 
 def test_generate_text_table_strategy(default_conf, mocker):

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -7,7 +7,7 @@ from arrow import Arrow
 from freqtrade.edge import PairInfo
 from freqtrade.optimize.optimize_reports import (
     generate_pair_results, generate_edge_table, generate_sell_reason_stats,
-    generate_text_table, generate_text_table_sell_reason,
+    generate_text_table, generate_text_table_sell_reason, generate_strategy_summary,
     generate_text_table_strategy, store_backtest_result)
 from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
@@ -173,7 +173,12 @@ def test_generate_text_table_strategy(default_conf, mocker):
         '| TestStrategy2 |      3 |          30.00 |          90.00 |       1.30000000 |'
         '          45.00 |        0:20:00 |      3 |       0 |        0 |'
     )
-    assert generate_text_table_strategy('BTC', 2, all_results=results) == result_str
+
+    strategy_results = generate_strategy_summary(stake_currency='BTC',
+                                                 max_open_trades=2,
+                                                 all_results=results)
+
+    assert generate_text_table_strategy(strategy_results, 'BTC') == result_str
 
 
 def test_generate_edge_table(edge_conf, mocker):

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -6,8 +6,8 @@ from arrow import Arrow
 
 from freqtrade.edge import PairInfo
 from freqtrade.optimize.optimize_reports import (
-    generate_pair_results, generate_edge_table, generate_sell_reason_stats,
-    generate_text_table, generate_text_table_sell_reason, generate_strategy_summary,
+    generate_pair_metrics, generate_edge_table, generate_sell_reason_stats,
+    generate_text_table, generate_text_table_sell_reason, generate_strategy_metrics,
     generate_text_table_strategy, store_backtest_result)
 from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
@@ -38,13 +38,13 @@ def test_generate_text_table(default_conf, mocker):
         '          15.00 |        0:20:00 |      2 |       0 |        0 |'
     )
 
-    pair_results = generate_pair_results(data={'ETH/BTC': {}}, stake_currency='BTC',
+    pair_results = generate_pair_metrics(data={'ETH/BTC': {}}, stake_currency='BTC',
                                          max_open_trades=2, results=results)
     assert generate_text_table(pair_results,
                                stake_currency='BTC') == result_str
 
 
-def test_generate_pair_results(default_conf, mocker):
+def test_generate_pair_metrics(default_conf, mocker):
 
     results = pd.DataFrame(
         {
@@ -58,7 +58,7 @@ def test_generate_pair_results(default_conf, mocker):
         }
     )
 
-    pair_results = generate_pair_results(data={'ETH/BTC': {}}, stake_currency='BTC',
+    pair_results = generate_pair_metrics(data={'ETH/BTC': {}}, stake_currency='BTC',
                                          max_open_trades=2, results=results)
     assert isinstance(pair_results, list)
     assert len(pair_results) == 2
@@ -174,7 +174,7 @@ def test_generate_text_table_strategy(default_conf, mocker):
         '          45.00 |        0:20:00 |      3 |       0 |        0 |'
     )
 
-    strategy_results = generate_strategy_summary(stake_currency='BTC',
+    strategy_results = generate_strategy_metrics(stake_currency='BTC',
                                                  max_open_trades=2,
                                                  all_results=results)
 


### PR DESCRIPTION
## Summary
First step in refactoring backtest report.

The final result will generate one large dict containing all metrics calculated and shown during backtesting - which can also be stored alongside with the backtest results.

Nothing in the output does change - just the way how backtest-methods are called.

## Quick changelog

- seperate metric generation from metric visualization (currently still artificially, but will be moved out of this function in the next PR)
- use dicts instead of lists of lists - to make it clear that list[5] contains profit_pct - and not something random.
- Add a bit more detail to certain tests.
