### PR TITLE
Strategic stake amount

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -433,7 +433,8 @@ class FreqtradeBot:
                 Trade.total_open_trades_stakes()
             )
         else:
-            stake_amount = self.strategy.get_stake_amount(pair)
+            stake_amount = strategy_safe_wrapper(self.strategy.get_stake_amount,
+                                                 default_retval=0)(pair)
             if stake_amount == constants.UNLIMITED_STAKE_AMOUNT:
                 stake_amount = self._calculate_unlimited_stake_amount()
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -433,7 +433,7 @@ class FreqtradeBot:
                 Trade.total_open_trades_stakes()
             )
         else:
-            stake_amount = self.config['stake_amount']
+            stake_amount = self.strategy.get_stake_amount(pair)
             if stake_amount == constants.UNLIMITED_STAKE_AMOUNT:
                 stake_amount = self._calculate_unlimited_stake_amount()
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -298,7 +298,7 @@ class Backtesting:
         :param position_stacking: do we allow position stacking?
         :return: DataFrame with trades (results of backtesting)
         """
-        logger.debug(f"Run backtest, stake_amount: {stake_amount}, "
+        logger.debug(f"Run backtest, "
                      f"start_date: {start_date}, end_date: {end_date}, "
                      f"max_open_trades: {max_open_trades}, position_stacking: {position_stacking}"
                      )

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -344,7 +344,8 @@ class Backtesting:
                         and tmp != end_date
                         and row[BUY_IDX] == 1 and row[SELL_IDX] != 1):
                     # Enter trade
-                    stake_amount = get_stake_amount(pair, row[DATE_IDX])
+                    prev_date = data[pair][indexes[pair] - 1][DATE_IDX]
+                    stake_amount = get_stake_amount(pair, prev_date)
                     trade = Trade(
                         pair=pair,
                         open_rate=row[OPEN_IDX],

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -537,7 +537,6 @@ class Hyperopt:
 
         backtesting_results = self.backtesting.backtest(
             processed=processed,
-            stake_amount=self.config['stake_amount'],
             start_date=min_date.datetime,
             end_date=max_date.datetime,
             max_open_trades=self.max_open_trades,

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -267,7 +267,7 @@ class IStrategy(ABC):
         """
         return []
 
-    def get_stake_amount(self, pair: str, date: datetime) -> float:
+    def get_stake_amount(self, pair: str, date: Optional[datetime] = None) -> float:
         """ Called when placing a buy order
         :param pair: Pair that's about to be bought.
         :param date: date of the trade (should be the latest candle for live run mode).
@@ -436,13 +436,13 @@ class IStrategy(ABC):
         :param pair: pair in format ANT/BTC
         :param timeframe: timeframe to use
         :param dataframe: Analyzed dataframe to get signal from.
-        :return: (Buy, Sell) A bool-tuple indicating buy/sell signal
+        :return: (Buy, Sell, Date) A tuple indicating buy/sell signal for the latest date
         """
         if not isinstance(dataframe, DataFrame) or dataframe.empty:
             logger.warning(f'Empty candle (OHLCV) data for pair {pair}')
             return False, False
 
-        latest_date = dataframe['date'].max()
+        latest_date: datetime = dataframe['date'].max()
         latest = dataframe.loc[dataframe['date'] == latest_date].iloc[-1]
         # Explicitly convert to arrow object to ensure the below comparison does not fail
         latest_date = arrow.get(latest_date)
@@ -459,7 +459,7 @@ class IStrategy(ABC):
 
         (buy, sell) = latest[SignalType.BUY.value] == 1, latest[SignalType.SELL.value] == 1
         logger.debug('trigger: %s (pair=%s) buy=%s sell=%s',
-                     latest['date'], pair, str(buy), str(sell))
+                    latest['date'], pair, str(buy), str(sell))
         return buy, sell
 
     def should_sell(self, trade: Trade, rate: float, date: datetime, buy: bool,

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -436,13 +436,13 @@ class IStrategy(ABC):
         :param pair: pair in format ANT/BTC
         :param timeframe: timeframe to use
         :param dataframe: Analyzed dataframe to get signal from.
-        :return: (Buy, Sell, Date) A tuple indicating buy/sell signal for the latest date
+        :return: (Buy, Sell) A bool-tuple indicating buy/sell signal
         """
         if not isinstance(dataframe, DataFrame) or dataframe.empty:
             logger.warning(f'Empty candle (OHLCV) data for pair {pair}')
             return False, False
 
-        latest_date: datetime = dataframe['date'].max()
+        latest_date = dataframe['date'].max()
         latest = dataframe.loc[dataframe['date'] == latest_date].iloc[-1]
         # Explicitly convert to arrow object to ensure the below comparison does not fail
         latest_date = arrow.get(latest_date)
@@ -459,7 +459,7 @@ class IStrategy(ABC):
 
         (buy, sell) = latest[SignalType.BUY.value] == 1, latest[SignalType.SELL.value] == 1
         logger.debug('trigger: %s (pair=%s) buy=%s sell=%s',
-                    latest['date'], pair, str(buy), str(sell))
+                     latest['date'], pair, str(buy), str(sell))
         return buy, sell
 
     def should_sell(self, trade: Trade, rate: float, date: datetime, buy: bool,

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -267,6 +267,13 @@ class IStrategy(ABC):
         """
         return []
 
+    def get_stake_amount(self, pair: str, date: datetime) -> float:
+        """ Called when placing a buy order
+        :param pair: Pair that's about to be bought.
+        :param date: date of the trade (should be the latest candle for live run mode).
+        """
+        return self.config['stake_amount']
+
 ###
 # END - Intended to be overridden by strategy
 ###

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -384,7 +384,6 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
     min_date, max_date = get_timerange({pair: frame})
     results = backtesting.backtest(
         processed=data_processed,
-        stake_amount=default_conf['stake_amount'],
         start_date=min_date,
         end_date=max_date,
         max_open_trades=10,

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -90,7 +90,6 @@ def simple_backtest(config, contour, num_results, mocker, testdatadir) -> None:
     assert isinstance(processed, dict)
     results = backtesting.backtest(
         processed=processed,
-        stake_amount=config['stake_amount'],
         start_date=min_date,
         end_date=max_date,
         max_open_trades=1,
@@ -110,7 +109,6 @@ def _make_backtest_conf(mocker, datadir, conf=None, pair='UNITTEST/BTC'):
     min_date, max_date = get_timerange(processed)
     return {
         'processed': processed,
-        'stake_amount': conf['stake_amount'],
         'start_date': min_date,
         'end_date': max_date,
         'max_open_trades': 10,
@@ -353,7 +351,6 @@ def test_backtesting_start(default_conf, mocker, testdatadir, caplog) -> None:
     # check the logs, that will contain the backtest result
     exists = [
         'Using stake_currency: BTC ...',
-        'Using stake_amount: 0.001 ...',
         'Backtesting with data from 2017-11-14 21:17:00 '
         'up to 2017-11-14 22:59:00 (0 days)..'
     ]
@@ -452,7 +449,6 @@ def test_backtest(default_conf, fee, mocker, testdatadir) -> None:
     min_date, max_date = get_timerange(processed)
     results = backtesting.backtest(
         processed=processed,
-        stake_amount=default_conf['stake_amount'],
         start_date=min_date,
         end_date=max_date,
         max_open_trades=10,
@@ -507,7 +503,6 @@ def test_backtest_1min_timeframe(default_conf, fee, mocker, testdatadir) -> None
     min_date, max_date = get_timerange(processed)
     results = backtesting.backtest(
         processed=processed,
-        stake_amount=default_conf['stake_amount'],
         start_date=min_date,
         end_date=max_date,
         max_open_trades=1,
@@ -623,7 +618,6 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
     min_date, max_date = get_timerange(processed)
     backtest_conf = {
         'processed': processed,
-        'stake_amount': default_conf['stake_amount'],
         'start_date': min_date,
         'end_date': max_date,
         'max_open_trades': 3,
@@ -639,7 +633,6 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
 
     backtest_conf = {
         'processed': processed,
-        'stake_amount': default_conf['stake_amount'],
         'start_date': min_date,
         'end_date': max_date,
         'max_open_trades': 1,
@@ -678,7 +671,6 @@ def test_backtest_start_timerange(default_conf, mocker, caplog, testdatadir):
         'Parameter --timerange detected: 1510694220-1510700340 ...',
         f'Using data directory: {testdatadir} ...',
         'Using stake_currency: BTC ...',
-        'Using stake_amount: 0.001 ...',
         'Loading data from 2017-11-14 20:57:00 '
         'up to 2017-11-14 22:58:00 (0 days)..',
         'Backtesting with data from 2017-11-14 21:17:00 '
@@ -742,7 +734,6 @@ def test_backtest_start_multi_strat(default_conf, mocker, caplog, testdatadir):
         'Parameter --timerange detected: 1510694220-1510700340 ...',
         f'Using data directory: {testdatadir} ...',
         'Using stake_currency: BTC ...',
-        'Using stake_amount: 0.001 ...',
         'Loading data from 2017-11-14 20:57:00 '
         'up to 2017-11-14 22:58:00 (0 days)..',
         'Backtesting with data from 2017-11-14 21:17:00 '
@@ -821,7 +812,6 @@ def test_backtest_start_multi_strat_nomock(default_conf, mocker, caplog, testdat
         'Parameter --timerange detected: 1510694220-1510700340 ...',
         f'Using data directory: {testdatadir} ...',
         'Using stake_currency: BTC ...',
-        'Using stake_amount: 0.001 ...',
         'Loading data from 2017-11-14 20:57:00 '
         'up to 2017-11-14 22:58:00 (0 days)..',
         'Backtesting with data from 2017-11-14 21:17:00 '


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
allows the strategy to handle stake amount for each trade

## Quick changelog

- the bot get the stake amount from the strategy `get_stake_amount` method
- during backtesting the date is provided to allow the strategy to return the correct stake amount for the candle


Some places where there is some logging about the stake amount used were removed, but not all of them, like the ones in the rpc code..some options
- just remove it everywhere
- change it to something like `minimum_stake_amount` and maybe touple it with the stake currency