### PR TITLE
Allow Notification finetuning for telegram messages

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -116,7 +116,16 @@
     "telegram": {
         "enabled": true,
         "token": "your_telegram_token",
-        "chat_id": "your_telegram_chat_id"
+        "chat_id": "your_telegram_chat_id",
+        "notification_settings": {
+            "status": "on",
+            "warning": "on",
+            "startup": "on",
+            "buy": "on",
+            "sell": "on",
+            "buy_cancel": "on",
+            "sell_cancel": "on"
+        }
     },
     "api_server": {
         "enabled": false,

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -44,7 +44,7 @@ Get your "Id", you will use it for the config parameter `chat_id`.
 ## Control telegram noise
 
 Freqtrade provides means to control the verbosity of your telegram bot.
-Each setting has the follwoing possible values:
+Each setting has the following possible values:
 
 * `on` - Messages will be sent, and user will be notified.
 * `silent` - Message will be sent, Notification will be without sound / vibration.

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -41,6 +41,34 @@ Talk to the [userinfobot](https://telegram.me/userinfobot)
 
 Get your "Id", you will use it for the config parameter `chat_id`.
 
+## Control telegram noise
+
+Freqtrade provides means to control the verbosity of your telegram bot.
+Each setting has the follwoing possible values:
+
+* `on` - Messages will be sent, and user will be notified.
+* `silent` - Message will be sent, Notification will be without sound / vibration.
+* `off` - Skip sending a message-type all together.
+
+Example configuration showing the different settings:
+
+``` json
+"telegram": {
+      "enabled": true,
+      "token": "your_telegram_token",
+      "chat_id": "your_telegram_chat_id",
+      "notification_settings": {
+         "status": "silent",
+         "warning": "on",
+         "startup": "off",
+         "buy": "silent",
+         "sell": "on",
+         "buy_cancel": "silent",
+         "sell_cancel": "on"
+      }
+   },
+```
+
 ## Telegram commands
 
 Per default, the Telegram bot shows predefined commands. Some commands

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -39,6 +39,8 @@ USERPATH_HYPEROPTS = 'hyperopts'
 USERPATH_STRATEGIES = 'strategies'
 USERPATH_NOTEBOOKS = 'notebooks'
 
+TELEGRAM_SETTING_OPTIONS = ['on', 'off', 'silent']
+
 # Soure files with destination directories within user-directory
 USER_DATA_FILES = {
     'sample_strategy.py': USERPATH_STRATEGIES,
@@ -201,6 +203,18 @@ CONF_SCHEMA = {
                 'enabled': {'type': 'boolean'},
                 'token': {'type': 'string'},
                 'chat_id': {'type': 'string'},
+                'notification_settings': {
+                    'type': 'object',
+                    'properties': {
+                        'status': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'warning': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'startup': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'buy': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'sell': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'buy_cancel': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS},
+                        'sell_cancel': {'type': 'string', 'enum': TELEGRAM_SETTING_OPTIONS}
+                    }
+                }
             },
             'required': ['enabled', 'token', 'chat_id']
         },

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -36,6 +36,9 @@ class RPCMessageType(Enum):
     def __repr__(self):
         return self.value
 
+    def __str__(self):
+        return self.value
+
 
 class RPCException(Exception):
     """

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class RPCMessageType(Enum):
     STATUS_NOTIFICATION = 'status'
     WARNING_NOTIFICATION = 'warning'
-    CUSTOM_NOTIFICATION = 'custom'
+    STARTUP_NOTIFICATION = 'startup'
     BUY_NOTIFICATION = 'buy'
     BUY_CANCEL_NOTIFICATION = 'buy_cancel'
     SELL_NOTIFICATION = 'sell'

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -59,7 +59,7 @@ class RPCManager:
             try:
                 mod.send_msg(msg)
             except NotImplementedError:
-                logger.error(f"Message type {msg['type']} not implemented by handler {mod.name}.")
+                logger.error(f"Message type '{msg['type']}' not implemented by handler {mod.name}.")
 
     def startup_messages(self, config: Dict[str, Any], pairlist) -> None:
         if config['dry_run']:

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -76,7 +76,7 @@ class RPCManager:
         exchange_name = config['exchange']['name']
         strategy_name = config.get('strategy', '')
         self.send_msg({
-            'type': RPCMessageType.CUSTOM_NOTIFICATION,
+            'type': RPCMessageType.STARTUP_NOTIFICATION,
             'status': f'*Exchange:* `{exchange_name}`\n'
                       f'*Stake per trade:* `{stake_amount} {stake_currency}`\n'
                       f'*Minimum ROI:* `{minimal_roi}`\n'
@@ -85,7 +85,7 @@ class RPCManager:
                       f'*Strategy:* `{strategy_name}`'
         })
         self.send_msg({
-            'type': RPCMessageType.STATUS_NOTIFICATION,
+            'type': RPCMessageType.STARTUP_NOTIFICATION,
             'status': f'Searching for {stake_currency} pairs to buy and sell '
                       f'based on {pairlist.short_desc()}'
         })

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -190,7 +190,7 @@ class Telegram(RPC):
         elif msg['type'] == RPCMessageType.WARNING_NOTIFICATION:
             message = '\N{WARNING SIGN} *Warning:* `{status}`'.format(**msg)
 
-        elif msg['type'] == RPCMessageType.CUSTOM_NOTIFICATION:
+        elif msg['type'] == RPCMessageType.STARTUP_NOTIFICATION:
             message = '{status}'.format(**msg)
 
         else:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -133,7 +133,7 @@ class Telegram(RPC):
         """ Send a message to telegram channel """
 
         noti = self._config['telegram'].get('notification_settings', {}
-                                            ).get(msg['type'], 'on')
+                                            ).get(str(msg['type']), 'on')
         if noti == 'off':
             logger.info(f"Notification '{msg['type']}' not sent.")
             # Notification disabled

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -133,9 +133,9 @@ class Telegram(RPC):
         """ Send a message to telegram channel """
 
         noti = self._config['telegram'].get('notification_settings', {}
-                                            ).get(msg['type'].value, 'on')
+                                            ).get(msg['type'], 'on')
         if noti == 'off':
-            logger.info(f"Notification {msg['type']} not sent.")
+            logger.info(f"Notification '{msg['type']}' not sent.")
             # Notification disabled
             return
 

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -48,7 +48,7 @@ class Webhook(RPC):
             elif msg['type'] == RPCMessageType.SELL_CANCEL_NOTIFICATION:
                 valuedict = self._config['webhook'].get('webhooksellcancel', None)
             elif msg['type'] in (RPCMessageType.STATUS_NOTIFICATION,
-                                 RPCMessageType.CUSTOM_NOTIFICATION,
+                                 RPCMessageType.STARTUP_NOTIFICATION,
                                  RPCMessageType.WARNING_NOTIFICATION):
                 valuedict = self._config['webhook'].get('webhookstatus', None)
             else:

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -54,7 +54,7 @@ class Webhook(RPC):
             else:
                 raise NotImplementedError('Unknown message type: {}'.format(msg['type']))
             if not valuedict:
-                logger.info("Message type %s not configured for webhooks", msg['type'])
+                logger.info("Message type '%s' not configured for webhooks", msg['type'])
                 return
 
             payload = {key: value.format(**msg) for (key, value) in valuedict.items()}

--- a/tests/rpc/test_rpc_manager.py
+++ b/tests/rpc/test_rpc_manager.py
@@ -127,7 +127,7 @@ def test_send_msg_webhook_CustomMessagetype(mocker, default_conf, caplog) -> Non
     rpc_manager.send_msg({'type': RPCMessageType.STARTUP_NOTIFICATION,
                           'status': 'TestMessage'})
     assert log_has(
-        "Message type RPCMessageType.STARTUP_NOTIFICATION not implemented by handler webhook.",
+        "Message type 'startup' not implemented by handler webhook.",
         caplog)
 
 

--- a/tests/rpc/test_rpc_manager.py
+++ b/tests/rpc/test_rpc_manager.py
@@ -124,10 +124,10 @@ def test_send_msg_webhook_CustomMessagetype(mocker, default_conf, caplog) -> Non
     rpc_manager = RPCManager(get_patched_freqtradebot(mocker, default_conf))
 
     assert 'webhook' in [mod.name for mod in rpc_manager.registered_modules]
-    rpc_manager.send_msg({'type': RPCMessageType.CUSTOM_NOTIFICATION,
+    rpc_manager.send_msg({'type': RPCMessageType.STARTUP_NOTIFICATION,
                           'status': 'TestMessage'})
     assert log_has(
-        "Message type RPCMessageType.CUSTOM_NOTIFICATION not implemented by handler webhook.",
+        "Message type RPCMessageType.STARTUP_NOTIFICATION not implemented by handler webhook.",
         caplog)
 
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1485,7 +1485,7 @@ def test_warning_notification(default_conf, mocker) -> None:
     assert msg_mock.call_args[0][0] == '\N{WARNING SIGN} *Warning:* `message`'
 
 
-def test_custom_notification(default_conf, mocker) -> None:
+def test_startup_notification(default_conf, mocker) -> None:
     msg_mock = MagicMock()
     mocker.patch.multiple(
         'freqtrade.rpc.telegram.Telegram',
@@ -1495,7 +1495,7 @@ def test_custom_notification(default_conf, mocker) -> None:
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     telegram = Telegram(freqtradebot)
     telegram.send_msg({
-        'type': RPCMessageType.CUSTOM_NOTIFICATION,
+        'type': RPCMessageType.STARTUP_NOTIFICATION,
         'status': '*Custom:* `Hello World`'
     })
     assert msg_mock.call_args[0][0] == '*Custom:* `Hello World`'

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -174,7 +174,7 @@ def test_exception_send_msg(default_conf, mocker, caplog):
 
     webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
     webhook.send_msg({'type': RPCMessageType.BUY_NOTIFICATION})
-    assert log_has(f"Message type {RPCMessageType.BUY_NOTIFICATION} not configured for webhooks",
+    assert log_has(f"Message type '{RPCMessageType.BUY_NOTIFICATION}' not configured for webhooks",
                    caplog)
 
     default_conf["webhook"] = get_webhook_dict()

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -150,7 +150,7 @@ def test_send_msg(default_conf, mocker):
             default_conf["webhook"]["webhooksellcancel"]["value3"].format(**msg))
     for msgtype in [RPCMessageType.STATUS_NOTIFICATION,
                     RPCMessageType.WARNING_NOTIFICATION,
-                    RPCMessageType.CUSTOM_NOTIFICATION]:
+                    RPCMessageType.STARTUP_NOTIFICATION]:
         # Test notification
         msg = {
             'type': msgtype,


### PR DESCRIPTION
## Summary
Allow finetuning of telegram notifications.

Possible settings are 
* "on" (sending all notifications
* "off" - Don't send this notification type
* "silent" - send notification, but without notification sound (There will be a notification, but the phone will not vibrate / ring).



## Quick changelog

- Allow finetuning of Notification types to reduce notification noise generated by the bot

This will mainly come in handy iwth later enhancements which will introduce additional notification types (like fill confirmations).