### PR TITLE
Plot startup candles

### DIFF
--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -9,9 +9,9 @@ from freqtrade.data.btanalysis import (calculate_max_drawdown, combine_dataframe
                                        create_cum_profit, extract_trades_of_period, load_trades)
 from freqtrade.data.converter import trim_dataframe
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.data.history import load_data
+from freqtrade.data.history import get_timerange, load_data
 from freqtrade.exceptions import OperationalException
-from freqtrade.exchange import timeframe_to_prev_date
+from freqtrade.exchange import timeframe_to_prev_date, timeframe_to_seconds
 from freqtrade.misc import pair_to_filename
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.strategy import IStrategy
@@ -29,7 +29,7 @@ except ImportError:
     exit(1)
 
 
-def init_plotscript(config):
+def init_plotscript(config, startup_candles: int = 0):
     """
     Initialize objects needed for plotting
     :return: Dict with candle (OHLCV) data, trades and pairs
@@ -48,8 +48,15 @@ def init_plotscript(config):
         pairs=pairs,
         timeframe=config.get('timeframe', '5m'),
         timerange=timerange,
+        startup_candles=startup_candles,
         data_format=config.get('dataformat_ohlcv', 'json'),
     )
+
+    if startup_candles:
+        min_date, max_date = get_timerange(data)
+        logger.info(f"Loading data from {min_date} to {max_date}")
+        timerange.adjust_start_if_necessary(timeframe_to_seconds(config.get('timeframe', '5m')),
+                                            startup_candles, min_date)
 
     no_trades = False
     filename = config.get('exportfilename')
@@ -72,6 +79,7 @@ def init_plotscript(config):
     return {"ohlcv": data,
             "trades": trades,
             "pairs": pairs,
+            "timerange": timerange,
             }
 
 
@@ -474,7 +482,8 @@ def load_and_plot_trades(config: Dict[str, Any]):
 
     exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config)
     IStrategy.dp = DataProvider(config, exchange)
-    plot_elements = init_plotscript(config)
+    plot_elements = init_plotscript(config, strategy.startup_candle_count)
+    timerange = plot_elements['timerange']
     trades = plot_elements['trades']
     pair_counter = 0
     for pair, data in plot_elements["ohlcv"].items():
@@ -482,6 +491,7 @@ def load_and_plot_trades(config: Dict[str, Any]):
         logger.info("analyse pair %s", pair)
 
         df_analyzed = strategy.analyze_ticker(data, {'pair': pair})
+        df_analyzed = trim_dataframe(df_analyzed, timerange)
         trades_pair = trades.loc[trades['pair'] == pair]
         trades_pair = extract_trades_of_period(df_analyzed, trades_pair)
 

--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -63,7 +63,7 @@ class {{ strategy }}(IStrategy):
     ignore_roi_if_buy_signal = False
 
     # Number of candles the strategy requires before producing valid signals
-    startup_candle_count: int = 20
+    startup_candle_count: int = 30
 
     # Optional order type mapping.
     order_types = {

--- a/freqtrade/templates/sample_strategy.py
+++ b/freqtrade/templates/sample_strategy.py
@@ -64,7 +64,7 @@ class SampleStrategy(IStrategy):
     ignore_roi_if_buy_signal = False
 
     # Number of candles the strategy requires before producing valid signals
-    startup_candle_count: int = 20
+    startup_candle_count: int = 30
 
     # Optional order type mapping.
     order_types = {

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -51,9 +51,10 @@ def test_init_plotscript(default_conf, mocker, testdatadir):
     assert "ohlcv" in ret
     assert "trades" in ret
     assert "pairs" in ret
+    assert 'timerange' in ret
 
     default_conf['pairs'] = ["TRX/BTC", "ADA/BTC"]
-    ret = init_plotscript(default_conf)
+    ret = init_plotscript(default_conf, 20)
     assert "ohlcv" in ret
     assert "TRX/BTC" in ret["ohlcv"]
     assert "ADA/BTC" in ret["ohlcv"]


### PR DESCRIPTION
## Summary
Plotting should support startup candles

Closes #3943

## Quick changelog

- support startup-candles for plotting, to allow plotting with correct startup period.
- increase startup_candle_count for sample-strategy since TEMA(9) requires 24 startup candles, not 9.