### PR TITLE
Update sandbox documentation

### DIFF
--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -3,7 +3,7 @@
 Some exchanges provide sandboxes or testbeds for risk-free testing, while running the bot against a real exchange.
 With some configuration, freqtrade (in combination with ccxt) provides access to these.
 
-This document is a light overview of configuring Freqtrade to be used with sandboxes.
+This document is an overview to configure Freqtrade to be used with sandboxes.
 This can be useful to developers and trader alike.
 
 ## Exchanges known to have a sandbox / testnet
@@ -22,14 +22,14 @@ This can be useful to developers and trader alike.
 
 ## Configure a Sandbox account
 
-When testing your API connectivity, make sure to use the following URLs.
+When testing your API connectivity, make sure to use the appropriate sandbox / testnet URL.
 
 In general, you should follow these steps to enable an exchange's sandbox:
 
-- Figure out if an exchange has a sandbox (most likely by using google or the exchange's support documents)
-- Create a sandbox account (often the sandbox-account requires separate registration)
-- [Add some test assets to account](#add-test-funds)
-- Create API keys
+* Figure out if an exchange has a sandbox (most likely by using google or the exchange's support documents)
+* Create a sandbox account (often the sandbox-account requires separate registration)
+* [Add some test assets to account](#add-test-funds)
+* Create API keys
 
 ### Add test funds
 
@@ -37,7 +37,7 @@ Usually, sandbox exchanges allow depositing funds directly via web-interface.
 You should make sure to have a realistic amount of funds available to your test-account, so results are representable of your real account funds.
 
 !!! Warning
-    Test exchanges will NEVER require your real credit card or banking details!
+    Test exchanges will **NEVER** require your real credit card or banking details!
 
 ## Configure freqtrade to use a exchange's sandbox
 
@@ -46,8 +46,8 @@ You should make sure to have a realistic amount of funds available to your test-
 Freqtrade makes use of CCXT which in turn provides a list of URLs to Freqtrade.
 These include `['test']` and `['api']`.
 
-- `[Test]` if available will point to an Exchanges sandbox.
-- `[Api]` normally used, and resolves to live API target on the exchange.
+* `[Test]` if available will point to an Exchanges sandbox.
+* `[Api]` normally used, and resolves to live API target on the exchange.
 
 To make use of sandbox / test add "sandbox": true, to your config.json
 
@@ -68,9 +68,9 @@ To make use of sandbox / test add "sandbox": true, to your config.json
 
 Also the following information:
 
-- api-key (created for the sandbox webpage)
-- api-secret (noted earlier)
-- password (the passphrase - noted earlier)
+* api-key (created for the sandbox webpage)
+* api-secret (noted earlier)
+* password (the passphrase - noted earlier)
 
 !!! Tip "Different data directory"
     We also recommend to set `datadir` to something identifying downloaded data as sandbox data, to avoid having sandbox data mixed with data from the real exchange.

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -91,3 +91,27 @@ Sandbox exchange instances often have very low volume, which can cause some prob
 
 Since Sandboxes often have low volume, candles can be quite old and show no volume.
 To disable the error "Outdated history for pair ...", best increase the parameter `"outdated_offset"` to a number that seems realistic for the sandbox you're using.
+
+### Unfilled orders
+
+Sandboxes often have very low volumes - which means that many trades can go unfilled, or can go unfilled for a very long time.
+
+To mitigate this, you can try to match the first order on the opposite orderbook side using the following configuration:
+
+``` jsonc
+  "order_types": {
+    "buy": "limit",
+    "sell": "limit"
+    // ...
+  },
+  "bid_strategy": {
+    "price_side": "ask",
+    // ...
+  },
+  "ask_strategy":{
+    "price_side": "bid",
+    // ...
+  },
+  ```
+
+  The configuration is similar to the suggested configuration for market orders - however by using limit-orders you can avoid moving the price too much, and you can set the worst price you might get.

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -1,104 +1,59 @@
 # Sandbox API testing
 
-Where an exchange provides a sandbox for risk-free integration, or end-to-end, testing CCXT provides access to these.
+Some exchanges provide sandboxes or testbeds for risk-free testing, while running the bot against a real exchange.
+With some configuration, freqtrade (in combination with ccxt) provides access to these.
 
-This document is a *light overview of configuring Freqtrade and GDAX sandbox.
-This can be useful to developers and trader alike as Freqtrade is quite customisable.
+This document is a light overview of configuring Freqtrade to be used with sandboxes.
+This can be useful to developers and trader alike.
+
+## Exchanges known to have a sandbox / testnet
+
+* [binance](https://testnet.binance.vision/)
+* [coinbasepro](https://public.sandbox.pro.coinbase.com)
+* [gemini](https://exchange.sandbox.gemini.com/)
+* [huobipro](https://www.testnet.huobi.pro/)
+* [kucoin](https://sandbox.kucoin.com/)
+* [phemex](https://testnet.phemex.com/) 
+
+!!! Note
+    We did not test correct functioning of all of the above testnets. Please report your experiences with each sandbox.
+
+---
+
+## Configure a Sandbox account
 
 When testing your API connectivity, make sure to use the following URLs.
-***Website**
-https://public.sandbox.gdax.com
-***REST API**
-https://api-public.sandbox.gdax.com
 
----
+In general, you should follow these steps to enable an exchange's sandbox:
 
-# Configure a Sandbox account on Gdax
+- Figure out if an exchange has a sandbox (most likely by using google or the exchange's support documents)
+- Create a sandbox account (often the sandbox-account requires separate registration)
+- [Add some test assets to account](#add-test-funds)
+- Create API keys
 
-Aim of this document section
+### Add test funds
 
-- An sanbox account
-- create 2FA (needed to create an API)
-- Add test 50BTC to account 
-- Create :
-- - API-KEY
-- - API-Secret
-- - API Password
+Usually, sandbox exchanges allow depositing funds directly via web-interface.
+You should make sure to have a realistic amount of funds available to your test-account, so results are representable of your real account funds.
 
-## Acccount
+!!! Warning
+    Test exchanges will NEVER require your real credit card or banking details!
 
-This link will redirect to the sandbox main page to login / create account dialogues:
-https://public.sandbox.pro.coinbase.com/orders/
+## Configure freqtrade to use a exchange's sandbox
 
-After registration and Email confimation you wil be redirected into your sanbox account.  It is easy to verify you're in sandbox by checking the URL bar.
-> https://public.sandbox.pro.coinbase.com/
-
-## Enable 2Fa (a prerequisite to creating sandbox API Keys)
-
-From within sand box site select your profile, top right.
->Or as a direct link: https://public.sandbox.pro.coinbase.com/profile
-
-From the menu panel to the left of the screen select
-
-> Security: "*View or Update*"
-
-In the new site select "enable authenticator" as typical google Authenticator.
-
-- open Google Authenticator on your phone
-- scan barcode
-- enter your generated 2fa
-
-## Enable API Access
-
-From within sandbox select profile>api>create api-keys
->or as a direct link: https://public.sandbox.pro.coinbase.com/profile/api
-
-Click on "create one" and ensure  **view** and **trade**  are "checked" and sumbit your 2FA
-
-- **Copy and paste the Passphase** into a notepade this will be needed later
-- **Copy and paste the API Secret** popup into a notepad this will needed later
-- **Copy and paste the API Key** into a notepad this will needed later
-
-## Add 50 BTC test funds
-
-To add funds, use the web interface deposit and withdraw buttons.
-
-To begin select 'Wallets' from the top menu.
-> Or as a direct link: https://public.sandbox.pro.coinbase.com/wallets
-
-- Deposits (bottom left of screen)
-- - Deposit Funds Bitcoin
-- - - Coinbase BTC Wallet
-- - - - Max (50 BTC)
-- - - - - Deposit
-
-*This process may be repeated for other currencies, ETH as example*
-
----
-
-# Configure Freqtrade to use Gax Sandbox 
-
-The aim of this document section
-
-- Enable sandbox URLs in Freqtrade
-- Configure API
-- - secret
-- - key
-- - passphrase
- 
-## Sandbox URLs
+### Sandbox URLs
 
 Freqtrade makes use of CCXT which in turn provides a list of URLs to Freqtrade.
 These include `['test']` and `['api']`.
 
-- `[Test]` if available will point to an Exchanges sandbox. 
-- `[Api]` normally used, and resolves to live API target on the exchange 
+- `[Test]` if available will point to an Exchanges sandbox.
+- `[Api]` normally used, and resolves to live API target on the exchange.
 
 To make use of sandbox / test add "sandbox": true, to your config.json
 
 ```json
   "exchange": {
-        "name": "gdax",
+        "name": "coinbasepro",
         "sandbox": true,
         "key": "5wowfxemogxeowo;heiohgmd",
         "secret": "/ZMH1P62rCVmwefewrgcewX8nh4gob+lywxfwfxwwfxwfNsH1ySgvWCUR/w==",
@@ -106,36 +61,33 @@ To make use of sandbox / test add "sandbox": true, to your config.json
         "outdated_offset": 5
         "pair_whitelist": [
             "BTC/USD"
+        ]
+  },
+  "datadir": "user_data/data/coinbasepro_sandbox"
 ```
 
-Also insert your 
+Also the following information:
 
-- api-key  (noted earlier)
+- api-key (created for the sandbox webpage)
 - api-secret (noted earlier)
 - password (the passphrase - noted earlier)
+
+!!! Tip "Different data directory"
+    We also recommend to set `datadir` to something identifying downloaded data as sandbox data, to avoid having sandbox data mixed with data from the real exchange.
+    This can be done by adding the `"datadir"` key to the configuration.
+    Now, whenever you use this configuration, your data directory will be set to this directory.
 
 ---
 
 ## You should now be ready to test your sandbox
 
-Ensure Freqtrade logs show the sandbox URL, and trades made are shown in sandbox.
-** Typically the  BTC/USD has the most activity in sandbox to test against.
+Ensure Freqtrade logs show the sandbox URL, and trades made are shown in sandbox. Also make sure to select a pair which shows at least some decent value (which very often is BTC/<somestablecoin>).
 
-## GDAX - Old Candles problem
+## Common problems with sandbox exchanges
 
-It is my experience that GDAX sandbox candles may be 20+- minutes out of date. This can cause trades to fail as one of Freqtrades safety checks.
+Sandbox exchange instances often have very low volume, which can cause some problems which usually are not seen on a real exchange instance.
 
-To disable this check, add / change the `"outdated_offset"` parameter in the exchange section of your configuration to adjust for this delay.
-Example based on the above configuration:
+### Old Candles problem
 
-```json
-  "exchange": {
-        "name": "gdax",
-        "sandbox": true,
-        "key": "5wowfxemogxeowo;heiohgmd",
-        "secret": "/ZMH1P62rCVmwefewrgcewX8nh4gob+lywxfwfxwwfxwfNsH1ySgvWCUR/w==",
-        "password": "1bkjfkhfhfu6sr",
-        "outdated_offset": 30
-        "pair_whitelist": [
-            "BTC/USD"
-```
+Since Sandboxes often have low volume, candles can be quite old and show no volume.
+To disable the error "Outdated history for pair ...", best increase the parameter `"outdated_offset"` to a number that seems realistic for the sandbox you're using.


### PR DESCRIPTION
## Summary
The sandbox documentation should not be focused on one sandbox, but should instead be generalized to work for 

closes #1630

## Quick changelog

- Remove custom instructions for gdax (gdax is not an exchange anymore ... and steps may change over time).
- List potential candidates that have a testnet / sandbox