### PR TITLE
Minor: Better exchange debug logging

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -891,9 +891,8 @@ class Exchange:
                      f"since: {since}, until: {until}, from_id: {from_id}")
 
         if until is None:
-            exchange_msec = ccxt.Exchange.milliseconds()
-            logger.debug(f"Exchange milliseconds: {exchange_msec}")
-            until = exchange_msec
+            until = ccxt.Exchange.milliseconds()
+            logger.debug(f"Exchange milliseconds: {until}")
 
         if self._trades_pagination == 'time':
             return await self._async_get_trade_history_time(

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -887,14 +887,20 @@ class Exchange:
         Async wrapper handling downloading trades using either time or id based methods.
         """
 
+        logger.debug(f"_async_get_trade_history(), pair: {pair}, "
+                     f"since: {since}, until: {until}, from_id: {from_id}")
+
+        if not until:
+            exchange_msec = ccxt.Exchange.milliseconds()
+            logger.debug(f"Exchange milliseconds: {exchange_msec}")
+            until = exchange_msec
+
         if self._trades_pagination == 'time':
             return await self._async_get_trade_history_time(
-                pair=pair, since=since,
-                until=until or ccxt.Exchange.milliseconds())
+                pair=pair, since=since, until=until)
         elif self._trades_pagination == 'id':
             return await self._async_get_trade_history_id(
-                pair=pair, since=since,
-                until=until or ccxt.Exchange.milliseconds(), from_id=from_id
+                pair=pair, since=since, until=until, from_id=from_id
             )
         else:
             raise OperationalException(f"Exchange {self.name} does use neither time, "

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -890,7 +890,7 @@ class Exchange:
         logger.debug(f"_async_get_trade_history(), pair: {pair}, "
                      f"since: {since}, until: {until}, from_id: {from_id}")
 
-        if not until:
+        if until is None:
             exchange_msec = ccxt.Exchange.milliseconds()
             logger.debug(f"Exchange milliseconds: {exchange_msec}")
             until = exchange_msec


### PR DESCRIPTION
Log exchange milliseconds (as debug) to see where downloading trades for each pairs should stop
(now only "since" miliseconds are printed in the log, and "until" is not shown)
