### PR TITLE
Added emoji's to the Telegram RPC

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -154,9 +154,9 @@ class Telegram(RPC):
                 microsecond=0) - msg['open_date'].replace(microsecond=0)
             msg['duration_min'] = msg['duration'].total_seconds() / 60
 
-            msg['emoij'] = self._get_sell_emoij(msg)
+            msg['emoji'] = self._get_sell_emoji(msg)
 
-            message = ("{emoij} *{exchange}:* Selling {pair}\n"
+            message = ("{emoji} *{exchange}:* Selling {pair}\n"
                        "*Amount:* `{amount:.8f}`\n"
                        "*Open Rate:* `{open_rate:.8f}`\n"
                        "*Current Rate:* `{current_rate:.8f}`\n"
@@ -192,7 +192,7 @@ class Telegram(RPC):
 
         self._send_msg(message)
 
-    def _get_sell_emoij(self, msg):
+    def _get_sell_emoji(self, msg):
         """
         Get emoji for sell-side
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -154,25 +154,16 @@ class Telegram(RPC):
                 microsecond=0) - msg['open_date'].replace(microsecond=0)
             msg['duration_min'] = msg['duration'].total_seconds() / 60
 
-            if float(msg['profit_percent']) >= 5.0:
-                message = ("\N{ROCKET} *{exchange}:* Selling {pair}\n").format(**msg)
+            msg['emoij'] = self._get_sell_emoij(msg)
 
-            elif float(msg['profit_percent']) >= 0.0:
-                message = "\N{EIGHT SPOKED ASTERISK} *{exchange}:* Selling {pair}\n"
-
-            elif msg['sell_reason'] == "stop_loss":
-                message = ("\N{WARNING SIGN} *{exchange}:* Selling {pair}\n").format(**msg)
-
-            else:
-                message = ("\N{CROSS MARK} *{exchange}:* Selling {pair}\n").format(**msg)
-
-            message += ("*Amount:* `{amount:.8f}`\n"
-                        "*Open Rate:* `{open_rate:.8f}`\n"
-                        "*Current Rate:* `{current_rate:.8f}`\n"
-                        "*Close Rate:* `{limit:.8f}`\n"
-                        "*Sell Reason:* `{sell_reason}`\n"
-                        "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
-                        "*Profit:* `{profit_percent:.2f}%`").format(**msg)
+            message = ("{emoij} *{exchange}:* Selling {pair}\n"
+                       "*Amount:* `{amount:.8f}`\n"
+                       "*Open Rate:* `{open_rate:.8f}`\n"
+                       "*Current Rate:* `{current_rate:.8f}`\n"
+                       "*Close Rate:* `{limit:.8f}`\n"
+                       "*Sell Reason:* `{sell_reason}`\n"
+                       "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
+                       "*Profit:* `{profit_percent:.2f}%`").format(**msg)
 
             # Check if all sell properties are available.
             # This might not be the case if the message origin is triggered by /forcesell
@@ -200,6 +191,20 @@ class Telegram(RPC):
             raise NotImplementedError('Unknown message type: {}'.format(msg['type']))
 
         self._send_msg(message)
+
+    def _get_sell_emoij(self, msg):
+        """
+        Get emoji for sell-side
+        """
+
+        if float(msg['profit_percent']) >= 5.0:
+            return "\N{ROCKET}"
+        elif float(msg['profit_percent']) >= 0.0:
+            return "\N{EIGHT SPOKED ASTERISK}"
+        elif msg['sell_reason'] == "stop_loss":
+            return"\N{WARNING SIGN}"
+        else:
+            return "\N{CROSS MARK}"
 
     @authorized_only
     def _status(self, update: Update, context: CallbackContext) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -126,12 +126,6 @@ class Telegram(RPC):
     def send_msg(self, msg: Dict[str, Any]) -> None:
         """ Send a message to telegram channel """
 
-        '🔵'.encode('ascii', 'namereplace')
-        '🚀'.encode('ascii', 'namereplace')
-        '✳'.encode('ascii', 'namereplace')
-        '❌'.encode('ascii', 'namereplace')
-        '⚠'.encode('ascii', 'namereplace')
-
         if msg['type'] == RPCMessageType.BUY_NOTIFICATION:
             if self._fiat_converter:
                 msg['stake_amount_fiat'] = self._fiat_converter.convert_amount(

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -144,7 +144,8 @@ class Telegram(RPC):
             message += ")`"
 
         elif msg['type'] == RPCMessageType.BUY_CANCEL_NOTIFICATION:
-            message = "\N{WARNING SIGN} *{exchange}:* Cancelling Open Buy Order for {pair}".format(**msg)
+            message = "\N{WARNING SIGN} *{exchange}:* " \
+                      "Cancelling Open Buy Order for {pair}".format(**msg)
 
         elif msg['type'] == RPCMessageType.SELL_NOTIFICATION:
             msg['amount'] = round(msg['amount'], 8)

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1485,6 +1485,29 @@ def test_send_msg_sell_notification_no_fiat(default_conf, mocker) -> None:
            '*Profit:* `-57.41%`'
 
 
+@pytest.mark.parametrize('msg,expected', [
+    ({'profit_percent': 20.1, 'sell_reason': 'roi'}, "\N{ROCKET}"),
+    ({'profit_percent': 5.1, 'sell_reason': 'roi'}, "\N{ROCKET}"),
+    ({'profit_percent': 2.56, 'sell_reason': 'roi'}, "\N{EIGHT SPOKED ASTERISK}"),
+    ({'profit_percent': 1.0, 'sell_reason': 'roi'}, "\N{EIGHT SPOKED ASTERISK}"),
+    ({'profit_percent': 0.0, 'sell_reason': 'roi'}, "\N{EIGHT SPOKED ASTERISK}"),
+    ({'profit_percent': -5.0, 'sell_reason': 'stop_loss'}, "\N{WARNING SIGN}"),
+    ({'profit_percent': -2.0, 'sell_reason': 'sell_signal'}, "\N{CROSS MARK}"),
+])
+def test__sell_emoji(default_conf, mocker, msg, expected):
+    del default_conf['fiat_display_currency']
+    msg_mock = MagicMock()
+    mocker.patch.multiple(
+        'freqtrade.rpc.telegram.Telegram',
+        _init=MagicMock(),
+        _send_msg=msg_mock
+    )
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+    telegram = Telegram(freqtradebot)
+
+    assert telegram._get_sell_emoij(msg) == expected
+
+
 def test__send_msg(default_conf, mocker) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram._init', MagicMock())
     bot = MagicMock()

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1221,7 +1221,6 @@ def test_send_msg_buy_notification(default_conf, mocker) -> None:
         'amount': 1333.3333333333335,
         'open_date': arrow.utcnow().shift(hours=-1)
     })
-    '🔵'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == '\N{LARGE BLUE CIRCLE} *Bittrex:* Buying ETH/BTC\n' \
            '*Amount:* `1333.33333333`\n' \
@@ -1244,7 +1243,6 @@ def test_send_msg_buy_cancel_notification(default_conf, mocker) -> None:
         'exchange': 'Bittrex',
         'pair': 'ETH/BTC',
     })
-    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == ('\N{WARNING SIGN} *Bittrex:* Cancelling Open Buy Order for ETH/BTC')
 
@@ -1278,7 +1276,6 @@ def test_send_msg_sell_notification(default_conf, mocker) -> None:
         'open_date': arrow.utcnow().shift(hours=-1),
         'close_date': arrow.utcnow(),
     })
-    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == ('\N{WARNING SIGN} *Binance:* Selling KEY/ETH\n'
             '*Amount:* `1333.33333333`\n'
@@ -1337,7 +1334,6 @@ def test_send_msg_sell_cancel_notification(default_conf, mocker) -> None:
         'pair': 'KEY/ETH',
         'reason': 'Cancelled on exchange'
     })
-    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == ('\N{WARNING SIGN} *Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: Cancelled on exchange')
 
@@ -1383,7 +1379,6 @@ def test_warning_notification(default_conf, mocker) -> None:
         'type': RPCMessageType.WARNING_NOTIFICATION,
         'status': 'message'
     })
-    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] == '\N{WARNING SIGN} *Warning:* `message`'
 
 
@@ -1442,7 +1437,6 @@ def test_send_msg_buy_notification_no_fiat(default_conf, mocker) -> None:
         'amount': 1333.3333333333335,
         'open_date': arrow.utcnow().shift(hours=-1)
     })
-    '🔵'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == '\N{LARGE BLUE CIRCLE} *Bittrex:* Buying ETH/BTC\n' \
            '*Amount:* `1333.33333333`\n' \
@@ -1479,7 +1473,6 @@ def test_send_msg_sell_notification_no_fiat(default_conf, mocker) -> None:
         'open_date': arrow.utcnow().shift(hours=-2, minutes=-35, seconds=-3),
         'close_date': arrow.utcnow(),
     })
-    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
         == '\N{WARNING SIGN} *Binance:* Selling KEY/ETH\n' \
            '*Amount:* `1333.33333333`\n' \

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1505,7 +1505,7 @@ def test__sell_emoji(default_conf, mocker, msg, expected):
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     telegram = Telegram(freqtradebot)
 
-    assert telegram._get_sell_emoij(msg) == expected
+    assert telegram._get_sell_emoji(msg) == expected
 
 
 def test__send_msg(default_conf, mocker) -> None:

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1335,7 +1335,8 @@ def test_send_msg_sell_cancel_notification(default_conf, mocker) -> None:
         'reason': 'Cancelled on exchange'
     })
     assert msg_mock.call_args[0][0] \
-        == ('\N{WARNING SIGN} *Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: Cancelled on exchange')
+        == ('\N{WARNING SIGN} *Binance:* Cancelling Open Sell Order for KEY/ETH. '
+            'Reason: Cancelled on exchange')
 
     msg_mock.reset_mock()
     telegram.send_msg({

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1221,8 +1221,9 @@ def test_send_msg_buy_notification(default_conf, mocker) -> None:
         'amount': 1333.3333333333335,
         'open_date': arrow.utcnow().shift(hours=-1)
     })
+    '🔵'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == '*Bittrex:* Buying ETH/BTC\n' \
+        == '\N{LARGE BLUE CIRCLE} *Bittrex:* Buying ETH/BTC\n' \
            '*Amount:* `1333.33333333`\n' \
            '*Open Rate:* `0.00001099`\n' \
            '*Current Rate:* `0.00001099`\n' \
@@ -1243,8 +1244,9 @@ def test_send_msg_buy_cancel_notification(default_conf, mocker) -> None:
         'exchange': 'Bittrex',
         'pair': 'ETH/BTC',
     })
+    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == ('*Bittrex:* Cancelling Open Buy Order for ETH/BTC')
+        == ('\N{WARNING SIGN} *Bittrex:* Cancelling Open Buy Order for ETH/BTC')
 
 
 def test_send_msg_sell_notification(default_conf, mocker) -> None:
@@ -1276,8 +1278,9 @@ def test_send_msg_sell_notification(default_conf, mocker) -> None:
         'open_date': arrow.utcnow().shift(hours=-1),
         'close_date': arrow.utcnow(),
     })
+    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == ('*Binance:* Selling KEY/ETH\n'
+        == ('\N{WARNING SIGN} *Binance:* Selling KEY/ETH\n'
             '*Amount:* `1333.33333333`\n'
             '*Open Rate:* `0.00007500`\n'
             '*Current Rate:* `0.00003201`\n'
@@ -1305,7 +1308,7 @@ def test_send_msg_sell_notification(default_conf, mocker) -> None:
         'close_date': arrow.utcnow(),
     })
     assert msg_mock.call_args[0][0] \
-        == ('*Binance:* Selling KEY/ETH\n'
+        == ('\N{WARNING SIGN} *Binance:* Selling KEY/ETH\n'
             '*Amount:* `1333.33333333`\n'
             '*Open Rate:* `0.00007500`\n'
             '*Current Rate:* `0.00003201`\n'
@@ -1334,8 +1337,9 @@ def test_send_msg_sell_cancel_notification(default_conf, mocker) -> None:
         'pair': 'KEY/ETH',
         'reason': 'Cancelled on exchange'
     })
+    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == ('*Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: Cancelled on exchange')
+        == ('\N{WARNING SIGN} *Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: Cancelled on exchange')
 
     msg_mock.reset_mock()
     telegram.send_msg({
@@ -1345,7 +1349,7 @@ def test_send_msg_sell_cancel_notification(default_conf, mocker) -> None:
         'reason': 'timeout'
     })
     assert msg_mock.call_args[0][0] \
-        == ('*Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: timeout')
+        == ('\N{WARNING SIGN} *Binance:* Cancelling Open Sell Order for KEY/ETH. Reason: timeout')
     # Reset singleton function to avoid random breaks
     telegram._fiat_converter.convert_amount = old_convamount
 
@@ -1379,7 +1383,8 @@ def test_warning_notification(default_conf, mocker) -> None:
         'type': RPCMessageType.WARNING_NOTIFICATION,
         'status': 'message'
     })
-    assert msg_mock.call_args[0][0] == '*Warning:* `message`'
+    '⚠'.encode('ascii', 'namereplace')
+    assert msg_mock.call_args[0][0] == '\N{WARNING SIGN} *Warning:* `message`'
 
 
 def test_custom_notification(default_conf, mocker) -> None:
@@ -1437,8 +1442,9 @@ def test_send_msg_buy_notification_no_fiat(default_conf, mocker) -> None:
         'amount': 1333.3333333333335,
         'open_date': arrow.utcnow().shift(hours=-1)
     })
+    '🔵'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == '*Bittrex:* Buying ETH/BTC\n' \
+        == '\N{LARGE BLUE CIRCLE} *Bittrex:* Buying ETH/BTC\n' \
            '*Amount:* `1333.33333333`\n' \
            '*Open Rate:* `0.00001099`\n' \
            '*Current Rate:* `0.00001099`\n' \
@@ -1473,8 +1479,9 @@ def test_send_msg_sell_notification_no_fiat(default_conf, mocker) -> None:
         'open_date': arrow.utcnow().shift(hours=-2, minutes=-35, seconds=-3),
         'close_date': arrow.utcnow(),
     })
+    '⚠'.encode('ascii', 'namereplace')
     assert msg_mock.call_args[0][0] \
-        == '*Binance:* Selling KEY/ETH\n' \
+        == '\N{WARNING SIGN} *Binance:* Selling KEY/ETH\n' \
            '*Amount:* `1333.33333333`\n' \
            '*Open Rate:* `0.00007500`\n' \
            '*Current Rate:* `0.00003201`\n' \


### PR DESCRIPTION
## Summary
Adding some readability to the Telegram messages, depending on whether you make a profit or loss.

Closes #2502

## Quick changelog
Nothing

## What's new?
Added emoji's to the Telegram messages, (all emoji's are unicoded so that they can work on all platforms, as request by Matthias):
* Blue circle (neutral color) for buying pairs.
* Green star emoji when the user made a profitable sell.
* Rocket emoji when the user made a profit >5.0%, to the moooon! (remove this if you don't like this one, or want to keep it more simplistic).
* Red cross emoji when the user made a loss.
* Warning emoji when the user hit a stoploss, warning messages or buy/sell cancels.
