### PR TITLE
Added range checks to min_days_listed in AgeFilter

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -66,7 +66,7 @@
         },
         {"method": "AgeFilter", "min_days_listed": 10},
         {"method": "PrecisionFilter"},
-        {"method": "PriceFilter", "low_price_ratio": 0.01},
+        {"method": "PriceFilter", "low_price_ratio": 0.01, "min_price": 0.00000010},
         {"method": "SpreadFilter", "max_spread_ratio": 0.005}
     ],
     "exchange": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,16 +662,25 @@ Filters low-value coins which would not allow setting stoplosses.
 
 #### PriceFilter
 
-The `PriceFilter` allows filtering of pairs by price.
+The `PriceFilter` allows filtering of pairs by price. Currently the following price filters are supported:
+* `min_price`
+* `max_price`
+* `low_price_ratio`
 
-Currently, only `low_price_ratio` setting is implemented, where a raise of 1 price unit (pip) is below the `low_price_ratio` ratio.
+The `min_price` setting removes pairs where the price is below the specified price. This is useful if you wish to avoid trading very low-priced pairs.
+This option is disabled by default, and will only apply if set to <> 0.
+
+The `max_price` setting removes pairs where the price is above the specified price. This is useful if you wish to trade only low-priced pairs.
+This option is disabled by default, and will only apply if set to <> 0.
+
+The `low_price_ratio` setting removes pairs where a raise of 1 price unit (pip) is above the `low_price_ratio` ratio.
 This option is disabled by default, and will only apply if set to <> 0.
 
 Calculation example:
 
 Min price precision is 8 decimals. If price is 0.00000011 - one step would be 0.00000012 - which is almost 10% higher than the previous value.
 
-These pairs are dangerous since it may be impossible to place the desired stoploss - and often result in high losses. Here is what the PriceFilters takes over.
+These pairs are dangerous since it may be impossible to place the desired stoploss - and often result in high losses.
 
 #### ShuffleFilter
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -188,6 +188,11 @@ class Exchange:
         return list((self._api.timeframes or {}).keys())
 
     @property
+    def ohlcv_candle_limit(self) -> int:
+        """exchange ohlcv candle limit"""
+        return int(self._ohlcv_candle_limit)
+
+    @property
     def markets(self) -> Dict:
         """exchange ccxt markets"""
         if not self._api.markets:

--- a/freqtrade/pairlist/AgeFilter.py
+++ b/freqtrade/pairlist/AgeFilter.py
@@ -5,6 +5,7 @@ import logging
 import arrow
 from typing import Any, Dict
 
+from freqtrade.exceptions import OperationalException
 from freqtrade.misc import plural
 from freqtrade.pairlist.IPairList import IPairList
 
@@ -25,14 +26,11 @@ class AgeFilter(IPairList):
         self._min_days_listed = pairlistconfig.get('min_days_listed', 10)
 
         if self._min_days_listed < 1:
-            self.log_on_refresh(logger.info, "min_days_listed must be >= 1, "
-                                             "ignoring filter")
+            raise OperationalException("AgeFilter requires min_days_listed must be >= 1")
         if self._min_days_listed > exchange.ohlcv_candle_limit:
-            self._min_days_listed = min(self._min_days_listed, exchange.ohlcv_candle_limit)
-            self.log_on_refresh(logger.info, "min_days_listed exceeds "
-                                             "exchange max request size "
-                                             f"({exchange.ohlcv_candle_limit}), using "
-                                             f"min_days_listed={self._min_days_listed}")
+            raise OperationalException("AgeFilter requires min_days_listed must not exceed "
+                                       "exchange max request size "
+                                       f"({exchange.ohlcv_candle_limit})")
         self._enabled = self._min_days_listed >= 1
 
     @property

--- a/freqtrade/pairlist/AgeFilter.py
+++ b/freqtrade/pairlist/AgeFilter.py
@@ -23,6 +23,16 @@ class AgeFilter(IPairList):
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
         self._min_days_listed = pairlistconfig.get('min_days_listed', 10)
+
+        if self._min_days_listed < 1:
+            self.log_on_refresh(logger.info, "min_days_listed must be >= 1, "
+                                             "ignoring filter")
+        if self._min_days_listed > exchange.ohlcv_candle_limit:
+            self._min_days_listed = min(self._min_days_listed, exchange.ohlcv_candle_limit)
+            self.log_on_refresh(logger.info, "min_days_listed exceeds "
+                                             "exchange max request size "
+                                             f"({exchange.ohlcv_candle_limit}), using "
+                                             f"min_days_listed={self._min_days_listed}")
         self._enabled = self._min_days_listed >= 1
 
     @property

--- a/freqtrade/pairlist/PriceFilter.py
+++ b/freqtrade/pairlist/PriceFilter.py
@@ -20,9 +20,9 @@ class PriceFilter(IPairList):
         self._low_price_ratio = pairlistconfig.get('low_price_ratio', 0)
         self._min_price = pairlistconfig.get('min_price', 0)
         self._max_price = pairlistconfig.get('max_price', 0)
-        self._enabled = (self._low_price_ratio != 0) or \
-                        (self._min_price != 0) or \
-                        (self._max_price != 0)
+        self._enabled = ((self._low_price_ratio != 0) or
+                         (self._min_price != 0) or
+                         (self._max_price != 0))
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/pairlist/PriceFilter.py
+++ b/freqtrade/pairlist/PriceFilter.py
@@ -18,7 +18,11 @@ class PriceFilter(IPairList):
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
         self._low_price_ratio = pairlistconfig.get('low_price_ratio', 0)
-        self._enabled = self._low_price_ratio != 0
+        self._min_price = pairlistconfig.get('min_price', 0)
+        self._max_price = pairlistconfig.get('max_price', 0)
+        self._enabled = (self._low_price_ratio != 0) or \
+                        (self._min_price != 0) or \
+                        (self._max_price != 0)
 
     @property
     def needstickers(self) -> bool:
@@ -33,7 +37,18 @@ class PriceFilter(IPairList):
         """
         Short whitelist method description - used for startup-messages
         """
-        return f"{self.name} - Filtering pairs priced below {self._low_price_ratio * 100}%."
+        active_price_filters = []
+        if self._low_price_ratio != 0:
+            active_price_filters.append(f"below {self._low_price_ratio * 100}%")
+        if self._min_price != 0:
+            active_price_filters.append(f"below {self._min_price:.8f}")
+        if self._max_price != 0:
+            active_price_filters.append(f"above {self._max_price:.8f}")
+
+        if len(active_price_filters):
+            return f"{self.name} - Filtering pairs priced {' or '.join(active_price_filters)}."
+
+        return f"{self.name} - No price filters configured."
 
     def _validate_pair(self, ticker) -> bool:
         """
@@ -46,10 +61,28 @@ class PriceFilter(IPairList):
                                 f"Removed {ticker['symbol']} from whitelist, because "
                                 "ticker['last'] is empty (Usually no trade in the last 24h).")
             return False
-        compare = self._exchange.price_get_one_pip(ticker['symbol'], ticker['last'])
-        changeperc = compare / ticker['last']
-        if changeperc > self._low_price_ratio:
-            self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
-                                             f"because 1 unit is {changeperc * 100:.3f}%")
-            return False
+
+        # Perform low_price_ratio check.
+        if self._low_price_ratio != 0:
+            compare = self._exchange.price_get_one_pip(ticker['symbol'], ticker['last'])
+            changeperc = compare / ticker['last']
+            if changeperc > self._low_price_ratio:
+                self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                                 f"because 1 unit is {changeperc * 100:.3f}%")
+                return False
+
+        # Perform min_price check.
+        if self._min_price != 0:
+            if ticker['last'] < self._min_price:
+                self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                                 f"because last price < {self._min_price:.8f}")
+                return False
+
+        # Perform max_price check.
+        if self._max_price != 0:
+            if ticker['last'] > self._max_price:
+                self.log_on_refresh(logger.info, f"Removed {ticker['symbol']} from whitelist, "
+                                                 f"because last price > {self._max_price:.8f}")
+                return False
+
         return True

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -524,7 +524,7 @@ def test_volumepairlist_caching(mocker, markets, whitelist_conf, tickers):
     assert freqtrade.pairlists._pairlist_handlers[0]._last_refresh == lrf
 
 
-def test_agefilter_min_days_listed_too_small(mocker, default_conf, markets, tickers, caplog) -> None:
+def test_agefilter_min_days_listed_too_small(mocker, default_conf, markets, tickers, caplog):
     default_conf['pairlists'] = [{'method': 'VolumePairList', 'number_assets': 10},
                                  {'method': 'AgeFilter', 'min_days_listed': -1}]
 
@@ -540,7 +540,7 @@ def test_agefilter_min_days_listed_too_small(mocker, default_conf, markets, tick
                       r'ignoring filter', caplog)
 
 
-def test_agefilter_min_days_listed_too_large(mocker, default_conf, markets, tickers, caplog) -> None:
+def test_agefilter_min_days_listed_too_large(mocker, default_conf, markets, tickers, caplog):
     default_conf['pairlists'] = [{'method': 'VolumePairList', 'number_assets': 10},
                                  {'method': 'AgeFilter', 'min_days_listed': 99999}]
 

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -543,10 +543,9 @@ def test_agefilter_min_days_listed_too_small(mocker, default_conf, markets, tick
                           get_tickers=tickers
                           )
 
-    get_patched_freqtradebot(mocker, default_conf)
-
-    assert log_has_re(r'min_days_listed must be >= 1, '
-                      r'ignoring filter', caplog)
+    with pytest.raises(OperationalException,
+                       match=r'AgeFilter requires min_days_listed must be >= 1'):
+        get_patched_freqtradebot(mocker, default_conf)
 
 
 def test_agefilter_min_days_listed_too_large(mocker, default_conf, markets, tickers, caplog):
@@ -559,10 +558,10 @@ def test_agefilter_min_days_listed_too_large(mocker, default_conf, markets, tick
                           get_tickers=tickers
                           )
 
-    get_patched_freqtradebot(mocker, default_conf)
-
-    assert log_has_re(r'^min_days_listed exceeds '
-                      r'exchange max request size', caplog)
+    with pytest.raises(OperationalException,
+                       match=r'AgeFilter requires min_days_listed must not exceed '
+                             r'exchange max request size \([0-9]+\)'):
+        get_patched_freqtradebot(mocker, default_conf)
 
 
 def test_agefilter_caching(mocker, markets, whitelist_conf_3, tickers, ohlcv_history_list):


### PR DESCRIPTION
## Summary
Adds range checks to min_days_listed in AgeFilter, logs messages if too low/high.

## Quick changelog
- Added range checks to min_days_listed in AgeFilter.
- Added tests for above.

## What's new?
Using min_days_listed < 1 will cause AgeFilter to be ignored.
Using min_days_listed > exchange's ohlcv_candle_limit will cap min_days_listed to this value.