### PR TITLE
Kraken stoploss-limit

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -23,7 +23,7 @@ Binance has been split into 3, and users must use the correct ccxt exchange ID f
 ## Kraken
 
 !!! Tip "Stoploss on Exchange"
-    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it.
+    Kraken supports `stoploss_on_exchange`. It provides great advantages, so we recommend to benefit from it.
 
 ### Historic Kraken data
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -23,7 +23,7 @@ Binance has been split into 3, and users must use the correct ccxt exchange ID f
 ## Kraken
 
 !!! Tip "Stoploss on Exchange"
-    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it, however since the resulting order is a stoploss-market order, sell-rates are not guaranteed, which makes this feature less secure than on other exchanges. This limitation is based on kraken's policy [source](https://blog.kraken.com/post/1234/announcement-delisting-pairs-and-temporary-suspension-of-advanced-order-types/) and [source2](https://blog.kraken.com/post/1494/kraken-enables-advanced-orders-and-adds-10-currency-pairs/) - which has stoploss-limit orders disabled.
+    Kraken supports `stoploss_on_exchange` and uses stop-loss-market orders. It provides great advantages, so we recommend to benefit from it.
 
 ### Historic Kraken data
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -23,7 +23,8 @@ Binance has been split into 3, and users must use the correct ccxt exchange ID f
 ## Kraken
 
 !!! Tip "Stoploss on Exchange"
-    Kraken supports `stoploss_on_exchange`. It provides great advantages, so we recommend to benefit from it.
+    Kraken supports `stoploss_on_exchange` and can use both stop-loss-market and stop-loss-limit orders. It provides great advantages, so we recommend to benefit from it.
+    You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to decide which type to use.
 
 ### Historic Kraken data
 
@@ -75,8 +76,7 @@ print(res)
 
 !!! Tip "Stoploss on Exchange"
     FTX supports `stoploss_on_exchange` and can use both stop-loss-market and stop-loss-limit orders. It provides great advantages, so we recommend to benefit from it.
-    You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to decide.
-
+    You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to decide which type of stoploss shall be used.
 
 ### Using subaccounts
 
@@ -99,10 +99,10 @@ To use subaccounts with FTX, you need to edit the configuration and add the foll
 
 Should you experience constant errors with Nonce (like `InvalidNonce`), it is best to regenerate the API keys. Resetting Nonce is difficult and it's usually easier to regenerate the API keys.
 
-
 ## Random notes for other exchanges
 
 * The Ocean (exchange id: `theocean`) exchange uses Web3 functionality and requires `web3` python package to be installed:
+
 ```shell
 $ pip3 install web3
 ```

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -23,11 +23,12 @@ These modes can be configured with these values:
 ```
 
 !!! Note
-    Stoploss on exchange is only supported for Binance (stop-loss-limit), Kraken (stop-loss-market) and FTX (stop limit and stop-market) as of now.  
-    <ins>Do not set too low stoploss value if using stop loss on exchange!</ins>  
-    If set to low/tight then you have greater risk of missing fill on the order and stoploss will not work
+    Stoploss on exchange is only supported for Binance (stop-loss-limit), Kraken (stop-loss-market, stop-loss-limit) and FTX (stop limit and stop-market) as of now.  
+    <ins>Do not set too low/tight stoploss value if using stop loss on exchange!</ins>  
+    If set to low/tight then you have greater risk of missing fill on the order and stoploss will not work.
 
 ### stoploss_on_exchange and stoploss_on_exchange_limit_ratio
+
 Enable or Disable stop loss on exchange.
 If the stoploss is *on exchange* it means a stoploss limit order is placed on the exchange immediately after buy order happens successfully. This will protect you against sudden crashes in market as the order will be in the queue immediately and if market goes down then the order has more chance of being fulfilled.
 
@@ -40,13 +41,18 @@ Stop-price is 95$, then limit would be `95 * 0.99 = 94.05$` - so the limit order
 
 For example, assuming the stoploss is on exchange, and trailing stoploss is enabled, and the market is going up, then the bot automatically cancels the previous stoploss order and puts a new one with a stop value higher than the previous stoploss order.
 
+!!! Note
+    If `stoploss_on_exchange` is enabled and the stoploss is cancelled manually on the exchange, then the bot will create a new stoploss order.
+
 ### stoploss_on_exchange_interval
+
 In case of stoploss on exchange there is another parameter called `stoploss_on_exchange_interval`. This configures the interval in seconds at which the bot will check the stoploss and update it if necessary.  
 The bot cannot do these every 5 seconds (at each iteration), otherwise it would get banned by the exchange.
 So this parameter will tell the bot how often it should update the stoploss order. The default value is 60 (1 minute).
 This same logic will reapply a stoploss order on the exchange should you cancel it accidentally.
 
 ### emergencysell
+
 `emergencysell` is an optional value, which defaults to `market` and is used when creating stop loss on exchange orders fails.
 The below is the default which is used if not changed in strategy or configuration file.
 

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -77,8 +77,15 @@ class Kraken(Exchange):
         Creates a stoploss market order.
         Stoploss market orders is the only stoploss type supported by kraken.
         """
+        params = self._params.copy()
 
-        ordertype = "stop-loss"
+        if order_types.get('stoploss', 'market') == 'limit':
+            ordertype = "stop-loss-limit"
+            limit_price_pct = order_types.get('stoploss_on_exchange_limit_ratio', 0.99)
+            limit_rate = stop_price * limit_price_pct
+            params['price2'] = self.price_to_precision(pair, limit_rate)
+        else:
+            ordertype = "stop-loss"
 
         stop_price = self.price_to_precision(pair, stop_price)
 
@@ -88,8 +95,6 @@ class Kraken(Exchange):
             return dry_order
 
         try:
-            params = self._params.copy()
-
             amount = self.amount_to_precision(pair, amount)
 
             order = self._api.create_order(symbol=pair, type=ordertype, side='sell',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,13 +20,13 @@ nav:
     - Hyperopt: hyperopt.md
     - Edge Positioning: edge.md
     - Utility Subcommands: utils.md
-    - Exchange-specific Notes: exchanges.md
     - FAQ: faq.md
     - Data Analysis:
         - Jupyter Notebooks: data-analysis.md
         - Strategy analysis: strategy_analysis_example.md
         - Plotting: plotting.md
     - SQL Cheatsheet: sql_cheatsheet.md
+    - Exchange-specific Notes: exchanges.md
     - Advanced Post-installation Tasks: advanced-setup.md
     - Advanced Strategy: strategy-advanced.md
     - Advanced Hyperopt: advanced-hyperopt.md


### PR DESCRIPTION
## Summary
Implement kraken stoploss-limit

replaces #3954 - which unfortunately has the repository deleted, so updating that branch is no longer possible.
I did however use the existing commits to update the documentation.

## Quick changelog

- Implement stoploss-limit for kraken, which is now [supported again](https://blog.kraken.com/post/5282/stop-loss-limit-take-profit-limit-two-new-advanced-orders-go-live-on-kraken/).