### PR TITLE
Verify sell-rate returns a value.

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -676,6 +676,8 @@ class FreqtradeBot:
                 raise PricingError from e
         else:
             rate = self.exchange.fetch_ticker(pair)[ask_strategy['price_side']]
+        if rate is None:
+            raise PricingError(f"Sell-Rate for {pair} was empty.")
         self._sell_rate_cache[pair] = rate
         return rate
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3935,7 +3935,8 @@ def test_get_sell_rate_exception(default_conf, mocker, caplog):
     # Ticker on one side can be empty in certain circumstances.
     default_conf['ask_strategy']['price_side'] = 'ask'
     pair = "ETH/BTC"
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'ask': None, 'bid': 0.12})
+    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+                 return_value={'ask': None, 'bid': 0.12})
     ft = get_patched_freqtradebot(mocker, default_conf)
     with pytest.raises(PricingError, match=r"Sell-Rate for ETH/BTC was empty."):
         ft.get_sell_rate(pair, True)
@@ -3943,7 +3944,8 @@ def test_get_sell_rate_exception(default_conf, mocker, caplog):
     ft.config['ask_strategy']['price_side'] = 'bid'
     assert ft.get_sell_rate(pair, True) == 0.12
     # Reverse sides
-    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'ask': 0.13, 'bid': None})
+    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker',
+                 return_value={'ask': 0.13, 'bid': None})
     with pytest.raises(PricingError, match=r"Sell-Rate for ETH/BTC was empty."):
         ft.get_sell_rate(pair, True)
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3931,6 +3931,26 @@ def test_get_sell_rate_orderbook_exception(default_conf, mocker, caplog):
     assert log_has("Sell Price at location from orderbook could not be determined.", caplog)
 
 
+def test_get_sell_rate_exception(default_conf, mocker, caplog):
+    # Ticker on one side can be empty in certain circumstances.
+    default_conf['ask_strategy']['price_side'] = 'ask'
+    pair = "ETH/BTC"
+    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'ask': None, 'bid': 0.12})
+    ft = get_patched_freqtradebot(mocker, default_conf)
+    with pytest.raises(PricingError, match=r"Sell-Rate for ETH/BTC was empty."):
+        ft.get_sell_rate(pair, True)
+
+    ft.config['ask_strategy']['price_side'] = 'bid'
+    assert ft.get_sell_rate(pair, True) == 0.12
+    # Reverse sides
+    mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'ask': 0.13, 'bid': None})
+    with pytest.raises(PricingError, match=r"Sell-Rate for ETH/BTC was empty."):
+        ft.get_sell_rate(pair, True)
+
+    ft.config['ask_strategy']['price_side'] = 'ask'
+    assert ft.get_sell_rate(pair, True) == 0.13
+
+
 def test_startup_state(default_conf, mocker):
     default_conf['pairlist'] = {'method': 'VolumePairList',
                                 'config': {'number_assets': 20}


### PR DESCRIPTION
## Summary
Verify sell-rate got a value - otherwise downstream code does not work.

Using PricingException here will cease operation for this pair for this
iteration - postponing handling to the next iteration - where hopefully
a price is again present.

Closes #3347

## Quick changelog

- Verify if price is None, in which case, we raise PricingException and continue with the next pair.