### PR TITLE
change hyperopt output to print ready to copy to strategy

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -12,7 +12,7 @@ from math import ceil
 from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat
 from typing import Any, Dict, List, Optional
 
 import rapidjson
@@ -244,11 +244,21 @@ class Hyperopt:
     def _params_pretty_print(params, space: str, header: str) -> None:
         if space in params:
             space_params = Hyperopt._space_params(params, space, 5)
+            print(f"\n    # {header}")
             if space == 'stoploss':
-                print(header, space_params.get('stoploss'))
+                print("    stoploss =", space_params.get('stoploss'))
+            elif space == 'roi':
+                minimal_roi_result = rapidjson.dumps(
+                    OrderedDict(
+                        (str(k), v) for k, v in space_params.items()
+                    ),
+                    default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
+                minimal_roi_result = minimal_roi_result.replace("\n", "\n    ")
+                print(f"    minimal_roi = {minimal_roi_result}")
             else:
-                print(header)
-                pprint(space_params, indent=4)
+                params_result = pformat(space_params, indent=4).replace("}", "\n}")
+                params_result = params_result.replace("{", "{\n ").replace("\n", "\n    ")
+                print(f"    {space}_params = {params_result}")
 
     @staticmethod
     def _space_params(params, space: str, r: int = None) -> Dict:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -230,6 +230,9 @@ class Hyperopt:
             if space in ['buy', 'sell']:
                 result_dict.setdefault('params', {}).update(space_params)
             elif space == 'roi':
+                # TODO: get rid of OrderedDict when support for python 3.6 will be
+                # dropped (dicts keep the order as the language feature)
+
                 # Convert keys in min_roi dict to strings because
                 # rapidjson cannot dump dicts with integer keys...
                 # OrderedDict is used to keep the numeric order of the items
@@ -244,21 +247,24 @@ class Hyperopt:
     def _params_pretty_print(params, space: str, header: str) -> None:
         if space in params:
             space_params = Hyperopt._space_params(params, space, 5)
-            print(f"\n    # {header}")
+            params_result = f"\n# {header}\n"
             if space == 'stoploss':
-                print("    stoploss =", space_params.get('stoploss'))
+                params_result += f"stoploss = {space_params.get('stoploss')}"
             elif space == 'roi':
                 minimal_roi_result = rapidjson.dumps(
+                # TODO: get rid of OrderedDict when support for python 3.6 will be
+                # dropped (dicts keep the order as the language feature)
                     OrderedDict(
                         (str(k), v) for k, v in space_params.items()
                     ),
                     default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
-                minimal_roi_result = minimal_roi_result.replace("\n", "\n    ")
-                print(f"    minimal_roi = {minimal_roi_result}")
+                params_result += f"minimal_roi = {minimal_roi_result}"
             else:
-                params_result = pformat(space_params, indent=4).replace("}", "\n}")
-                params_result = params_result.replace("{", "{\n ").replace("\n", "\n    ")
-                print(f"    {space}_params = {params_result}")
+                params_result += f"{space}_params = {pformat(space_params, indent=4)}"
+                params_result = params_result.replace("}", "\n}").replace("{", "{\n ")
+
+            params_result = params_result.replace("\n", "\n    ")
+            print(params_result)
 
     @staticmethod
     def _space_params(params, space: str, r: int = None) -> Dict:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -251,9 +251,9 @@ class Hyperopt:
             if space == 'stoploss':
                 params_result += f"stoploss = {space_params.get('stoploss')}"
             elif space == 'roi':
-                minimal_roi_result = rapidjson.dumps(
                 # TODO: get rid of OrderedDict when support for python 3.6 will be
                 # dropped (dicts keep the order as the language feature)
+                minimal_roi_result = rapidjson.dumps(
                     OrderedDict(
                         (str(k), v) for k, v in space_params.items()
                     ),


### PR DESCRIPTION
# Summary

format the roi, in order to facilitate the copy, in the return of the hyperoptmize

changed to python output to easy use in strategy file without mistakes

# Quick changelog

- New Format in hyperopt output
Actual return 
``` Buy hyperspace params:
{   'bb_width-value': 22.07556,
    'bbwidth-enabled': True,
    'direction': 'sma-enabled',
    'ema-value': 65,
    'rsi-enabled': True,
    'rsi-value': 38,
    'sma-value': 76,
    'trigger': 'bb_lower3',
    'width': 'bb_width1'}
Sell hyperspace params:
{   'sell-rsi-enabled': True,
    'sell-rsi-value': 98,
    'sell-trigger': 'sell-bb_lower1'}
ROI table:
{0: 0.16532, 14: 0.05331, 31: 0.02645, 57: 0}
``` 
changed to 
``` python
    # Buy hyperspace params:
    buy_params = {
        'bb_width-value': 4.66539,
        'bbwidth-enabled': True,
        'direction': 'ema-enabled',
        'ema-value': 32,
        'rsi-enabled': False,
        'rsi-value': 31,
        'sma-value': 27,
        'trigger': 'bb_lowerband2',
        'width': 'bb_width3'
    }

    # Sell hyperspace params:
    sell_params = {
        'sell-rsi-enabled': False,
        'sell-rsi-value': 42,
        'sell-trigger': 'bb_lowerband1'
    }

    # ROI table:
    minimal_roi = {
        "0": 0.23458,
        "28": 0.03915,
        "57": 0.02861,
        "169": 0
    }

    # Stoploss:
    stoploss = -0.08436
```