### PR TITLE
RangeStabilityFilter filter - filter for pairs without much movement

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -69,8 +69,8 @@
         {"method": "PriceFilter", "low_price_ratio": 0.01, "min_price": 0.00000010},
         {"method": "SpreadFilter", "max_spread_ratio": 0.005},
         {
-            "method": "VolatilityFilter",
-            "volatility_over_days": 10,
+            "method": "RangeStabilityFilter",
+            "lookback_days": 10,
             "min_volatility": 0.01,
             "refresh_period": 1440
         }

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -67,7 +67,13 @@
         {"method": "AgeFilter", "min_days_listed": 10},
         {"method": "PrecisionFilter"},
         {"method": "PriceFilter", "low_price_ratio": 0.01, "min_price": 0.00000010},
-        {"method": "SpreadFilter", "max_spread_ratio": 0.005}
+        {"method": "SpreadFilter", "max_spread_ratio": 0.005},
+        {
+            "method": "VolatilityFilter",
+            "volatility_over_days": 10,
+            "min_volatility": 0.01,
+            "refresh_period": 1440
+        }
     ],
     "exchange": {
         "name": "bittrex",

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -71,7 +71,7 @@
         {
             "method": "RangeStabilityFilter",
             "lookback_days": 10,
-            "min_volatility": 0.01,
+            "min_rate_of_change": 0.01,
             "refresh_period": 1440
         }
     ],

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -19,6 +19,7 @@ Inactive markets are always removed from the resulting pairlist. Explicitly blac
 * [`PriceFilter`](#pricefilter)
 * [`ShuffleFilter`](#shufflefilter)
 * [`SpreadFilter`](#spreadfilter)
+* [`VolatilityFilter`](#volatilityfilter)
 
 !!! Tip "Testing pairlists"
     Pairlist configurations can be quite tricky to get right. Best use the [`test-pairlist`](utils.md#test-pairlist) utility sub-command to test your configuration quickly.
@@ -118,6 +119,27 @@ Example:
 
 If `DOGE/BTC` maximum bid is 0.00000026 and minimum ask is 0.00000027, the ratio is calculated as: `1 - bid/ask ~= 0.037` which is `> 0.005` and this pair will be filtered out.
 
+#### VolatilityFilter
+
+Removes pairs where the difference between lowest low and highest high over `volatility_over_days` days is below `min_volatility`. Since this is a filter that requires additional data, the results are cached for `refresh_period`.
+
+In the below example:
+If volatility over the last 10 days is <1%, remove the pair from the whitelist.
+
+```json
+"pairlists": [
+    {
+        "method": "VolatilityFilter",
+        "volatility_over_days": 10,
+        "min_volatility": 0.01,
+        "refresh_period": 1440
+    }
+]
+```
+
+!!! Tip
+    This Filter can be used to automatically remove stable coin pairs, which have a very low volatility, and are therefore extremely hard to trade with profit.
+
 ### Full example of Pairlist Handlers
 
 The below example blacklists `BNB/BTC`, uses `VolumePairList` with `20` assets, sorting pairs by `quoteVolume` and applies both [`PrecisionFilter`](#precisionfilter) and [`PriceFilter`](#price-filter), filtering all assets where 1 price unit is > 1%. Then the `SpreadFilter` is applied and pairs are finally shuffled with the random seed set to some predefined value.
@@ -137,6 +159,12 @@ The below example blacklists `BNB/BTC`, uses `VolumePairList` with `20` assets, 
     {"method": "PrecisionFilter"},
     {"method": "PriceFilter", "low_price_ratio": 0.01},
     {"method": "SpreadFilter", "max_spread_ratio": 0.005},
+    {
+        "method": "VolatilityFilter",
+        "volatility_over_days": 10,
+        "min_volatility": 0.01,
+        "refresh_period": 1440
+    },
     {"method": "ShuffleFilter", "seed": 42}
     ],
 ```

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -19,7 +19,7 @@ Inactive markets are always removed from the resulting pairlist. Explicitly blac
 * [`PriceFilter`](#pricefilter)
 * [`ShuffleFilter`](#shufflefilter)
 * [`SpreadFilter`](#spreadfilter)
-* [`VolatilityFilter`](#volatilityfilter)
+* [`RangeStabilityFilter`](#rangestabilityfilter)
 
 !!! Tip "Testing pairlists"
     Pairlist configurations can be quite tricky to get right. Best use the [`test-pairlist`](utils.md#test-pairlist) utility sub-command to test your configuration quickly.
@@ -119,26 +119,26 @@ Example:
 
 If `DOGE/BTC` maximum bid is 0.00000026 and minimum ask is 0.00000027, the ratio is calculated as: `1 - bid/ask ~= 0.037` which is `> 0.005` and this pair will be filtered out.
 
-#### VolatilityFilter
+#### RangeStabilityFilter
 
-Removes pairs where the difference between lowest low and highest high over `volatility_over_days` days is below `min_volatility`. Since this is a filter that requires additional data, the results are cached for `refresh_period`.
+Removes pairs where the difference between lowest low and highest high over `lookback_days` days is below `min_rate_of_change`. Since this is a filter that requires additional data, the results are cached for `refresh_period`.
 
 In the below example:
-If volatility over the last 10 days is <1%, remove the pair from the whitelist.
+If the trading range over the last 10 days is <1%, remove the pair from the whitelist.
 
 ```json
 "pairlists": [
     {
-        "method": "VolatilityFilter",
-        "volatility_over_days": 10,
-        "min_volatility": 0.01,
+        "method": "RangeStabilityFilter",
+        "lookback_days": 10,
+        "min_rate_of_change": 0.01,
         "refresh_period": 1440
     }
 ]
 ```
 
 !!! Tip
-    This Filter can be used to automatically remove stable coin pairs, which have a very low volatility, and are therefore extremely difficult to trade with profit.
+    This Filter can be used to automatically remove stable coin pairs, which have a very low trading range, and are therefore extremely difficult to trade with profit.
 
 ### Full example of Pairlist Handlers
 
@@ -160,9 +160,9 @@ The below example blacklists `BNB/BTC`, uses `VolumePairList` with `20` assets, 
     {"method": "PriceFilter", "low_price_ratio": 0.01},
     {"method": "SpreadFilter", "max_spread_ratio": 0.005},
     {
-        "method": "VolatilityFilter",
-        "volatility_over_days": 10,
-        "min_volatility": 0.01,
+        "method": "RangeStabilityFilter",
+        "lookback_days": 10,
+        "min_rate_of_change": 0.01,
         "refresh_period": 1440
     },
     {"method": "ShuffleFilter", "seed": 42}

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -138,7 +138,7 @@ If volatility over the last 10 days is <1%, remove the pair from the whitelist.
 ```
 
 !!! Tip
-    This Filter can be used to automatically remove stable coin pairs, which have a very low volatility, and are therefore extremely hard to trade with profit.
+    This Filter can be used to automatically remove stable coin pairs, which have a very low volatility, and are therefore extremely difficult to trade with profit.
 
 ### Full example of Pairlist Handlers
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -25,7 +25,7 @@ HYPEROPT_LOSS_BUILTIN = ['ShortTradeDurHyperOptLoss', 'OnlyProfitHyperOptLoss',
                          'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
                        'AgeFilter', 'PrecisionFilter', 'PriceFilter',
-                       'ShuffleFilter', 'SpreadFilter', 'VolatilityFilter']
+                       'RangeStabilityFilter', 'ShuffleFilter', 'SpreadFilter']
 AVAILABLE_DATAHANDLERS = ['json', 'jsongz', 'hdf5']
 DRY_RUN_WALLET = 1000
 DATETIME_PRINT_FORMAT = '%Y-%m-%d %H:%M:%S'

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -25,7 +25,7 @@ HYPEROPT_LOSS_BUILTIN = ['ShortTradeDurHyperOptLoss', 'OnlyProfitHyperOptLoss',
                          'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
                        'AgeFilter', 'PrecisionFilter', 'PriceFilter',
-                       'ShuffleFilter', 'SpreadFilter']
+                       'ShuffleFilter', 'SpreadFilter', 'VolatilityFilter']
 AVAILABLE_DATAHANDLERS = ['json', 'jsongz', 'hdf5']
 DRY_RUN_WALLET = 1000
 DATETIME_PRINT_FORMAT = '%Y-%m-%d %H:%M:%S'

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -689,7 +689,7 @@ class Exchange:
                                  since_ms: int) -> DataFrame:
         """
         Minimal wrapper around get_historic_ohlcv - converting the result into a dataframe
-                :param pair: Pair to download
+        :param pair: Pair to download
         :param timeframe: Timeframe to get data for
         :param since_ms: Timestamp in milliseconds to get history from
         :return: OHLCV DataFrame

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -679,11 +679,24 @@ class Exchange:
         :param pair: Pair to download
         :param timeframe: Timeframe to get data for
         :param since_ms: Timestamp in milliseconds to get history from
-        :returns List with candle (OHLCV) data
+        :return: List with candle (OHLCV) data
         """
         return asyncio.get_event_loop().run_until_complete(
             self._async_get_historic_ohlcv(pair=pair, timeframe=timeframe,
                                            since_ms=since_ms))
+
+    def get_historic_ohlcv_as_df(self, pair: str, timeframe: str,
+                                 since_ms: int) -> DataFrame:
+        """
+        Minimal wrapper around get_historic_ohlcv - converting the result into a dataframe
+                :param pair: Pair to download
+        :param timeframe: Timeframe to get data for
+        :param since_ms: Timestamp in milliseconds to get history from
+        :return: OHLCV DataFrame
+        """
+        ticks = self.get_historic_ohlcv(pair, timeframe, since_ms=since_ms)
+        return ohlcv_to_dataframe(ticks, timeframe, pair=pair, fill_missing=True,
+                                  drop_incomplete=self._ohlcv_partial_candle)
 
     async def _async_get_historic_ohlcv(self, pair: str,
                                         timeframe: str,

--- a/freqtrade/pairlist/AgeFilter.py
+++ b/freqtrade/pairlist/AgeFilter.py
@@ -49,7 +49,7 @@ class AgeFilter(IPairList):
         return (f"{self.name} - Filtering pairs with age less than "
                 f"{self._min_days_listed} {plural(self._min_days_listed, 'day')}.")
 
-    def _validate_pair(self, ticker: dict) -> bool:
+    def _validate_pair(self, ticker: Dict) -> bool:
         """
         Validate age for the ticker
         :param ticker: ticker dict as returned from ccxt.load_markets()

--- a/freqtrade/pairlist/VolumePairList.py
+++ b/freqtrade/pairlist/VolumePairList.py
@@ -49,7 +49,7 @@ class VolumePairList(IPairList):
     def needstickers(self) -> bool:
         """
         Boolean property defining if tickers are necessary.
-        If no Pairlist requires tickers, an empty List is passed
+        If no Pairlist requires tickers, an empty Dict is passed
         as tickers argument to filter_pairlist
         """
         return True

--- a/freqtrade/pairlist/rangestabilityfilter.py
+++ b/freqtrade/pairlist/rangestabilityfilter.py
@@ -1,5 +1,5 @@
 """
-Minimum age (days listed) pair list filter
+Rate of change pairlist filter
 """
 import logging
 from typing import Any, Dict

--- a/freqtrade/pairlist/rangestabilityfilter.py
+++ b/freqtrade/pairlist/rangestabilityfilter.py
@@ -15,23 +15,23 @@ from freqtrade.pairlist.IPairList import IPairList
 logger = logging.getLogger(__name__)
 
 
-class VolatilityFilter(IPairList):
+class RangeStabilityFilter(IPairList):
 
     def __init__(self, exchange, pairlistmanager,
                  config: Dict[str, Any], pairlistconfig: Dict[str, Any],
                  pairlist_pos: int) -> None:
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
-        self._days = pairlistconfig.get('volatility_over_days', 10)
-        self._min_volatility = pairlistconfig.get('min_volatility', 0.01)
+        self._days = pairlistconfig.get('lookback_days', 10)
+        self._min_rate_of_change = pairlistconfig.get('min_rate_of_change', 0.01)
         self._refresh_period = pairlistconfig.get('refresh_period', 1440)
 
         self._pair_cache: TTLCache = TTLCache(maxsize=100, ttl=self._refresh_period)
 
         if self._days < 1:
-            raise OperationalException("VolatilityFilter requires volatility_over_days to be >= 1")
+            raise OperationalException("RangeStabilityFilter requires lookback_days to be >= 1")
         if self._days > exchange.ohlcv_candle_limit:
-            raise OperationalException("VolatilityFilter requires volatility_over_days to not "
+            raise OperationalException("RangeStabilityFilter requires lookback_days to not "
                                        "exceed exchange max request size "
                                        f"({exchange.ohlcv_candle_limit})")
 
@@ -48,12 +48,12 @@ class VolatilityFilter(IPairList):
         """
         Short whitelist method description - used for startup-messages
         """
-        return (f"{self.name} - Filtering pairs with volatility below {self._min_volatility} "
-                f"over the last {plural(self._days, 'day')}.")
+        return (f"{self.name} - Filtering pairs with rate of change below "
+                f"{self._min_rate_of_change} over the last {plural(self._days, 'day')}.")
 
     def _validate_pair(self, ticker: Dict) -> bool:
         """
-        Validate volatility
+        Validate trading range
         :param ticker: ticker dict as returned from ccxt.load_markets()
         :return: True if the pair can stay, False if it should be removed
         """
@@ -75,14 +75,14 @@ class VolatilityFilter(IPairList):
             highest_high = daily_candles['high'].max()
             lowest_low = daily_candles['low'].min()
             pct_change = ((highest_high - lowest_low) / lowest_low) if lowest_low > 0 else 0
-            if pct_change >= self._min_volatility:
+            if pct_change >= self._min_rate_of_change:
                 result = True
             else:
                 self.log_on_refresh(logger.info,
                                     f"Removed {pair} from whitelist, "
-                                    f"because volatility over {plural(self._days, 'day')} is "
+                                    f"because rate of change over {plural(self._days, 'day')} is "
                                     f"{pct_change:.3f}, which is below the "
-                                    f"threshold of {self._min_volatility}.")
+                                    f"threshold of {self._min_rate_of_change}.")
                 result = False
             self._pair_cache[pair] = result
 

--- a/freqtrade/pairlist/rangestabilityfilter.py
+++ b/freqtrade/pairlist/rangestabilityfilter.py
@@ -71,7 +71,7 @@ class RangeStabilityFilter(IPairList):
                                                                 timeframe='1d',
                                                                 since_ms=since_ms)
         result = False
-        if daily_candles is not None:
+        if daily_candles is not None and not daily_candles.empty:
             highest_high = daily_candles['high'].max()
             lowest_low = daily_candles['low'].min()
             pct_change = ((highest_high - lowest_low) / lowest_low) if lowest_low > 0 else 0

--- a/freqtrade/pairlist/volatilityfilter.py
+++ b/freqtrade/pairlist/volatilityfilter.py
@@ -31,8 +31,8 @@ class VolatilityFilter(IPairList):
         if self._days < 1:
             raise OperationalException("VolatilityFilter requires volatility_over_days to be >= 1")
         if self._days > exchange.ohlcv_candle_limit:
-            raise OperationalException("VolatilityFilter requires volatility_over_days to not exceed "
-                                       "exchange max request size "
+            raise OperationalException("VolatilityFilter requires volatility_over_days to not "
+                                       "exceed exchange max request size "
                                        f"({exchange.ohlcv_candle_limit})")
 
     @property

--- a/freqtrade/pairlist/volatilityfilter.py
+++ b/freqtrade/pairlist/volatilityfilter.py
@@ -1,0 +1,89 @@
+"""
+Minimum age (days listed) pair list filter
+"""
+import logging
+from typing import Any, Dict
+
+import arrow
+from cachetools.ttl import TTLCache
+
+from freqtrade.exceptions import OperationalException
+from freqtrade.misc import plural
+from freqtrade.pairlist.IPairList import IPairList
+
+
+logger = logging.getLogger(__name__)
+
+
+class VolatilityFilter(IPairList):
+
+    def __init__(self, exchange, pairlistmanager,
+                 config: Dict[str, Any], pairlistconfig: Dict[str, Any],
+                 pairlist_pos: int) -> None:
+        super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
+
+        self._days = pairlistconfig.get('volatility_over_days', 10)
+        self._min_volatility = pairlistconfig.get('min_volatility', 0.01)
+        self._refresh_period = pairlistconfig.get('refresh_period', 1440)
+
+        self._pair_cache: TTLCache = TTLCache(maxsize=100, ttl=self._refresh_period)
+
+        if self._days < 1:
+            raise OperationalException("VolatilityFilter requires min_days_listed to be >= 1")
+        if self._days > exchange.ohlcv_candle_limit:
+            raise OperationalException("VolatilityFilter requires min_days_listed to not exceed "
+                                       "exchange max request size "
+                                       f"({exchange.ohlcv_candle_limit})")
+
+    @property
+    def needstickers(self) -> bool:
+        """
+        Boolean property defining if tickers are necessary.
+        If no Pairlist requires tickers, an empty List is passed
+        as tickers argument to filter_pairlist
+        """
+        return True
+
+    def short_desc(self) -> str:
+        """
+        Short whitelist method description - used for startup-messages
+        """
+        return (f"{self.name} - Filtering pairs with volatility below {self._min_volatility} "
+                f"over the last {plural(self._days, 'day')}.")
+
+    def _validate_pair(self, ticker: Dict) -> bool:
+        """
+        Validate volatility
+        :param ticker: ticker dict as returned from ccxt.load_markets()
+        :return: True if the pair can stay, False if it should be removed
+        """
+        pair = ticker['symbol']
+        # Check symbol in cache
+        if pair in self._pair_cache:
+            return self._pair_cache[pair]
+
+        since_ms = int(arrow.utcnow()
+                       .floor('day')
+                       .shift(days=-self._days)
+                       .float_timestamp) * 1000
+
+        daily_candles = self._exchange.get_historic_ohlcv_as_df(pair=pair,
+                                                                timeframe='1d',
+                                                                since_ms=since_ms)
+        result = False
+        if daily_candles is not None:
+            highest_high = daily_candles['high'].max()
+            lowest_low = daily_candles['low'].min()
+            pct_change = (highest_high - lowest_low) / lowest_low
+            if pct_change >= self._min_volatility:
+                result = True
+            else:
+                self.log_on_refresh(logger.info,
+                                    f"Removed {pair} from whitelist, "
+                                    f"because volatility over {plural(self._days, 'day')} is "
+                                    f"{pct_change:.3f}, which is below the "
+                                    f"threshold of {self._min_volatility}.")
+                result = False
+            self._pair_cache[pair] = result
+
+        return result

--- a/freqtrade/pairlist/volatilityfilter.py
+++ b/freqtrade/pairlist/volatilityfilter.py
@@ -29,9 +29,9 @@ class VolatilityFilter(IPairList):
         self._pair_cache: TTLCache = TTLCache(maxsize=100, ttl=self._refresh_period)
 
         if self._days < 1:
-            raise OperationalException("VolatilityFilter requires min_days_listed to be >= 1")
+            raise OperationalException("VolatilityFilter requires volatility_over_days to be >= 1")
         if self._days > exchange.ohlcv_candle_limit:
-            raise OperationalException("VolatilityFilter requires min_days_listed to not exceed "
+            raise OperationalException("VolatilityFilter requires volatility_over_days to not exceed "
                                        "exchange max request size "
                                        f"({exchange.ohlcv_candle_limit})")
 

--- a/freqtrade/pairlist/volatilityfilter.py
+++ b/freqtrade/pairlist/volatilityfilter.py
@@ -74,7 +74,7 @@ class VolatilityFilter(IPairList):
         if daily_candles is not None:
             highest_high = daily_candles['high'].max()
             lowest_low = daily_candles['low'].min()
-            pct_change = (highest_high - lowest_low) / lowest_low
+            pct_change = ((highest_high - lowest_low) / lowest_low) if lowest_low > 0 else 0
             if pct_change >= self._min_volatility:
                 result = True
             else:

--- a/tests/pairlist/test_pairlist.py
+++ b/tests/pairlist/test_pairlist.py
@@ -340,6 +340,10 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
     ([{"method": "VolumePairList", "number_assets": 20, "sort_key": "quoteVolume"},
       {"method": "PriceFilter", "low_price_ratio": 0.02}],
         "USDT", ['ETH/USDT', 'NANO/USDT']),
+    ([{"method": "StaticPairList"},
+      {"method": "VolatilityFilter", "volatility_over_days": 10,
+       "min_volatility": 0.01, "refresh_period": 1440}],
+     "BTC", ['ETH/BTC', 'TKN/BTC', 'HOT/BTC']),
 ])
 def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, tickers,
                                       ohlcv_history_list, pairlists, base_currency,
@@ -617,6 +621,11 @@ def test_agefilter_caching(mocker, markets, whitelist_conf_3, tickers, ohlcv_his
      None,
      "PriceFilter requires max_price to be >= 0"
      ),  # OperationalException expected
+    ({"method": "VolatilityFilter", "volatility_over_days": 10, "min_volatility": 0.01},
+     "[{'VolatilityFilter': 'VolatilityFilter - Filtering pairs with volatility below 0.01 "
+     "over the last days.'}]",
+        None
+     ),
 ])
 def test_pricefilter_desc(mocker, whitelist_conf, markets, pairlistconfig,
                           desc_expected, exception_expected):


### PR DESCRIPTION
## Summary
This PR will introduce the RangeStabilityFilter
It's calculated over the last 10 days (by default)- using the % change between highest high and lowest low in this time interval.
If this Range % is below the specified threshold (1% by default) the pair is rejected from the pairlist.

This can be useful to remove stable-coins from the pairlist without explicitly blacklisting them, as stable-coins usually move within a very tight range, which makes trading them profitable very difficult.

## Quick changelog

- Introduce RangeStabilityFilter Filter
- Added tests for this new filter
