### PR TITLE
Warning message bot is stopped and left open trades

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -177,7 +177,7 @@ class FreqtradeBot:
 
     def check_for_open_trades(self):
         """
-        Notify the user when he stops the bot
+        Notify the user when the bot is stopped
         and there are still open trades active.
         """
         open_trades = Trade.get_trades([Trade.is_open == True,
@@ -186,9 +186,10 @@ class FreqtradeBot:
         if len(open_trades) is not 0:
             msg = {
                 f'type': RPCMessageType.WARNING_NOTIFICATION,
-                f'status': f'{len(open_trades)} OPEN TRADES ACTIVE\n\n'
-                           f'Handle these trades manually or \'/start\' the bot again '
-                           f'and use \'/stopbuy\' to handle open trades gracefully.'
+                f'status': f'{len(open_trades)} open trades active.\n\n'
+                           f'Handle these trades manually on {self.exchange.name}, '
+                           f'or \'/start\' the bot again and use \'/stopbuy\' '
+                           f'to handle open trades gracefully.'
             }
             self.rpc.send_msg(msg)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -119,6 +119,8 @@ class FreqtradeBot:
         if self.config['cancel_open_orders_on_exit']:
             self.cancel_all_open_orders()
 
+        self.check_for_open_trades()
+
         self.rpc.cleanup()
         persistence.cleanup()
 
@@ -185,10 +187,11 @@ class FreqtradeBot:
         if len(open_trades) != 0:
             msg = {
                 'type': RPCMessageType.WARNING_NOTIFICATION,
-                'status':  f'{len(open_trades)} open trades active.\n\n'
-                           f'Handle these trades manually on {self.exchange.name}, '
-                           f'or \'/start\' the bot again and use \'/stopbuy\' '
-                           f'to handle open trades gracefully.',
+                'status':  f"{len(open_trades)} open trades active.\n\n"
+                           f"Handle these trades manually on {self.exchange.name}, "
+                           f"or '/start' the bot again and use '/stopbuy' "
+                           f"to handle open trades gracefully. \n"
+                           f"{'Trades are simulated.' if self.config['dry_run'] else ''}",
             }
             self.rpc.send_msg(msg)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -176,6 +176,10 @@ class FreqtradeBot:
             self.cancel_all_open_orders()
 
     def check_for_open_trades(self):
+        """
+        Notify the user when he stops the bot
+        and there are still open trades active.
+        """
         open_trades = Trade.get_trades([Trade.is_open == True,
                                    ]).all()
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -180,16 +180,16 @@ class FreqtradeBot:
         Notify the user when the bot is stopped
         and there are still open trades active.
         """
-        open_trades = Trade.get_trades([Trade.is_open == True,
-                                   ]).all()
+        open_trades = Trade.get_trades([Trade.is_open == 1,
+                                       ]).all()
 
-        if len(open_trades) is not 0:
+        if len(open_trades) != 0:
             msg = {
-                f'type': RPCMessageType.WARNING_NOTIFICATION,
-                f'status': f'{len(open_trades)} open trades active.\n\n'
+                'type': RPCMessageType.WARNING_NOTIFICATION,
+                'status':  f'{len(open_trades)} open trades active.\n\n'
                            f'Handle these trades manually on {self.exchange.name}, '
                            f'or \'/start\' the bot again and use \'/stopbuy\' '
-                           f'to handle open trades gracefully.'
+                           f'to handle open trades gracefully.',
             }
             self.rpc.send_msg(msg)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -180,8 +180,7 @@ class FreqtradeBot:
         Notify the user when the bot is stopped
         and there are still open trades active.
         """
-        open_trades = Trade.get_trades([Trade.is_open == 1,
-                                       ]).all()
+        open_trades = Trade.get_trades([Trade.is_open == 1]).all()
 
         if len(open_trades) != 0:
             msg = {

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -175,6 +175,19 @@ class FreqtradeBot:
         if self.config['cancel_open_orders_on_exit']:
             self.cancel_all_open_orders()
 
+    def check_for_open_trades(self):
+        open_trades = Trade.get_trades([Trade.is_open == True,
+                                   ]).all()
+
+        if len(open_trades) is not 0:
+            msg = {
+                f'type': RPCMessageType.WARNING_NOTIFICATION,
+                f'status': f'{len(open_trades)} OPEN TRADES ACTIVE\n\n'
+                           f'Handle these trades manually or \'/start\' the bot again '
+                           f'and use \'/stopbuy\' to handle open trades gracefully.'
+            }
+            self.rpc.send_msg(msg)
+
     def _refresh_active_whitelist(self, trades: List[Trade] = []) -> List[str]:
         """
         Refresh active whitelist from pairlist or edge and extend it with

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -90,6 +90,9 @@ class Worker:
             if state == State.RUNNING:
                 self.freqtrade.startup()
 
+            if state == State.STOPPED:
+                self.freqtrade.check_for_open_trades()
+
             # Reset heartbeat timestamp to log the heartbeat message at
             # first throttling iteration when the state changes
             self._heartbeat_msg = 0


### PR DESCRIPTION
## Summary
When the bot is stopped while there are still open trades, the user gets a notification about this. Just to make sure he's aware of this.

## Quick changelog

- Added the warning message  

## What's new?
When the bots state changes to `stopped` and there are open trades, the user will get a notification on Telegram with how many open trades there are, and instructions on what to do if he didn't know this or didn't want this (the /stopbuy). See screenshot below.

![left open trades](https://user-images.githubusercontent.com/24569139/85929416-d4152100-b8b4-11ea-9ea8-a7757f43b953.png)

