### PR TITLE
Download data remove stake_currency

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -35,6 +35,9 @@ def start_download_data(args: Dict[str, Any]) -> None:
     if 'timerange' in config:
         timerange = timerange.parse_timerange(config['timerange'])
 
+    # Remove stake-currency to skip checks which are not relevant for datadownload
+    config['stake_currency'] = ''
+
     if 'pairs' not in config:
         raise OperationalException(
             "Downloading data requires a list of pairs. "

--- a/freqtrade/commands/deploy_commands.py
+++ b/freqtrade/commands/deploy_commands.py
@@ -133,7 +133,7 @@ def start_new_hyperopt(args: Dict[str, Any]) -> None:
 
         if new_path.exists():
             raise OperationalException(f"`{new_path}` already exists. "
-                                       "Please choose another Strategy Name.")
+                                       "Please choose another Hyperopt Name.")
         deploy_new_hyperopt(args['hyperopt'], new_path, args['template'])
     else:
         raise OperationalException("`new-hyperopt` requires --hyperopt to be set.")

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -476,6 +476,12 @@ def test_start_new_strategy(mocker, caplog):
     assert "CoolNewStrategy" in wt_mock.call_args_list[0][0][0]
     assert log_has_re("Writing strategy to .*", caplog)
 
+    mocker.patch('freqtrade.commands.deploy_commands.setup_utils_configuration')
+    mocker.patch.object(Path, "exists", MagicMock(return_value=True))
+    with pytest.raises(OperationalException,
+                       match=r".* already exists. Please choose another Strategy Name\."):
+        start_new_strategy(get_args(args))
+
 
 def test_start_new_strategy_DefaultStrat(mocker, caplog):
     args = [
@@ -511,6 +517,12 @@ def test_start_new_hyperopt(mocker, caplog):
     assert wt_mock.call_count == 1
     assert "CoolNewhyperopt" in wt_mock.call_args_list[0][0][0]
     assert log_has_re("Writing hyperopt to .*", caplog)
+
+    mocker.patch('freqtrade.commands.deploy_commands.setup_utils_configuration')
+    mocker.patch.object(Path, "exists", MagicMock(return_value=True))
+    with pytest.raises(OperationalException,
+                       match=r".* already exists. Please choose another Hyperopt Name\."):
+        start_new_hyperopt(get_args(args))
 
 
 def test_start_new_hyperopt_DefaultHyperopt(mocker, caplog):

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -792,6 +792,25 @@ def test_start_test_pairlist(mocker, caplog, tickers, default_conf, capsys):
     assert re.match(r"Pairs for .*", captured.out)
     assert re.match("['ETH/BTC', 'TKN/BTC', 'BLK/BTC', 'LTC/BTC', 'XRP/BTC']", captured.out)
 
+    args = [
+        'test-pairlist',
+        '-c', 'config.json.example',
+        '--one-column',
+    ]
+    start_test_pairlist(get_args(args))
+    captured = capsys.readouterr()
+    assert re.match(r"ETH/BTC\nTKN/BTC\nBLK/BTC\nLTC/BTC\nXRP/BTC\n", captured.out)
+
+    args = [
+        'test-pairlist',
+        '-c', 'config.json.example',
+        '--print-json',
+    ]
+    start_test_pairlist(get_args(args))
+    captured = capsys.readouterr()
+    assert re.match(r'Pairs for BTC: \n\["ETH/BTC","TKN/BTC","BLK/BTC","LTC/BTC","XRP/BTC"\]\n',
+                    captured.out)
+
 
 def test_hyperopt_list(mocker, capsys, caplog, hyperopt_results):
     mocker.patch(

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -435,6 +435,16 @@ def test_list_markets(mocker, markets, capsys):
     assert re.search(r"^BLK/BTC$", captured.out, re.MULTILINE)
     assert re.search(r"^LTC/USD$", captured.out, re.MULTILINE)
 
+    mocker.patch('freqtrade.exchange.Exchange.markets', PropertyMock(side_effect=ValueError))
+    # Test --one-column
+    args = [
+        "list-markets",
+        '--config', 'config.json.example',
+        "--one-column"
+    ]
+    with pytest.raises(OperationalException, match=r"Cannot get markets.*"):
+        start_list_markets(get_args(args), False)
+
 
 def test_create_datadir_failed(caplog):
 
@@ -707,6 +717,7 @@ def test_start_list_strategies(mocker, caplog, capsys):
         "list-strategies",
         "--strategy-path",
         str(Path(__file__).parent.parent / "strategy" / "strats"),
+        '--no-color',
     ]
     pargs = get_args(args)
     # pargs['config'] = None


### PR DESCRIPTION
## Summary
`freqtrade download-data` does not require stake-currency - and it can lead to failures when it's set to something not matching the pairs downloaded.
It's therefore sensible to set it to empty for that run to avoid these problems.

closes #3901

## Quick changelog

- set stake-currency to "" for download-data
- Improve some tests