### PR TITLE
prettify hyperopt console output

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -324,8 +324,9 @@ class Hyperopt:
                          'results_metrics.avg_profit', 'results_metrics.total_profit',
                          'results_metrics.profit', 'results_metrics.duration',
                          'loss', 'is_initial_point', 'is_best']]
-        trials.columns = ['Best', 'Epoch', 'Trades', 'W/D/L', 'Avg profit', 'Total profit',
-                          'Profit', 'Avg duration', 'Objective', 'is_initial_point', 'is_best']
+        trials.columns = ['Best', 'Epoch', 'Trades', ' Win Draw Loss', 'Avg profit',
+                          'Total profit', 'Profit', 'Avg duration', 'Objective',
+                          'is_initial_point', 'is_best']
         trials['is_profit'] = False
         trials.loc[trials['is_initial_point'], 'Best'] = '*     '
         trials.loc[trials['is_best'], 'Best'] = 'Best'
@@ -574,7 +575,7 @@ class Hyperopt:
             'wins': wins,
             'draws': draws,
             'losses': losses,
-            'winsdrawslosses': f"{wins:04}/{draws:04}/{losses:04}",
+            'winsdrawslosses': f"{wins:>4} {draws:>4} {losses:>4}",
             'avg_profit': backtesting_results.profit_percent.mean() * 100.0,
             'median_profit': backtesting_results.profit_percent.median() * 100.0,
             'total_profit': backtesting_results.profit_abs.sum(),

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -574,7 +574,7 @@ class Hyperopt:
             'wins': wins,
             'draws': draws,
             'losses': losses,
-            'winsdrawslosses': f"{wins}/{draws}/{losses}",
+            'winsdrawslosses': f"{wins:04}/{draws:04}/{losses:04}",
             'avg_profit': backtesting_results.profit_percent.mean() * 100.0,
             'median_profit': backtesting_results.profit_percent.median() * 100.0,
             'total_profit': backtesting_results.profit_abs.sum(),

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -813,7 +813,7 @@ def test_generate_optimizer(mocker, hyperopt_conf) -> None:
                             'draws': 0,
                             'duration': 100.0,
                             'losses': 0,
-                            'winsdrawslosses': '0001/0000/0000',
+                            'winsdrawslosses': '   1    0    0',
                             'median_profit': 2.3117,
                             'profit': 2.3117,
                             'total_profit': 0.000233,

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -813,7 +813,7 @@ def test_generate_optimizer(mocker, hyperopt_conf) -> None:
                             'draws': 0,
                             'duration': 100.0,
                             'losses': 0,
-                            'winsdrawslosses': '1/0/0',
+                            'winsdrawslosses': '0001/0000/0000',
                             'median_profit': 2.3117,
                             'profit': 2.3117,
                             'total_profit': 0.000233,


### PR DESCRIPTION
## Summary
zero pad wins/draws/losses (W/D/L) column to preserve alignment in console pretty print

## Quick changelog
- zero pad wins/draws/losses (W/D/L) column to preserve alignment in console pretty print

## What's new?
zero pad wins/draws/losses (W/D/L) column to preserve alignment in console pretty print
