### PR TITLE
Logging endpoints

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -116,6 +116,7 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `trades` | List last trades.
 | `delete_trade <trade_id>` | Remove trade from the database. Tries to close open orders. Requires manual handling of this trade on the exchange.
 | `show_config` | Shows part of the current configuration with relevant settings to operation
+| `logs` | Shows last log messages
 | `status` | Lists all open trades
 | `count` | Displays number of trades used and available
 | `profit` | Display a summary of your profit/loss from close trades and some stats about your performance
@@ -138,78 +139,83 @@ python3 scripts/rest_client.py help
 
 ``` output
 Possible commands:
+
 balance
-        Get the account balance
-        :returns: json object
+	Get the account balance.
 
 blacklist
-        Show the current blacklist
+	Show the current blacklist.
+
         :param add: List of coins to add (example: "BNB/BTC")
-        :returns: json object
 
 count
-        Returns the amount of open trades
-        :returns: json object
+	Return the amount of open trades.
 
 daily
-        Returns the amount of open trades
-        :returns: json object
+	Return the amount of open trades.
+
+delete_trade
+	Delete trade from the database.
+        Tries to close open orders. Requires manual handling of this asset on the exchange.
+
+        :param trade_id: Deletes the trade with this ID from the database.
 
 edge
-        Returns information about edge
-        :returns: json object
+	Return information about edge.
 
 forcebuy
-        Buy an asset
+	Buy an asset.
+
         :param pair: Pair to buy (ETH/BTC)
         :param price: Optional - price to buy
-        :returns: json object of the trade
 
 forcesell
-        Force-sell a trade
+	Force-sell a trade.
+
         :param tradeid: Id of the trade (can be received via status command)
-        :returns: json object
+
+logs
+	Show latest logs.
+
+        :param limit: Limits log messages to the last <limit> logs. No limit to get all the trades.
 
 performance
-        Returns the performance of the different coins
-        :returns: json object
+	Return the performance of the different coins.
 
 profit
-        Returns the profit summary
-        :returns: json object
+	Return the profit summary.
 
 reload_config
-        Reload configuration
-        :returns: json object
+	Reload configuration.
 
 show_config
+	
         Returns part of the configuration, relevant for trading operations.
-        :return: json object containing the version
 
 start
-        Start the bot if it's in stopped state.
-        :returns: json object
+	Start the bot if it's in the stopped state.
 
 status
-        Get the status of open trades
-        :returns: json object
+	Get the status of open trades.
 
 stop
-        Stop the bot. Use start to restart
-        :returns: json object
+	Stop the bot. Use `start` to restart.
 
 stopbuy
-        Stop buying (but handle sells gracefully).
-        use reload_config to reset
-        :returns: json object
+	Stop buying (but handle sells gracefully). Use `reload_config` to reset.
+
+trades
+	Return trades history.
+
+        :param limit: Limits trades to the X last trades. No limit to get all the trades.
 
 version
-        Returns the version of the bot
-        :returns: json object containing the version
+	Return the version of the bot.
 
 whitelist
-        Show the current whitelist
-        :returns: json object
+	Show the current whitelist.
+
+
 ```
 
 ## Advanced API usage using JWT tokens

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -54,6 +54,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/stopbuy` | Stops the trader from opening new trades. Gracefully closes open trades according to their rules.
 | `/reload_config` | Reloads the configuration file
 | `/show_config` | Shows part of the current configuration with relevant settings to operation
+| `/logs [limit]` | Show last log messages.
 | `/status` | Lists all open trades
 | `/status table` | List all open trades in a table format. Pending buy orders are marked with an asterisk (*) Pending sell orders are marked with a double asterisk (**)
 | `/trades [limit]` | List all recently closed trades in a table format.

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -41,13 +41,14 @@ def setup_logging_pre() -> None:
     """
     Early setup for logging.
     Uses INFO loglevel and only the Streamhandler.
-    Early messages (before proper logging setup) will therefore only be available
-    after the proper logging setup.
+    Early messages (before proper logging setup) will therefore only be sent to additional
+    logging handlers after the real initialization, because we don't know which
+    ones the user desires beforehand.
     """
     logging.basicConfig(
         level=logging.INFO,
         format=LOGFORMAT,
-        handlers=[logging.StreamHandler(sys.stderr)]
+        handlers=[logging.StreamHandler(sys.stderr), bufferHandler]
     )
 
 

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -1,5 +1,4 @@
 import logging
-import queue
 import sys
 from logging import Formatter
 from logging.handlers import (BufferingHandler, RotatingFileHandler,
@@ -9,7 +8,6 @@ from typing import Any, Dict
 from freqtrade.exceptions import OperationalException
 
 logger = logging.getLogger(__name__)
-log_queue = queue.Queue(-1)
 LOGFORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
 # Initialize bufferhandler - will be used for /log endpoints
@@ -41,9 +39,10 @@ def _set_loggers(verbosity: int = 0, api_verbosity: str = 'info') -> None:
 
 def setup_logging_pre() -> None:
     """
-    Setup early logging.
-    This uses a queuehandler, which delays logging.
-    # TODO: How does QueueHandler work if no listenerhandler is attached??
+    Early setup for logging.
+    Uses INFO loglevel and only the Streamhandler.
+    Early messages (before proper logging setup) will therefore only be available
+    after the proper logging setup.
     """
     logging.basicConfig(
         level=logging.INFO,

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -82,18 +82,18 @@ def setup_logging(config: Dict[str, Any]) -> None:
             except ImportError:
                 raise OperationalException("You need the systemd python package be installed in "
                                            "order to use logging to journald.")
-            handler = JournaldLogHandler()
+            handler_jd = JournaldLogHandler()
             # No datetime field for logging into journald, to allow syslog
             # to perform reduction of repeating messages if this is set in the
             # syslog config. The messages should be equal for this.
-            handler.setFormatter(Formatter('%(name)s - %(levelname)s - %(message)s'))
-            logging.root.addHandler(handler)
+            handler_jd.setFormatter(Formatter('%(name)s - %(levelname)s - %(message)s'))
+            logging.root.addHandler(handler_jd)
         else:
-            handler = RotatingFileHandler(logfile,
-                                          maxBytes=1024 * 1024 * 10,  # 10Mb
-                                          backupCount=10)
-            handler.setFormatter(Formatter(LOGFORMAT))
-            logging.root.addHandler(handler)
+            handler_rf = RotatingFileHandler(logfile,
+                                             maxBytes=1024 * 1024 * 10,  # 10Mb
+                                             backupCount=10)
+            handler_rf.setFormatter(Formatter(LOGFORMAT))
+            logging.root.addHandler(handler_rf)
 
     logging.root.setLevel(logging.INFO if verbosity < 1 else logging.DEBUG)
     _set_loggers(verbosity, config.get('api_server', {}).get('verbosity', 'info'))

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -92,7 +92,7 @@ def setup_logging(config: Dict[str, Any]) -> None:
             logging.root.addHandler(handler)
         else:
             handler = RotatingFileHandler(logfile,
-                                          maxBytes=1024 * 1024,  # 1Mb
+                                          maxBytes=1024 * 1024 * 10,  # 10Mb
                                           backupCount=10)
             handler.setFormatter(Formatter(LOGFORMAT))
             logging.root.addHandler(handler)

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -48,6 +48,7 @@ def setup_logging_pre() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format=LOGFORMAT,
+        handlers=[logging.StreamHandler(sys.stderr)]
     )
 
 
@@ -60,8 +61,6 @@ def setup_logging(config: Dict[str, Any]) -> None:
     logging.root.addHandler(bufferHandler)
 
     logfile = config.get('logfile')
-
-    logging.root.addHandler(logging.StreamHandler(sys.stderr))
 
     if logfile:
         s = logfile.split(':')

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -1,7 +1,9 @@
 import logging
 import queue
+import sys
 from logging import Formatter
-from logging.handlers import RotatingFileHandler, SysLogHandler, BufferingHandler
+from logging.handlers import (BufferingHandler, RotatingFileHandler,
+                              SysLogHandler)
 from typing import Any, Dict
 
 from freqtrade.exceptions import OperationalException
@@ -58,6 +60,9 @@ def setup_logging(config: Dict[str, Any]) -> None:
     logging.root.addHandler(bufferHandler)
 
     logfile = config.get('logfile')
+
+    logging.root.addHandler(logging.StreamHandler(sys.stderr))
+
     if logfile:
         s = logfile.split(':')
         if s[0] == 'syslog':

--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -1,7 +1,7 @@
 import logging
 import queue
 from logging import Formatter
-from logging.handlers import RotatingFileHandler, SysLogHandler
+from logging.handlers import RotatingFileHandler, SysLogHandler, BufferingHandler
 from typing import Any, Dict
 
 from freqtrade.exceptions import OperationalException
@@ -9,6 +9,10 @@ from freqtrade.exceptions import OperationalException
 logger = logging.getLogger(__name__)
 log_queue = queue.Queue(-1)
 LOGFORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+# Initialize bufferhandler - will be used for /log endpoints
+bufferHandler = BufferingHandler(1000)
+bufferHandler.setFormatter(Formatter(LOGFORMAT))
 
 
 def _set_loggers(verbosity: int = 0, api_verbosity: str = 'info') -> None:
@@ -51,6 +55,7 @@ def setup_logging(config: Dict[str, Any]) -> None:
     """
     # Log level
     verbosity = config['verbosity']
+    logging.root.addHandler(bufferHandler)
 
     logfile = config.get('logfile')
     if logfile:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -3,7 +3,6 @@
 Main Freqtrade bot script.
 Read the documentation to know what cli arguments you need.
 """
-# flake8: noqa E402
 import logging
 import sys
 from typing import Any, List

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -3,18 +3,18 @@
 Main Freqtrade bot script.
 Read the documentation to know what cli arguments you need.
 """
-
-from freqtrade.exceptions import FreqtradeException, OperationalException
+# flake8: noqa E402
+import logging
 import sys
+from typing import Any, List
+
 # check min. python version
 if sys.version_info < (3, 6):
     sys.exit("Freqtrade requires Python version >= 3.6")
 
-# flake8: noqa E402
-import logging
-from typing import Any, List
-
 from freqtrade.commands import Arguments
+from freqtrade.exceptions import FreqtradeException, OperationalException
+from freqtrade.loggers import setup_logging_pre
 
 
 logger = logging.getLogger('freqtrade')
@@ -28,6 +28,7 @@ def main(sysargv: List[str] = None) -> None:
 
     return_code: Any = 1
     try:
+        setup_logging_pre()
         arguments = Arguments(sysargv)
         args = arguments.get_parsed_arg()
 

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -186,6 +186,7 @@ class ApiServer(RPC):
         self.app.add_url_rule(f'{BASE_URI}/count', 'count', view_func=self._count, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/daily', 'daily', view_func=self._daily, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/edge', 'edge', view_func=self._edge, methods=['GET'])
+        self.app.add_url_rule(f'{BASE_URI}/logs', 'log', view_func=self._get_logs, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/profit', 'profit',
                               view_func=self._profit, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/performance', 'performance',
@@ -347,6 +348,18 @@ class ApiServer(RPC):
                                        )
 
         return self.rest_dump(stats)
+
+    @require_login
+    @rpc_catch_errors
+    def _get_logs(self):
+        """
+        Returns latest logs
+         get:
+          param:
+            limit: Only get a certain number of records
+        """
+        limit = int(request.args.get('limit', 0)) or None
+        return self.rest_dump(self._rpc_get_logs(limit))
 
     @require_login
     @rpc_catch_errors

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -639,12 +639,13 @@ class RPC:
             buffer = bufferHandler.buffer[-limit:]
         else:
             buffer = bufferHandler.buffer
-        records = [[r.asctime, r.created, r.name, r.levelname, r.message] for r in buffer]
+        records = [[datetime.fromtimestamp(r.created), r.created, r.name, r.levelname, r.message]
+                   for r in buffer]
 
         return {'log_count': len(records), 'logs': records}
 
     def _rpc_get_logs_as_string(self, limit: Optional[int]) -> Dict[str, List]:
-        """Returns the last X logs"""
+        """Returns the last X logs as formatted string (Using the default log format)"""
         if limit:
             buffer = bufferHandler.buffer[-limit:]
         else:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -639,18 +639,11 @@ class RPC:
             buffer = bufferHandler.buffer[-limit:]
         else:
             buffer = bufferHandler.buffer
-        records = [[datetime.fromtimestamp(r.created), r.created, r.name, r.levelname, r.message]
+        records = [[datetime.fromtimestamp(r.created).strftime("%Y-%m-%d %H:%M:%S"),
+                   r.created, r.name, r.levelname, r.message]
                    for r in buffer]
 
         return {'log_count': len(records), 'logs': records}
-
-    def _rpc_get_logs_as_string(self, limit: Optional[int]) -> List[str]:
-        """Returns the last X logs as formatted string (Using the default log format)"""
-        if limit:
-            buffer = bufferHandler.buffer[-limit:]
-        else:
-            buffer = bufferHandler.buffer
-        return [bufferHandler.format(r) for r in buffer]
 
     def _rpc_edge(self) -> List[Dict[str, Any]]:
         """ Returns information related to Edge """

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -640,7 +640,8 @@ class RPC:
         else:
             buffer = bufferHandler.buffer
         records = [[datetime.fromtimestamp(r.created).strftime("%Y-%m-%d %H:%M:%S"),
-                   r.created, r.name, r.levelname, r.message]
+                   r.created, r.name, r.levelname,
+                   r.message + ('\n' + r.exc_text if r.exc_text else '')]
                    for r in buffer]
 
         return {'log_count': len(records), 'logs': records}

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -644,10 +644,10 @@ class RPC:
                    r.message + ('\n' + r.exc_text if r.exc_text else '')]
                    for r in buffer]
 
-        # Logs format:
+        # Log format:
         # [logtime-formatted, logepoch, logger-name, loglevel, message \n + exception]
         # e.g. ["2020-08-27 11:35:01", 1598520901097.9397,
-        # "freqtrade.worker", "INFO", "Starting worker develop"]
+        #       "freqtrade.worker", "INFO", "Starting worker develop"]
 
         return {'log_count': len(records), 'logs': records}
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -640,9 +640,14 @@ class RPC:
         else:
             buffer = bufferHandler.buffer
         records = [[datetime.fromtimestamp(r.created).strftime("%Y-%m-%d %H:%M:%S"),
-                   r.created, r.name, r.levelname,
+                   r.created * 1000, r.name, r.levelname,
                    r.message + ('\n' + r.exc_text if r.exc_text else '')]
                    for r in buffer]
+
+        # Logs format:
+        # [logtime-formatted, logepoch, logger-name, loglevel, message \n + exception]
+        # e.g. ["2020-08-27 11:35:01", 1598520901097.9397,
+        # "freqtrade.worker", "INFO", "Starting worker develop"]
 
         return {'log_count': len(records), 'logs': records}
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -11,9 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import arrow
 from numpy import NAN, mean
 
-from freqtrade.exceptions import (ExchangeError,
-                                  PricingError)
+from freqtrade.exceptions import ExchangeError, PricingError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_msecs
+from freqtrade.loggers import bufferHandler
 from freqtrade.misc import shorten_date
 from freqtrade.persistence import Trade
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
@@ -632,6 +632,24 @@ class RPC:
                'errors': errors,
                }
         return res
+
+    def _rpc_get_logs(self, limit: Optional[int]) -> Dict[str, List]:
+        """Returns the last X logs"""
+        if limit:
+            buffer = bufferHandler.buffer[-limit:]
+        else:
+            buffer = bufferHandler.buffer
+        records = [[r.asctime, r.created, r.name, r.levelname, r.message] for r in buffer]
+
+        return {'log_count': len(records), 'logs': records}
+
+    def _rpc_get_logs_as_string(self, limit: Optional[int]) -> Dict[str, List]:
+        """Returns the last X logs"""
+        if limit:
+            buffer = bufferHandler.buffer[-limit:]
+        else:
+            buffer = bufferHandler.buffer
+        return [bufferHandler.format(r) for r in buffer]
 
     def _rpc_edge(self) -> List[Dict[str, Any]]:
         """ Returns information related to Edge """

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -633,7 +633,7 @@ class RPC:
                }
         return res
 
-    def _rpc_get_logs(self, limit: Optional[int]) -> Dict[str, List]:
+    def _rpc_get_logs(self, limit: Optional[int]) -> Dict[str, Any]:
         """Returns the last X logs"""
         if limit:
             buffer = bufferHandler.buffer[-limit:]
@@ -644,7 +644,7 @@ class RPC:
 
         return {'log_count': len(records), 'logs': records}
 
-    def _rpc_get_logs_as_string(self, limit: Optional[int]) -> Dict[str, List]:
+    def _rpc_get_logs_as_string(self, limit: Optional[int]) -> List[str]:
         """Returns the last X logs as formatted string (Using the default log format)"""
         if limit:
             buffer = bufferHandler.buffer[-limit:]

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -649,20 +649,22 @@ class Telegram(RPC):
                 limit = int(context.args[0])
             except (TypeError, ValueError, IndexError):
                 limit = 10
-            logs = self._rpc_get_logs_as_string(limit)
-            msg = ''
-            message_container = "<pre>{}</pre>"
+            logs = self._rpc_get_logs(limit)['logs']
+            msgs = ''
+            msg_template = "*{}* {}: {} - `{}`"
             for logrec in logs:
-                if len(msg + logrec) + 10 >= MAX_TELEGRAM_MESSAGE_LENGTH:
+                msg = msg_template.format(logrec[0], logrec[2], logrec[3], logrec[4])
+
+                if len(msgs + msg) + 10 >= MAX_TELEGRAM_MESSAGE_LENGTH:
                     # Send message immediately if it would become too long
-                    self._send_msg(message_container.format(msg), parse_mode=ParseMode.HTML)
-                    msg = logrec + '\n'
+                    self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN)
+                    msgs = msg + '\n'
                 else:
                     # Append message to messages to send
-                    msg += logrec + '\n'
+                    msgs += msg + '\n'
 
-            if msg:
-                self._send_msg(message_container.format(msg), parse_mode=ParseMode.HTML)
+            if msgs:
+                self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN)
         except RPCException as e:
             self._send_msg(str(e))
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -12,6 +12,7 @@ from tabulate import tabulate
 from telegram import ParseMode, ReplyKeyboardMarkup, Update
 from telegram.error import NetworkError, TelegramError
 from telegram.ext import CallbackContext, CommandHandler, Updater
+from telegram.utils.helpers import escape_markdown
 
 from freqtrade.__init__ import __version__
 from freqtrade.rpc import RPC, RPCException, RPCMessageType
@@ -651,20 +652,22 @@ class Telegram(RPC):
                 limit = 10
             logs = self._rpc_get_logs(limit)['logs']
             msgs = ''
-            msg_template = "*{}* {}: {} - `{}`"
+            msg_template = "*{}* {}: {} \\- `{}`"
             for logrec in logs:
-                msg = msg_template.format(logrec[0], logrec[2], logrec[3], logrec[4])
-
+                msg = msg_template.format(escape_markdown(logrec[0], version=2),
+                                          escape_markdown(logrec[2], version=2),
+                                          escape_markdown(logrec[3], version=2),
+                                          escape_markdown(logrec[4], version=2))
                 if len(msgs + msg) + 10 >= MAX_TELEGRAM_MESSAGE_LENGTH:
                     # Send message immediately if it would become too long
-                    self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN)
+                    self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN_V2)
                     msgs = msg + '\n'
                 else:
                     # Append message to messages to send
                     msgs += msg + '\n'
 
             if msgs:
-                self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN)
+                self._send_msg(msgs, parse_mode=ParseMode.MARKDOWN_V2)
         except RPCException as e:
             self._send_msg(str(e))
 

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -159,6 +159,14 @@ class FtRestClient():
         """
         return self._get("show_config")
 
+    def logs(self, limit=None):
+        """Show latest logs.
+
+        :param limit: Limits log messages to the last <limit> logs. No limit to get all the trades.
+        :return: json object
+        """
+        return self._get("logs", params={"limit": limit} if limit else 0)
+
     def trades(self, limit=None):
         """Return trades history.
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -447,6 +447,14 @@ def test_api_logs(botclient):
     assert isinstance(rc.json['logs'][0][3], str)
     assert isinstance(rc.json['logs'][0][4], str)
 
+    rc = client_get(client, f"{BASE_URI}/logs?limit=5")
+    assert_response(rc)
+    assert len(rc.json) == 2
+    assert 'logs' in rc.json
+    # Using a fixed comparison here would make this test fail!
+    assert rc.json['log_count'] == 5
+    assert len(rc.json['logs']) == rc.json['log_count']
+
 
 def test_api_edge_disabled(botclient, mocker, ticker, fee, markets):
     ftbot, client = botclient

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -10,10 +10,12 @@ from flask import Flask
 from requests.auth import _basic_auth_str
 
 from freqtrade.__init__ import __version__
+from freqtrade.loggers import setup_logging, setup_logging_pre
 from freqtrade.persistence import Trade
 from freqtrade.rpc.api_server import BASE_URI, ApiServer
 from freqtrade.state import State
-from tests.conftest import get_patched_freqtradebot, log_has, patch_get_signal, create_mock_trades
+from tests.conftest import (create_mock_trades, get_patched_freqtradebot,
+                            log_has, patch_get_signal)
 
 _TEST_USER = "FreqTrader"
 _TEST_PASS = "SuperSecurePassword1!"
@@ -21,6 +23,9 @@ _TEST_PASS = "SuperSecurePassword1!"
 
 @pytest.fixture
 def botclient(default_conf, mocker):
+    setup_logging_pre()
+    setup_logging(default_conf)
+
     default_conf.update({"api_server": {"enabled": True,
                                         "listen_ip_address": "127.0.0.1",
                                         "listen_port": 8080,
@@ -421,6 +426,26 @@ def test_api_delete_trade(botclient, mocker, fee, markets):
     assert rc.json['result_msg'] == 'Deleted trade 2. Closed 2 open orders.'
     assert len(trades) - 2 == len(Trade.query.all())
     assert stoploss_mock.call_count == 1
+
+
+def test_api_logs(botclient):
+    ftbot, client = botclient
+    rc = client_get(client, f"{BASE_URI}/logs")
+    assert_response(rc)
+    assert len(rc.json) == 2
+    assert 'logs' in rc.json
+    # Using a fixed comparison here would make this test fail!
+    assert rc.json['log_count'] > 10
+    assert len(rc.json['logs']) == rc.json['log_count']
+
+    assert isinstance(rc.json['logs'][0], list)
+    # date
+    assert isinstance(rc.json['logs'][0][0], str)
+    # created_timestamp
+    assert isinstance(rc.json['logs'][0][1], float)
+    assert isinstance(rc.json['logs'][0][2], str)
+    assert isinstance(rc.json['logs'][0][3], str)
+    assert isinstance(rc.json['logs'][0][4], str)
 
 
 def test_api_edge_disabled(botclient, mocker, ticker, fee, markets):

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -76,7 +76,7 @@ def test_telegram_init(default_conf, mocker, caplog) -> None:
                    "['balance'], ['start'], ['stop'], ['forcesell'], ['forcebuy'], ['trades'], "
                    "['delete'], ['performance'], ['daily'], ['count'], ['reload_config', "
                    "'reload_conf'], ['show_config', 'show_conf'], ['stopbuy'], "
-                   "['whitelist'], ['blacklist'], ['edge'], ['help'], ['version']]")
+                   "['whitelist'], ['blacklist'], ['logs'], ['edge'], ['help'], ['version']]")
 
     assert log_has(message_str, caplog)
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1127,6 +1127,21 @@ def test_telegram_logs(default_conf, update, mocker) -> None:
     assert "freqtrade.rpc.telegram" in msg_mock.call_args_list[0][0][0]
     assert "freqtrade.resolvers.iresolver" in msg_mock.call_args_list[0][0][0]
 
+    msg_mock.reset_mock()
+    context.args = ["1"]
+    telegram._logs(update=update, context=context)
+    assert msg_mock.call_count == 1
+
+    msg_mock.reset_mock()
+    # Test with changed MaxMessageLength
+    mocker.patch('freqtrade.rpc.telegram.MAX_TELEGRAM_MESSAGE_LENGTH', 200)
+    context = MagicMock()
+    context.args = []
+    telegram._logs(update=update, context=context)
+    # Called at least 3 times. Exact times will change with unrelated changes to setup messages
+    # Therefore we don't test for this explicitly.
+    assert msg_mock.call_count > 3
+
 
 def test_edge_disabled(default_conf, update, mocker) -> None:
     msg_mock = MagicMock()

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1124,8 +1124,8 @@ def test_telegram_logs(default_conf, update, mocker) -> None:
     context.args = []
     telegram._logs(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert "freqtrade.rpc.telegram" in msg_mock.call_args_list[0][0][0]
-    assert "freqtrade.resolvers.iresolver" in msg_mock.call_args_list[0][0][0]
+    assert "freqtrade\\.rpc\\.telegram" in msg_mock.call_args_list[0][0][0]
+    assert "freqtrade\\.resolvers\\.iresolver" in msg_mock.call_args_list[0][0][0]
 
     msg_mock.reset_mock()
     context.args = ["1"]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -729,7 +729,10 @@ def test_set_logfile(default_conf, mocker):
     assert validated_conf['logfile'] == "test_file.log"
     f = Path("test_file.log")
     assert f.is_file()
-    f.unlink()
+    try:
+        f.unlink()
+    except Exception:
+        pass
 
 
 def test_load_config_warn_forcebuy(default_conf, mocker, caplog) -> None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -21,7 +21,7 @@ from freqtrade.configuration.deprecated_settings import (
 from freqtrade.configuration.load_config import load_config_file, log_config_error_range
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
 from freqtrade.exceptions import OperationalException
-from freqtrade.loggers import _set_loggers, setup_logging
+from freqtrade.loggers import _set_loggers, setup_logging, setup_logging_pre
 from freqtrade.state import RunMode
 from tests.conftest import (log_has, log_has_re,
                             patched_configuration_load_config_file)
@@ -674,6 +674,7 @@ def test_set_loggers_syslog(mocker):
               'logfile': 'syslog:/dev/log',
               }
 
+    setup_logging_pre()
     setup_logging(config)
     assert len(logger.handlers) == 3
     assert [x for x in logger.handlers if type(x) == logging.handlers.SysLogHandler]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -678,6 +678,7 @@ def test_set_loggers_syslog(mocker):
     assert len(logger.handlers) == 3
     assert [x for x in logger.handlers if type(x) == logging.handlers.SysLogHandler]
     assert [x for x in logger.handlers if type(x) == logging.StreamHandler]
+    assert [x for x in logger.handlers if type(x) == logging.handlers.BufferingHandler]
     # reset handlers to not break pytest
     logger.handlers = orig_handlers
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -675,7 +675,7 @@ def test_set_loggers_syslog(mocker):
               }
 
     setup_logging(config)
-    assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 3
     assert [x for x in logger.handlers if type(x) == logging.handlers.SysLogHandler]
     assert [x for x in logger.handlers if type(x) == logging.StreamHandler]
     # reset handlers to not break pytest


### PR DESCRIPTION
## Summary
Add logging endpoints (`/log` in telegram, `api/log` endpoint in the rest api).

Basically replicates the idea of #3308 - but in a proper way (without assuming a file is there, and reading from file).

## Quick changelog

- Use `BufferHandler` to keep the last 1000 logmessages in memory for easy query
- Expose last logs via RPC methods 
- Add "early-logging" - so also the first messages out of worker (before initialization) are logged correctly unless they are < INFO log level.


## Telegram output

![2020-08-15-083037_539x451_scrot](https://user-images.githubusercontent.com/5024695/90306883-9ce4e880-ded1-11ea-8733-7d59a9cfb203.png)

