### PR TITLE
Improve error when hyperopt-loss-function is missing

### DIFF
--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -4,6 +4,7 @@ Definition of cli arguments used in arguments.py
 from argparse import ArgumentTypeError
 
 from freqtrade import __version__, constants
+from freqtrade.constants import HYPEROPT_LOSS_BUILTIN
 
 
 def check_int_positive(value: str) -> int:
@@ -257,8 +258,7 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify the class name of the hyperopt loss function class (IHyperOptLoss). '
         'Different functions can generate completely different results, '
         'since the target for optimization is different. Built-in Hyperopt-loss-functions are: '
-        'ShortTradeDurHyperOptLoss, OnlyProfitHyperOptLoss, SharpeHyperOptLoss, '
-        'SharpeHyperOptLossDaily, SortinoHyperOptLoss, SortinoHyperOptLossDaily.',
+        f'{", ".join(HYPEROPT_LOSS_BUILTIN)}',
         metavar='NAME',
     ),
     "hyperoptexportfilename": Arg(

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -20,6 +20,9 @@ REQUIRED_ORDERTYPES = ['buy', 'sell', 'stoploss', 'stoploss_on_exchange']
 ORDERBOOK_SIDES = ['ask', 'bid']
 ORDERTYPE_POSSIBILITIES = ['limit', 'market']
 ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
+HYPEROPT_LOSS_BUILTIN = ['ShortTradeDurHyperOptLoss', 'OnlyProfitHyperOptLoss',
+                         'SharpeHyperOptLoss', 'SharpeHyperOptLossDaily',
+                         'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
                        'AgeFilter', 'PrecisionFilter', 'PriceFilter',
                        'ShuffleFilter', 'SpreadFilter']

--- a/freqtrade/resolvers/hyperopt_resolver.py
+++ b/freqtrade/resolvers/hyperopt_resolver.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Dict
 
-from freqtrade.constants import USERPATH_HYPEROPTS
+from freqtrade.constants import HYPEROPT_LOSS_BUILTIN, USERPATH_HYPEROPTS
 from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss
@@ -72,8 +72,11 @@ class HyperOptLossResolver(IResolver):
 
         hyperoptloss_name = config.get('hyperopt_loss')
         if not hyperoptloss_name:
-            raise OperationalException("No Hyperopt loss set. Please use `--hyperopt-loss` to "
-                                       "specify the Hyperopt-Loss class to use.")
+            raise OperationalException(
+                "No Hyperopt loss set. Please use `--hyperopt-loss` to "
+                "specify the Hyperopt-Loss class to use.\n"
+                f"Built-in Hyperopt-loss-functions are: {', '.join(HYPEROPT_LOSS_BUILTIN)}"
+            )
         hyperoptloss = HyperOptLossResolver.load_object(hyperoptloss_name,
                                                         config, kwargs={},
                                                         extra_dir=config.get('hyperopt_path'))


### PR DESCRIPTION
## Summary
Improve message of missing hyperopt-loss function by providing a list of builtin loss functions.

## Quick changelog

- Improved exception message