### PR TITLE
Catch asyncio.TimeoutError when reloading async markets

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -282,7 +282,7 @@ class Exchange:
                 asyncio.get_event_loop().run_until_complete(
                     self._api_async.load_markets(reload=reload))
 
-        except ccxt.BaseError as e:
+        except (asyncio.TimeoutError, ccxt.BaseError) as e:
             logger.warning('Could not load async markets. Reason: %s', e)
             return
 


### PR DESCRIPTION
## Summary
Catch asyncio timeout exception when reloading async markets

Closes #3941 
