### PR TITLE
Docker stage pi

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,25 +1,40 @@
-FROM --platform=linux/arm/v7 python:3.7.7-slim-buster
+FROM --platform=linux/arm/v7 python:3.7.9-slim-buster as base
 
+# Setup env
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONFAULTHANDLER 1
+ENV PATH=/root/.local/bin:$PATH
+
+# Prepare environment
+RUN mkdir /freqtrade
+WORKDIR /freqtrade
+
+# Install dependencies
+FROM base as python-deps
 RUN apt-get update \
   && apt-get -y install curl build-essential libssl-dev libffi-dev libatlas3-base libgfortran5 sqlite3 \
   && apt-get clean \
   && pip install --upgrade pip \
   && echo "[global]\nextra-index-url=https://www.piwheels.org/simple" > /etc/pip.conf
 
-# Prepare environment
-RUN mkdir /freqtrade
-WORKDIR /freqtrade
-
 # Install TA-lib
 COPY build_helpers/* /tmp/
 RUN cd /tmp && /tmp/install_ta-lib.sh && rm -r /tmp/*ta-lib*
-
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Install dependencies
 COPY requirements.txt /freqtrade/
-RUN pip install numpy --no-cache-dir \
-  && pip install -r requirements.txt --no-cache-dir
+RUN  pip install --user --no-cache-dir numpy \
+  && pip install --user --no-cache-dir -r requirements.txt
+
+# Copy dependencies to runtime-image
+FROM base as runtime-image
+COPY --from=python-deps /usr/local/lib /usr/local/lib
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+COPY --from=python-deps /root/.local /root/.local
 
 # Install and execute
 COPY . /freqtrade/

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,10 +11,13 @@ ENV PATH=/root/.local/bin:$PATH
 RUN mkdir /freqtrade
 WORKDIR /freqtrade
 
+RUN  apt-get update \
+  && apt-get -y install libatlas3-base curl sqlite3 \
+  && apt-get clean
+
 # Install dependencies
 FROM base as python-deps
-RUN apt-get update \
-  && apt-get -y install curl build-essential libssl-dev libffi-dev libatlas3-base libgfortran5 sqlite3 \
+RUN  apt-get -y install build-essential libssl-dev libffi-dev libgfortran5 \
   && apt-get clean \
   && pip install --upgrade pip \
   && echo "[global]\nextra-index-url=https://www.piwheels.org/simple" > /etc/pip.conf


### PR DESCRIPTION
## Summary
Align Raspberry build to regular build using staged dockerfiles.
Replicates #4046 for the arm build.

The image builds correctly ase can be seen [here](https://github.com/freqtrade/freqtrade/actions/runs/422600036), and it's running just fine, reducing the image sice by ~200 MB.

## Quick changelog

- use multistage docker build.