### PR TITLE
Backtesting should load pairlists after the strategy

### DIFF
--- a/freqtrade/pairlist/PrecisionFilter.py
+++ b/freqtrade/pairlist/PrecisionFilter.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Dict
 
 from freqtrade.pairlist.IPairList import IPairList
-
+from freqtrade.exceptions import OperationalException
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,10 @@ class PrecisionFilter(IPairList):
                  pairlist_pos: int) -> None:
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
+        if 'stoploss' not in self._config:
+            raise OperationalException(
+                'PrecisionFilter can only work with stoploss defined. Please add the '
+                'stoploss key to your configuration (overwrites eventual strategy settings).')
         self._stoploss = self._config['stoploss']
         self._enabled = self._stoploss != 0
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -401,7 +401,6 @@ def test_backtesting_no_pair_left(default_conf, mocker, caplog, testdatadir) -> 
         Backtesting(default_conf)
 
 
-
 def test_backtesting_pairlist_list(default_conf, mocker, caplog, testdatadir, tickers) -> None:
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
     mocker.patch('freqtrade.exchange.Exchange.get_tickers', tickers)
@@ -426,6 +425,12 @@ def test_backtesting_pairlist_list(default_conf, mocker, caplog, testdatadir, ti
 
     default_conf['pairlists'] = [{"method": "StaticPairList"}, {"method": "PrecisionFilter"}, ]
     Backtesting(default_conf)
+
+    # Multiple strategies
+    default_conf['strategy_list'] = ['DefaultStrategy', 'TestStrategyLegacy']
+    with pytest.raises(OperationalException,
+                       match='PrecisionFilter not allowed for backtesting multiple strategies.'):
+        Backtesting(default_conf)
 
 
 def test_backtest(default_conf, fee, mocker, testdatadir) -> None:

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -362,6 +362,17 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, t
                     assert not log_has(logmsg, caplog)
 
 
+def test_PrecisionFilter_error(mocker, whitelist_conf, tickers) -> None:
+    whitelist_conf['pairlists'] = [{"method": "StaticPairList"}, {"method": "PrecisionFilter"}]
+    del whitelist_conf['stoploss']
+
+    mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
+
+    with pytest.raises(OperationalException,
+                       match=r"PrecisionFilter can only work with stoploss defined\..*"):
+        PairListManager(MagicMock, whitelist_conf)
+
+
 def test_gen_pair_whitelist_not_supported(mocker, default_conf, tickers) -> None:
     default_conf['pairlists'] = [{'method': 'VolumePairList', 'number_assets': 10}]
 


### PR DESCRIPTION
## Summary
Backtesting should load pairlists after the strategy to avoid running into problems if attributes needed in the pairlist are loaded from the strategy.

closes #3363 
closes #3463

## Quick changelog

- Load pairlist after strategy
- Explicitly fail if strategy-list is used in combination with PrecisionFilter.
- Explicitly fail loading PrecisionFilter if stoploss is not available (for test-pairlist ...)