### PR TITLE
[minor] Fix sell rate caching

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -719,6 +719,9 @@ class FreqtradeBot:
                     raise PricingError from e
                 logger.debug(f"  order book {config_ask_strategy['price_side']} top {i}: "
                              f"{sell_rate:0.8f}")
+                # Assign sell-rate to cache - otherwise sell-rate is never updated in the cache,
+                # resulting in outdated RPC messages
+                self._sell_rate_cache[trade.pair] = sell_rate
 
                 if self._check_and_execute_sell(trade, sell_rate, buy, sell):
                     return True


### PR DESCRIPTION
## Summary
Sell rate caching works by saving the latest sell rate to the cache dict.
However, when orderbook is on on the sell side, get_sell_rate is never called, preventing the cache from updating.
The result is that telegram / rpc get's old / outdated rates - while the bot itself works on updated rates.

This can easily be fixed by assigning the latest used rate to the cache in handle_trade (where the sell-rate looping is done).
