### PR TITLE
Telegram: specify custom keyboard in config

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -88,17 +88,22 @@ Example configuration showing the different settings:
 ```
 
 ## Create a custom keyboard (command shortcut buttons)
+
 Telegram allows us to create a custom keyboard with buttons for commands.
 The default custom keyboard looks like this.
+
 ```python
 [
-    ['/daily', '/profit', '/balance'], # row 1, 3 commands
-    ['/status', '/status table', '/performance'], # row 2, 3 commands
-    ['/count', '/start', '/stop', '/help'] # row 3, 4 commands
+    ["/daily", "/profit", "/balance"], # row 1, 3 commands
+    ["/status", "/status table", "/performance"], # row 2, 3 commands
+    ["/count", "/start", "/stop", "/help"] # row 3, 4 commands
 ]
-``` 
+```
+
 ### Usage
+
 You can create your own keyboard in `config.json`:
+
 ``` json
 "telegram": {
       "enabled": true,
@@ -107,14 +112,15 @@ You can create your own keyboard in `config.json`:
       "keyboard": [   
           ["/daily", "/stats", "/balance", "/profit"],
           ["/status table", "/performance"],
-          ["/reload_config", "/count",   "/logs"]
+          ["/reload_config", "/count", "/logs"]
       ]
    },
 ```
-!!! Note
-    Only a certain list of commands are allowed. Command arguments are not supported!
-### Supported Commands
- `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
+
+!!! Note "Supported Commands"
+    Only the following commands are allowed. Command arguments are not supported!
+
+    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
 
 ## Telegram commands
 

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -87,7 +87,7 @@ Example configuration showing the different settings:
    },
 ```
 
-## Create a custom keyboard (command shortcuts buttons)
+## Create a custom keyboard (command shortcut buttons)
 Telegram allows us to create a custom keyboard with buttons for commands.
 The default custom keyboard looks like this.
 ```python
@@ -104,7 +104,7 @@ You can create your own keyboard in `config.json`:
       "enabled": true,
       "token": "your_telegram_token",
       "chat_id": "your_telegram_chat_id",
-      "shortcut_btns": [   
+      "keyboard": [   
           ["/daily", "/stats", "/balance", "/profit"],
           ["/status table", "/performance"],
           ["/reload_config", "/count",   "/logs"]

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -87,6 +87,35 @@ Example configuration showing the different settings:
    },
 ```
 
+## Create a custom keyboard (command shortcuts buttons)
+Telegram allows us to create a custom keyboard with buttons for commands.
+The default custom keyboard looks like this.
+```python
+[
+    ['/daily', '/profit', '/balance'], # row 1, 3 commands
+    ['/status', '/status table', '/performance'], # row 2, 3 commands
+    ['/count', '/start', '/stop', '/help'] # row 3, 4 commands
+]
+``` 
+### Usage
+You can create your own keyboard in `config.json`:
+``` json
+"telegram": {
+      "enabled": true,
+      "token": "your_telegram_token",
+      "chat_id": "your_telegram_chat_id",
+      "shortcut_btns": [   
+          ["/daily", "/stats", "/balance", "/profit"],
+          ["/status table", "/performance"],
+          ["/reload_config", "/count",   "/logs"]
+      ]
+   },
+```
+!! NOTE: Only a certain list of commands are allowed. Command arguments are not
+supported!
+### Supported Commands
+ `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
+
 ## Telegram commands
 
 Per default, the Telegram bot shows predefined commands. Some commands

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -111,8 +111,8 @@ You can create your own keyboard in `config.json`:
       ]
    },
 ```
-!! NOTE: Only a certain list of commands are allowed. Command arguments are not
-supported!
+!!! Note
+    Only a certain list of commands are allowed. Command arguments are not supported!
 ### Supported Commands
  `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -110,8 +110,9 @@ class Telegram(RPC):
             invalid_keys = [b for b in chain.from_iterable(cust_keyboard)
                             if b not in valid_keys]
             if len(invalid_keys):
-                err_msg = ('config.telegram.keyboard: invalid commands for '
-                           f'custom keyboard: {invalid_keys}')
+                err_msg = ('config.telegram.keyboard: Invalid commands for '
+                           f'custom Telegram keyboard: {invalid_keys}'
+                           f'\nvalid commands are: {valid_keys}')
                 raise OperationalException(err_msg)
             else:
                 self._keyboard = cust_keyboard

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -7,11 +7,11 @@ import json
 import logging
 from datetime import timedelta
 from itertools import chain
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Union
 
 import arrow
 from tabulate import tabulate
-from telegram import ParseMode, ReplyKeyboardMarkup, Update
+from telegram import KeyboardButton, ParseMode, ReplyKeyboardMarkup, Update
 from telegram.error import NetworkError, TelegramError
 from telegram.ext import CallbackContext, CommandHandler, Updater
 from telegram.utils.helpers import escape_markdown
@@ -85,7 +85,7 @@ class Telegram(RPC):
         Validates the keyboard configuration from telegram config
         section.
         """
-        self._keyboard: List[List[str]] = [
+        self._keyboard: List[List[Union[str, KeyboardButton]]] = [
             ['/daily', '/profit', '/balance'],
             ['/status', '/status table', '/performance'],
             ['/count', '/start', '/stop', '/help']

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -872,6 +872,9 @@ class Telegram(RPC):
 
         # do not allow commands with mandatory arguments and critical cmds
         # like /forcesell and /forcebuy
+        # TODO: DRY! - its not good to list all valid cmds here. But this
+        #       needs refacoring of the whole telegram module (same problem
+        #       in _help()).
         valid_btns: List[str] = ['/start', '/stop', '/status', '/status table',
                                  '/trades', '/profit', '/performance', '/daily',
                                  '/stats', '/count', '/locks', '/balance',
@@ -885,16 +888,13 @@ class Telegram(RPC):
             invalid_shortcut_btns = [b for b in chain.from_iterable(shortcut_btns)
                                      if b not in valid_btns]
             if len(invalid_shortcut_btns):
-                logger.warning('rpc.telegram: invalid shortcut_btns %s',
-                               invalid_shortcut_btns)
-                logger.info('rpc.telegram: using default shortcut_btns %s',
-                            keyboard)
+                logger.warning('rpc.telegram: invalid commands for custom '
+                               f'keyboard: {invalid_shortcut_btns}')
+                logger.info('rpc.telegram: using default keyboard.')
             else:
                 keyboard = shortcut_btns
-                logger.info(
-                        'rpc.telegram uses custom shortcut bottons specified in ' +
-                        'config.json %s', [btn for btn in keyboard]
-                )
+                logger.info('rpc.telegram using custom keyboard from '
+                            f'config.json: {[btn for btn in keyboard]}')
 
         reply_markup = ReplyKeyboardMarkup(keyboard)
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -5,8 +5,8 @@ This module manage Telegram communication
 """
 import json
 import logging
-from itertools import chain
 from datetime import timedelta
+from itertools import chain
 from typing import Any, Callable, Dict, List, Union
 
 import arrow

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -882,17 +882,17 @@ class Telegram(RPC):
                                  '/logs', '/whitelist', '/blacklist', '/edge',
                                  '/help', '/version']
         # custom shortcuts specified in config.json
-        shortcut_btns = self._config['telegram'].get('shortcut_btns', [])
-        if shortcut_btns:
+        cust_keyboard = self._config['telegram'].get('keyboard', [])
+        if cust_keyboard:
             # check for valid shortcuts
-            invalid_shortcut_btns = [b for b in chain.from_iterable(shortcut_btns)
-                                     if b not in valid_btns]
-            if len(invalid_shortcut_btns):
+            invalid_keys = [b for b in chain.from_iterable(cust_keyboard)
+                            if b not in valid_btns]
+            if len(invalid_keys):
                 logger.warning('rpc.telegram: invalid commands for custom '
-                               f'keyboard: {invalid_shortcut_btns}')
+                               f'keyboard: {invalid_keys}')
                 logger.info('rpc.telegram: using default keyboard.')
             else:
-                keyboard = shortcut_btns
+                keyboard = cust_keyboard
                 logger.info('rpc.telegram using custom keyboard from '
                             f'config.json: {[btn for btn in keyboard]}')
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -110,8 +110,8 @@ class Telegram(RPC):
             invalid_keys = [b for b in chain.from_iterable(cust_keyboard)
                             if b not in valid_keys]
             if len(invalid_keys):
-                err_msg = ('invalid commands for custom keyboard: '
-                           f'{invalid_keys}')
+                err_msg = ('config.telegram.keyboard: invalid commands for '
+                           f'custom keyboard: {invalid_keys}')
                 raise OperationalException(err_msg)
             else:
                 self._keyboard = cust_keyboard

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1750,15 +1750,15 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
                         ['/count', '/start', '/reload_config', '/help']]
     custom_keyboard = ReplyKeyboardMarkup(custom_keys_list)
 
-    # no shortcut_btns in config -> default keyboard
+    # no keyboard in config -> default keyboard
     telegram._config['telegram']['enabled'] = True
     telegram._send_msg('test')
     used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
     assert used_keyboard == default_keyboard
 
-    # invalid shortcut_btns in config -> default keyboard
+    # invalid keyboard in config -> default keyboard
     telegram._config['telegram']['enabled'] = True
-    telegram._config['telegram']['shortcut_btns'] = invalid_keys_list
+    telegram._config['telegram']['keyboard'] = invalid_keys_list
     telegram._send_msg('test')
     used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
     assert used_keyboard == default_keyboard
@@ -1766,9 +1766,9 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
                    "['/not_valid', '/alsoinvalid']", caplog)
     assert log_has('rpc.telegram: using default keyboard.', caplog)
 
-    # valid shortcut_btns in config -> custom keyboard
+    # valid keyboard in config -> custom keyboard
     telegram._config['telegram']['enabled'] = True
-    telegram._config['telegram']['shortcut_btns'] = custom_keys_list
+    telegram._config['telegram']['keyboard'] = custom_keys_list
     telegram._send_msg('test')
     used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
     assert used_keyboard == custom_keyboard

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1753,14 +1753,14 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     # no keyboard in config -> default keyboard
     telegram._config['telegram']['enabled'] = True
     telegram._send_msg('test')
-    used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
+    used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == default_keyboard
 
     # invalid keyboard in config -> default keyboard
     telegram._config['telegram']['enabled'] = True
     telegram._config['telegram']['keyboard'] = invalid_keys_list
     telegram._send_msg('test')
-    used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
+    used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == default_keyboard
     assert log_has("rpc.telegram: invalid commands for custom keyboard: "
                    "['/not_valid', '/alsoinvalid']", caplog)
@@ -1770,7 +1770,7 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     telegram._config['telegram']['enabled'] = True
     telegram._config['telegram']['keyboard'] = custom_keys_list
     telegram._send_msg('test')
-    used_keyboard = bot.send_message.call_args.kwargs['reply_markup']
+    used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == custom_keyboard
     assert log_has("rpc.telegram using custom keyboard from config.json: "
                    "[['/daily', '/stats', '/balance', '/profit'], ['/count', "

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1764,8 +1764,9 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     # invalid keyboard in config -> default keyboard
     freqtradebot.config['telegram']['enabled'] = True
     freqtradebot.config['telegram']['keyboard'] = invalid_keys_list
-    err_msg = re.escape("config.telegram.keyboard: invalid commands for "
-                        "custom keyboard: ['/not_valid', '/alsoinvalid']")
+    err_msg = re.escape("config.telegram.keyboard: Invalid commands for custom "
+                        "Telegram keyboard: ['/not_valid', '/alsoinvalid']"
+                        "\nvalid commands are: ") + r"*"
     with pytest.raises(OperationalException, match=err_msg):
         telegram = init_telegram(freqtradebot)
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -10,7 +10,7 @@ from unittest.mock import ANY, MagicMock, PropertyMock
 
 import arrow
 import pytest
-from telegram import Chat, Message, Update, ReplyKeyboardMarkup
+from telegram import Chat, Message, ReplyKeyboardMarkup, Update
 from telegram.error import NetworkError
 
 from freqtrade import __version__

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1751,14 +1751,17 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     custom_keyboard = ReplyKeyboardMarkup(custom_keys_list)
 
     # no keyboard in config -> default keyboard
-    telegram._config['telegram']['enabled'] = True
+    # telegram._config['telegram']['enabled'] = True
     telegram._send_msg('test')
     used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == default_keyboard
 
     # invalid keyboard in config -> default keyboard
-    telegram._config['telegram']['enabled'] = True
-    telegram._config['telegram']['keyboard'] = invalid_keys_list
+    freqtradebot.config['telegram']['enabled'] = True
+    freqtradebot.config['telegram']['keyboard'] = invalid_keys_list
+    telegram = Telegram(freqtradebot)
+    telegram._updater = MagicMock()
+    telegram._updater.bot = bot
     telegram._send_msg('test')
     used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == default_keyboard
@@ -1767,6 +1770,11 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     assert log_has('rpc.telegram: using default keyboard.', caplog)
 
     # valid keyboard in config -> custom keyboard
+    freqtradebot.config['telegram']['enabled'] = True
+    freqtradebot.config['telegram']['keyboard'] = custom_keys_list
+    telegram = Telegram(freqtradebot)
+    telegram._updater = MagicMock()
+    telegram._updater.bot = bot
     telegram._config['telegram']['enabled'] = True
     telegram._config['telegram']['keyboard'] = custom_keys_list
     telegram._send_msg('test')


### PR DESCRIPTION
## Summary
Telegram: specify custom keyboard in config.
See docs/telegram-usage.md

closes #3942
closes #4081


