### PR TITLE
Show winning vs. losing trades

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -284,7 +284,7 @@ class RPC:
                 profit_ratio = trade.close_profit
                 profit_closed_coin.append(trade.close_profit_abs)
                 profit_closed_ratio.append(profit_ratio)
-                if trade.close_profit > 0:
+                if trade.close_profit >= 0:
                     winning_trades += 1
                 else:
                     losing_trades += 1

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -269,6 +269,8 @@ class RPC:
         profit_closed_coin = []
         profit_closed_ratio = []
         durations = []
+        winning_trades = 0
+        losing_trades = 0
 
         for trade in trades:
             current_rate: float = 0.0
@@ -282,6 +284,10 @@ class RPC:
                 profit_ratio = trade.close_profit
                 profit_closed_coin.append(trade.close_profit_abs)
                 profit_closed_ratio.append(profit_ratio)
+                if trade.close_profit > 0:
+                    winning_trades += 1
+                else:
+                    losing_trades += 1
             else:
                 # Get current rate
                 try:
@@ -344,6 +350,8 @@ class RPC:
             'avg_duration': str(timedelta(seconds=sum(durations) / num)).split('.')[0],
             'best_pair': best_pair[0] if best_pair else '',
             'best_rate': round(best_pair[1] * 100, 2) if best_pair else 0,
+            'winning_trades': winning_trades,
+            'losing_trades': losing_trades,
         }
 
     def _rpc_balance(self, stake_currency: str, fiat_display_currency: str) -> Dict:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -366,7 +366,9 @@ class Telegram(RPC):
                              f"∙ `{profit_all_fiat:.3f} {fiat_disp_cur}`\n"
                              f"*Total Trade Count:* `{trade_count}`\n"
                              f"*First Trade opened:* `{first_trade_date}`\n"
-                             f"*Latest Trade opened:* `{latest_trade_date}`")
+                             f"*Latest Trade opened:* `{latest_trade_date}\n`"
+                             f"*Win / Loss:* `{stats['winning_trades']} / {stats['losing_trades']}`"
+                             )
             if stats['closed_trade_count'] > 0:
                 markdown_msg += (f"\n*Avg. Duration:* `{avg_duration}`\n"
                                  f"*Best Performing:* `{best_pair}: {best_rate:.2f}%`")

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -444,6 +444,8 @@ def test_api_profit(botclient, mocker, ticker, fee, markets, limit_buy_order, li
                        'profit_closed_percent_sum': 6.2,
                        'trade_count': 1,
                        'closed_trade_count': 1,
+                       'winning_trades': 1,
+                       'losing_trades': 0,
                        }
 
 


### PR DESCRIPTION
## Summary
Show winning vs. Losing trades in `/profit` calls.

This will allow to easily determine if a strategy made profit on most trades, or only had a few big winners.


## Quick changelog

- add Win / Loss to profit output.