### PR TITLE
Add question template ...

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Have you searched for similar issues before posting it?
 If you have discovered a bug in the bot, please [search our issue tracker](https://github.com/freqtrade/freqtrade/issues?q=is%3Aissue). 
 If it hasn't been reported, please create a new issue.
 
-Please do not use bug reports to request for new features.
+Please do not use bug reports to request new features.
 -->
 
 ## Describe your environment

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,25 @@
+---
+name: BQuestion
+about: Ask a question you could not find an answer in the docs
+title: ''
+labels: "Question"
+assignees: ''
+
+---
+<!-- 
+Have you searched for similar issues before posting it?
+Did you have a VERY good look at the [documentation](https://www.freqtrade.io/en/latest/) and are sure that the question is not explained there
+
+Please do not use the question template to report bugs or to request new features.
+-->
+
+## Describe your environment
+
+  * Operating system: ____
+  * Python Version: _____ (`python -V`)
+  * CCXT version: _____ (`pip freeze | grep ccxt`)
+  * Freqtrade Version: ____ (`freqtrade -V` or `docker-compose run --rm freqtrade -V` for Freqtrade running in docker)
+  
+## Your question
+
+*Ask the question you have not been able to find an answer in our [Documentation](https://www.freqtrade.io/en/latest/)*


### PR DESCRIPTION
## Summary
Add a 3rd template for questions - since we're getting a lot of these (not bugs or feature request, but simple questions).

This allows us to point to the documentation again (and again) - hoping that can solve a few questions before they are asked.
