### PR TITLE
Remove trailing_stop from default config example - it'll be misleading

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -7,7 +7,6 @@
     "timeframe": "5m",
     "dry_run": false,
     "cancel_open_orders_on_exit": false,
-    "trailing_stop": false,
     "unfilledtimeout": {
         "buy": 10,
         "sell": 30

--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -7,7 +7,6 @@
     "timeframe": "5m",
     "dry_run": true,
     "cancel_open_orders_on_exit": false,
-    "trailing_stop": false,
     "unfilledtimeout": {
         "buy": 10,
         "sell": 30

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -7,7 +7,6 @@
     "timeframe": "5m",
     "dry_run": true,
     "cancel_open_orders_on_exit": false,
-    "trailing_stop": false,
     "unfilledtimeout": {
         "buy": 10,
         "sell": 30


### PR DESCRIPTION
## Summary
Trailing stop should not be in the default config.
It'll be confusing and throw people off trying to match hyperopt results with backtests.
