### PR TITLE
Adding a dataprovider to the strategy before plotting

### DIFF
--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -15,6 +15,7 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_prev_date
 from freqtrade.misc import pair_to_filename
 from freqtrade.resolvers import StrategyResolver
+from freqtrade.data.dataprovider import DataProvider
 
 logger = logging.getLogger(__name__)
 
@@ -474,6 +475,7 @@ def load_and_plot_trades(config: Dict[str, Any]):
         pair_counter += 1
         logger.info("analyse pair %s", pair)
 
+        strategy.dp = DataProvider(config, config["exchange"])
         df_analyzed = strategy.analyze_ticker(data, {'pair': pair})
         trades_pair = trades.loc[trades['pair'] == pair]
         trades_pair = extract_trades_of_period(df_analyzed, trades_pair)

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -10,12 +10,13 @@ from freqtrade.data.btanalysis import (calculate_max_drawdown,
                                        create_cum_profit,
                                        extract_trades_of_period, load_trades)
 from freqtrade.data.converter import trim_dataframe
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import load_data
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_prev_date
 from freqtrade.misc import pair_to_filename
-from freqtrade.resolvers import StrategyResolver
-from freqtrade.data.dataprovider import DataProvider
+from freqtrade.resolvers import ExchangeResolver, StrategyResolver
+from freqtrade.strategy import IStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -468,6 +469,8 @@ def load_and_plot_trades(config: Dict[str, Any]):
     """
     strategy = StrategyResolver.load_strategy(config)
 
+    exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config)
+    IStrategy.dp = DataProvider(config, exchange)
     plot_elements = init_plotscript(config)
     trades = plot_elements['trades']
     pair_counter = 0
@@ -475,7 +478,6 @@ def load_and_plot_trades(config: Dict[str, Any]):
         pair_counter += 1
         logger.info("analyse pair %s", pair)
 
-        strategy.dp = DataProvider(config, config["exchange"])
         df_analyzed = strategy.analyze_ticker(data, {'pair': pair})
         trades_pair = trades.loc[trades['pair'] == pair]
         trades_pair = extract_trades_of_period(df_analyzed, trades_pair)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -21,7 +21,7 @@ from freqtrade.plot.plotting import (add_indicators, add_profit,
                                      load_and_plot_trades, plot_profit,
                                      plot_trades, store_plot_file)
 from freqtrade.resolvers import StrategyResolver
-from tests.conftest import get_args, log_has, log_has_re
+from tests.conftest import get_args, log_has, log_has_re, patch_exchange
 
 
 def fig_generating_mock(fig, *args, **kwargs):
@@ -316,6 +316,8 @@ def test_start_plot_dataframe(mocker):
 
 
 def test_load_and_plot_trades(default_conf, mocker, caplog, testdatadir):
+    patch_exchange(mocker)
+
     default_conf['trade_source'] = 'file'
     default_conf["datadir"] = testdatadir
     default_conf['exportfilename'] = testdatadir / "backtest-result_test.json"


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Fixes #3544 

## Quick changelog

- adding a DataProvider before plotting the strategy

## What's new?
*We can now plot dataframes that makes use historical data coming from other pairs or other interval* 
