### PR TITLE
bittrex fetch_orderbook API change.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,15 +5,15 @@
     "tradable_balance_ratio": 0.99,
     "fiat_display_currency": "USD",
     "timeframe": "5m",
-    "dry_run": false,
+    "dry_run": true,
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
         "sell": 30
     },
     "bid_strategy": {
-        "ask_last_balance": 0.0,
         "use_order_book": false,
+        "ask_last_balance": 0.0,
         "order_book_top": 1,
         "check_depth_of_market": {
             "enabled": false,

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -7,7 +7,7 @@
     "amount_reserve_percent": 0.05,
     "amend_last_stake_amount": false,
     "last_stake_amount_min_ratio": 0.5,
-    "dry_run": false,
+    "dry_run": true,
     "cancel_open_orders_on_exit": false,
     "timeframe": "5m",
     "trailing_stop": false,

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -27,12 +27,11 @@
         "use_sell_signal": true,
         "sell_profit_only": false,
         "ignore_roi_if_buy_signal": false
-
     },
     "exchange": {
         "name": "kraken",
-        "key": "",
-        "secret": "",
+        "key": "your_exchange_key",
+        "secret": "your_exchange_key",
         "ccxt_config": {"enableRateLimit": true},
         "ccxt_async_config": {
             "enableRateLimit": true,

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -5,6 +5,7 @@ from freqtrade.exchange.exchange import Exchange
 # isort: on
 from freqtrade.exchange.bibox import Bibox
 from freqtrade.exchange.binance import Binance
+from freqtrade.exchange.bittrex import Bittrex
 from freqtrade.exchange.exchange import (available_exchanges, ccxt_exchanges,
                                          get_exchange_bad_reason, is_exchange_bad,
                                          is_exchange_known_ccxt, is_exchange_officially_supported,

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -20,19 +20,8 @@ class Binance(Exchange):
         "order_time_in_force": ['gtc', 'fok', 'ioc'],
         "trades_pagination": "id",
         "trades_pagination_arg": "fromId",
+        "l2_limit_range": [5, 10, 20, 50, 100, 500, 1000],
     }
-
-    def fetch_l2_order_book(self, pair: str, limit: int = 100) -> dict:
-        """
-        get order book level 2 from exchange
-
-        20180619: binance support limits but only on specific range
-        """
-        limit_range = [5, 10, 20, 50, 100, 500, 1000]
-        # get next-higher step in the limit_range list
-        limit = min(list(filter(lambda x: limit <= x, limit_range)))
-
-        return super().fetch_l2_order_book(pair, limit)
 
     def stoploss_adjust(self, stop_loss: float, order: Dict) -> bool:
         """

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -1,0 +1,23 @@
+""" Bittrex exchange subclass """
+import logging
+from typing import Dict
+
+from freqtrade.exchange import Exchange
+
+
+logger = logging.getLogger(__name__)
+
+
+class Bittrex(Exchange):
+    """
+    Bittrex exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+
+    Please note that this exchange is not included in the list of exchanges
+    officially supported by the Freqtrade development team. So some features
+    may still not work as expected.
+    """
+
+    _ft_has: Dict = {
+        "l2_limit_range": [1, 25, 500],
+    }

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1077,7 +1077,7 @@ class Exchange:
         """
         if not limit_range:
             return limit
-        return min([x for x in limit_range if limit <= x])
+        return min([x for x in limit_range if limit <= x] + [max(limit_range)])
 
     @retrier
     def fetch_l2_order_book(self, pair: str, limit: int = 100) -> dict:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1072,12 +1072,12 @@ class Exchange:
     @staticmethod
     def get_next_limit_in_list(limit: int, limit_range: Optional[List[int]]):
         """
-        Get next greater limit
+        Get next greater value in the list.
+        Used by fetch_l2_order_book if the api only supports a limited range
         """
         if not limit_range:
             return limit
-
-        return min(list(filter(lambda x: limit <= x, limit_range)))
+        return min([x for x in limit_range if limit <= x])
 
     @retrier
     def fetch_l2_order_book(self, pair: str, limit: int = 100) -> dict:

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -132,7 +132,7 @@ def test_orderbook(mocker, default_conf, order_book_l2):
     res = dp.orderbook('ETH/BTC', 5)
     assert order_book_l2.call_count == 1
     assert order_book_l2.call_args_list[0][0][0] == 'ETH/BTC'
-    assert order_book_l2.call_args_list[0][0][1] == 5
+    assert order_book_l2.call_args_list[0][0][1] >= 5
 
     assert type(res) is dict
     assert 'bids' in res

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1458,7 +1458,9 @@ def test_get_next_limit_in_list():
     assert Exchange.get_next_limit_in_list(21, limit_range) == 50
     assert Exchange.get_next_limit_in_list(51, limit_range) == 100
     assert Exchange.get_next_limit_in_list(1000, limit_range) == 1000
-    # assert Exchange.get_next_limit_in_list(1001, limit_range) == 1001
+    # Going over the limit ...
+    assert Exchange.get_next_limit_in_list(1001, limit_range) == 1000
+    assert Exchange.get_next_limit_in_list(2000, limit_range) == 1000
 
     assert Exchange.get_next_limit_in_list(21, None) == 21
     assert Exchange.get_next_limit_in_list(100, None) == 100


### PR DESCRIPTION
## Summary
Fix bug after API update by bittrex that breaks fetch-orderbooks as they removed the option to get custom levels of orderbook amounts, and now only support 1, 25 and 500 (removing the previous 1000 that was used). 



closes #3865
## Quick changelog

- Implement generic way for exchanges that only support a limited number of "limit" for orderbooks
- Add supported orderbook values for bittrex (subclassing Bittrex)
- Align sample configs (all should use dry-run by default ... )