### PR TITLE
removed duplicate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,7 @@ the static list of pairs) if we should buy.
 The `order_types` configuration parameter maps actions (`buy`, `sell`, `stoploss`, `emergencysell`) to order-types (`market`, `limit`, ...) as well as configures stoploss to be on the exchange and defines stoploss on exchange update interval in seconds.
 
 This allows to buy using limit orders, sell using
-limit-orders, and create stoplosses using using market orders. It also allows to set the
+limit-orders, and create stoplosses using market orders. It also allows to set the
 stoploss "on exchange" which means stoploss order would be placed immediately once
 the buy order is fulfilled.
 If `stoploss_on_exchange` and `trailing_stop` are both set, then the bot will use `stoploss_on_exchange_interval` to check and update the stoploss on exchange periodically.


### PR DESCRIPTION
removed duplicate word using using

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR
Word using is typed twice... Visual aesthetic correction.

Solve the issue: # none

## Quick changelog

- <change log #1> Removed duplicate wording

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
Remove duplicate wording in the documentation