### PR TITLE
Improve RPC Blacklist by adding feedback

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -533,16 +533,26 @@ class RPC:
 
     def _rpc_blacklist(self, add: List[str] = None) -> Dict:
         """ Returns the currently active blacklist"""
+        errors = {}
         if add:
             stake_currency = self._freqtrade.config.get('stake_currency')
             for pair in add:
-                if (self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency
-                        and pair not in self._freqtrade.pairlists.blacklist):
-                    self._freqtrade.pairlists.blacklist.append(pair)
+                if self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency:
+                    if pair not in self._freqtrade.pairlists.blacklist:
+                        self._freqtrade.pairlists.blacklist.append(pair)
+                    else:
+                        errors[pair] = {
+                            'error_msg': f'Pair {pair} already in pairlist.'}
+
+                else:
+                    errors[pair] = {
+                        'error_msg': f"Pair {pair} does not match stake currency."
+                    }
 
         res = {'method': self._freqtrade.pairlists.name_list,
                'length': len(self._freqtrade.pairlists.blacklist),
                'blacklist': self._freqtrade.pairlists.blacklist,
+               'errors': errors,
                }
         return res
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -534,6 +534,11 @@ class Telegram(RPC):
         try:
 
             blacklist = self._rpc_blacklist(context.args)
+            errmsgs = []
+            for pair, error in blacklist['errors'].items():
+                errmsgs.append(f"Error adding `{pair}` to blacklist: `{error['error_msg']}`")
+            if errmsgs:
+                self._send_msg('\n'.join(errmsgs))
 
             message = f"Blacklist contains {blacklist['length']} pairs\n"
             message += f"`{', '.join(blacklist['blacklist'])}`"

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -833,6 +833,20 @@ def test_rpc_blacklist(mocker, default_conf) -> None:
     assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']
     assert ret['blacklist'] == ['DOGE/BTC', 'HOT/BTC', 'ETH/BTC']
 
+    ret = rpc._rpc_blacklist(["ETH/BTC"])
+    assert 'errors' in ret
+    assert isinstance(ret['errors'], dict)
+    assert ret['errors']['ETH/BTC']['error_msg'] == 'Pair ETH/BTC already in pairlist.'
+
+    ret = rpc._rpc_blacklist(["ETH/ETH"])
+    assert 'StaticPairList' in ret['method']
+    assert len(ret['blacklist']) == 3
+    assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']
+    assert ret['blacklist'] == ['DOGE/BTC', 'HOT/BTC', 'ETH/BTC']
+    assert 'errors' in ret
+    assert isinstance(ret['errors'], dict)
+    assert ret['errors']['ETH/ETH']['error_msg'] == 'Pair ETH/ETH does not match stake currency.'
+
 
 def test_rpc_edge_disabled(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -554,7 +554,9 @@ def test_api_blacklist(botclient, mocker):
     assert_response(rc)
     assert rc.json == {"blacklist": ["DOGE/BTC", "HOT/BTC"],
                        "length": 2,
-                       "method": ["StaticPairList"]}
+                       "method": ["StaticPairList"],
+                       "errors": {},
+                       }
 
     # Add ETH/BTC to blacklist
     rc = client_post(client, f"{BASE_URI}/blacklist",
@@ -562,7 +564,9 @@ def test_api_blacklist(botclient, mocker):
     assert_response(rc)
     assert rc.json == {"blacklist": ["DOGE/BTC", "HOT/BTC", "ETH/BTC"],
                        "length": 3,
-                       "method": ["StaticPairList"]}
+                       "method": ["StaticPairList"],
+                       "errors": {},
+                       }
 
 
 def test_api_whitelist(botclient):

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1085,6 +1085,18 @@ def test_blacklist_static(default_conf, update, mocker) -> None:
             in msg_mock.call_args_list[0][0][0])
     assert freqtradebot.pairlists.blacklist == ["DOGE/BTC", "HOT/BTC", "ETH/BTC"]
 
+    msg_mock.reset_mock()
+    context = MagicMock()
+    context.args = ["ETH/ETH"]
+    telegram._blacklist(update=update, context=context)
+    assert msg_mock.call_count == 2
+    assert ("Error adding `ETH/ETH` to blacklist: `Pair ETH/ETH does not match stake currency.`"
+            in msg_mock.call_args_list[0][0][0])
+
+    assert ("Blacklist contains 3 pairs\n`DOGE/BTC, HOT/BTC, ETH/BTC`"
+            in msg_mock.call_args_list[1][0][0])
+    assert freqtradebot.pairlists.blacklist == ["DOGE/BTC", "HOT/BTC", "ETH/BTC"]
+
 
 def test_edge_disabled(default_conf, update, mocker) -> None:
     msg_mock = MagicMock()


### PR DESCRIPTION
## Summary
Adding a pair to pairlists should provide feedback (errormessages) if wrong input was given.

This applies to both telegram and the rest api.

## Quick changelog

- Add feedback message to blacklist addition
- Use error_msg to eventually add additional error informations at a later point

![2020-05-28-070513_587x138_scrot](https://user-images.githubusercontent.com/5024695/83101009-994f7b80-a0b1-11ea-823f-bc1ee172e583.png)

