### PR TITLE
Update exchanges.md - Kraken supports stop loss limit again

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -23,7 +23,7 @@ Binance has been split into 3, and users must use the correct ccxt exchange ID f
 ## Kraken
 
 !!! Tip "Stoploss on Exchange"
-    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it.
+    Kraken supports `stoploss_on_exchange`. It provides great advantages, so we recommend to benefit from it.
 
 ### Historic Kraken data
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -23,7 +23,7 @@ Binance has been split into 3, and users must use the correct ccxt exchange ID f
 ## Kraken
 
 !!! Tip "Stoploss on Exchange"
-    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it, however since the resulting order is a stoploss-market order, sell-rates are not guaranteed, which makes this feature less secure than on other exchanges. This limitation is based on kraken's policy [source](https://blog.kraken.com/post/1234/announcement-delisting-pairs-and-temporary-suspension-of-advanced-order-types/) and [source2](https://blog.kraken.com/post/1494/kraken-enables-advanced-orders-and-adds-10-currency-pairs/) - which has stoploss-limit orders disabled.
+    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it.
 
 ### Historic Kraken data
 


### PR DESCRIPTION
Stop Loss Limit orders on Kraken are enabled again
source: https://blog.kraken.com/post/5282/stop-loss-limit-take-profit-limit-two-new-advanced-orders-go-live-on-kraken/