### PR TITLE
Rename persistence.init to init_db

### DIFF
--- a/freqtrade/commands/list_commands.py
+++ b/freqtrade/commands/list_commands.py
@@ -205,14 +205,14 @@ def start_show_trades(args: Dict[str, Any]) -> None:
     """
     import json
 
-    from freqtrade.persistence import Trade, init
+    from freqtrade.persistence import Trade, init_db
     config = setup_utils_configuration(args, RunMode.UTIL_NO_EXCHANGE)
 
     if 'db_url' not in config:
         raise OperationalException("--db-url is required for this command.")
 
     logger.info(f'Using DB: "{config["db_url"]}"')
-    init(config['db_url'], clean_open_orders=False)
+    init_db(config['db_url'], clean_open_orders=False)
     tfilter = []
 
     if config.get('trade_ids'):

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -9,10 +9,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 
-from freqtrade import persistence
 from freqtrade.constants import LAST_BT_RESULT_FN
 from freqtrade.misc import json_load
-from freqtrade.persistence import Trade
+from freqtrade.persistence import Trade, init_db
 
 
 logger = logging.getLogger(__name__)
@@ -218,7 +217,7 @@ def load_trades_from_db(db_url: str, strategy: Optional[str] = None) -> pd.DataF
                      Can also serve as protection to load the correct result.
     :return: Dataframe containing Trades
     """
-    persistence.init(db_url, clean_open_orders=False)
+    init_db(db_url, clean_open_orders=False)
 
     columns = ["pair", "open_date", "close_date", "profit", "profit_percent",
                "open_rate", "close_rate", "amount", "trade_duration", "sell_reason",

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 import arrow
 from cachetools import TTLCache
 
-from freqtrade import __version__, constants, persistence
+from freqtrade import __version__, constants
 from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
@@ -22,7 +22,7 @@ from freqtrade.exceptions import (DependencyException, ExchangeError, Insufficie
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date
 from freqtrade.misc import safe_value_fallback, safe_value_fallback2
 from freqtrade.pairlist.pairlistmanager import PairListManager
-from freqtrade.persistence import Order, Trade
+from freqtrade.persistence import Order, Trade, cleanup_db, init_db
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.rpc import RPCManager, RPCMessageType
 from freqtrade.state import State
@@ -68,7 +68,7 @@ class FreqtradeBot:
 
         self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
 
-        persistence.init(self.config.get('db_url', None), clean_open_orders=self.config['dry_run'])
+        init_db(self.config.get('db_url', None), clean_open_orders=self.config['dry_run'])
 
         self.wallets = Wallets(self.config, self.exchange)
 
@@ -123,7 +123,7 @@ class FreqtradeBot:
         self.check_for_open_trades()
 
         self.rpc.cleanup()
-        persistence.cleanup()
+        cleanup_db()
 
     def startup(self) -> None:
         """

--- a/freqtrade/persistence/__init__.py
+++ b/freqtrade/persistence/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
 
-from freqtrade.persistence.models import Order, Trade, clean_dry_run_db, cleanup, init
+from freqtrade.persistence.models import Order, Trade, clean_dry_run_db, cleanup_db, init_db

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -29,7 +29,7 @@ _DECL_BASE: Any = declarative_base()
 _SQL_DOCS_URL = 'http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls'
 
 
-def init(db_url: str, clean_open_orders: bool = False) -> None:
+def init_db(db_url: str, clean_open_orders: bool = False) -> None:
     """
     Initializes this module with the given config,
     registers all known command handlers
@@ -72,7 +72,7 @@ def init(db_url: str, clean_open_orders: bool = False) -> None:
         clean_dry_run_db()
 
 
-def cleanup() -> None:
+def cleanup_db() -> None:
     """
     Flushes all pending operations to disk.
     :return: None
@@ -399,7 +399,7 @@ class Trade(_DECL_BASE):
             self.close(order['average'])
         else:
             raise ValueError(f'Unknown order type: {order_type}')
-        cleanup()
+        cleanup_db()
 
     def close(self, rate: float) -> None:
         """

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1149,7 +1149,7 @@ def test_start_list_data(testdatadir, capsys):
 
 @pytest.mark.usefixtures("init_persistence")
 def test_show_trades(mocker, fee, capsys, caplog):
-    mocker.patch("freqtrade.persistence.init")
+    mocker.patch("freqtrade.persistence.init_db")
     create_mock_trades(fee)
     args = [
         "show-trades",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,13 @@ import numpy as np
 import pytest
 from telegram import Chat, Message, Update
 
-from freqtrade import constants, persistence
+from freqtrade import constants
 from freqtrade.commands import Arguments
 from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.edge import Edge, PairInfo
 from freqtrade.exchange import Exchange
 from freqtrade.freqtradebot import FreqtradeBot
-from freqtrade.persistence import Trade
+from freqtrade.persistence import Trade, init_db
 from freqtrade.resolvers import ExchangeResolver
 from freqtrade.worker import Worker
 from tests.conftest_trades import (mock_trade_1, mock_trade_2, mock_trade_3, mock_trade_4,
@@ -131,7 +131,7 @@ def patch_freqtradebot(mocker, config) -> None:
     :return: None
     """
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    persistence.init(config['db_url'])
+    init_db(config['db_url'])
     patch_exchange(mocker)
     mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
@@ -219,7 +219,7 @@ def patch_coingekko(mocker) -> None:
 
 @pytest.fixture(scope='function')
 def init_persistence(default_conf):
-    persistence.init(default_conf['db_url'], default_conf['dry_run'])
+    init_db(default_conf['db_url'], default_conf['dry_run'])
 
 
 @pytest.fixture(scope="function")

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -114,7 +114,7 @@ def test_load_trades_from_db(default_conf, fee, mocker):
 
     create_mock_trades(fee)
     # remove init so it does not init again
-    init_mock = mocker.patch('freqtrade.persistence.init', MagicMock())
+    init_mock = mocker.patch('freqtrade.data.btanalysis.init_db', MagicMock())
 
     trades = load_trades_from_db(db_url=default_conf['db_url'])
     assert init_mock.call_count == 1

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -15,8 +15,7 @@ from freqtrade.exceptions import (DependencyException, ExchangeError, Insufficie
                                   InvalidOrderException, OperationalException, PricingError,
                                   TemporaryError)
 from freqtrade.freqtradebot import FreqtradeBot
-from freqtrade.persistence import Trade
-from freqtrade.persistence.models import Order
+from freqtrade.persistence import Order, Trade
 from freqtrade.rpc import RPCMessageType
 from freqtrade.state import RunMode, State
 from freqtrade.strategy.interface import SellCheckTuple, SellType
@@ -66,7 +65,7 @@ def test_process_stopped(mocker, default_conf) -> None:
 
 
 def test_bot_cleanup(mocker, default_conf, caplog) -> None:
-    mock_cleanup = mocker.patch('freqtrade.persistence.cleanup')
+    mock_cleanup = mocker.patch('freqtrade.freqtradebot.cleanup_db')
     coo_mock = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.cancel_all_open_orders')
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
     freqtrade.cleanup()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,7 +65,7 @@ def test_main_fatal_exception(mocker, default_conf, caplog) -> None:
     mocker.patch('freqtrade.worker.Worker._worker', MagicMock(side_effect=Exception))
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.init_db', MagicMock())
 
     args = ['trade', '-c', 'config.json.example']
 
@@ -83,7 +83,7 @@ def test_main_keyboard_interrupt(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.wallets.Wallets.update', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.init_db', MagicMock())
 
     args = ['trade', '-c', 'config.json.example']
 
@@ -104,7 +104,7 @@ def test_main_operational_exception(mocker, default_conf, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.wallets.Wallets.update', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.init_db', MagicMock())
 
     args = ['trade', '-c', 'config.json.example']
 
@@ -155,7 +155,7 @@ def test_main_reload_config(mocker, default_conf, caplog) -> None:
     reconfigure_mock = mocker.patch('freqtrade.worker.Worker._reconfigure', MagicMock())
 
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.init_db', MagicMock())
 
     args = Arguments(['trade', '-c', 'config.json.example']).get_parsed_arg()
     worker = Worker(args=args, config=default_conf)
@@ -178,7 +178,7 @@ def test_reconfigure(mocker, default_conf) -> None:
     mocker.patch('freqtrade.wallets.Wallets.update', MagicMock())
     patched_configuration_load_config_file(mocker, default_conf)
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
+    mocker.patch('freqtrade.freqtradebot.init_db', MagicMock())
 
     args = Arguments(['trade', '-c', 'config.json.example']).get_parsed_arg()
     worker = Worker(args=args, config=default_conf)


### PR DESCRIPTION
## Summary
Rename persistence.init to init_db to avoid importing the whole module and make the name clear.

## Quick changelog

- rename `init` to `init_db`
- rename `cleanup` to `cleanup_db`