### PR TITLE
Allow 0 fee value by correctly checking for None

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -101,7 +101,7 @@ class Backtesting:
         if len(self.pairlists.whitelist) == 0:
             raise OperationalException("No pair in whitelist.")
 
-        if config.get('fee'):
+        if config.get('fee', None) is not None:
             self.fee = config['fee']
         else:
             self.fee = self.exchange.get_fee(symbol=self.pairlists.whitelist[0])

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -308,6 +308,11 @@ def test_data_with_fee(default_conf, mocker, testdatadir) -> None:
     assert backtesting.fee == 0.1234
     assert fee_mock.call_count == 0
 
+    default_conf['fee'] = 0.0
+    backtesting = Backtesting(default_conf)
+    assert backtesting.fee == 0.0
+    assert fee_mock.call_count == 0
+
 
 def test_data_to_dataframe_bt(default_conf, mocker, testdatadir) -> None:
     patch_exchange(mocker)


### PR DESCRIPTION
## Summary
Fees of 0.0 (or 0) sholuld also be allowed, since some exchanges allow free trades (and it can be useful for testing, eventually).

closes #3594
