### PR TITLE
Remove deprecated experimental settings

### DIFF
--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -62,12 +62,11 @@ def process_deprecated_setting(config: Dict[str, Any],
 
 def process_temporary_deprecated_settings(config: Dict[str, Any]) -> None:
 
-    check_conflicting_settings(config, 'ask_strategy', 'use_sell_signal',
-                               'experimental', 'use_sell_signal')
-    check_conflicting_settings(config, 'ask_strategy', 'sell_profit_only',
-                               'experimental', 'sell_profit_only')
-    check_conflicting_settings(config, 'ask_strategy', 'ignore_roi_if_buy_signal',
-                               'experimental', 'ignore_roi_if_buy_signal')
+    # Kept for future deprecated / moved settings
+    # check_conflicting_settings(config, 'ask_strategy', 'use_sell_signal',
+    #                            'experimental', 'use_sell_signal')
+    # process_deprecated_setting(config, 'ask_strategy', 'use_sell_signal',
+    #                            'experimental', 'use_sell_signal')
 
     process_removed_setting(config, 'experimental', 'use_sell_signal',
                             'ask_strategy', 'use_sell_signal')

--- a/freqtrade/configuration/deprecated_settings.py
+++ b/freqtrade/configuration/deprecated_settings.py
@@ -26,6 +26,24 @@ def check_conflicting_settings(config: Dict[str, Any],
         )
 
 
+def process_removed_setting(config: Dict[str, Any],
+                            section1: str, name1: str,
+                            section2: str, name2: str) -> None:
+    """
+    :param section1: Removed section
+    :param name1: Removed setting name
+    :param section2: new section for this key
+    :param name2: new setting name
+    """
+    section1_config = config.get(section1, {})
+    if name1 in section1_config:
+        raise OperationalException(
+            f"Setting `{section1}.{name1}` has been moved to `{section2}.{name2}. "
+            f"Please delete it from your configuration and use the `{section2}.{name2}` "
+            "setting instead."
+        )
+
+
 def process_deprecated_setting(config: Dict[str, Any],
                                section1: str, name1: str,
                                section2: str, name2: str) -> None:
@@ -51,12 +69,12 @@ def process_temporary_deprecated_settings(config: Dict[str, Any]) -> None:
     check_conflicting_settings(config, 'ask_strategy', 'ignore_roi_if_buy_signal',
                                'experimental', 'ignore_roi_if_buy_signal')
 
-    process_deprecated_setting(config, 'ask_strategy', 'use_sell_signal',
-                               'experimental', 'use_sell_signal')
-    process_deprecated_setting(config, 'ask_strategy', 'sell_profit_only',
-                               'experimental', 'sell_profit_only')
-    process_deprecated_setting(config, 'ask_strategy', 'ignore_roi_if_buy_signal',
-                               'experimental', 'ignore_roi_if_buy_signal')
+    process_removed_setting(config, 'experimental', 'use_sell_signal',
+                            'ask_strategy', 'use_sell_signal')
+    process_removed_setting(config, 'experimental', 'sell_profit_only',
+                            'ask_strategy', 'sell_profit_only')
+    process_removed_setting(config, 'experimental', 'ignore_roi_if_buy_signal',
+                            'ask_strategy', 'ignore_roi_if_buy_signal')
 
     if (config.get('edge', {}).get('enabled', False)
        and 'capital_available_percentage' in config.get('edge', {})):

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -182,9 +182,6 @@ CONF_SCHEMA = {
         'experimental': {
             'type': 'object',
             'properties': {
-                'use_sell_signal': {'type': 'boolean'},
-                'sell_profit_only': {'type': 'boolean'},
-                'ignore_roi_if_buy_signal': {'type': 'boolean'},
                 'block_bad_exchanges': {'type': 'boolean'}
             }
         },

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1101,7 +1101,7 @@ def test_process_temporary_deprecated_settings(mocker, default_conf, setting, ca
         ("experimental", "sell_profit_only", True),
         ("experimental", "ignore_roi_if_buy_signal", True),
     ])
-def test_process_removed_settings(mocker, default_conf, setting, caplog):
+def test_process_removed_settings(mocker, default_conf, setting):
     patched_configuration_load_config_file(mocker, default_conf)
 
     # Create sections for new and deprecated settings
@@ -1115,7 +1115,8 @@ def test_process_removed_settings(mocker, default_conf, setting, caplog):
                        match=r'Setting .* has been moved'):
         process_temporary_deprecated_settings(default_conf)
 
-def test_process_deprecated_setting_edge(mocker, edge_conf, caplog):
+
+def test_process_deprecated_setting_edge(mocker, edge_conf):
     patched_configuration_load_config_file(mocker, edge_conf)
     edge_conf.update({'edge': {
         'enabled': True,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -16,6 +16,7 @@ from freqtrade.configuration import (Configuration, check_exchange, remove_crede
 from freqtrade.configuration.config_validation import validate_config_schema
 from freqtrade.configuration.deprecated_settings import (check_conflicting_settings,
                                                          process_deprecated_setting,
+                                                         process_removed_setting,
                                                          process_temporary_deprecated_settings)
 from freqtrade.configuration.load_config import load_config_file, log_config_error_range
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
@@ -1061,13 +1062,11 @@ def test_pairlist_resolving_fallback(mocker):
     assert config['datadir'] == Path.cwd() / "user_data/data/binance"
 
 
+@pytest.mark.skip(reason='Currently no deprecated / moved sections')
+# The below is kept as a sample for the future.
 @pytest.mark.parametrize("setting", [
         ("ask_strategy", "use_sell_signal", True,
          "experimental", "use_sell_signal", False),
-        ("ask_strategy", "sell_profit_only", False,
-         "experimental", "sell_profit_only", True),
-        ("ask_strategy", "ignore_roi_if_buy_signal", False,
-         "experimental", "ignore_roi_if_buy_signal", True),
     ])
 def test_process_temporary_deprecated_settings(mocker, default_conf, setting, caplog):
     patched_configuration_load_config_file(mocker, default_conf)
@@ -1096,6 +1095,25 @@ def test_process_temporary_deprecated_settings(mocker, default_conf, setting, ca
     # value of the deprecated one
     assert default_conf[setting[0]][setting[1]] == setting[5]
 
+
+@pytest.mark.parametrize("setting", [
+        ("experimental", "use_sell_signal", False),
+        ("experimental", "sell_profit_only", True),
+        ("experimental", "ignore_roi_if_buy_signal", True),
+    ])
+def test_process_removed_settings(mocker, default_conf, setting, caplog):
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    # Create sections for new and deprecated settings
+    # (they may not exist in the config)
+    default_conf[setting[0]] = {}
+    # Assign removed setting
+    default_conf[setting[0]][setting[1]] = setting[2]
+
+    # New and deprecated settings are conflicting ones
+    with pytest.raises(OperationalException,
+                       match=r'Setting .* has been moved'):
+        process_temporary_deprecated_settings(default_conf)
 
 def test_process_deprecated_setting_edge(mocker, edge_conf, caplog):
     patched_configuration_load_config_file(mocker, edge_conf)
@@ -1194,6 +1212,30 @@ def test_process_deprecated_setting(mocker, default_conf, caplog):
                                'sectionB', 'deprecated_setting')
     assert not log_has_re('DEPRECATED', caplog)
     assert default_conf['sectionA']['new_setting'] == 'valA'
+
+
+def test_process_removed_setting(mocker, default_conf, caplog):
+    patched_configuration_load_config_file(mocker, default_conf)
+
+    # Create sections for new and deprecated settings
+    # (they may not exist in the config)
+    default_conf['sectionA'] = {}
+    default_conf['sectionB'] = {}
+    # Assign new setting
+    default_conf['sectionB']['somesetting'] = 'valA'
+
+    # Only new setting exists (nothing should happen)
+    process_removed_setting(default_conf,
+                            'sectionA', 'somesetting',
+                            'sectionB', 'somesetting')
+    # Assign removed setting
+    default_conf['sectionA']['somesetting'] = 'valB'
+
+    with pytest.raises(OperationalException,
+                       match=r"Setting .* has been moved"):
+        process_removed_setting(default_conf,
+                                'sectionA', 'somesetting',
+                                'sectionB', 'somesetting')
 
 
 def test_process_deprecated_ticker_interval(mocker, default_conf, caplog):


### PR DESCRIPTION
## Summary
Remove long deprecated settings, which moved from experimental to ask_strategy.

From now on, freqtrade will fail to start if these settings are still in experimental


## Quick changelog

- Fail if `use_sell_signal`, `sell_profit_only` or  `ignore_roi_if_buy_signal`  are still configured in the experimental section