### PR TITLE
Rpc/candlehistory

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -145,6 +145,12 @@ python3 scripts/rest_client.py help
 ``` output
 Possible commands:
 
+available_pairs
+	Return available pair (backtest data) based on timeframe / stake_currency selection
+
+        :param timeframe: Only pairs with this timeframe available.
+        :param stake_currency: Only pairs that include this timeframe
+
 balance
 	Get the account balance.
 
@@ -184,8 +190,26 @@ logs
 
         :param limit: Limits log messages to the last <limit> logs. No limit to get all the trades.
 
+pair_candles
+	Return live dataframe for <pair><timeframe>.
+
+        :param pair: Pair to get data for
+        :param timeframe: Only pairs with this timeframe available.
+        :param limit: Limit result to the last n candles.
+
+pair_history
+	Return historic, analyzed dataframe
+
+        :param pair: Pair to get data for
+        :param timeframe: Only pairs with this timeframe available.
+        :param strategy: Strategy to analyze and get values for
+        :param timerange: Timerange to get data for (same format than --timerange endpoints)
+
 performance
 	Return the performance of the different coins.
+
+plot_config
+	Return plot configuration if the strategy defines one.
 
 profit
 	Return the profit summary.
@@ -209,6 +233,9 @@ stop
 stopbuy
 	Stop buying (but handle sells gracefully). Use `reload_config` to reset.
 
+strategies
+	Lists available strategies
+
 trades
 	Return trades history.
 
@@ -219,7 +246,6 @@ version
 
 whitelist
 	Show the current whitelist.
-
 
 ```
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -129,12 +129,15 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `whitelist` | Show the current whitelist
 | `blacklist [pair]` | Show the current blacklist, or adds a pair to the blacklist.
 | `edge` | Show validated pairs by Edge if it is enabled.
-| `pair_candles` | Returns dataframe for a pair / timeframe combination while the bot is running.
-| `pair_history` | Returns an analyzed dataframe for a given timerange, analyzed by a given strategy.
-| `plot_config` | Get plot config from the strategy (or nothing if not configured).
-| `strategies` | List strategies in strategy directory.
-| `available_pairs` | List available backtest data.
+| `pair_candles` | Returns dataframe for a pair / timeframe combination while the bot is running. **Alpha**
+| `pair_history` | Returns an analyzed dataframe for a given timerange, analyzed by a given strategy. **Alpha**
+| `plot_config` | Get plot config from the strategy (or nothing if not configured). **Alpha**
+| `strategies` | List strategies in strategy directory. **Alpha**
+| `available_pairs` | List available backtest data. **Alpha**
 | `version` | Show version
+
+!!! Warning "Alpha status"
+    Endpoints labeled with *Alpha status* above may change at any time without notice.
 
 Possible commands can be listed from the rest-client script using the `help` command.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -133,6 +133,7 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `pair_history` | Returns an analyzed dataframe for a given timerange, analyzed by a given strategy. **Alpha**
 | `plot_config` | Get plot config from the strategy (or nothing if not configured). **Alpha**
 | `strategies` | List strategies in strategy directory. **Alpha**
+| `strategy <strategy>` | Get specific Strategy content. **Alpha**
 | `available_pairs` | List available backtest data. **Alpha**
 | `version` | Show version
 
@@ -238,6 +239,11 @@ stopbuy
 
 strategies
 	Lists available strategies
+
+strategy
+	Get strategy details
+
+        :param strategy: Strategy class name
 
 trades
 	Return trades history.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -104,7 +104,7 @@ By default, the script assumes `127.0.0.1` (localhost) and port `8080` to be use
 python3 scripts/rest_client.py --config rest_config.json <command> [optional parameters]
 ```
 
-## Available commands
+## Available endpoints
 
 |  Command | Description |
 |----------|-------------|
@@ -129,6 +129,11 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `whitelist` | Show the current whitelist
 | `blacklist [pair]` | Show the current blacklist, or adds a pair to the blacklist.
 | `edge` | Show validated pairs by Edge if it is enabled.
+| `pair_candles` | Returns dataframe for a pair / timeframe combination while the bot is running.
+| `pair_history` | Returns an analyzed dataframe for a given timerange, analyzed by a given strategy.
+| `plot_config` | Get plot config from the strategy (or nothing if not configured).
+| `strategies` | List strategies in strategy directory.
+| `available_pairs` | List available backtest data.
 | `version` | Show version
 
 Possible commands can be listed from the rest-client script using the `help` command.

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -77,7 +77,7 @@ class IResolver:
         return valid_objects_gen
 
     @classmethod
-    def _search_object(cls, directory: Path, object_name: str, add_source: bool = False
+    def _search_object(cls, directory: Path, *, object_name: str, add_source: bool = False
                        ) -> Union[Tuple[Any, Path], Tuple[None, None]]:
         """
         Search for the objectname in the given directory
@@ -103,7 +103,7 @@ class IResolver:
         return (None, None)
 
     @classmethod
-    def _load_object(cls, paths: List[Path], object_name: str, add_source: bool = False,
+    def _load_object(cls, paths: List[Path], *, object_name: str, add_source: bool = False,
                      kwargs: dict = {}) -> Optional[Any]:
         """
         Try to load object from path list.
@@ -125,7 +125,7 @@ class IResolver:
         return None
 
     @classmethod
-    def load_object(cls, object_name: str, config: dict, kwargs: dict,
+    def load_object(cls, object_name: str, config: dict, *, kwargs: dict,
                     extra_dir: Optional[str] = None) -> Any:
         """
         Search and loads the specified object as configured in hte child class.

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -98,7 +98,7 @@ class IResolver:
             if obj:
                 obj[0].__file__ = str(entry)
                 if add_source:
-                    obj[0].__code__ = obj[1]
+                    obj[0].__source__ = obj[1]
                 return (obj[0], module_path)
         return (None, None)
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -174,7 +174,9 @@ class StrategyResolver(IResolver):
 
         strategy = StrategyResolver._load_object(paths=abs_paths,
                                                  object_name=strategy_name,
-                                                 kwargs={'config': config})
+                                                 add_source=True,
+                                                 kwargs={'config': config},
+                                                 )
         if strategy:
             strategy._populate_fun_len = len(getfullargspec(strategy.populate_indicators).args)
             strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -166,8 +166,8 @@ class ApiServer(RPC):
         """ Helper function to jsonify object for a webserver """
         return jsonify(return_value)
 
-    def rest_error(self, error_msg):
-        return jsonify({"error": error_msg}), 502
+    def rest_error(self, error_msg, error_code=502):
+        return jsonify({"error": error_msg}), error_code
 
     def register_rest_rpc_urls(self):
         """
@@ -531,6 +531,8 @@ class ApiServer(RPC):
         pair = request.args.get("pair")
         timeframe = request.args.get("timeframe")
         limit = request.args.get("limit", type=int)
+        if not pair or not timeframe:
+            return self.rest_error("Mandatory parameter missing.", 400)
 
         results = self._analysed_dataframe(pair, timeframe, limit)
         return self.rest_dump(results)
@@ -556,7 +558,7 @@ class ApiServer(RPC):
         strategy = request.args.get("strategy")
 
         if not pair or not timeframe or not timerange or not strategy:
-            return self.rest_error("Mandatory parameter missing.")
+            return self.rest_error("Mandatory parameter missing.", 400)
 
         config = deepcopy(self._config)
         config.update({

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -517,7 +517,7 @@ class ApiServer(RPC):
         """
         pair = request.args.get("pair")
         timeframe = request.args.get("timeframe")
-        limit = request.args.get("limit")
+        limit = request.args.get("limit", type=int)
 
         results = self._rpc_analysed_history(pair, timeframe, limit)
         return self.rest_dump(results)

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -214,6 +214,8 @@ class ApiServer(RPC):
                               view_func=self._trades_delete, methods=['DELETE'])
         self.app.add_url_rule(f'{BASE_URI}/pair_history', 'pair_history',
                               view_func=self._analysed_history, methods=['GET'])
+        self.app.add_url_rule(f'{BASE_URI}/plot_config', 'plot_config',
+                              view_func=self._plot_config, methods=['GET'])
         # Combined actions and infos
         self.app.add_url_rule(f'{BASE_URI}/blacklist', 'blacklist', view_func=self._blacklist,
                               methods=['GET', 'POST'])
@@ -521,3 +523,11 @@ class ApiServer(RPC):
 
         results = self._rpc_analysed_history(pair, timeframe, limit)
         return self.rest_dump(results)
+
+    @require_login
+    @rpc_catch_errors
+    def _plot_config(self):
+        """
+        Handler for /plot_config.
+        """
+        return self.rest_dump(self._rpc_plot_config())

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -551,6 +551,10 @@ class ApiServer(RPC):
         timeframe = request.args.get("timeframe")
         timerange = request.args.get("timerange")
         strategy = request.args.get("strategy")
+
+        if not pair or not timeframe or not timerange or not strategy:
+            return self.rest_error("Mandatory parameter missing.")
+
         config = deepcopy(self._config)
         config.update({
             'strategy': strategy,
@@ -575,4 +579,4 @@ class ApiServer(RPC):
         strategy_objs = StrategyResolver.search_all_objects(directory, False)
         strategy_objs = sorted(strategy_objs, key=lambda x: x['name'])
 
-        return self.rest_dump([x['name'] for x in strategy_objs])
+        return self.rest_dump({'strategies': [x['name'] for x in strategy_objs]})

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -608,7 +608,7 @@ class ApiServer(RPC):
 
         return self.rest_dump({
             'strategy': strategy_obj.get_strategy_name(),
-            'code': strategy_obj.__code__,
+            'code': strategy_obj.__source__,
          })
 
     @require_login

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -223,6 +223,8 @@ class ApiServer(RPC):
                               view_func=self._plot_config, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/strategies', 'strategies',
                               view_func=self._list_strategies, methods=['GET'])
+        self.app.add_url_rule(f'{BASE_URI}/strategy/<string:strategy>', 'strategy',
+                              view_func=self._get_strategy, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/available_pairs', 'pairs',
                               view_func=self._list_available_pairs, methods=['GET'])
 
@@ -585,6 +587,24 @@ class ApiServer(RPC):
         strategy_objs = sorted(strategy_objs, key=lambda x: x['name'])
 
         return self.rest_dump({'strategies': [x['name'] for x in strategy_objs]})
+
+    @require_login
+    @rpc_catch_errors
+    def _get_strategy(self, strategy: str):
+        """
+        Get a single strategy
+        get:
+          parameters:
+            - strategy: Only get this strategy
+        """
+        config = deepcopy(self._config)
+        from freqtrade.resolvers.strategy_resolver import StrategyResolver
+        strategy_obj = StrategyResolver._load_strategy(strategy, config, None)
+
+        return self.rest_dump({
+            'strategy': strategy_obj.get_strategy_name(),
+            'code': strategy_obj.__code__,
+         })
 
     @require_login
     @rpc_catch_errors

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -163,10 +163,6 @@ class ApiServer(RPC):
         """
         pass
 
-    def rest_dump(self, return_value):
-        """ Helper function to jsonify object for a webserver """
-        return jsonify(return_value)
-
     def rest_error(self, error_msg, error_code=502):
         return jsonify({"error": error_msg}), error_code
 
@@ -244,7 +240,7 @@ class ApiServer(RPC):
         """
         Return "404 not found", 404.
         """
-        return self.rest_dump({
+        return jsonify({
             'status': 'error',
             'reason': f"There's no API call for {request.base_url}.",
             'code': 404
@@ -264,7 +260,7 @@ class ApiServer(RPC):
                 'access_token': create_access_token(identity=keystuff),
                 'refresh_token': create_refresh_token(identity=keystuff),
             }
-            return self.rest_dump(ret)
+            return jsonify(ret)
 
         return jsonify({"error": "Unauthorized"}), 401
 
@@ -279,7 +275,7 @@ class ApiServer(RPC):
         new_token = create_access_token(identity=current_user, fresh=False)
 
         ret = {'access_token': new_token}
-        return self.rest_dump(ret)
+        return jsonify(ret)
 
     @require_login
     @rpc_catch_errors
@@ -289,7 +285,7 @@ class ApiServer(RPC):
         Starts TradeThread in bot if stopped.
         """
         msg = self._rpc_start()
-        return self.rest_dump(msg)
+        return jsonify(msg)
 
     @require_login
     @rpc_catch_errors
@@ -299,7 +295,7 @@ class ApiServer(RPC):
         Stops TradeThread in bot if running
         """
         msg = self._rpc_stop()
-        return self.rest_dump(msg)
+        return jsonify(msg)
 
     @require_login
     @rpc_catch_errors
@@ -309,14 +305,14 @@ class ApiServer(RPC):
         Sets max_open_trades to 0 and gracefully sells all open trades
         """
         msg = self._rpc_stopbuy()
-        return self.rest_dump(msg)
+        return jsonify(msg)
 
     @rpc_catch_errors
     def _ping(self):
         """
         simple ping version
         """
-        return self.rest_dump({"status": "pong"})
+        return jsonify({"status": "pong"})
 
     @require_login
     @rpc_catch_errors
@@ -324,7 +320,7 @@ class ApiServer(RPC):
         """
         Prints the bot's version
         """
-        return self.rest_dump({"version": __version__})
+        return jsonify({"version": __version__})
 
     @require_login
     @rpc_catch_errors
@@ -332,7 +328,7 @@ class ApiServer(RPC):
         """
         Prints the bot's version
         """
-        return self.rest_dump(self._rpc_show_config(self._config))
+        return jsonify(self._rpc_show_config(self._config))
 
     @require_login
     @rpc_catch_errors
@@ -342,7 +338,7 @@ class ApiServer(RPC):
         Triggers a config file reload
         """
         msg = self._rpc_reload_config()
-        return self.rest_dump(msg)
+        return jsonify(msg)
 
     @require_login
     @rpc_catch_errors
@@ -352,7 +348,7 @@ class ApiServer(RPC):
         Returns the number of trades running
         """
         msg = self._rpc_count()
-        return self.rest_dump(msg)
+        return jsonify(msg)
 
     @require_login
     @rpc_catch_errors
@@ -370,7 +366,7 @@ class ApiServer(RPC):
                                        self._config.get('fiat_display_currency', '')
                                        )
 
-        return self.rest_dump(stats)
+        return jsonify(stats)
 
     @require_login
     @rpc_catch_errors
@@ -382,7 +378,7 @@ class ApiServer(RPC):
             limit: Only get a certain number of records
         """
         limit = int(request.args.get('limit', 0)) or None
-        return self.rest_dump(self._rpc_get_logs(limit))
+        return jsonify(self._rpc_get_logs(limit))
 
     @require_login
     @rpc_catch_errors
@@ -393,7 +389,7 @@ class ApiServer(RPC):
         """
         stats = self._rpc_edge()
 
-        return self.rest_dump(stats)
+        return jsonify(stats)
 
     @require_login
     @rpc_catch_errors
@@ -409,7 +405,7 @@ class ApiServer(RPC):
                                            self._config.get('fiat_display_currency')
                                            )
 
-        return self.rest_dump(stats)
+        return jsonify(stats)
 
     @require_login
     @rpc_catch_errors
@@ -422,7 +418,7 @@ class ApiServer(RPC):
         """
         stats = self._rpc_performance()
 
-        return self.rest_dump(stats)
+        return jsonify(stats)
 
     @require_login
     @rpc_catch_errors
@@ -434,9 +430,9 @@ class ApiServer(RPC):
         """
         try:
             results = self._rpc_trade_status()
-            return self.rest_dump(results)
+            return jsonify(results)
         except RPCException:
-            return self.rest_dump([])
+            return jsonify([])
 
     @require_login
     @rpc_catch_errors
@@ -448,7 +444,7 @@ class ApiServer(RPC):
         """
         results = self._rpc_balance(self._config['stake_currency'],
                                     self._config.get('fiat_display_currency', ''))
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -460,7 +456,7 @@ class ApiServer(RPC):
         """
         limit = int(request.args.get('limit', 0))
         results = self._rpc_trade_history(limit)
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -473,7 +469,7 @@ class ApiServer(RPC):
             tradeid: Numeric trade-id assigned to the trade.
         """
         result = self._rpc_delete(tradeid)
-        return self.rest_dump(result)
+        return jsonify(result)
 
     @require_login
     @rpc_catch_errors
@@ -482,7 +478,7 @@ class ApiServer(RPC):
         Handler for /whitelist.
         """
         results = self._rpc_whitelist()
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -492,7 +488,7 @@ class ApiServer(RPC):
         """
         add = request.json.get("blacklist", None) if request.method == 'POST' else None
         results = self._rpc_blacklist(add)
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -504,9 +500,9 @@ class ApiServer(RPC):
         price = request.json.get("price", None)
         trade = self._rpc_forcebuy(asset, price)
         if trade:
-            return self.rest_dump(trade.to_json())
+            return jsonify(trade.to_json())
         else:
-            return self.rest_dump({"status": f"Error buying pair {asset}."})
+            return jsonify({"status": f"Error buying pair {asset}."})
 
     @require_login
     @rpc_catch_errors
@@ -516,7 +512,7 @@ class ApiServer(RPC):
         """
         tradeid = request.json.get("tradeid")
         results = self._rpc_forcesell(tradeid)
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -538,7 +534,7 @@ class ApiServer(RPC):
             return self.rest_error("Mandatory parameter missing.", 400)
 
         results = self._rpc_analysed_dataframe(pair, timeframe, limit)
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -568,7 +564,7 @@ class ApiServer(RPC):
             'strategy': strategy,
         })
         results = self._rpc_analysed_history_full(config, pair, timeframe, timerange)
-        return self.rest_dump(results)
+        return jsonify(results)
 
     @require_login
     @rpc_catch_errors
@@ -576,7 +572,7 @@ class ApiServer(RPC):
         """
         Handler for /plot_config.
         """
-        return self.rest_dump(self._rpc_plot_config())
+        return jsonify(self._rpc_plot_config())
 
     @require_login
     @rpc_catch_errors
@@ -587,7 +583,7 @@ class ApiServer(RPC):
         strategy_objs = StrategyResolver.search_all_objects(directory, False)
         strategy_objs = sorted(strategy_objs, key=lambda x: x['name'])
 
-        return self.rest_dump({'strategies': [x['name'] for x in strategy_objs]})
+        return jsonify({'strategies': [x['name'] for x in strategy_objs]})
 
     @require_login
     @rpc_catch_errors
@@ -606,7 +602,7 @@ class ApiServer(RPC):
         except OperationalException:
             return self.rest_error("Strategy not found.", 404)
 
-        return self.rest_dump({
+        return jsonify({
             'strategy': strategy_obj.get_strategy_name(),
             'code': strategy_obj.__source__,
          })
@@ -644,4 +640,4 @@ class ApiServer(RPC):
             'pairs': pairs,
             'pair_interval': pair_interval,
         }
-        return self.rest_dump(result)
+        return jsonify(result)

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -214,6 +214,7 @@ class ApiServer(RPC):
                               view_func=self._trades, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/trades/<int:tradeid>', 'trades_delete',
                               view_func=self._trades_delete, methods=['DELETE'])
+
         self.app.add_url_rule(f'{BASE_URI}/pair_candles', 'pair_candles',
                               view_func=self._analysed_candles, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/pair_history', 'pair_history',
@@ -518,7 +519,7 @@ class ApiServer(RPC):
     @rpc_catch_errors
     def _analysed_candles(self):
         """
-        Handler for /pair_history.
+        Handler for /pair_candles.
         Returns the dataframe the bot is using during live/dry operations.
         Takes the following get arguments:
         get:

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -172,7 +172,7 @@ class ApiServer(RPC):
 
     def register_rest_rpc_urls(self):
         """
-        Registers flask app URLs that are calls to functonality in rpc.rpc.
+        Registers flask app URLs that are calls to functionality in rpc.rpc.
 
         First two arguments passed are /URL and 'Label'
         Label can be used as a shortcut when refactoring
@@ -314,7 +314,7 @@ class ApiServer(RPC):
     @rpc_catch_errors
     def _ping(self):
         """
-        simple poing version
+        simple ping version
         """
         return self.rest_dump({"status": "pong"})
 
@@ -537,7 +537,7 @@ class ApiServer(RPC):
         if not pair or not timeframe:
             return self.rest_error("Mandatory parameter missing.", 400)
 
-        results = self._analysed_dataframe(pair, timeframe, limit)
+        results = self._rpc_analysed_dataframe(pair, timeframe, limit)
         return self.rest_dump(results)
 
     @require_login

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -328,7 +328,7 @@ class ApiServer(RPC):
         """
         Prints the bot's version
         """
-        return self.rest_dump(self._rpc_show_config())
+        return self.rest_dump(self._rpc_show_config(self._config))
 
     @require_login
     @rpc_catch_errors

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -1,4 +1,3 @@
-from freqtrade.exceptions import OperationalException
 import logging
 import threading
 from copy import deepcopy
@@ -19,6 +18,7 @@ from werkzeug.serving import make_server
 
 from freqtrade.__init__ import __version__
 from freqtrade.constants import DATETIME_PRINT_FORMAT, USERPATH_STRATEGIES
+from freqtrade.exceptions import OperationalException
 from freqtrade.persistence import Trade
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.rpc.rpc import RPC, RPCException

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 import threading
 from datetime import date, datetime
@@ -538,14 +539,19 @@ class ApiServer(RPC):
         parameters:
             - pair: Pair
             - timeframe: Timeframe to get data for (should be aligned to strategy.timeframe)
+            - strategy: Strategy to use - Must exist in configured strategy-path!
             - timerange: timerange in the format YYYYMMDD-YYYYMMDD (YYYYMMDD- or (-YYYYMMDD))
                          are als possible. If omitted uses all available data.
         """
         pair = request.args.get("pair")
         timeframe = request.args.get("timeframe")
         timerange = request.args.get("timerange")
-
-        results = self._rpc_analysed_history_full(pair, timeframe, timerange)
+        strategy = request.args.get("strategy")
+        config = deepcopy(self._config)
+        config.update({
+            'strategy': strategy,
+        })
+        results = self._rpc_analysed_history_full(config, pair, timeframe, timerange)
         return self.rest_dump(results)
 
     @require_login

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -1,3 +1,4 @@
+from freqtrade.exceptions import OperationalException
 import logging
 import threading
 from copy import deepcopy
@@ -599,7 +600,11 @@ class ApiServer(RPC):
         """
         config = deepcopy(self._config)
         from freqtrade.resolvers.strategy_resolver import StrategyResolver
-        strategy_obj = StrategyResolver._load_strategy(strategy, config, None)
+        try:
+            strategy_obj = StrategyResolver._load_strategy(strategy, config,
+                                                           extra_dir=config.get('strategy_path'))
+        except OperationalException:
+            return self.rest_error("Strategy not found.", 404)
 
         return self.rest_dump({
             'strategy': strategy_obj.get_strategy_name(),

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -548,7 +548,6 @@ class ApiServer(RPC):
         results = self._rpc_analysed_history_full(pair, timeframe, timerange)
         return self.rest_dump(results)
 
-
     @require_login
     @rpc_catch_errors
     def _plot_config(self):

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -212,6 +212,8 @@ class ApiServer(RPC):
                               view_func=self._trades, methods=['GET'])
         self.app.add_url_rule(f'{BASE_URI}/trades/<int:tradeid>', 'trades_delete',
                               view_func=self._trades_delete, methods=['DELETE'])
+        self.app.add_url_rule(f'{BASE_URI}/pair_history', 'pair_history',
+                              view_func=self._analysed_history, methods=['GET'])
         # Combined actions and infos
         self.app.add_url_rule(f'{BASE_URI}/blacklist', 'blacklist', view_func=self._blacklist,
                               methods=['GET', 'POST'])
@@ -499,4 +501,16 @@ class ApiServer(RPC):
         """
         tradeid = request.json.get("tradeid")
         results = self._rpc_forcesell(tradeid)
+        return self.rest_dump(results)
+
+    @require_login
+    @rpc_catch_errors
+    def _analysed_history(self):
+        """
+        Handler for /pair_history.
+        """
+        pair = request.args.get("pair")
+        timeframe = request.args.get("timeframe")
+
+        results = self._rpc_analysed_history(pair, timeframe)
         return self.rest_dump(results)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -653,3 +653,13 @@ class RPC:
         if not self._freqtrade.edge:
             raise RPCException('Edge is not enabled.')
         return self._freqtrade.edge.accepted_pairs()
+
+    def _rpc_analysed_history(self, pair, timeframe):
+
+        data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
+        return {
+            'columns': data.columns,
+            'data': data.values.tolist(),
+            'length': len(data),
+            'last_analyzed': last_analyzed,
+        }

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -93,13 +93,12 @@ class RPC:
     def send_msg(self, msg: Dict[str, str]) -> None:
         """ Sends a message to all registered rpc modules """
 
-    def _rpc_show_config(self) -> Dict[str, Any]:
+    def _rpc_show_config(self, config) -> Dict[str, Any]:
         """
         Return a dict of config options.
         Explicitly does NOT return the full config to avoid leakage of sensitive
         information via rpc.
         """
-        config = self._freqtrade.config
         val = {
             'dry_run': config['dry_run'],
             'stake_currency': config['stake_currency'],
@@ -120,7 +119,7 @@ class RPC:
             'forcebuy_enabled': config.get('forcebuy_enable', False),
             'ask_strategy': config.get('ask_strategy', {}),
             'bid_strategy': config.get('bid_strategy', {}),
-            'state': str(self._freqtrade.state)
+            'state': str(self._freqtrade.state) if self._freqtrade else '',
         }
         return val
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -711,15 +711,15 @@ class RPC:
         return self._convert_dataframe_to_dict(self._freqtrade.config['strategy'],
                                                pair, timeframe, _data, last_analyzed)
 
-    def _rpc_analysed_history_full(self, config: Dict[str, any], pair: str, timeframe: str,
+    def _rpc_analysed_history_full(self, config, pair: str, timeframe: str,
                                    timerange: str) -> Dict[str, Any]:
-        timerange = TimeRange.parse_timerange(timerange)
+        timerange_parsed = TimeRange.parse_timerange(timerange)
 
         _data = load_data(
             datadir=config.get("datadir"),
             pairs=[pair],
             timeframe=timeframe,
-            timerange=timerange,
+            timerange=timerange_parsed,
             data_format=config.get('dataformat_ohlcv', 'json'),
         )
         from freqtrade.resolvers.strategy_resolver import StrategyResolver

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -654,9 +654,11 @@ class RPC:
             raise RPCException('Edge is not enabled.')
         return self._freqtrade.edge.accepted_pairs()
 
-    def _rpc_analysed_history(self, pair, timeframe):
+    def _rpc_analysed_history(self, pair, timeframe, limit):
 
         data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
+        if limit:
+            data = data.iloc[:-limit]
         return {
             'columns': data.columns,
             'data': data.values.tolist(),

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -656,8 +656,8 @@ class RPC:
             raise RPCException('Edge is not enabled.')
         return self._freqtrade.edge.accepted_pairs()
 
-    def _convert_dataframe_to_dict(self, strategy: str, pair: str, dataframe: DataFrame,
-                                   last_analyzed: datetime) -> Dict[str, Any]:
+    def _convert_dataframe_to_dict(self, strategy: str, pair: str, timeframe: str,
+                                   dataframe: DataFrame, last_analyzed: datetime) -> Dict[str, Any]:
         has_content = len(dataframe) != 0
         if has_content:
 
@@ -673,6 +673,8 @@ class RPC:
 
         res = {
             'pair': pair,
+            'timeframe': timeframe,
+            'timeframe_ms': timeframe_to_msecs(timeframe),
             'strategy': strategy,
             'columns': list(dataframe.columns),
             'data': dataframe.values.tolist(),
@@ -701,7 +703,7 @@ class RPC:
         if limit:
             _data = _data.iloc[-limit:]
         return self._convert_dataframe_to_dict(self._freqtrade.config['strategy'],
-                                               pair, _data, last_analyzed)
+                                               pair, timeframe, _data, last_analyzed)
 
     def _rpc_analysed_history_full(self, config: Dict[str, any], pair: str, timeframe: str,
                                    timerange: str) -> Dict[str, Any]:
@@ -718,8 +720,8 @@ class RPC:
         strategy = StrategyResolver.load_strategy(config)
         df_analyzed = strategy.analyze_ticker(_data[pair], {'pair': pair})
 
-        return self._convert_dataframe_to_dict(strategy.get_strategy_name(), pair, df_analyzed,
-                                               arrow.Arrow.utcnow().datetime)
+        return self._convert_dataframe_to_dict(strategy.get_strategy_name(), pair, timeframe,
+                                               df_analyzed, arrow.Arrow.utcnow().datetime)
 
     def _rpc_plot_config(self) -> Dict[str, Any]:
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -701,7 +701,7 @@ class RPC:
             })
         return res
 
-    def _analysed_dataframe(self, pair: str, timeframe: str, limit: int) -> Dict[str, Any]:
+    def _rpc_analysed_dataframe(self, pair: str, timeframe: str, limit: int) -> Dict[str, Any]:
 
         _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(
             pair, timeframe)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -657,7 +657,8 @@ class RPC:
             raise RPCException('Edge is not enabled.')
         return self._freqtrade.edge.accepted_pairs()
 
-    def _convert_dataframe_to_dict(self, pair: str, dataframe: DataFrame, last_analyzed: datetime):
+    def _convert_dataframe_to_dict(self, strategy: str, pair: str, dataframe: DataFrame,
+                                   last_analyzed: datetime):
 
         dataframe.loc[:, '__date_ts'] = dataframe.loc[:, 'date'].astype(int64) // 1000 // 1000
         # Move open to seperate column when signal for easy plotting
@@ -671,6 +672,7 @@ class RPC:
 
         return {
             'pair': pair,
+            'strategy': strategy,
             'columns': list(dataframe.columns),
             'data': dataframe.values.tolist(),
             'length': len(dataframe),
@@ -687,7 +689,8 @@ class RPC:
         _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
         if limit:
             _data = _data.iloc[-limit:].copy()
-        return self._convert_dataframe_to_dict(pair, _data, last_analyzed)
+        return self._convert_dataframe_to_dict(self._freqtrade.config['strategy'],
+                                               pair, _data, last_analyzed)
 
     def _rpc_analysed_history_full(self, config: Dict[str, any], pair: str, timeframe: str,
                                    timerange: str) -> Dict[str, Any]:
@@ -704,7 +707,8 @@ class RPC:
         strategy = StrategyResolver.load_strategy(config)
         df_analyzed = strategy.analyze_ticker(_data[pair], {'pair': pair})
 
-        return self._convert_dataframe_to_dict(pair, df_analyzed, arrow.Arrow.utcnow().datetime)
+        return self._convert_dataframe_to_dict(strategy.get_strategy_name(), pair, df_analyzed,
+                                               arrow.Arrow.utcnow().datetime)
 
     def _rpc_plot_config(self) -> Dict[str, Any]:
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -676,6 +676,10 @@ class RPC:
             'length': len(dataframe),
             'last_analyzed': last_analyzed,
             'last_analyzed_ts': int(last_analyzed.timestamp()),
+            'data_start': str(dataframe.iloc[0]['date']),
+            'data_start_ts': int(dataframe.iloc[0]['__date_ts']),
+            'data_stop': str(dataframe.iloc[-1]['date']),
+            'data_stop_ts': int(dataframe.iloc[-1]['__date_ts']),
         }
 
     def _analysed_dataframe(self, pair: str, timeframe: str, limit: int) -> Dict[str, Any]:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -654,7 +654,7 @@ class RPC:
             raise RPCException('Edge is not enabled.')
         return self._freqtrade.edge.accepted_pairs()
 
-    def _rpc_analysed_history(self, pair, timeframe, limit):
+    def _rpc_analysed_history(self, pair, timeframe, limit) -> Dict[str, Any]:
 
         _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
         if limit:
@@ -667,3 +667,7 @@ class RPC:
             'length': len(_data),
             'last_analyzed': last_analyzed,
         }
+
+    def _rpc_plot_config(self) -> Dict[str, Any]:
+
+        return self._freqtrade.strategy.plot_config

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -659,15 +659,19 @@ class RPC:
     def _convert_dataframe_to_dict(self, strategy: str, pair: str, timeframe: str,
                                    dataframe: DataFrame, last_analyzed: datetime) -> Dict[str, Any]:
         has_content = len(dataframe) != 0
+        buy_signals = 0
+        sell_signals = 0
         if has_content:
 
             dataframe.loc[:, '__date_ts'] = dataframe.loc[:, 'date'].astype(int64) // 1000 // 1000
             # Move open to seperate column when signal for easy plotting
             if 'buy' in dataframe.columns:
                 buy_mask = (dataframe['buy'] == 1)
+                buy_signals = int(buy_mask.sum())
                 dataframe.loc[buy_mask, '_buy_signal_open'] = dataframe.loc[buy_mask, 'open']
             if 'sell' in dataframe.columns:
                 sell_mask = (dataframe['sell'] == 1)
+                sell_signals = int(sell_mask.sum())
                 dataframe.loc[sell_mask, '_sell_signal_open'] = dataframe.loc[sell_mask, 'open']
             dataframe = dataframe.replace({NAN: None})
 
@@ -679,6 +683,8 @@ class RPC:
             'columns': list(dataframe.columns),
             'data': dataframe.values.tolist(),
             'length': len(dataframe),
+            'buy_signals': buy_signals,
+            'sell_signals': sell_signals,
             'last_analyzed': last_analyzed,
             'last_analyzed_ts': int(last_analyzed.timestamp()),
             'data_start': '',

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -689,19 +689,19 @@ class RPC:
             _data = _data.iloc[-limit:].copy()
         return self._convert_dataframe_to_dict(pair, _data, last_analyzed)
 
-    def _rpc_analysed_history_full(self, pair: str, timeframe: str,
+    def _rpc_analysed_history_full(self, config: Dict[str, any], pair: str, timeframe: str,
                                    timerange: str) -> Dict[str, Any]:
         timerange = TimeRange.parse_timerange(timerange)
 
         _data = load_data(
-            datadir=self._freqtrade.config.get("datadir"),
+            datadir=config.get("datadir"),
             pairs=[pair],
-            timeframe=self._freqtrade.config.get('timeframe', '5m'),
+            timeframe=timeframe,
             timerange=timerange,
-            data_format=self._freqtrade.config.get('dataformat_ohlcv', 'json'),
+            data_format=config.get('dataformat_ohlcv', 'json'),
         )
         from freqtrade.resolvers.strategy_resolver import StrategyResolver
-        strategy = StrategyResolver.load_strategy(self._freqtrade.config)
+        strategy = StrategyResolver.load_strategy(config)
         df_analyzed = strategy.analyze_ticker(_data[pair], {'pair': pair})
 
         return self._convert_dataframe_to_dict(pair, df_analyzed, arrow.Arrow.utcnow().datetime)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -9,7 +9,7 @@ from math import isnan
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import arrow
-from numpy import NAN, mean
+from numpy import NAN, mean, int64
 
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.exceptions import ExchangeError, PricingError
@@ -656,12 +656,14 @@ class RPC:
 
     def _rpc_analysed_history(self, pair, timeframe, limit):
 
-        data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
+        _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(pair, timeframe)
         if limit:
-            data = data.iloc[:-limit]
+            _data = _data.iloc[-limit:]
+        _data = _data.replace({NAN: None})
+        _data['date'] = _data['date'].astype(int64) // 1000 // 1000
         return {
-            'columns': data.columns,
-            'data': data.values.tolist(),
-            'length': len(data),
+            'columns': list(_data.columns),
+            'data': _data.values.tolist(),
+            'length': len(_data),
             'last_analyzed': last_analyzed,
         }

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -755,7 +755,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        val = self._rpc_show_config()
+        val = self._rpc_show_config(self._freqtrade.config)
         if val['trailing_stop']:
             sl_info = (
                 f"*Initial Stoploss:* `{val['stoploss']}`\n"

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -123,6 +123,8 @@ class IStrategy(ABC):
     # and wallets - access to the current balance.
     dp: Optional[DataProvider] = None
     wallets: Optional[Wallets] = None
+    # container variable for strategy source code
+    __source__: str = ''
 
     # Definition of plot_config. See plotting documentation for more details.
     plot_config: Dict = {}

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -231,6 +231,14 @@ class FtRestClient():
         """
         return self._get("strategies")
 
+    def strategy(self, strategy):
+        """Get strategy details
+
+        :param strategy: Strategy class name
+        :return: json object
+        """
+        return self._get(f"strategy/{strategy}")
+
     def plot_config(self):
         """Return plot configuration if the strategy defines one.
 

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -224,6 +224,62 @@ class FtRestClient():
 
         return self._post("forcesell", data={"tradeid": tradeid})
 
+    def strategies(self):
+        """Lists available strategies
+
+        :return: json object
+        """
+        return self._get("strategies")
+
+    def plot_config(self):
+        """Return plot configuration if the strategy defines one.
+
+        :return: json object
+        """
+        return self._get("plot_config")
+
+    def available_pairs(self, timeframe=None, stake_currency=None):
+        """Return available pair (backtest data) based on timeframe / stake_currency selection
+
+        :param timeframe: Only pairs with this timeframe available.
+        :param stake_currency: Only pairs that include this timeframe
+        :return: json object
+        """
+        return self._get("available_pairs", params={
+            "stake_currency": stake_currency if timeframe else '',
+            "timeframe": timeframe if timeframe else '',
+        })
+
+    def pair_candles(self, pair, timeframe, limit=None):
+        """Return live dataframe for <pair><timeframe>.
+
+        :param pair: Pair to get data for
+        :param timeframe: Only pairs with this timeframe available.
+        :param limit: Limit result to the last n candles.
+        :return: json object
+        """
+        return self._get("available_pairs", params={
+            "pair": pair,
+            "timeframe": timeframe,
+            "limit": limit,
+        })
+
+    def pair_history(self, pair, timeframe, strategy, timerange=None):
+        """Return historic, analyzed dataframe
+
+        :param pair: Pair to get data for
+        :param timeframe: Only pairs with this timeframe available.
+        :param strategy: Strategy to analyze and get values for
+        :param timerange: Timerange to get data for (same format than --timerange endpoints)
+        :return: json object
+        """
+        return self._get("pair_history", params={
+            "pair": pair,
+            "timeframe": timeframe,
+            "strategy": strategy,
+            "timerange": timerange if timerange else '',
+        })
+
 
 def add_arguments():
     parser = argparse.ArgumentParser()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,7 @@ def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
     :return: FreqtradeBot
     """
     patch_freqtradebot(mocker, config)
+    config['datadir'] = Path(config['datadir'])
     return FreqtradeBot(config)
 
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -818,6 +818,16 @@ def test_api_pair_candles(botclient, ohlcv_history):
     timeframe = '5m'
     amount = 2
 
+    # No pair
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_candles?limit={amount}&timeframe={timeframe}")
+    assert_response(rc, 400)
+
+    # No timeframe
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_candles?pair=XRP%2FBTC")
+    assert_response(rc, 400)
+
     rc = client_get(client,
                     f"{BASE_URI}/pair_candles?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
     assert_response(rc)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -876,6 +876,52 @@ def test_api_pair_candles(botclient, ohlcv_history):
              ])
 
 
+def test_api_pair_history(botclient, ohlcv_history):
+    ftbot, client = botclient
+    timeframe = '5m'
+
+    # No pair
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_history?timeframe={timeframe}"
+                    "&timerange=20180111-20180112&strategy=DefaultStrategy")
+    assert_response(rc, 400)
+
+    # No Timeframe
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_history?pair=UNITTEST%2FBTC"
+                    "&timerange=20180111-20180112&strategy=DefaultStrategy")
+    assert_response(rc, 400)
+
+    # No timerange
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_history?pair=UNITTEST%2FBTC&timeframe={timeframe}"
+                    "&strategy=DefaultStrategy")
+    assert_response(rc, 400)
+
+    # No strategy
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_history?pair=UNITTEST%2FBTC&timeframe={timeframe}"
+                    "&timerange=20180111-20180112")
+    assert_response(rc, 400)
+
+    # Working
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_history?pair=UNITTEST%2FBTC&timeframe={timeframe}"
+                    "&timerange=20180111-20180112&strategy=DefaultStrategy")
+    assert_response(rc, 200)
+    assert rc.json['length'] == 289
+    assert len(rc.json['data']) == rc.json['length']
+    assert 'columns' in rc.json
+    assert 'data' in rc.json
+    assert rc.json['pair'] == 'UNITTEST/BTC'
+    assert rc.json['strategy'] == 'DefaultStrategy'
+    assert rc.json['data_start'] == '2018-01-11 00:00:00+00:00'
+    assert rc.json['data_start_ts'] == 1515628800000
+    assert rc.json['data_stop'] == '2018-01-12 00:00:00+00:00'
+    assert rc.json['data_stop_ts'] == 1515715200000
+
+
+
 def test_api_plot_config(botclient):
     ftbot, client = botclient
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -3,6 +3,7 @@ Unit test file for rpc/api_server.py
 """
 
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import ANY, MagicMock, PropertyMock
 
 import pytest
@@ -943,6 +944,21 @@ def test_api_strategies(botclient):
 
     assert_response(rc)
     assert rc.json == {'strategies': ['DefaultStrategy', 'TestStrategyLegacy']}
+
+
+def test_api_strategy(botclient):
+    ftbot, client = botclient
+
+    rc = client_get(client, f"{BASE_URI}/strategy/DefaultStrategy")
+
+    assert_response(rc)
+    assert rc.json['strategy'] == 'DefaultStrategy'
+
+    data = (Path(__file__).parents[1] / "strategy/strats/default_strategy.py").read_text()
+    assert rc.json['code'] == data
+
+    rc = client_get(client, f"{BASE_URI}/strategy/NoStrat")
+    assert_response(rc, 404)
 
 
 def test_list_available_pairs(botclient):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -840,7 +840,7 @@ def test_api_pair_candles(botclient, ohlcv_history):
     assert len(rc.json['data']) == 0
     ohlcv_history['sma'] = ohlcv_history['close'].rolling(2).mean()
     ohlcv_history['buy'] = 0
-    ohlcv_history.iloc[1]['buy'] = 1
+    ohlcv_history.loc[1, 'buy'] = 1
     ohlcv_history['sell'] = 0
 
     ftbot.dataprovider._set_cached_df("XRP/BTC", timeframe, ohlcv_history)
@@ -873,7 +873,7 @@ def test_api_pair_candles(botclient, ohlcv_history):
             [['2017-11-26 08:50:00', 8.794e-05, 8.948e-05, 8.794e-05, 8.88e-05, 0.0877869,
               None, 0, 0, 1511686200000, None, None],
              ['2017-11-26 08:55:00', 8.88e-05, 8.942e-05, 8.88e-05,
-                 8.893e-05, 0.05874751, 8.886500000000001e-05, 0, 0, 1511686500000, None, None]
+                 8.893e-05, 0.05874751, 8.886500000000001e-05, 1, 0, 1511686500000, 8.88e-05, None]
              ])
 
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -878,3 +878,29 @@ def test_api_strategies(botclient):
 
     assert_response(rc)
     assert rc.json == {'strategies': ['DefaultStrategy', 'TestStrategyLegacy']}
+
+
+def test_list_available_pairs(botclient):
+    ftbot, client = botclient
+
+    rc = client_get(client, f"{BASE_URI}/available_pairs")
+
+    assert_response(rc)
+    assert rc.json['length'] == 12
+    assert isinstance(rc.json['pairs'], list)
+
+    rc = client_get(client, f"{BASE_URI}/available_pairs?timeframe=5m")
+    assert_response(rc)
+    assert rc.json['length'] == 12
+
+    rc = client_get(client, f"{BASE_URI}/available_pairs?stake_currency=ETH")
+    assert_response(rc)
+    assert rc.json['length'] == 1
+    assert rc.json['pairs'] == ['XRP/ETH']
+    assert len(rc.json['pair_interval']) == 2
+
+    rc = client_get(client, f"{BASE_URI}/available_pairs?stake_currency=ETH&timeframe=5m")
+    assert_response(rc)
+    assert rc.json['length'] == 1
+    assert rc.json['pairs'] == ['XRP/ETH']
+    assert len(rc.json['pair_interval']) == 1

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -867,3 +867,12 @@ def test_api_plot_config(botclient):
     assert_response(rc)
     assert rc.json == ftbot.strategy.plot_config
     assert isinstance(rc.json['main_plot'], dict)
+
+
+def test_api_strategies(botclient):
+    ftbot, client = botclient
+
+    rc = client_get(client, f"{BASE_URI}/strategies")
+
+    assert_response(rc)
+    assert rc.json == ['DefaultStrategy', 'TestStrategyLegacy']

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -877,4 +877,4 @@ def test_api_strategies(botclient):
     rc = client_get(client, f"{BASE_URI}/strategies")
 
     assert_response(rc)
-    assert rc.json == ['DefaultStrategy', 'TestStrategyLegacy']
+    assert rc.json == {'strategies': ['DefaultStrategy', 'TestStrategyLegacy']}

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -827,6 +827,8 @@ def test_api_pair_candles(botclient, ohlcv_history):
     rc = client_get(client,
                     f"{BASE_URI}/pair_candles?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
     assert_response(rc)
+    assert 'strategy' in rc.json
+    assert rc.json['strategy'] == 'DefaultStrategy'
     assert 'columns' in rc.json
     assert 'data_start_ts' in rc.json
     assert 'data_start' in rc.json

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -835,3 +835,18 @@ def test_api_pair_history(botclient, ohlcv_history):
              [1511686500000, 8.88e-05, 8.942e-05, 8.88e-05,
                  8.893e-05, 0.05874751, 8.886500000000001e-05]
              ])
+
+
+def test_api_plot_config(botclient):
+    ftbot, client = botclient
+
+    rc = client_get(client, f"{BASE_URI}/plot_config")
+    assert_response(rc)
+    assert rc.json == {}
+
+    ftbot.strategy.plot_config = {'main_plot': {'sma': {}},
+                                  'subplots': {'RSI': {'rsi': {'color': 'red'}}}}
+    rc = client_get(client, f"{BASE_URI}/plot_config")
+    assert_response(rc)
+    assert rc.json == ftbot.strategy.plot_config
+    assert isinstance(rc.json['main_plot'], dict)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -817,6 +817,16 @@ def test_api_pair_candles(botclient, ohlcv_history):
     ftbot, client = botclient
     timeframe = '5m'
     amount = 2
+
+    rc = client_get(client,
+                    f"{BASE_URI}/pair_candles?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
+    assert_response(rc)
+    assert 'columns' in rc.json
+    assert 'data_start_ts' in rc.json
+    assert 'data_start' in rc.json
+    assert 'data_stop' in rc.json
+    assert 'data_stop_ts' in rc.json
+    assert len(rc.json['data']) == 0
     ohlcv_history['sma'] = ohlcv_history['close'].rolling(2).mean()
     ohlcv_history['buy'] = 0
     ohlcv_history.iloc[1]['buy'] = 1

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -921,7 +921,6 @@ def test_api_pair_history(botclient, ohlcv_history):
     assert rc.json['data_stop_ts'] == 1515715200000
 
 
-
 def test_api_plot_config(botclient):
     ftbot, client = botclient
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -818,6 +818,10 @@ def test_api_pair_candles(botclient, ohlcv_history):
     timeframe = '5m'
     amount = 2
     ohlcv_history['sma'] = ohlcv_history['close'].rolling(2).mean()
+    ohlcv_history['buy'] = 0
+    ohlcv_history.iloc[1]['buy'] = 1
+    ohlcv_history['sell'] = 0
+
     ftbot.dataprovider._set_cached_df("XRP/BTC", timeframe, ohlcv_history)
 
     rc = client_get(client,
@@ -825,7 +829,9 @@ def test_api_pair_candles(botclient, ohlcv_history):
     assert_response(rc)
     assert 'columns' in rc.json
     assert isinstance(rc.json['columns'], list)
-    assert rc.json['columns'] == ['date', 'open', 'high', 'low', 'close', 'volume', 'sma']
+    assert rc.json['columns'] == ['date', 'open', 'high',
+                                  'low', 'close', 'volume', 'sma', 'buy', 'sell',
+                                  '_buy_signal_open', '_sell_signal_open']
     assert 'pair' in rc.json
     assert rc.json['pair'] == 'XRP/BTC'
 
@@ -833,9 +839,10 @@ def test_api_pair_candles(botclient, ohlcv_history):
     assert len(rc.json['data']) == amount
 
     assert (rc.json['data'] ==
-            [[1511686200000, 8.794e-05, 8.948e-05, 8.794e-05, 8.88e-05, 0.0877869, None],
+            [[1511686200000, 8.794e-05, 8.948e-05, 8.794e-05, 8.88e-05, 0.0877869,
+              None, 0, 0, None, None],
              [1511686500000, 8.88e-05, 8.942e-05, 8.88e-05,
-                 8.893e-05, 0.05874751, 8.886500000000001e-05]
+                 8.893e-05, 0.05874751, 8.886500000000001e-05, 0, 0, None, None]
              ])
 
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -813,7 +813,7 @@ def test_api_forcesell(botclient, mocker, ticker, fee, markets):
     assert rc.json == {'result': 'Created sell order for trade 1.'}
 
 
-def test_api_pair_history(botclient, ohlcv_history):
+def test_api_pair_candles(botclient, ohlcv_history):
     ftbot, client = botclient
     timeframe = '5m'
     amount = 2
@@ -821,11 +821,13 @@ def test_api_pair_history(botclient, ohlcv_history):
     ftbot.dataprovider._set_cached_df("XRP/BTC", timeframe, ohlcv_history)
 
     rc = client_get(client,
-                    f"{BASE_URI}/pair_history?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
+                    f"{BASE_URI}/pair_candles?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
     assert_response(rc)
     assert 'columns' in rc.json
     assert isinstance(rc.json['columns'], list)
     assert rc.json['columns'] == ['date', 'open', 'high', 'low', 'close', 'volume', 'sma']
+    assert 'pair' in rc.json
+    assert rc.json['pair'] == 'XRP/BTC'
 
     assert 'data' in rc.json
     assert len(rc.json['data']) == amount

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -828,10 +828,18 @@ def test_api_pair_candles(botclient, ohlcv_history):
                     f"{BASE_URI}/pair_candles?limit={amount}&pair=XRP%2FBTC&timeframe={timeframe}")
     assert_response(rc)
     assert 'columns' in rc.json
+    assert 'data_start_ts' in rc.json
+    assert 'data_start' in rc.json
+    assert 'data_stop' in rc.json
+    assert 'data_stop_ts' in rc.json
+    assert rc.json['data_start'] == '2017-11-26 08:50:00+00:00'
+    assert rc.json['data_start_ts'] == 1511686200000
+    assert rc.json['data_stop'] == '2017-11-26 08:55:00+00:00'
+    assert rc.json['data_stop_ts'] == 1511686500000
     assert isinstance(rc.json['columns'], list)
     assert rc.json['columns'] == ['date', 'open', 'high',
                                   'low', 'close', 'volume', 'sma', 'buy', 'sell',
-                                  '_buy_signal_open', '_sell_signal_open']
+                                  '__date_ts', '_buy_signal_open', '_sell_signal_open']
     assert 'pair' in rc.json
     assert rc.json['pair'] == 'XRP/BTC'
 
@@ -839,10 +847,10 @@ def test_api_pair_candles(botclient, ohlcv_history):
     assert len(rc.json['data']) == amount
 
     assert (rc.json['data'] ==
-            [[1511686200000, 8.794e-05, 8.948e-05, 8.794e-05, 8.88e-05, 0.0877869,
-              None, 0, 0, None, None],
-             [1511686500000, 8.88e-05, 8.942e-05, 8.88e-05,
-                 8.893e-05, 0.05874751, 8.886500000000001e-05, 0, 0, None, None]
+            [['2017-11-26 08:50:00', 8.794e-05, 8.948e-05, 8.794e-05, 8.88e-05, 0.0877869,
+              None, 0, 0, 1511686200000, None, None],
+             ['2017-11-26 08:55:00', 8.88e-05, 8.942e-05, 8.88e-05,
+                 8.893e-05, 0.05874751, 8.886500000000001e-05, 0, 0, 1511686500000, None, None]
              ])
 
 

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -55,8 +55,8 @@ def test_load_strategy(default_conf, result):
                          'strategy_path': str(Path(__file__).parents[2] / 'freqtrade/templates')
                          })
     strategy = StrategyResolver.load_strategy(default_conf)
-    assert isinstance(strategy.__code__, str)
-    assert 'class SampleStrategy' in strategy.__code__
+    assert isinstance(strategy.__source__, str)
+    assert 'class SampleStrategy' in strategy.__source__
     assert isinstance(strategy.__file__, str)
     assert 'rsi' in strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 

--- a/tests/strategy/test_strategy.py
+++ b/tests/strategy/test_strategy.py
@@ -18,13 +18,15 @@ def test_search_strategy():
 
     s, _ = StrategyResolver._search_object(
         directory=default_location,
-        object_name='DefaultStrategy'
+        object_name='DefaultStrategy',
+        add_source=True,
     )
     assert issubclass(s, IStrategy)
 
     s, _ = StrategyResolver._search_object(
         directory=default_location,
-        object_name='NotFoundStrategy'
+        object_name='NotFoundStrategy',
+        add_source=True,
     )
     assert s is None
 
@@ -53,6 +55,9 @@ def test_load_strategy(default_conf, result):
                          'strategy_path': str(Path(__file__).parents[2] / 'freqtrade/templates')
                          })
     strategy = StrategyResolver.load_strategy(default_conf)
+    assert isinstance(strategy.__code__, str)
+    assert 'class SampleStrategy' in strategy.__code__
+    assert isinstance(strategy.__file__, str)
     assert 'rsi' in strategy.advise_indicators(result, {'pair': 'ETH/BTC'})
 
 


### PR DESCRIPTION
## Summary
Implement a few methods to support real-time graphs in [freqUI](https://github.com/freqtrade/frequi).

## Quick changelog

Adds the following new API methods.
* `/pair_candles`
* `/pair_history`
* `/plot_config`
* `/strategies`
* `/strategy <strategy>`
* `/available_pairs`


All methods are currently marked as "alpha" - which means there can be breaking changes to them at any time in the future.

