### PR TITLE
Move clock warning to installation pages

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -5,6 +5,9 @@ This page explains the different parameters of the bot and how to run it.
 !!! Note
     If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
 
+!!! Warning "Up-to-date clock"
+    The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
+
 ## Bot commands
 
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -12,6 +12,9 @@ Optionally, [docker-compose](https://docs.docker.com/compose/install/) should be
 
 Once you have Docker installed, simply prepare the config file (e.g. `config.json`) and run the image for `freqtrade` as explained below.
 
+!!! Warning "Up-to-date clock"
+    The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
+
 ## Freqtrade with docker-compose
 
 Freqtrade provides an official Docker image on [Dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/), as well as a [docker-compose file](https://github.com/freqtrade/freqtrade/blob/develop/docker-compose.yml) ready for usage.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,13 +37,9 @@ Freqtrade is a crypto-currency algorithmic trading software developed in python 
 
 ## Requirements
 
-### Up to date clock
-
-The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
-
 ### Hardware requirements
 
-To run this bot we recommend you a cloud instance with a minimum of:
+To run this bot we recommend you a linux cloud instance with a minimum of:
 
 - 2GB RAM
 - 1GB disk space

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,9 @@ Click each one for install guide:
 
  We also recommend a [Telegram bot](telegram-usage.md#setup-your-telegram-bot), which is optional but recommended.
 
+!!! Warning "Up-to-date clock"
+    The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
+
 ## Quick start
 
 Freqtrade provides the Linux/MacOS Easy Installation script to install all dependencies and help you configure the bot.


### PR DESCRIPTION
## Summary
Move warnings related to clock sync to the installation sections - it's not really well suited for a "welcome" page.

closes #2491
