### PR TITLE
[Documentation] Fix parameter name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ In the example above this would mean:
     This option only applies with [Static stake amount](#static-stake-amount) - since [Dynamic stake amount](#dynamic-stake-amount) divides the balances evenly.
 
 !!! Note
-    The minimum last stake amount can be configured using `amend_last_stake_amount` - which defaults to 0.5 (50%). This means that the minimum stake amount that's ever used is `stake_amount * 0.5`. This avoids very low stake amounts, that are close to the minimum tradable amount for the pair and can be refused by the exchange.
+    The minimum last stake amount can be configured using `last_stake_amount_min_ratio` - which defaults to 0.5 (50%). This means that the minimum stake amount that's ever used is `stake_amount * 0.5`. This avoids very low stake amounts, that are close to the minimum tradable amount for the pair and can be refused by the exchange.
 
 #### Static stake amount
 


### PR DESCRIPTION
Correct which parameter name was referred to within the 2nd Note under "Amend last stake amount"

## Summary
Make sure someone seeking to adjust the last stake amount min ratio knows to use `last_stake_amount_min_ratio` instead of `last_stake_amount_min_ratio`.

## Quick changelog

- Fix parameter in documentation.

