### PR TITLE
Test if return value is an exception when downloading historic data

### DIFF
--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1295,6 +1295,15 @@ def test_get_historic_ohlcv(default_conf, mocker, caplog, exchange_name):
     # Returns twice the above OHLCV data
     assert len(ret) == 2
 
+    caplog.clear()
+
+    async def mock_get_candle_hist_error(pair, *args, **kwargs):
+        raise TimeoutError()
+
+    exchange._async_get_candle_history = MagicMock(side_effect=mock_get_candle_hist_error)
+    ret = exchange.get_historic_ohlcv(pair, "5m", int((arrow.utcnow().timestamp - since) * 1000))
+    assert log_has_re(r"Async code raised an exception: .*", caplog)
+
 
 def test_refresh_latest_ohlcv(mocker, default_conf, caplog) -> None:
     ohlcv = [


### PR DESCRIPTION
## Summary
Test if return value is an exception when downloading historic data

closes #3883

## Quick changelog

- Verify if the return-value is an exception or a tuple (as expected) and handle that case accordingly.