### PR TITLE
Fix RPC Cors

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -82,6 +82,7 @@
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "",
         "password": ""
     },

--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -87,6 +87,7 @@
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "",
         "password": ""
     },

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -123,6 +123,7 @@
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -93,6 +93,7 @@
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "",
         "password": ""
     },

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -13,6 +13,7 @@ Sample configuration:
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "Freqtrader",
         "password": "SuperSecret1!"
     },
@@ -232,3 +233,26 @@ Since the access token has a short timeout (15 min) - the `token/refresh` reques
 > curl -X POST --header "Authorization: Bearer ${refresh_token}"http://localhost:8080/api/v1/token/refresh
 {"access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODkxMTk5NzQsIm5iZiI6MTU4OTExOTk3NCwianRpIjoiMDBjNTlhMWUtMjBmYS00ZTk0LTliZjAtNWQwNTg2MTdiZDIyIiwiZXhwIjoxNTg5MTIwODc0LCJpZGVudGl0eSI6eyJ1IjoiRnJlcXRyYWRlciJ9LCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.1seHlII3WprjjclY6DpRhen0rqdF4j6jbvxIhUFaSbs"}
 ```
+
+## CORS
+
+All web-based frontends are subject to [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) - Cross-Origin Resource Sharing.
+Since most request to the Freqtrade API must be authenticated, a proper CORS policy is key to avoid security problems.
+Also, the Standard disallows `*` CORS policies for requests with credentials, so this setting must be done appropriately.
+
+Users can configure this themselfs via the `CORS_origins` configuration setting.
+It consists of a list of allowed sites that are allowed to consume resources from the bot's API.
+
+Assuming your Application would be deployed as `https://frequi.freqtrade.io/home/` - this would mean that the following configuration becomes necessary:
+
+```jsonc
+{
+    //...
+    "jwt_secret_key": "somethingrandom",
+    "CORS_origins": ["https://frequi.freqtrade.io"],
+    //...
+}
+```
+
+!!! Note
+    We strongly recommend to also set `jwt_secret_key` to something random and known only to yourself to avoid unauthorized access to your bot.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -237,13 +237,13 @@ Since the access token has a short timeout (15 min) - the `token/refresh` reques
 ## CORS
 
 All web-based frontends are subject to [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) - Cross-Origin Resource Sharing.
-Since most request to the Freqtrade API must be authenticated, a proper CORS policy is key to avoid security problems.
-Also, the Standard disallows `*` CORS policies for requests with credentials, so this setting must be done appropriately.
+Since most of the requests to the Freqtrade API must be authenticated, a proper CORS policy is key to avoid security problems.
+Also, the standard disallows `*` CORS policies for requests with credentials, so this setting must be set appropriately.
 
-Users can configure this themselfs via the `CORS_origins` configuration setting.
+Users can configure this themselves via the `CORS_origins` configuration setting.
 It consists of a list of allowed sites that are allowed to consume resources from the bot's API.
 
-Assuming your Application would be deployed as `https://frequi.freqtrade.io/home/` - this would mean that the following configuration becomes necessary:
+Assuming your application is deployed as `https://frequi.freqtrade.io/home/` - this would mean that the following configuration becomes necessary:
 
 ```jsonc
 {

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -221,6 +221,8 @@ CONF_SCHEMA = {
                 },
                 'username': {'type': 'string'},
                 'password': {'type': 'string'},
+                'jwt_secret_key': {'type': 'string'},
+                'CORS_origins': {'type': 'array', 'items': {'type': 'string'}},
                 'verbosity': {'type': 'string', 'enum': ['error', 'info']},
             },
             'required': ['enabled', 'listen_ip_address', 'listen_port', 'username', 'password']

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -90,7 +90,9 @@ class ApiServer(RPC):
         self._config = freqtrade.config
         self.app = Flask(__name__)
         self._cors = CORS(self.app,
-                          resources={r"/api/*": {"supports_credentials": True, }}
+                          resources={r"/api/*": {
+                              "supports_credentials": True,
+                              "origins": self._config['api_server'].get('CORS_origins', [])}}
                           )
 
         # Setup the Flask-JWT-Extended extension

--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -59,6 +59,7 @@
         "listen_port": 8080,
         "verbosity": "info",
         "jwt_secret_key": "somethingrandom",
+        "CORS_origins": [],
         "username": "",
         "password": ""
     },

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -24,6 +24,7 @@ def botclient(default_conf, mocker):
     default_conf.update({"api_server": {"enabled": True,
                                         "listen_ip_address": "127.0.0.1",
                                         "listen_port": 8080,
+                                        "CORS_origins": ['http://example.com'],
                                         "username": _TEST_USER,
                                         "password": _TEST_PASS,
                                         }})
@@ -40,13 +41,13 @@ def client_post(client, url, data={}):
                        content_type="application/json",
                        data=data,
                        headers={'Authorization': _basic_auth_str(_TEST_USER, _TEST_PASS),
-                                'Origin': 'example.com'})
+                                'Origin': 'http://example.com'})
 
 
 def client_get(client, url):
     # Add fake Origin to ensure CORS kicks in
     return client.get(url, headers={'Authorization': _basic_auth_str(_TEST_USER, _TEST_PASS),
-                                    'Origin': 'example.com'})
+                                    'Origin': 'http://example.com'})
 
 
 def assert_response(response, expected_code=200, needs_cors=True):
@@ -54,6 +55,7 @@ def assert_response(response, expected_code=200, needs_cors=True):
     assert response.content_type == "application/json"
     if needs_cors:
         assert ('Access-Control-Allow-Credentials', 'true') in response.headers._list
+        assert ('Access-Control-Allow-Origin', 'http://example.com') in response.headers._list
 
 
 def test_api_not_found(botclient):
@@ -110,7 +112,7 @@ def test_api_token_login(botclient):
     rc = client.get(f"{BASE_URI}/count",
                     content_type="application/json",
                     headers={'Authorization': f'Bearer {rc.json["access_token"]}',
-                             'Origin': 'example.com'})
+                             'Origin': 'http://example.com'})
     assert_response(rc)
 
 
@@ -122,7 +124,7 @@ def test_api_token_refresh(botclient):
                      content_type="application/json",
                      data=None,
                      headers={'Authorization': f'Bearer {rc.json["refresh_token"]}',
-                              'Origin': 'example.com'})
+                              'Origin': 'http://example.com'})
     assert_response(rc)
     assert 'access_token' in rc.json
     assert 'refresh_token' not in rc.json


### PR DESCRIPTION
## Summary
When making authenticated calls to the rest API from a different ressource (and be that only a different localhost port), then a valid CORS policy is a must to allow the requests to not be blocked by the browser.

This PR will enable this by adding a setting, where users can define their source themselfs.
Regular users won't need to change this - but developers and people working on FreqUI might to allow cross-origin testing (without routing everything throught the webpack server).

## Quick changelog

- add `CORS_origins`  setting to api_server