### PR TITLE
Add missing data fillup to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,6 +49,16 @@ You can use the `/forcesell all` command from Telegram.
 
 Please look at the [advanced setup documentation Page](advanced-setup.md#running-multiple-instances-of-freqtrade).
 
+### I'm getting "Missing data fillup" messages in the log
+
+This message is just a warning that the latest candles had missing candles in them.
+Depending on the exchange, this can indicate that the pair didn't have a trade for `<yourtimeframe>` - and the exchange does only return candles with volume.
+On low volume pairs, this is a rather common occurance.
+
+If this happens for all pairs in the pairlist, this might indicate a recent exchange downtime. Please check your exchange's public channels for details.
+
+Independently of the reason, Freqtrade will fill up these candles with "empty" candles, where open, high, low and close are set to the previous candle close - and volume is empty. In a chart, this will look like a `_` - and is aligned with how exchanges usually represent 0 volume candles.
+
 ### I'm getting the "RESTRICTED_MARKET" message in the log
 
 Currently known to happen for US Bittrex users.  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,12 +52,12 @@ Please look at the [advanced setup documentation Page](advanced-setup.md#running
 ### I'm getting "Missing data fillup" messages in the log
 
 This message is just a warning that the latest candles had missing candles in them.
-Depending on the exchange, this can indicate that the pair didn't have a trade for `<yourtimeframe>` - and the exchange does only return candles with volume.
+Depending on the exchange, this can indicate that the pair didn't have a trade for the timeframe you are using - and the exchange does only return candles with volume.
 On low volume pairs, this is a rather common occurance.
 
 If this happens for all pairs in the pairlist, this might indicate a recent exchange downtime. Please check your exchange's public channels for details.
 
-Independently of the reason, Freqtrade will fill up these candles with "empty" candles, where open, high, low and close are set to the previous candle close - and volume is empty. In a chart, this will look like a `_` - and is aligned with how exchanges usually represent 0 volume candles.
+Irrespectively of the reason, Freqtrade will fill up these candles with "empty" candles, where open, high, low and close are set to the previous candle close - and volume is empty. In a chart, this will look like a `_` - and is aligned with how exchanges usually represent 0 volume candles.
 
 ### I'm getting the "RESTRICTED_MARKET" message in the log
 


### PR DESCRIPTION
## Summary
Since this seems to be a common point of confusion - the FAQ now contains a "missing data fillup" section.