### PR TITLE
[minor] Reduce severity of hyperopt "does not provide" messages

### DIFF
--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -42,14 +42,14 @@ class HyperOptResolver(IResolver):
                                                 extra_dir=config.get('hyperopt_path'))
 
         if not hasattr(hyperopt, 'populate_indicators'):
-            logger.warning("Hyperopt class does not provide populate_indicators() method. "
-                           "Using populate_indicators from the strategy.")
+            logger.info("Hyperopt class does not provide populate_indicators() method. "
+                        "Using populate_indicators from the strategy.")
         if not hasattr(hyperopt, 'populate_buy_trend'):
-            logger.warning("Hyperopt class does not provide populate_buy_trend() method. "
-                           "Using populate_buy_trend from the strategy.")
+            logger.info("Hyperopt class does not provide populate_buy_trend() method. "
+                        "Using populate_buy_trend from the strategy.")
         if not hasattr(hyperopt, 'populate_sell_trend'):
-            logger.warning("Hyperopt class does not provide populate_sell_trend() method. "
-                           "Using populate_sell_trend from the strategy.")
+            logger.info("Hyperopt class does not provide populate_sell_trend() method. "
+                        "Using populate_sell_trend from the strategy.")
         return hyperopt
 
 


### PR DESCRIPTION

## Summary
Reduce severity of hyperopt "does not provide" messages
They're not really warnings, as it's most of the time preferred to have the populate* methods in the strategy, not in the hyeropt file.
We do however need the message to help debug problems with this - as otherwise typos can become undebuggable.

closes #3371
