### PR TITLE
Remove deprecated setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,8 +53,8 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `dry_run_wallet` | Define the starting amount in stake currency for the simulated wallet used by the bot running in the Dry Run mode.<br>*Defaults to `1000`.* <br> **Datatype:** Float
 | `cancel_open_orders_on_exit` | Cancel open orders when the `/stop` RPC command is issued, `Ctrl+C` is pressed or the bot dies unexpectedly. When set to `true`, this allows you to use `/stop` to cancel unfilled and partially filled orders in the event of a market crash. It does not impact open positions. <br>*Defaults to `false`.* <br> **Datatype:** Boolean
 | `process_only_new_candles` | Enable processing of indicators only when new candles arrive. If false each loop populates the indicators, this will mean the same candle is processed many times creating system load but can be useful of your strategy depends on tick data not only candle. [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `false`.*  <br> **Datatype:** Boolean
-| `minimal_roi` | **Required.** Set the threshold in percent the bot will use to sell a trade. [More information below](#understand-minimal_roi). [Strategy Override](#parameters-in-the-strategy). <br> **Datatype:** Dict
-| `stoploss` |  **Required.** Value of the stoploss in percent used by the bot. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-the-strategy).  <br> **Datatype:** Float (as ratio)
+| `minimal_roi` | **Required.** Set the threshold as ratio the bot will use to sell a trade. [More information below](#understand-minimal_roi). [Strategy Override](#parameters-in-the-strategy). <br> **Datatype:** Dict
+| `stoploss` |  **Required.** Value as ratio of the stoploss used by the bot. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-the-strategy).  <br> **Datatype:** Float (as ratio)
 | `trailing_stop` | Enables trailing stoploss (based on `stoploss` in either configuration or strategy file). More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-the-strategy). <br> **Datatype:** Boolean
 | `trailing_stop_positive` | Changes stoploss once profit has been reached. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-the-strategy). <br> **Datatype:** Float
 | `trailing_stop_positive_offset` | Offset on when to apply `trailing_stop_positive`. Percentage value which should be positive. More details in the [stoploss documentation](stoploss.md). [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `0.0` (no offset).* <br> **Datatype:** Float
@@ -217,7 +217,7 @@ To allow the bot to trade all the available `stake_currency` in your account (mi
 ### Understand minimal_roi
 
 The `minimal_roi` configuration parameter is a JSON object where the key is a duration
-in minutes and the value is the minimum ROI in percent.
+in minutes and the value is the minimum ROI as ratio.
 See the example below:
 
 ```json

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -148,7 +148,6 @@ Edge module has following configuration options:
 | `enabled` | If true, then Edge will run periodically. <br>*Defaults to `false`.* <br> **Datatype:** Boolean
 | `process_throttle_secs` | How often should Edge run in seconds. <br>*Defaults to `3600` (once per hour).* <br> **Datatype:** Integer
 | `calculate_since_number_of_days` | Number of days of data against which Edge calculates Win Rate, Risk Reward and Expectancy. <br> **Note** that it downloads historical data so increasing this number would lead to slowing down the bot. <br>*Defaults to `7`.* <br> **Datatype:** Integer
-| `capital_available_percentage` | **DEPRECATED - [replaced with `tradable_balance_ratio`](configuration.md#Available balance)** This is the percentage of the total capital on exchange in stake currency. <br>As an example if you have 10 ETH available in your wallet on the exchange and this value is 0.5 (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers it as available capital. <br>*Defaults to `0.5`.* <br> **Datatype:** Float
 | `allowed_risk` | Ratio of allowed risk per trade. <br>*Defaults to `0.01` (1%)).* <br> **Datatype:** Float
 | `stoploss_range_min` | Minimum stoploss. <br>*Defaults to `-0.01`.* <br> **Datatype:** Float
 | `stoploss_range_max` | Maximum stoploss. <br>*Defaults to `-0.10`.* <br> **Datatype:** Float

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -1,6 +1,6 @@
 # Stop Loss
 
-The `stoploss` configuration parameter is loss in percentage that should trigger a sale.
+The `stoploss` configuration parameter is loss as ratio that should trigger a sale.
 For example, value `-0.10` will cause immediate sell if the profit dips below -10% for a given trade. This parameter is optional.
 
 Most of the strategy files already include the optimal `stoploss` value.

--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -60,7 +60,7 @@ def process_temporary_deprecated_settings(config: Dict[str, Any]) -> None:
 
     if (config.get('edge', {}).get('enabled', False)
        and 'capital_available_percentage' in config.get('edge', {})):
-        logger.warning(
+        raise OperationalException(
             "DEPRECATED: "
             "Using 'edge.capital_available_percentage' has been deprecated in favor of "
             "'tradable_balance_ratio'. Please migrate your configuration to "

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -286,7 +286,6 @@ CONF_SCHEMA = {
                 'process_throttle_secs': {'type': 'integer', 'minimum': 600},
                 'calculate_since_number_of_days': {'type': 'integer'},
                 'allowed_risk': {'type': 'number'},
-                'capital_available_percentage': {'type': 'number'},
                 'stoploss_range_min': {'type': 'number'},
                 'stoploss_range_max': {'type': 'number'},
                 'stoploss_range_step': {'type': 'number'},

--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -57,9 +57,7 @@ class Edge:
         if self.config['stake_amount'] != UNLIMITED_STAKE_AMOUNT:
             raise OperationalException('Edge works only with unlimited stake amount')
 
-        # Deprecated capital_available_percentage. Will use tradable_balance_ratio in the future.
-        self._capital_percentage: float = self.edge_config.get(
-            'capital_available_percentage', self.config['tradable_balance_ratio'])
+        self._capital_ratio: float = self.config['tradable_balance_ratio']
         self._allowed_risk: float = self.edge_config.get('allowed_risk')
         self._since_number_of_days: int = self.edge_config.get('calculate_since_number_of_days', 14)
         self._last_updated: int = 0  # Timestamp of pairs last updated time
@@ -157,7 +155,7 @@ class Edge:
     def stake_amount(self, pair: str, free_capital: float,
                      total_capital: float, capital_in_trade: float) -> float:
         stoploss = self.stoploss(pair)
-        available_capital = (total_capital + capital_in_trade) * self._capital_percentage
+        available_capital = (total_capital + capital_in_trade) * self._capital_ratio
         allowed_capital_at_risk = available_capital * self._allowed_risk
         max_position_size = abs(allowed_capital_at_risk / stoploss)
         position_size = min(max_position_size, free_capital)

--- a/tests/config_test_comments.json
+++ b/tests/config_test_comments.json
@@ -92,7 +92,6 @@
         "enabled": false,
         "process_throttle_secs": 3600,
         "calculate_since_number_of_days": 7,
-        "capital_available_percentage": 0.5,
         "allowed_risk": 0.01,
         "stoploss_range_min": -0.01,
         "stoploss_range_max": -0.1,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1048,8 +1048,9 @@ def test_process_deprecated_setting_edge(mocker, edge_conf, caplog):
         'capital_available_percentage': 0.5,
     }})
 
-    process_temporary_deprecated_settings(edge_conf)
-    assert log_has_re(r"DEPRECATED.*Using 'edge.capital_available_percentage'*", caplog)
+    with pytest.raises(OperationalException,
+                       match=r"DEPRECATED.*Using 'edge.capital_available_percentage'*"):
+        process_temporary_deprecated_settings(edge_conf)
 
 
 def test_check_conflicting_settings(mocker, default_conf, caplog):


### PR DESCRIPTION
## Summary
Remove deprecated edge-config `capital_available_percentage` and raise an exception instead.

Part of #2971 (although i'm not sure what would be needed to completely suffice that issue)

## Quick changelog

- remove `capital_available_percentage` and raise error when it's used in combination with edge
- remove some occurances of percent where we mean ratio in the documentation
