### PR TITLE
change backtesting behaviour if roi and trailing-stop happen at the same time

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -278,6 +278,7 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Trailing stoploss
   - High happens first - adjusting stoploss
   - Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
+  - ROI applies before trailing-stop, ensuring profits are "top-capped" at ROI if both ROI and trailing stop applies
 - Sell-reason does not explain if a trade was positive or negative, just what triggered the sell (this can look odd if negative ROI values are used)
 - Stoploss (and trailing stoploss) is evaluated before ROI within one candle. So you can often see more trades with the `stoploss` and/or `trailing_stop` sell reason comparing to the results obtained with the same strategy in the Dry Run/Live Trade modes.
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -268,19 +268,24 @@ It contains some useful key metrics about performance of your strategy on backte
 Since backtesting lacks some detailed information about what happens within a candle, it needs to take a few assumptions:
 
 - Buys happen at open-price
-- Sell signal sells happen at open-price of the following candle
-- Low happens before high for stoploss, protecting capital first
+- Sell-signal sells happen at open-price of the consecutive candle
+- Sell-signal is favored over Stoploss, because sell-signals are assumed to trigger on candle's open
 - ROI
   - sells are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the sell will be at 2%)
   - sells are never "below the candle", so a ROI of 2% may result in a sell at 2.4% if low was at 2.4% profit
   - Forcesells caused by `<N>=-1` ROI entries use low as sell value, unless N falls on the candle open (e.g. `120: -1` for 1h candles)
 - Stoploss sells happen exactly at stoploss price, even if low was lower
+- Stoploss is evaluated before ROI within one candle. So you can often see more trades with the `stoploss` sell reason comparing to the results obtained with the same strategy in the Dry Run/Live Trade modes
+- Low happens before high for stoploss, protecting capital first
 - Trailing stoploss
   - High happens first - adjusting stoploss
   - Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
   - ROI applies before trailing-stop, ensuring profits are "top-capped" at ROI if both ROI and trailing stop applies
 - Sell-reason does not explain if a trade was positive or negative, just what triggered the sell (this can look odd if negative ROI values are used)
-- Stoploss (and trailing stoploss) is evaluated before ROI within one candle. So you can often see more trades with the `stoploss` and/or `trailing_stop` sell reason comparing to the results obtained with the same strategy in the Dry Run/Live Trade modes.
+- Evaluation sequence (if multiple signals happen on the same candle)
+  - ROI (if not stoploss)
+  - Sell-signal
+  - Stoploss
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.
 Also, keep in mind that past results don't guarantee future success.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -475,24 +475,24 @@ class IStrategy(ABC):
         stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade,
                                               current_time=date, current_profit=current_profit,
                                               force_stoploss=force_stoploss, high=high)
-        
+
         # Set current rate to high for backtesting sell
         current_rate = high or rate
         current_profit = trade.calc_profit_ratio(current_rate)
         config_ask_strategy = self.config.get('ask_strategy', {})
-        
+
         roi_reached = self.min_roi_reached(trade=trade, current_profit=current_profit,
-                                                current_time=date)
-        
+                                           current_time=date)
+
         if stoplossflag.sell_flag:
-            
+
             # When backtesting, in the case of trailing_stop_loss,
             # make sure we don't make a profit higher than ROI.
             if stoplossflag.sell_type == SellType.TRAILING_STOP_LOSS and roi_reached:
                 logger.debug(f"{trade.pair} - Required profit reached. sell_flag=True, "
                              f"sell_type=SellType.ROI")
                 return SellCheckTuple(sell_flag=True, sell_type=SellType.ROI)
-            
+
             logger.debug(f"{trade.pair} - Stoploss hit. sell_flag=True, "
                          f"sell_type={stoplossflag.sell_type}")
             return stoplossflag

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -328,6 +328,58 @@ tc20 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
+# Test 21: trailing_stop ROI collision.
+# Roi should trigger before Trailing stop - otherwise Trailing stop profits can be > ROI
+# which cannot happen in reality
+# stop-loss: 10%, ROI: 4%, Trailing stop adjusted at the sell candle
+tc21 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 4650, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.04}, profit_perc=0.04, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=2)]
+)
+
+# Test 22: trailing_stop Raises in candle 2 - but ROI applies at the same time.
+# applying a positive trailing stop of 3% - ROI should apply before trailing stop.
+# stop-loss: 10%, ROI: 4%, stoploss adjusted candle 2
+tc22 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 5100, 5100, 6172, 0, 0],
+    [3, 4850, 5050, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.04}, profit_perc=0.04, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=2)]
+)
+
+# Test 23: trailing_stop Raises in candle 2 (does not trigger)
+# applying a positive trailing stop of 3% since stop_positive_offset is reached.
+# ROI is changed after this to 4%, dropping ROI below trailing_stop_positive, causing a sell
+# in the candle after the raised stoploss candle with ROI reason.
+# Stoploss would trigger in this candle too, but it's no longer relevant.
+# stop-loss: 10%, ROI: 4%, stoploss adjusted candle 2, ROI adjusted in candle 3 (causing the sell)
+tc23 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 4950, 5100, 6172, 0, 0],
+    [2, 5100, 5251, 5100, 5100, 6172, 0, 0],
+    [3, 4850, 5251, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.1, "119": 0.03}, profit_perc=0.03, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.05,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
 
 TESTS = [
     tc0,
@@ -351,6 +403,9 @@ TESTS = [
     tc18,
     tc19,
     tc20,
+    tc21,
+    tc22,
+    tc23,
 ]
 
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -380,6 +380,66 @@ tc23 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
 )
 
+# Test 24: Sell with signal sell in candle 3 (stoploss also triggers on this candle)
+# Stoploss at 1%.
+# Stoploss wins over Sell-signal (because sell-signal is acted on in the next candle)
+tc24 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4987, 5012, 4986, 4600, 6172, 0, 0],
+    [3, 5010, 5000, 4855, 5010, 6172, 0, 1],  # Triggers stoploss + sellsignal
+    [4, 5010, 4987, 4977, 4995, 6172, 0, 0],
+    [5, 4995, 4995, 4995, 4950, 6172, 0, 0]],
+    stop_loss=-0.01, roi={"0": 1}, profit_perc=-0.01, use_sell_signal=True,
+    trades=[BTrade(sell_reason=SellType.STOP_LOSS, open_tick=1, close_tick=3)]
+)
+
+# Test 25: Sell with signal sell in candle 3 (stoploss also triggers on this candle)
+# Stoploss at 1%.
+# Sell-signal wins over stoploss
+tc25 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4987, 5012, 4986, 4600, 6172, 0, 0],
+    [3, 5010, 5000, 4986, 5010, 6172, 0, 1],
+    [4, 5010, 4987, 4855, 4995, 6172, 0, 0],  # Triggers stoploss + sellsignal acted on
+    [5, 4995, 4995, 4995, 4950, 6172, 0, 0]],
+    stop_loss=-0.01, roi={"0": 1}, profit_perc=0.002, use_sell_signal=True,
+    trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=4)]
+)
+
+# Test 26: Sell with signal sell in candle 3 (ROI at signal candle)
+# Stoploss at 10% (irrelevant), ROI at 5% (will trigger)
+# Sell-signal wins over stoploss
+tc26 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4987, 5012, 4986, 4600, 6172, 0, 0],
+    [3, 5010, 5251, 4986, 5010, 6172, 0, 1],  # Triggers ROI, sell-signal
+    [4, 5010, 4987, 4855, 4995, 6172, 0, 0],
+    [5, 4995, 4995, 4995, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.05}, profit_perc=0.05, use_sell_signal=True,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=3)]
+)
+
+# Test 27: Sell with signal sell in candle 3 (ROI at signal candle)
+# Stoploss at 10% (irrelevant), ROI at 5% (will trigger) - Wins over Sell-signal
+# TODO: figure out if sell-signal should win over ROI
+# Sell-signal wins over stoploss
+tc27 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4987, 5012, 4986, 4600, 6172, 0, 0],
+    [3, 5010, 5012, 4986, 5010, 6172, 0, 1],  # sell-signal
+    [4, 5010, 5251, 4855, 4995, 6172, 0, 0],  # Triggers ROI, sell-signal acted on
+    [5, 4995, 4995, 4995, 4950, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.05}, profit_perc=0.05, use_sell_signal=True,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=4)]
+)
 
 TESTS = [
     tc0,
@@ -406,6 +466,10 @@ TESTS = [
     tc21,
     tc22,
     tc23,
+    tc24,
+    tc25,
+    tc26,
+    tc27,
 ]
 
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3556,7 +3556,7 @@ def test_disable_ignore_roi_if_buy_signal(default_conf, limit_buy_order, limit_b
     # Test if buy-signal is absent
     patch_get_signal(freqtrade, value=(False, True))
     assert freqtrade.handle_trade(trade) is True
-    assert trade.sell_reason == SellType.STOP_LOSS.value
+    assert trade.sell_reason == SellType.SELL_SIGNAL.value
 
 
 def test_get_real_amount_quote(default_conf, trades_for_order, buy_order_fee, fee, caplog, mocker):


### PR DESCRIPTION

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Changed the `should_sell()` method, to handle the case where both ROI and trailing stoploss are reached in backtest. In that case, the sell reason should be ROI, and not stoploss.

## What's new?
When backtesting some strategies in long timeframes (1h, 2h, 4h..), I noticed that trailing stop loss made profits superior to the strategy's ROI.
I'm not sure if this behavior is intended, but it distorts backtest and hyperopt results significantly.

When reading the documentation, I understood that ROI is always tested first, in order to protect capital. But in this case, capital isn't protected, and profits are overestimated.

My suggestion is to add the roi_reached test in the case of trailing_stop_loss selltype. That way, stoploss is always checked first, but trailing stoploss can't make a profit larger than ROI.

This doesn't alter the strategy's behavior in live or dryrun modes, since ROI and trailing stoploss can't hit at the same time.


*edit*: fixes #2422