### PR TITLE
Dataformat informative pair

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: ".devcontainer/Dockerfile"
     volumes:
       # Allow git usage within container
-      - "/home/${USER}/.ssh:/home/ftuser/.ssh:ro"
-      - "/home/${USER}/.gitconfig:/home/ftuser/.gitconfig:ro"
+      - "${HOME}/.ssh:/home/ftuser/.ssh:ro"
+      - "${HOME}/.gitconfig:/home/ftuser/.gitconfig:ro"
       - ..:/freqtrade:cached
       # Persist bash-history
       - freqtrade-vscode-server:/home/ftuser/.vscode-server

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -88,7 +88,8 @@ class DataProvider:
         """
         return load_pair_history(pair=pair,
                                  timeframe=timeframe or self._config['timeframe'],
-                                 datadir=self._config['datadir']
+                                 datadir=self._config['datadir'],
+                                 data_format=self._config.get('dataformat_ohlcv', 'json')
                                  )
 
     def get_pair_dataframe(self, pair: str, timeframe: str = None) -> DataFrame:


### PR DESCRIPTION
## Summary
Use the value of `dataformat_ohlcv` when using `DataProvider.get_pair_dataframe`

Solve the issue: #3909

## Quick changelog

- Passing value of `dataformat_ohlcv` to `load_pair_history`
- Add unittest

## What's new?

Solves #3909 
