### PR TITLE
update bad exchanges

### DIFF
--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -16,6 +16,7 @@ BAD_EXCHANGES = {
                 "Details in https://github.com/freqtrade/freqtrade/issues/1983",
     "hitbtc": "This API cannot be used with Freqtrade. "
               "Use `hitbtc2` exchange id to access this exchange.",
+    "phemex": "Does not provide history. ",
     **dict.fromkeys([
         'adara',
         'anxpro',


### PR DESCRIPTION
added phemex to bad exchanges
reason: `"Could not fetch historical candle (OHLCV) data for pair BTC/EUR due to ArgumentsRequired. Message: phemex fetchOHLCV requires a since argument, or a limit argument, or both"`