### PR TITLE
Disabledataframecheck is not in internals and does not belong there

### DIFF
--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -70,7 +70,7 @@ class StrategyResolver(IResolver):
                       ("use_sell_signal",                 True,        'ask_strategy'),
                       ("sell_profit_only",                False,       'ask_strategy'),
                       ("ignore_roi_if_buy_signal",        False,       'ask_strategy'),
-                      ("disable_dataframe_checks",        False,       'internals')
+                      ("disable_dataframe_checks",        False,       None),
                       ]
         for attribute, default, subkey in attributes:
             if subkey:


### PR DESCRIPTION

## Summary
Followup to #3394 - removing the internals reference.

Internals contains only timing related things so far. This is closer to `process_only_new_candles` - which is at the top level of the config as well.