### PR TITLE
Allow numpy numbers as comparisons, too

### DIFF
--- a/freqtrade/vendor/qtpylib/indicators.py
+++ b/freqtrade/vendor/qtpylib/indicators.py
@@ -222,7 +222,7 @@ def crossed(series1, series2, direction=None):
     if isinstance(series1, np.ndarray):
         series1 = pd.Series(series1)
 
-    if isinstance(series2, (float, int, np.ndarray)):
+    if isinstance(series2, (float, int, np.ndarray, np.integer, np.floating)):
         series2 = pd.Series(index=series1.index, data=series2)
 
     if direction is None or direction == "above":

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,18 @@
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+import numpy as np
+import pandas as pd
+
+
+def test_crossed_numpy_types():
+    """
+    This test is only present since this method currently diverges from the qtpylib implementation.
+    And we must ensure to not break this again once we update from the original source.
+    """
+    series = pd.Series([56, 97, 19, 76, 65, 25, 87, 91, 79, 79])
+    expected_result = pd.Series([False, True, False, True, False, False, True, False, False, False])
+
+    assert qtpylib.crossed_above(series, 60).equals(expected_result)
+    assert qtpylib.crossed_above(series, 60.0).equals(expected_result)
+    assert qtpylib.crossed_above(series, np.int32(60)).equals(expected_result)
+    assert qtpylib.crossed_above(series, np.int64(60)).equals(expected_result)
+    assert qtpylib.crossed_above(series, np.float64(60.0)).equals(expected_result)

--- a/tests/test_talib.py
+++ b/tests/test_talib.py
@@ -1,5 +1,3 @@
-
-
 import talib.abstract as ta
 import pandas as pd
 


### PR DESCRIPTION
## Summary
Counterpart to https://github.com/ranaroussi/qtpylib/pull/160 - adding numpy scalar types to the supported list for `crossed()` methods

Fixes bad behaviour when passing in a numpy type instead of a regular integer
crossed_above(series, 25) does work, while crossed_above(series, np.int64(25)) does not work.

On it's own, this is not a problem as you can pick how to create the integer, however, it can become a problem depending where the 2nd variable came from, for example if it comes from a ml library like scikit-optimize.

closes #3718 

## Quick changelog

- add np.integer and np.floating as "to convert" types.