### PR TITLE
Fix bug in timeframe deprecation

### DIFF
--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -72,4 +72,9 @@ def process_temporary_deprecated_settings(config: Dict[str, Any]) -> None:
             "DEPRECATED: "
             "Please use 'timeframe' instead of 'ticker_interval."
         )
+        if 'timeframe' in config:
+            raise OperationalException(
+                "Both 'timeframe' and 'ticker_interval' detected."
+                "Please remove 'ticker_interval' from your configuration to continue operating."
+                )
         config['timeframe'] = config['ticker_interval']


### PR DESCRIPTION

# Summary
Fail if both ticker_interval and timeframe are present in a configuration

Otherwise the wrong might be used, as it's unclear which one corresponds to the current user desire.

closes #3488

## Quick changelog

- fail if both ticker_interval and timeframe are detected