### PR TITLE
Fix typo in windows installation docs

### DIFF
--- a/docs/windows_installation.md
+++ b/docs/windows_installation.md
@@ -32,7 +32,7 @@ python -m venv .env
 .env\Scripts\activate.ps1
 # optionally install ta-lib from wheel
 # Eventually adjust the below filename to match the downloaded wheel
-pip install build_helpes/TA_Lib‑0.4.19‑cp38‑cp38‑win_amd64.whl
+pip install build_helpers/TA_Lib-0.4.19-cp38-cp38-win_amd64.whl
 pip install -r requirements.txt
 pip install -e .
 freqtrade


### PR DESCRIPTION
- Fixed a typo
- Replaced the hyphens U+2011 with U+002D because otherwise pip will throw an error saying ```ERROR: TA_Lib‑0.4.19‑cp38‑cp38‑win_amd64.whl is not a valid wheel filename.```