### PR TITLE
Backtesting - handle mdifferent max_open_trades per strategy

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -423,8 +423,8 @@ class Backtesting:
                 'config': self.strategy.config,
             }
 
-        stats = generate_backtest_stats(data, all_results,
-                                        min_date=min_date, max_date=max_date)
+        stats = generate_backtest_stats(data, all_results, min_date=min_date, max_date=max_date)
+
         if self.config.get('export', False):
             store_backtest_stats(self.config['exportfilename'], stats)
 

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -277,6 +277,16 @@ def generate_backtest_stats(config: Dict, btdata: Dict[str, DataFrame],
             'max_open_trades': (config['max_open_trades']
                                 if config['max_open_trades'] != float('inf') else -1),
             'timeframe': config['timeframe'],
+            # Parameters relevant for backtesting
+            'stoploss': config['stoploss'],
+            'trailing_stop': config.get('trailing_stop', False),
+            'trailing_stop_positive': config.get('trailing_stop_positive'),
+            'trailing_stop_positive_offset': config.get('trailing_stop_positive_offset', 0.0),
+            'trailing_only_offset_is_reached': config.get('trailing_only_offset_is_reached', False),
+            'minimal_roi': config['minimal_roi'],
+            'use_sell_signal': config['ask_strategy']['use_sell_signal'],
+            'sell_profit_only': config['ask_strategy']['sell_profit_only'],
+            'ignore_roi_if_buy_signal': config['ask_strategy']['ignore_roi_if_buy_signal'],
             **daily_stats,
         }
         result['strategy'][strategy] = strat_stats

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from arrow import Arrow
 from pandas import DataFrame
@@ -143,19 +143,18 @@ def generate_sell_reason_stats(max_open_trades: int, results: DataFrame) -> List
     return tabular_data
 
 
-def generate_strategy_metrics(stake_currency: str, max_open_trades: int,
-                              all_results: Dict) -> List[Dict]:
+def generate_strategy_metrics(all_results: Dict) -> List[Dict]:
     """
     Generate summary per strategy
-    :param stake_currency: stake-currency - used to correctly name headers
-    :param max_open_trades: Maximum allowed open trades used for backtest
     :param all_results: Dict of <Strategyname: BacktestResult> containing results for all strategies
     :return: List of Dicts containing the metrics per Strategy
     """
 
     tabular_data = []
     for strategy, results in all_results.items():
-        tabular_data.append(_generate_result_line(results, max_open_trades, strategy))
+        tabular_data.append(_generate_result_line(
+            results['results'], results['config']['max_open_trades'], strategy)
+            )
     return tabular_data
 
 
@@ -219,25 +218,29 @@ def generate_daily_stats(results: DataFrame) -> Dict[str, Any]:
     }
 
 
-def generate_backtest_stats(config: Dict, btdata: Dict[str, DataFrame],
-                            all_results: Dict[str, DataFrame],
+def generate_backtest_stats(btdata: Dict[str, DataFrame],
+                            all_results: Dict[str, Dict[str, Union[DataFrame, Dict]]],
                             min_date: Arrow, max_date: Arrow
                             ) -> Dict[str, Any]:
     """
-    :param config: Configuration object used for backtest
     :param btdata: Backtest data
-    :param all_results: backtest result - dictionary with { Strategy: results}.
+    :param all_results: backtest result - dictionary in the form:
+                     { Strategy: {'results: results, 'config: config}}.
     :param min_date: Backtest start date
     :param max_date: Backtest end date
     :return:
     Dictionary containing results per strategy and a stratgy summary.
     """
-    stake_currency = config['stake_currency']
-    max_open_trades = config['max_open_trades']
     result: Dict[str, Any] = {'strategy': {}}
     market_change = calculate_market_change(btdata, 'close')
 
-    for strategy, results in all_results.items():
+    for strategy, content in all_results.items():
+        results: Dict[str, DataFrame] = content['results']
+        if not isinstance(results, DataFrame):
+            continue
+        config = content['config']
+        max_open_trades = config['max_open_trades']
+        stake_currency = config['stake_currency']
 
         pair_results = generate_pair_metrics(btdata, stake_currency=stake_currency,
                                              max_open_trades=max_open_trades,
@@ -310,9 +313,7 @@ def generate_backtest_stats(config: Dict, btdata: Dict[str, DataFrame],
                 'drawdown_end_ts': 0,
             })
 
-    strategy_results = generate_strategy_metrics(stake_currency=stake_currency,
-                                                 max_open_trades=max_open_trades,
-                                                 all_results=all_results)
+    strategy_results = generate_strategy_metrics(all_results=all_results)
 
     result['strategy_comparison'] = strategy_results
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -14,7 +14,7 @@ from freqtrade.commands.optimize_commands import (setup_optimize_configuration,
                                                   start_backtesting)
 from freqtrade.configuration import TimeRange
 from freqtrade.data import history
-from freqtrade.data.btanalysis import evaluate_result_multi
+from freqtrade.data.btanalysis import BT_DATA_COLUMNS, evaluate_result_multi
 from freqtrade.data.converter import clean_ohlcv_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange
@@ -694,7 +694,7 @@ def test_backtest_start_timerange(default_conf, mocker, caplog, testdatadir):
 def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
 
     patch_exchange(mocker)
-    backtestmock = MagicMock()
+    backtestmock = MagicMock(return_value=pd.DataFrame(columns=BT_DATA_COLUMNS + ['profit_abs']))
     mocker.patch('freqtrade.pairlist.pairlistmanager.PairListManager.whitelist',
                  PropertyMock(return_value=['UNITTEST/BTC']))
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', backtestmock)

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -26,7 +26,7 @@ from freqtrade.strategy.interface import SellType
 from tests.data.test_history import _backup_file, _clean_test_file
 
 
-def test_text_table_bt_results(default_conf, mocker):
+def test_text_table_bt_results():
 
     results = pd.DataFrame(
         {
@@ -174,7 +174,7 @@ def test_store_backtest_stats(testdatadir, mocker):
     assert str(dump_mock.call_args_list[0][0][0]).startswith(str(testdatadir / 'testresult'))
 
 
-def test_generate_pair_metrics(default_conf, mocker):
+def test_generate_pair_metrics():
 
     results = pd.DataFrame(
         {
@@ -222,7 +222,7 @@ def test_generate_daily_stats(testdatadir):
     assert res['losing_days'] == 0
 
 
-def test_text_table_sell_reason(default_conf):
+def test_text_table_sell_reason():
 
     results = pd.DataFrame(
         {
@@ -254,7 +254,7 @@ def test_text_table_sell_reason(default_conf):
                                   stake_currency='BTC') == result_str
 
 
-def test_generate_sell_reason_stats(default_conf):
+def test_generate_sell_reason_stats():
 
     results = pd.DataFrame(
         {
@@ -333,7 +333,7 @@ def test_text_table_strategy(default_conf):
     assert text_table_strategy(strategy_results, 'BTC') == result_str
 
 
-def test_generate_edge_table(edge_conf, mocker):
+def test_generate_edge_table():
 
     results = {}
     results['ETH/BTC'] = PairInfo(-0.01, 0.60, 2, 1, 3, 10, 60)

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -60,32 +60,35 @@ def test_generate_backtest_stats(default_conf, testdatadir):
     default_conf.update({'strategy': 'DefaultStrategy'})
     StrategyResolver.load_strategy(default_conf)
 
-    results = {'DefStrat': pd.DataFrame({"pair": ["UNITTEST/BTC", "UNITTEST/BTC",
-                                                  "UNITTEST/BTC", "UNITTEST/BTC"],
-                                         "profit_percent": [0.003312, 0.010801, 0.013803, 0.002780],
-                                         "profit_abs": [0.000003, 0.000011, 0.000014, 0.000003],
-                                         "open_date": [Arrow(2017, 11, 14, 19, 32, 00).datetime,
-                                                       Arrow(2017, 11, 14, 21, 36, 00).datetime,
-                                                       Arrow(2017, 11, 14, 22, 12, 00).datetime,
-                                                       Arrow(2017, 11, 14, 22, 44, 00).datetime],
-                                         "close_date": [Arrow(2017, 11, 14, 21, 35, 00).datetime,
-                                                        Arrow(2017, 11, 14, 22, 10, 00).datetime,
-                                                        Arrow(2017, 11, 14, 22, 43, 00).datetime,
-                                                        Arrow(2017, 11, 14, 22, 58, 00).datetime],
-                                         "open_rate": [0.002543, 0.003003, 0.003089, 0.003214],
-                                         "close_rate": [0.002546, 0.003014, 0.003103, 0.003217],
-                                         "trade_duration": [123, 34, 31, 14],
-                                         "open_at_end": [False, False, False, True],
-                                         "sell_reason": [SellType.ROI, SellType.STOP_LOSS,
-                                                         SellType.ROI, SellType.FORCE_SELL]
-                                         })}
+    results = {'DefStrat': {
+        'results': pd.DataFrame({"pair": ["UNITTEST/BTC", "UNITTEST/BTC",
+                                          "UNITTEST/BTC", "UNITTEST/BTC"],
+                                 "profit_percent": [0.003312, 0.010801, 0.013803, 0.002780],
+                                 "profit_abs": [0.000003, 0.000011, 0.000014, 0.000003],
+                                 "open_date": [Arrow(2017, 11, 14, 19, 32, 00).datetime,
+                                               Arrow(2017, 11, 14, 21, 36, 00).datetime,
+                                               Arrow(2017, 11, 14, 22, 12, 00).datetime,
+                                               Arrow(2017, 11, 14, 22, 44, 00).datetime],
+                                 "close_date": [Arrow(2017, 11, 14, 21, 35, 00).datetime,
+                                                Arrow(2017, 11, 14, 22, 10, 00).datetime,
+                                                Arrow(2017, 11, 14, 22, 43, 00).datetime,
+                                                Arrow(2017, 11, 14, 22, 58, 00).datetime],
+                                 "open_rate": [0.002543, 0.003003, 0.003089, 0.003214],
+                                 "close_rate": [0.002546, 0.003014, 0.003103, 0.003217],
+                                 "trade_duration": [123, 34, 31, 14],
+                                 "open_at_end": [False, False, False, True],
+                                 "sell_reason": [SellType.ROI, SellType.STOP_LOSS,
+                                                 SellType.ROI, SellType.FORCE_SELL]
+                                 }),
+        'config': default_conf}
+        }
     timerange = TimeRange.parse_timerange('1510688220-1510700340')
     min_date = Arrow.fromtimestamp(1510688220)
     max_date = Arrow.fromtimestamp(1510700340)
     btdata = history.load_data(testdatadir, '1m', ['UNITTEST/BTC'], timerange=timerange,
                                fill_up_missing=True)
 
-    stats = generate_backtest_stats(default_conf, btdata, results, min_date, max_date)
+    stats = generate_backtest_stats(btdata, results, min_date, max_date)
     assert isinstance(stats, dict)
     assert 'strategy' in stats
     assert 'DefStrat' in stats['strategy']
@@ -93,29 +96,32 @@ def test_generate_backtest_stats(default_conf, testdatadir):
     strat_stats = stats['strategy']['DefStrat']
     assert strat_stats['backtest_start'] == min_date.datetime
     assert strat_stats['backtest_end'] == max_date.datetime
-    assert strat_stats['total_trades'] == len(results['DefStrat'])
+    assert strat_stats['total_trades'] == len(results['DefStrat']['results'])
     # Above sample had no loosing trade
     assert strat_stats['max_drawdown'] == 0.0
 
-    results = {'DefStrat': pd.DataFrame(
-        {"pair": ["UNITTEST/BTC", "UNITTEST/BTC", "UNITTEST/BTC", "UNITTEST/BTC"],
-         "profit_percent": [0.003312, 0.010801, -0.013803, 0.002780],
-         "profit_abs": [0.000003, 0.000011, -0.000014, 0.000003],
-         "open_date": [Arrow(2017, 11, 14, 19, 32, 00).datetime,
-                       Arrow(2017, 11, 14, 21, 36, 00).datetime,
-                       Arrow(2017, 11, 14, 22, 12, 00).datetime,
-                       Arrow(2017, 11, 14, 22, 44, 00).datetime],
-         "close_date": [Arrow(2017, 11, 14, 21, 35, 00).datetime,
-                        Arrow(2017, 11, 14, 22, 10, 00).datetime,
-                        Arrow(2017, 11, 14, 22, 43, 00).datetime,
-                        Arrow(2017, 11, 14, 22, 58, 00).datetime],
-         "open_rate": [0.002543, 0.003003, 0.003089, 0.003214],
-         "close_rate": [0.002546, 0.003014, 0.0032903, 0.003217],
-         "trade_duration": [123, 34, 31, 14],
-         "open_at_end": [False, False, False, True],
-         "sell_reason": [SellType.ROI, SellType.STOP_LOSS,
-                         SellType.ROI, SellType.FORCE_SELL]
-         })}
+    results = {'DefStrat': {
+        'results': pd.DataFrame(
+            {"pair": ["UNITTEST/BTC", "UNITTEST/BTC", "UNITTEST/BTC", "UNITTEST/BTC"],
+             "profit_percent": [0.003312, 0.010801, -0.013803, 0.002780],
+             "profit_abs": [0.000003, 0.000011, -0.000014, 0.000003],
+             "open_date": [Arrow(2017, 11, 14, 19, 32, 00).datetime,
+                           Arrow(2017, 11, 14, 21, 36, 00).datetime,
+                           Arrow(2017, 11, 14, 22, 12, 00).datetime,
+                           Arrow(2017, 11, 14, 22, 44, 00).datetime],
+             "close_date": [Arrow(2017, 11, 14, 21, 35, 00).datetime,
+                            Arrow(2017, 11, 14, 22, 10, 00).datetime,
+                            Arrow(2017, 11, 14, 22, 43, 00).datetime,
+                            Arrow(2017, 11, 14, 22, 58, 00).datetime],
+             "open_rate": [0.002543, 0.003003, 0.003089, 0.003214],
+             "close_rate": [0.002546, 0.003014, 0.0032903, 0.003217],
+             "trade_duration": [123, 34, 31, 14],
+             "open_at_end": [False, False, False, True],
+             "sell_reason": [SellType.ROI, SellType.STOP_LOSS,
+                             SellType.ROI, SellType.FORCE_SELL]
+             }),
+        'config': default_conf}
+    }
 
     assert strat_stats['max_drawdown'] == 0.0
     assert strat_stats['drawdown_start'] == Arrow.fromtimestamp(0).datetime
@@ -283,9 +289,10 @@ def test_generate_sell_reason_stats(default_conf):
     assert stop_result['profit_mean_pct'] == round(stop_result['profit_mean'] * 100, 2)
 
 
-def test_text_table_strategy(default_conf, mocker):
+def test_text_table_strategy(default_conf):
+    default_conf['max_open_trades'] = 2
     results = {}
-    results['TestStrategy1'] = pd.DataFrame(
+    results['TestStrategy1'] = {'results': pd.DataFrame(
         {
             'pair': ['ETH/BTC', 'ETH/BTC', 'ETH/BTC'],
             'profit_percent': [0.1, 0.2, 0.3],
@@ -296,8 +303,8 @@ def test_text_table_strategy(default_conf, mocker):
             'losses': [0, 0, 1],
             'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
         }
-    )
-    results['TestStrategy2'] = pd.DataFrame(
+    ), 'config': default_conf}
+    results['TestStrategy2'] = {'results': pd.DataFrame(
         {
             'pair': ['LTC/BTC', 'LTC/BTC', 'LTC/BTC'],
             'profit_percent': [0.4, 0.2, 0.3],
@@ -308,7 +315,7 @@ def test_text_table_strategy(default_conf, mocker):
             'losses': [0, 0, 1],
             'sell_reason': [SellType.ROI, SellType.ROI, SellType.STOP_LOSS]
         }
-    )
+    ), 'config': default_conf}
 
     result_str = (
         '|      Strategy |   Buys |   Avg Profit % |   Cum Profit % |   Tot'
@@ -321,9 +328,7 @@ def test_text_table_strategy(default_conf, mocker):
         '          45.00 |        0:20:00 |      3 |       0 |        0 |'
     )
 
-    strategy_results = generate_strategy_metrics(stake_currency='BTC',
-                                                 max_open_trades=2,
-                                                 all_results=results)
+    strategy_results = generate_strategy_metrics(all_results=results)
 
     assert text_table_strategy(strategy_results, 'BTC') == result_str
 

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 from arrow import Arrow
-
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import LAST_BT_RESULT_FN
 from freqtrade.data import history
@@ -22,6 +21,7 @@ from freqtrade.optimize.optimize_reports import (generate_backtest_stats,
                                                  text_table_bt_results,
                                                  text_table_sell_reason,
                                                  text_table_strategy)
+from freqtrade.resolvers.strategy_resolver import StrategyResolver
 from freqtrade.strategy.interface import SellType
 from tests.data.test_history import _backup_file, _clean_test_file
 
@@ -57,6 +57,9 @@ def test_text_table_bt_results(default_conf, mocker):
 
 
 def test_generate_backtest_stats(default_conf, testdatadir):
+    default_conf.update({'strategy': 'DefaultStrategy'})
+    StrategyResolver.load_strategy(default_conf)
+
     results = {'DefStrat': pd.DataFrame({"pair": ["UNITTEST/BTC", "UNITTEST/BTC",
                                                   "UNITTEST/BTC", "UNITTEST/BTC"],
                                          "profit_percent": [0.003312, 0.010801, 0.013803, 0.002780],


### PR DESCRIPTION
## Summary
parameters that can be overriden in the strategy are not in the global backtesting config object.
Therefore, we need to keep the strategy-specific configs around - and use the correct values in backtesting outputs.


