### PR TITLE
Apiserver logging

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -76,6 +76,15 @@
         "token": "your_telegram_token",
         "chat_id": "your_telegram_chat_id"
     },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "info",
+        "jwt_secret_key": "somethingrandom",
+        "username": "",
+        "password": ""
+    },
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -81,6 +81,15 @@
         "token": "your_telegram_token",
         "chat_id": "your_telegram_chat_id"
     },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "info",
+        "jwt_secret_key": "somethingrandom",
+        "username": "",
+        "password": ""
+    },
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -121,6 +121,7 @@
         "enabled": false,
         "listen_ip_address": "127.0.0.1",
         "listen_port": 8080,
+        "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
         "username": "freqtrader",
         "password": "SuperSecurePassword"

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -87,6 +87,15 @@
         "token": "your_telegram_token",
         "chat_id": "your_telegram_chat_id"
     },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "info",
+        "jwt_secret_key": "somethingrandom",
+        "username": "",
+        "password": ""
+    },
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `api_server.enabled` | Enable usage of API Server. See the [API Server documentation](rest-api.md) for more details. <br> **Datatype:** Boolean
 | `api_server.listen_ip_address` | Bind IP address. See the [API Server documentation](rest-api.md) for more details. <br> **Datatype:** IPv4
 | `api_server.listen_port` | Bind Port. See the [API Server documentation](rest-api.md) for more details. <br>**Datatype:** Integer between 1024 and 65535
+| `api_server.verbosity` | Loggging verbosity. `info` will print all RPC Calls, while "error" will only display errors. <br>**Datatype:** Enum, either `info` or `error`. Defaults to `info`.
 | `api_server.username` | Username for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
 | `api_server.password` | Password for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
 | `db_url` | Declares database URL to use. NOTE: This defaults to `sqlite:///tradesv3.dryrun.sqlite` if `dry_run` is `true`, and to `sqlite:///tradesv3.sqlite` for production instances. <br> **Datatype:** String, SQLAlchemy connect string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `api_server.enabled` | Enable usage of API Server. See the [API Server documentation](rest-api.md) for more details. <br> **Datatype:** Boolean
 | `api_server.listen_ip_address` | Bind IP address. See the [API Server documentation](rest-api.md) for more details. <br> **Datatype:** IPv4
 | `api_server.listen_port` | Bind Port. See the [API Server documentation](rest-api.md) for more details. <br>**Datatype:** Integer between 1024 and 65535
-| `api_server.verbosity` | Loggging verbosity. `info` will print all RPC Calls, while "error" will only display errors. <br>**Datatype:** Enum, either `info` or `error`. Defaults to `info`.
+| `api_server.verbosity` | Logging verbosity. `info` will print all RPC Calls, while "error" will only display errors. <br>**Datatype:** Enum, either `info` or `error`. Defaults to `info`.
 | `api_server.username` | Username for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
 | `api_server.password` | Password for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
 | `db_url` | Declares database URL to use. NOTE: This defaults to `sqlite:///tradesv3.dryrun.sqlite` if `dry_run` is `true`, and to `sqlite:///tradesv3.sqlite` for production instances. <br> **Datatype:** String, SQLAlchemy connect string

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -11,6 +11,7 @@ Sample configuration:
         "enabled": true,
         "listen_ip_address": "127.0.0.1",
         "listen_port": 8080,
+        "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
         "username": "Freqtrader",
         "password": "SuperSecret1!"

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -221,6 +221,7 @@ CONF_SCHEMA = {
                 },
                 'username': {'type': 'string'},
                 'password': {'type': 'string'},
+                'verbosity': {'type': 'string', 'enum': ['error', 'info']},
             },
             'required': ['enabled', 'listen_ip_address', 'listen_port', 'username', 'password']
         },

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -11,7 +11,7 @@ from freqtrade.exceptions import OperationalException
 logger = logging.getLogger(__name__)
 
 
-def _set_loggers(verbosity: int = 0) -> None:
+def _set_loggers(verbosity: int = 0, api_verbosity: str = 'info') -> None:
     """
     Set the logging level for third party libraries
     :return: None
@@ -27,6 +27,10 @@ def _set_loggers(verbosity: int = 0) -> None:
         logging.INFO if verbosity <= 2 else logging.DEBUG
     )
     logging.getLogger('telegram').setLevel(logging.INFO)
+
+    logging.getLogger('werkzeug').setLevel(
+        logging.ERROR if api_verbosity == 'error' else logging.INFO
+    )
 
 
 def setup_logging(config: Dict[str, Any]) -> None:
@@ -77,5 +81,5 @@ def setup_logging(config: Dict[str, Any]) -> None:
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         handlers=log_handlers
     )
-    _set_loggers(verbosity)
+    _set_loggers(verbosity, config.get('api_server', {}).get('verbosity', 'info'))
     logger.info('Verbosity set to %s', verbosity)

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -360,7 +360,6 @@ class ApiServer(RPC):
         Returns a cumulative profit statistics
         :return: stats
         """
-        logger.info("LocalRPC - Profit Command Called")
 
         stats = self._rpc_trade_statistics(self._config['stake_currency'],
                                            self._config.get('fiat_display_currency')
@@ -377,8 +376,6 @@ class ApiServer(RPC):
         Returns a cumulative performance statistics
         :return: stats
         """
-        logger.info("LocalRPC - performance Command Called")
-
         stats = self._rpc_performance()
 
         return self.rest_dump(stats)

--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -53,6 +53,15 @@
         "token": "{{ telegram_token }}",
         "chat_id": "{{ telegram_chat_id }}"
     },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "info",
+        "jwt_secret_key": "somethingrandom",
+        "username": "",
+        "password": ""
+    },
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -634,6 +634,7 @@ def test_set_loggers() -> None:
     previous_value1 = logging.getLogger('requests').level
     previous_value2 = logging.getLogger('ccxt.base.exchange').level
     previous_value3 = logging.getLogger('telegram').level
+    previous_value3 = logging.getLogger('werkzeug').level
 
     _set_loggers()
 
@@ -654,12 +655,14 @@ def test_set_loggers() -> None:
     assert logging.getLogger('requests').level is logging.DEBUG
     assert logging.getLogger('ccxt.base.exchange').level is logging.INFO
     assert logging.getLogger('telegram').level is logging.INFO
+    assert logging.getLogger('werkzeug').level is logging.INFO
 
-    _set_loggers(verbosity=3)
+    _set_loggers(verbosity=3, api_verbosity='error')
 
     assert logging.getLogger('requests').level is logging.DEBUG
     assert logging.getLogger('ccxt.base.exchange').level is logging.DEBUG
     assert logging.getLogger('telegram').level is logging.INFO
+    assert logging.getLogger('werkzeug').level is logging.ERROR
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -634,7 +634,6 @@ def test_set_loggers() -> None:
     previous_value1 = logging.getLogger('requests').level
     previous_value2 = logging.getLogger('ccxt.base.exchange').level
     previous_value3 = logging.getLogger('telegram').level
-    previous_value3 = logging.getLogger('werkzeug').level
 
     _set_loggers()
 


### PR DESCRIPTION
## Summary
Allow reducing log verbosity for api-server explicitly.
This will allow to hide the "GET /api/v1/..." calls by setting verbosity within the api_server config section to error.

I think this is important for the UI - as that tends to call the API quite often - clogging up the log with rest messages (and therefore potentially hiding other important messages).

This also addes the api_server to all default configuration templates - so it's easier for people to enable this later on.
