### PR TITLE
Fix Hyperopt trailing output

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -262,6 +262,11 @@ class Hyperopt:
                     ),
                     default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
                 params_result += f"minimal_roi = {minimal_roi_result}"
+            elif space == 'trailing':
+
+                for k, v in space_params.items():
+                    params_result += f'{k} = {v}\n'
+
             else:
                 params_result += f"{space}_params = {pformat(space_params, indent=4)}"
                 params_result = params_result.replace("}", "\n}").replace("{", "{\n ")


### PR DESCRIPTION
## Summary
Output for hyperopt for trailing space should be copy/pasteable to the strategy to avoid confusion.

closes #3781 

## Quick changelog

Old results:

```
    # Trailing stop:
    trailing_params = {
        'trailing_only_offset_is_reached': True,
        'trailing_stop': True,
        'trailing_stop_positive': 0.2299,
        'trailing_stop_positive_offset': 0.25083
    }

```

New results:

```
    # Trailing stop:
    trailing_stop = True
    trailing_stop_positive = 0.2299
    trailing_stop_positive_offset = 0.25083
    trailing_only_offset_is_reached = True

```