### PR TITLE
[minor] Allow pairlists in backtesting

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -39,6 +39,12 @@ class DataProvider:
         """
         self.__cached_pairs[(pair, timeframe)] = (dataframe, Arrow.utcnow().datetime)
 
+    def add_pairlisthandler(self, pairlists) -> None:
+        """
+        Allow adding pairlisthandler after initialization
+        """
+        self._pairlists = pairlists
+
     def refresh(self,
                 pairlist: ListPairsWithTimeframes,
                 helping_pairs: ListPairsWithTimeframes = None) -> None:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -96,6 +96,7 @@ class Backtesting:
                 "PrecisionFilter not allowed for backtesting multiple strategies."
             )
 
+        dataprovider.add_pairlisthandler(self.pairlists)
         self.pairlists.refresh_pairlist()
 
         if len(self.pairlists.whitelist) == 0:

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -359,6 +359,7 @@ def test_backtesting_start(default_conf, mocker, testdatadir, caplog) -> None:
     ]
     for line in exists:
         assert log_has(line, caplog)
+    assert backtesting.strategy.dp._pairlists is not None
 
 
 def test_backtesting_start_no_data(default_conf, mocker, caplog, testdatadir) -> None:


### PR DESCRIPTION
## Summary
Allow pairlists through dataprovider in backtesting / hyperopt modes.

closes: #3726
