### PR TITLE
Convert np to None when loading hdf5 trades to allow duplicate detection

### DIFF
--- a/freqtrade/data/history/hdf5datahandler.py
+++ b/freqtrade/data/history/hdf5datahandler.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
+import numpy as np
 import pandas as pd
 
 from freqtrade import misc
@@ -175,7 +176,8 @@ class HDF5DataHandler(IDataHandler):
             if timerange.stoptype == 'date':
                 where.append(f"timestamp < {timerange.stopts * 1e3}")
 
-        trades = pd.read_hdf(filename, key=key, mode="r", where=where)
+        trades: pd.DataFrame = pd.read_hdf(filename, key=key, mode="r", where=where)
+        trades[['id', 'type']] = trades[['id', 'type']].replace({np.nan: None})
         return trades.values.tolist()
 
     def trades_purge(self, pair: str) -> bool:

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -724,6 +724,8 @@ def test_hdf5datahandler_trades_load(testdatadir):
 
     trades2 = dh._trades_load('XRP/ETH', timerange)
     assert len(trades) > len(trades2)
+    # Check that ID is None (If it's nan, it's wrong)
+    assert trades2[0][2] is None
 
     # unfiltered load has trades before starttime
     assert len([t for t in trades if t[0] < timerange.startts * 1000]) >= 0


### PR DESCRIPTION
## Summary
Convert np to None when loading hdf5 trades to allow duplicate detection

closes #3961 

## Quick changelog

- add test and fix for wrong duplicate detection when using hdf5 with trades