### PR TITLE
[minor] Add missing fields to to_json output of trade

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -271,10 +271,16 @@ class Trade(_DECL_BASE):
             'amount': round(self.amount, 8),
             'stake_amount': round(self.stake_amount, 8),
             'close_profit': self.close_profit,
+            'close_profit_abs': self.close_profit_abs,
             'sell_reason': self.sell_reason,
             'sell_order_status': self.sell_order_status,
             'stop_loss': self.stop_loss,
             'stop_loss_pct': (self.stop_loss_pct * 100) if self.stop_loss_pct else None,
+            'stoploss_order_id': self.stoploss_order_id,
+            'stoploss_last_update': (self.stoploss_last_update.strftime("%Y-%m-%d %H:%M:%S")
+                                     if self.stoploss_last_update else None),
+            'stoploss_last_update_timestamp': (int(self.stoploss_last_update.timestamp() * 1000)
+                                               if self.stoploss_last_update else None),
             'initial_stop_loss': self.initial_stop_loss,
             'initial_stop_loss_pct': (self.initial_stop_loss_pct * 100
                                       if self.initial_stop_loss_pct else None),
@@ -283,6 +289,7 @@ class Trade(_DECL_BASE):
             'strategy': self.strategy,
             'ticker_interval': self.ticker_interval,
             'open_order_id': self.open_order_id,
+            'exchange': self.exchange,
         }
 
     def adjust_min_max_rates(self, current_price: float) -> None:

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -77,13 +77,19 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'stake_amount': 0.001,
         'close_profit': None,
         'close_profit_pct': None,
+        'close_profit_abs': None,
         'current_profit': -0.00408133,
         'current_profit_pct': -0.41,
         'stop_loss': 0.0,
+        'stop_loss_pct': None,
+        'stoploss_order_id': None,
+        'stoploss_last_update': None,
+        'stoploss_last_update_timestamp': None,
         'initial_stop_loss': 0.0,
         'initial_stop_loss_pct': None,
-        'stop_loss_pct': None,
-        'open_order': '(limit buy rem=0.00000000)'
+        'open_order': '(limit buy rem=0.00000000)',
+        'exchange': 'bittrex',
+
     } == results[0]
 
     mocker.patch('freqtrade.freqtradebot.FreqtradeBot.get_sell_rate',
@@ -125,13 +131,18 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'stake_amount': 0.001,
         'close_profit': None,
         'close_profit_pct': None,
+        'close_profit_abs': None,
         'current_profit': ANY,
         'current_profit_pct': ANY,
         'stop_loss': 0.0,
+        'stop_loss_pct': None,
+        'stoploss_order_id': None,
+        'stoploss_last_update': None,
+        'stoploss_last_update_timestamp': None,
         'initial_stop_loss': 0.0,
         'initial_stop_loss_pct': None,
-        'stop_loss_pct': None,
-        'open_order': '(limit buy rem=0.00000000)'
+        'open_order': '(limit buy rem=0.00000000)',
+        'exchange': 'bittrex',
     } == results[0]
 
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -502,6 +502,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
                         'close_timestamp': None,
                         'close_profit': None,
                         'close_profit_pct': None,
+                        'close_profit_abs': None,
                         'close_rate': None,
                         'current_profit': -0.00408133,
                         'current_profit_pct': -0.41,
@@ -517,6 +518,9 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
                         'stake_amount': 0.001,
                         'stop_loss': 0.0,
                         'stop_loss_pct': None,
+                        'stoploss_order_id': None,
+                        'stoploss_last_update': None,
+                        'stoploss_last_update_timestamp': None,
                         'trade_id': 1,
                         'close_rate_requested': None,
                         'current_rate': 1.099e-05,
@@ -536,7 +540,9 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
                         'sell_reason': None,
                         'sell_order_status': None,
                         'strategy': 'DefaultStrategy',
-                        'ticker_interval': 5}]
+                        'ticker_interval': 5,
+                        'exchange': 'bittrex',
+                        }]
 
 
 def test_api_version(botclient):
@@ -627,8 +633,12 @@ def test_api_forcebuy(botclient, mocker, fee):
                        'stake_amount': 1,
                        'stop_loss': None,
                        'stop_loss_pct': None,
+                       'stoploss_order_id': None,
+                       'stoploss_last_update': None,
+                       'stoploss_last_update_timestamp': None,
                        'trade_id': None,
                        'close_profit': None,
+                       'close_profit_abs': None,
                        'close_rate_requested': None,
                        'fee_close': 0.0025,
                        'fee_close_cost': None,
@@ -645,7 +655,8 @@ def test_api_forcebuy(botclient, mocker, fee):
                        'sell_reason': None,
                        'sell_order_status': None,
                        'strategy': None,
-                       'ticker_interval': None
+                       'ticker_interval': None,
+                       'exchange': 'bittrex',
                        }
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -758,16 +758,22 @@ def test_to_json(default_conf, fee):
                       'amount': 123.0,
                       'stake_amount': 0.001,
                       'close_profit': None,
+                      'close_profit_abs': None,
                       'sell_reason': None,
                       'sell_order_status': None,
                       'stop_loss': None,
                       'stop_loss_pct': None,
+                      'stoploss_order_id': None,
+                      'stoploss_last_update': None,
+                      'stoploss_last_update_timestamp': None,
                       'initial_stop_loss': None,
                       'initial_stop_loss_pct': None,
                       'min_rate': None,
                       'max_rate': None,
                       'strategy': None,
-                      'ticker_interval': None}
+                      'ticker_interval': None,
+                      'exchange': 'bittrex',
+                      }
 
     # Simulate dry_run entries
     trade = Trade(
@@ -799,9 +805,13 @@ def test_to_json(default_conf, fee):
                       'stake_amount': 0.001,
                       'stop_loss': None,
                       'stop_loss_pct': None,
+                      'stoploss_order_id': None,
+                      'stoploss_last_update': None,
+                      'stoploss_last_update_timestamp': None,
                       'initial_stop_loss': None,
                       'initial_stop_loss_pct': None,
                       'close_profit': None,
+                      'close_profit_abs': None,
                       'close_rate_requested': None,
                       'fee_close': 0.0025,
                       'fee_close_cost': None,
@@ -818,7 +828,9 @@ def test_to_json(default_conf, fee):
                       'sell_reason': None,
                       'sell_order_status': None,
                       'strategy': None,
-                      'ticker_interval': None}
+                      'ticker_interval': None,
+                      'exchange': 'bittrex',
+                      }
 
 
 def test_stoploss_reinitialization(default_conf, fee):


### PR DESCRIPTION
## Summary
There were several database fields not in the to_json() method, basically hiding the information from show_trades (and other users of this method like RPC methods).
