### PR TITLE
[minor] Send timeframe min and ms in show_config response

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -12,6 +12,8 @@ import arrow
 from numpy import NAN, mean
 
 from freqtrade.exceptions import ExchangeError, PricingError
+
+from freqtrade.exchange import timeframe_to_msecs, timeframe_to_minutes
 from freqtrade.misc import shorten_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
@@ -103,6 +105,8 @@ class RPC:
             'trailing_only_offset_is_reached': config.get('trailing_only_offset_is_reached'),
             'ticker_interval': config['timeframe'],  # DEPRECATED
             'timeframe': config['timeframe'],
+            'timeframe_ms': timeframe_to_msecs(config['timeframe']),
+            'timeframe_min': timeframe_to_minutes(config['timeframe']),
             'exchange': config['exchange']['name'],
             'strategy': config['strategy'],
             'forcebuy_enabled': config.get('forcebuy_enable', False),

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -326,6 +326,8 @@ def test_api_show_config(botclient, mocker):
     assert rc.json['exchange'] == 'bittrex'
     assert rc.json['ticker_interval'] == '5m'
     assert rc.json['timeframe'] == '5m'
+    assert rc.json['timeframe_ms'] == 300000
+    assert rc.json['timeframe_min'] == 5
     assert rc.json['state'] == 'running'
     assert not rc.json['trailing_stop']
     assert 'bid_strategy' in rc.json


### PR DESCRIPTION
## Summary
Api response for /show_config will now contain timeframe_ms and timeframe_min.
Usefull for a UI (if calculations based on timeframes are necessary).



## Quick changelog

- add new fields timeframe_ms and timeframe_min to show_config response. (no change to telegram).