### PR TITLE
Fix example R calculation in edge documentation

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -82,20 +82,33 @@ Risk Reward Ratio ($R$) is a formula used to measure the expected gains of a giv
 $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
 
 ???+ Example "Worked example of $R$ calculation"
-    Let's say that you think that the price of *stonecoin* today is $10.0. You believe that, because they will start mining stonecoin, it will go up to $15.0 tomorrow. There is the risk that the stone is too hard, and the GPUs can't mine it, so the price might go to $0 tomorrow. You are planning to invest $100.<br>
-    Your potential profit is calculated as:<br>
+    Let's say that you think that the price of *stonecoin* today is $10.0. You believe that, because they will start mining stonecoin, it will go up to $15.0 tomorrow. There is the risk that the stone is too hard, and the GPUs can't mine it, so the price might go to $0 tomorrow. You are planning to invest $100.
+
+    Your potential profit is calculated as:
+
     $\begin{aligned} 
-        \text{potential_profit} &= (\text{potential_price} - \text{cost_per_unit}) * \frac{\text{investment}}{\text{cost_per_unit}} \\
-                                &= (15 - 10) * \frac{100}{15}\\
-                                &= 33.33
-    \end{aligned}$<br>
-    Since the price might go to $0, the $100 dolars invested could turn into 0. We can compute the Risk Reward Ratio as follows:<br>
+        \text{potential_profit} &= (\text{potential_price} - \text{entry_price}) * \text{investment} \\
+                                &= (15 - 10) * 100\\
+                                &= 500
+    \end{aligned}$
+
+    Since the price might go to $0, the $100 dollars invested could turn into 0.
+    
+    We do however use a stoploss of 15% - so in the worst case, we'll sell 15% below entry price (or at 8.5).
+
+    $\begin{aligned}
+        \text{risk} &= (\text{entry_price} - \text{stoploss}) * \text{investment} \\
+                                &= (10 - (10 * (1 - 0.15))) * 100\\
+                                &= 150
+    \end{aligned}$
+
+    We can compute the Risk Reward Ratio as follows:<br>
     $\begin{aligned}
         R   &= \frac{\text{potential_profit}}{\text{potential_loss}}\\
-            &= \frac{33.33}{100}\\
-            &= 0.333...
+            &= \frac{500}{150}\\
+            &= 3.33
     \end{aligned}$<br>
-    What it effectivelly means is that the strategy have the potential to make $0.33 for each $1 invested. 
+    What it effectively means is that the strategy have the potential to make 3$ for each $1 invested.
 
 On a long horizon, that is, on many trades, we can calculate the risk reward by dividing the strategy' average profit on winning trades by the strategy' average loss on losing trades. We can calculate the average profit, $\mu_{win}$, as follows:
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -93,11 +93,11 @@ $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
     \end{aligned}$
 
     Since the price might go to $0, the $100 dollars invested could turn into 0.
-    
+
     We do however use a stoploss of 15% - so in the worst case, we'll sell 15% below entry price (or at 8.5).
 
     $\begin{aligned}
-        \text{risk} &= (\text{entry_price} - \text{stoploss}) * \text{investment} \\
+        \text{potential_loss} &= (\text{entry_price} - \text{stoploss}) * \text{investment} \\
                                 &= (10 - (10 * (1 - 0.15))) * 100\\
                                 &= 150
     \end{aligned}$

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -94,11 +94,11 @@ $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
 
     Since the price might go to $0, the $100 dollars invested could turn into 0.
 
-    We do however use a stoploss of 15% - so in the worst case, we'll sell 15% below entry price (or at 8.5).
+    We do however use a stoploss of 15% - so in the worst case, we'll sell 15% below entry price (or at 8.5$).
 
     $\begin{aligned}
         \text{potential_loss} &= (\text{entry_price} - \text{stoploss}) * \text{investment} \\
-                                &= (10 - (10 * (1 - 0.15))) * 100\\
+                                &= (10 - 8.5) * 100\\
                                 &= 150
     \end{aligned}$
 
@@ -108,7 +108,7 @@ $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
             &= \frac{500}{150}\\
             &= 3.33
     \end{aligned}$<br>
-    What it effectively means is that the strategy have the potential to make 3$ for each $1 invested.
+    What it effectively means is that the strategy have the potential to make 3.33$ for each $1 invested.
 
 On a long horizon, that is, on many trades, we can calculate the risk reward by dividing the strategy' average profit on winning trades by the strategy' average loss on losing trades. We can calculate the average profit, $\mu_{win}$, as follows:
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -82,14 +82,14 @@ Risk Reward Ratio ($R$) is a formula used to measure the expected gains of a giv
 $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
 
 ???+ Example "Worked example of $R$ calculation"
-    Let's say that you think that the price of *stonecoin* today is $10.0. You believe that, because they will start mining stonecoin, it will go up to $15.0 tomorrow. There is the risk that the stone is too hard, and the GPUs can't mine it, so the price might go to $0 tomorrow. You are planning to invest $100.
+    Let's say that you think that the price of *stonecoin* today is $10.0. You believe that, because they will start mining stonecoin, it will go up to $15.0 tomorrow. There is the risk that the stone is too hard, and the GPUs can't mine it, so the price might go to $0 tomorrow. You are planning to invest $100, which will give you 10 shares (100 / 10).
 
     Your potential profit is calculated as:
 
     $\begin{aligned} 
-        \text{potential_profit} &= (\text{potential_price} - \text{entry_price}) * \text{investment} \\
-                                &= (15 - 10) * 100\\
-                                &= 500
+        \text{potential_profit} &= (\text{potential_price} - \text{entry_price}) * \frac{\text{investment}}{\text{entry_price}} \\
+                                &= (15 - 10) * (100 / 10) \\
+                                &= 50
     \end{aligned}$
 
     Since the price might go to $0, the $100 dollars invested could turn into 0.
@@ -97,15 +97,16 @@ $$ R = \frac{\text{potential_profit}}{\text{potential_loss}} $$
     We do however use a stoploss of 15% - so in the worst case, we'll sell 15% below entry price (or at 8.5$).
 
     $\begin{aligned}
-        \text{potential_loss} &= (\text{entry_price} - \text{stoploss}) * \text{investment} \\
-                                &= (10 - 8.5) * 100\\
-                                &= 150
+        \text{potential_loss} &= (\text{entry_price} - \text{stoploss}) * \frac{\text{investment}}{\text{entry_price}} \\
+                                &= (10 - 8.5) * (100 / 10)\\
+                                &= 15
     \end{aligned}$
 
-    We can compute the Risk Reward Ratio as follows:<br>
+    We can compute the Risk Reward Ratio as follows:
+
     $\begin{aligned}
         R   &= \frac{\text{potential_profit}}{\text{potential_loss}}\\
-            &= \frac{500}{150}\\
+            &= \frac{50}{15}\\
             &= 3.33
     \end{aligned}$<br>
     What it effectively means is that the strategy have the potential to make 3.33$ for each $1 invested.


### PR DESCRIPTION
## Summary
Fix example R calculation in edge documentation (as pointed out on slack, the old calculation has at least one typo in the "number example")

We should not calculate with 100% loss. However, the old formulae seems incorrect in total.

@silvavn i would appreciate if you could have a look at this.
Adding this example was your work initially (#3745) - so maybe i'm completely wrong on this and did not understand something...

The formulas used now are from [this page](https://analyzingalpha.com/risk-reward-ratio-for-stocks#:~:text=The%20risk%2Dreward%20ratio%20measures,risking%20%241%20to%20make%20%242.) - but other pages seem to use the same formula.

## Whats new
To have a reference on the changes (since this is hard to read in diffs, and needs rendering):

![2020-10-08-102441_779x629_scrot](https://user-images.githubusercontent.com/5024695/95433686-92ceeb80-0950-11eb-8ce6-371f296829ee.png)



Old version:
![2020-10-08-081320_769x437_scrot](https://user-images.githubusercontent.com/5024695/95421654-23e89700-093e-11eb-8b0e-81baadead1d1.png)
