### PR TITLE
Also reload async markets

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -285,6 +285,8 @@ class Exchange:
         logger.debug("Performing scheduled market reload..")
         try:
             self._api.load_markets(reload=True)
+            # Also reload async markets to avoid issues with newly listed pairs
+            self._load_async_markets(reload=True)
             self._last_markets_refresh = arrow.utcnow().timestamp
         except ccxt.BaseError:
             logger.exception("Could not reload markets.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def patched_configuration_load_config_file(mocker, config) -> None:
 
 
 def patch_exchange(mocker, api_mock=None, id='bittrex', mock_markets=True) -> None:
+    mocker.patch('freqtrade.exchange.Exchange._load_async_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange._load_markets', MagicMock(return_value={}))
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs', MagicMock())
     mocker.patch('freqtrade.exchange.Exchange.validate_timeframes', MagicMock())

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -319,7 +319,12 @@ def test_set_sandbox_exception(default_conf, mocker):
 
 
 def test__load_async_markets(default_conf, mocker, caplog):
-    exchange = get_patched_exchange(mocker, default_conf)
+    mocker.patch('freqtrade.exchange.Exchange._init_ccxt')
+    mocker.patch('freqtrade.exchange.Exchange.validate_pairs')
+    mocker.patch('freqtrade.exchange.Exchange.validate_timeframes')
+    mocker.patch('freqtrade.exchange.Exchange._load_markets')
+    mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
+    exchange = Exchange(default_conf)
     exchange._api_async.load_markets = get_mock_coro(None)
     exchange._load_async_markets()
     assert exchange._api_async.load_markets.call_count == 1


### PR DESCRIPTION

## Summary
Also reload async markets, otherwise the async exchange version does not have the new pairs - causing volumePairlist to cause errors when downloading data on newly listed pairs.

fixes #2876 - Logs and Empty ticker history  for new pair
