### PR TITLE
AgeFilter for filtering out newly listed pairs

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -64,6 +64,7 @@
             "sort_key": "quoteVolume",
             "refresh_period": 1800
         },
+        {"method": "AgeFilter", "min_days_listed": 10},
         {"method": "PrecisionFilter"},
         {"method": "PriceFilter", "low_price_ratio": 0.01},
         {"method": "SpreadFilter", "max_spread_ratio": 0.005}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -592,7 +592,7 @@ Pairlist Handlers define the list of pairs (pairlist) that the bot should trade.
 
 In your configuration, you can use Static Pairlist (defined by the [`StaticPairList`](#static-pair-list) Pairlist Handler) and Dynamic Pairlist (defined by the [`VolumePairList`](#volume-pair-list) Pairlist Handler).
 
-Additionaly, [`PrecisionFilter`](#precisionfilter), [`PriceFilter`](#pricefilter), [`ShuffleFilter`](#shufflefilter) and [`SpreadFilter`](#spreadfilter) act as Pairlist Filters, removing certain pairs and/or moving their positions in the pairlist.
+Additionaly, [`AgeFilter`](#agefilter), [`PrecisionFilter`](#precisionfilter), [`PriceFilter`](#pricefilter), [`ShuffleFilter`](#shufflefilter) and [`SpreadFilter`](#spreadfilter) act as Pairlist Filters, removing certain pairs and/or moving their positions in the pairlist.
 
 If multiple Pairlist Handlers are used, they are chained and a combination of all Pairlist Handlers forms the resulting pairlist the bot uses for trading and backtesting. Pairlist Handlers are executed in the sequence they are configured. You should always configure either `StaticPairList` or `VolumePairList` as the starting Pairlist Handler.
 
@@ -602,6 +602,7 @@ Inactive markets are always removed from the resulting pairlist. Explicitly blac
 
 * [`StaticPairList`](#static-pair-list) (default, if not configured differently)
 * [`VolumePairList`](#volume-pair-list)
+* [`AgeFilter`](#agefilter)
 * [`PrecisionFilter`](#precisionfilter)
 * [`PriceFilter`](#pricefilter)
 * [`ShuffleFilter`](#shufflefilter)
@@ -644,6 +645,16 @@ The `refresh_period` setting allows to define the period (in seconds), at which 
         "refresh_period": 1800,
 }],
 ```
+
+#### AgeFilter
+
+Removes pairs that have been listed on the exchange for less than `min_days_listed` days (defaults to `10`).
+
+When pairs are first listed on an exchange they can suffer huge price drops and volatility
+in the first few days while the pair goes through its price-discovery period. Bots can often
+be caught out buying before the pair has finished dropping in price.
+
+This filter allows freqtrade to ignore pairs until they have been listed for at least `min_days_listed` days.
 
 #### PrecisionFilter
 
@@ -692,6 +703,7 @@ The below example blacklists `BNB/BTC`, uses `VolumePairList` with `20` assets, 
         "number_assets": 20,
         "sort_key": "quoteVolume",
     },
+    {"method": "AgeFilter", "min_days_listed": 10},
     {"method": "PrecisionFilter"},
     {"method": "PriceFilter", "low_price_ratio": 0.01},
     {"method": "SpreadFilter", "max_spread_ratio": 0.005},

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -22,7 +22,8 @@ ORDERBOOK_SIDES = ['ask', 'bid']
 ORDERTYPE_POSSIBILITIES = ['limit', 'market']
 ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
-                       'PrecisionFilter', 'PriceFilter', 'ShuffleFilter', 'SpreadFilter']
+                       'AgeFilter', 'PrecisionFilter', 'PriceFilter',
+                       'ShuffleFilter', 'SpreadFilter']
 AVAILABLE_DATAHANDLERS = ['json', 'jsongz']
 DRY_RUN_WALLET = 1000
 MATH_CLOSE_PREC = 1e-14  # Precision used for float comparisons

--- a/freqtrade/pairlist/AgeFilter.py
+++ b/freqtrade/pairlist/AgeFilter.py
@@ -1,0 +1,76 @@
+"""
+Minimum age (days listed) pair list filter
+"""
+import logging
+import arrow
+from typing import Any, Dict
+
+from freqtrade.misc import plural
+from freqtrade.pairlist.IPairList import IPairList
+
+
+logger = logging.getLogger(__name__)
+
+
+class AgeFilter(IPairList):
+
+    # Checked symbols cache (dictionary of ticker symbol => timestamp)
+    _symbolsChecked: Dict[str, int] = {}
+
+    def __init__(self, exchange, pairlistmanager,
+                 config: Dict[str, Any], pairlistconfig: Dict[str, Any],
+                 pairlist_pos: int) -> None:
+        super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
+
+        self._min_days_listed = pairlistconfig.get('min_days_listed', 10)
+        self._enabled = self._min_days_listed >= 1
+
+    @property
+    def needstickers(self) -> bool:
+        """
+        Boolean property defining if tickers are necessary.
+        If no Pairlist requires tickers, an empty List is passed
+        as tickers argument to filter_pairlist
+        """
+        return True
+
+    def short_desc(self) -> str:
+        """
+        Short whitelist method description - used for startup-messages
+        """
+        return (f"{self.name} - Filtering pairs with age less than "
+                f"{self._min_days_listed} {plural(self._min_days_listed, 'day')}.")
+
+    def _validate_pair(self, ticker: dict) -> bool:
+        """
+        Validate age for the ticker
+        :param ticker: ticker dict as returned from ccxt.load_markets()
+        :return: True if the pair can stay, False if it should be removed
+        """
+
+        # Check symbol in cache
+        if ticker['symbol'] in self._symbolsChecked:
+            return True
+
+        since_ms = int(arrow.utcnow()
+                       .floor('day')
+                       .shift(days=-self._min_days_listed)
+                       .float_timestamp) * 1000
+
+        daily_candles = self._exchange.get_historic_ohlcv(pair=ticker['symbol'],
+                                                          timeframe='1d',
+                                                          since_ms=since_ms)
+
+        if daily_candles is not None:
+            if len(daily_candles) > self._min_days_listed:
+                # We have fetched at least the minimum required number of daily candles
+                # Add to cache, store the time we last checked this symbol
+                self._symbolsChecked[ticker['symbol']] = int(arrow.utcnow().float_timestamp) * 1000
+                return True
+            else:
+                self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                                 f"because age is less than "
+                                                 f"{self._min_days_listed} "
+                                                 f"{plural(self._min_days_listed, 'day')}")
+                return False
+        return False

--- a/freqtrade/pairlist/IPairList.py
+++ b/freqtrade/pairlist/IPairList.py
@@ -68,7 +68,7 @@ class IPairList(ABC):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
 

--- a/freqtrade/pairlist/PrecisionFilter.py
+++ b/freqtrade/pairlist/PrecisionFilter.py
@@ -27,7 +27,7 @@ class PrecisionFilter(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return True

--- a/freqtrade/pairlist/PriceFilter.py
+++ b/freqtrade/pairlist/PriceFilter.py
@@ -24,7 +24,7 @@ class PriceFilter(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return True

--- a/freqtrade/pairlist/ShuffleFilter.py
+++ b/freqtrade/pairlist/ShuffleFilter.py
@@ -25,7 +25,7 @@ class ShuffleFilter(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return False

--- a/freqtrade/pairlist/SpreadFilter.py
+++ b/freqtrade/pairlist/SpreadFilter.py
@@ -24,7 +24,7 @@ class SpreadFilter(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return True

--- a/freqtrade/pairlist/StaticPairList.py
+++ b/freqtrade/pairlist/StaticPairList.py
@@ -28,7 +28,7 @@ class StaticPairList(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return False

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -54,7 +54,7 @@ class VolumePairList(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requries tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty List is passed
         as tickers argument to filter_pairlist
         """
         return True


### PR DESCRIPTION
## Summary
Adds a new pairslist filter called AgeFilter.

## Quick changelog
- Fixed a few typos in comments
- Added AgeFilter (with tests)

## What's new?
AgeFilter checks that each pair has been listed on the exchange for a minimum number of days. It does this by requesting daily candles, once a pair has passed this check it is cached, so no further candle requests will be made. Pairs under the required age will still be checked until they also eventually pass the required age threshold.