### PR TITLE
set ohlcv limit on ccxt calls

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -6,6 +6,7 @@ from freqtrade.exchange.exchange import Exchange
 from freqtrade.exchange.bibox import Bibox
 from freqtrade.exchange.binance import Binance
 from freqtrade.exchange.bittrex import Bittrex
+from freqtrade.exchange.bybit import Bybit
 from freqtrade.exchange.exchange import (available_exchanges, ccxt_exchanges,
                                          get_exchange_bad_reason, is_exchange_bad,
                                          is_exchange_known_ccxt, is_exchange_officially_supported,

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -18,6 +18,7 @@ class Binance(Exchange):
     _ft_has: Dict = {
         "stoploss_on_exchange": True,
         "order_time_in_force": ['gtc', 'fok', 'ioc'],
+        "ohlcv_candle_limit": 1000,
         "trades_pagination": "id",
         "trades_pagination_arg": "fromId",
         "l2_limit_range": [5, 10, 20, 50, 100, 500, 1000],

--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -1,0 +1,24 @@
+""" Bybit exchange subclass """
+import logging
+from typing import Dict
+
+from freqtrade.exchange import Exchange
+
+
+logger = logging.getLogger(__name__)
+
+
+class Bybit(Exchange):
+    """
+    Bybit exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+
+    Please note that this exchange is not included in the list of exchanges
+    officially supported by the Freqtrade development team. So some features
+    may still not work as expected.
+    """
+
+    # fetchCurrencies API point requires authentication for Bybit,
+    _ft_has: Dict = {
+        "ohlcv_candle_limit": 200,
+    }

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -807,7 +807,8 @@ class Exchange:
             )
 
             data = await self._api_async.fetch_ohlcv(pair, timeframe=timeframe,
-                                                     since=since_ms)
+                                                     since=since_ms,
+                                                     limit=self._ohlcv_candle_limit)
 
             # Some exchanges sort OHLCV in ASC order and others in DESC.
             # Ex: Bittrex returns the list of OHLCV in ASC order (oldest first, newest last)

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -18,6 +18,7 @@ class Kraken(Exchange):
     _params: Dict = {"trading_agreement": "agree"}
     _ft_has: Dict = {
         "stoploss_on_exchange": True,
+        "ohlcv_candle_limit": 720,
         "trades_pagination": "id",
         "trades_pagination_arg": "since",
     }

--- a/freqtrade/pairlist/AgeFilter.py
+++ b/freqtrade/pairlist/AgeFilter.py
@@ -42,7 +42,7 @@ class AgeFilter(IPairList):
         If no Pairlist requires tickers, an empty Dict is passed
         as tickers argument to filter_pairlist
         """
-        return True
+        return False
 
     def short_desc(self) -> str:
         """

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -2153,7 +2153,7 @@ def test_get_fee(default_conf, mocker, exchange_name):
 
 
 def test_stoploss_order_unsupported_exchange(default_conf, mocker):
-    exchange = get_patched_exchange(mocker, default_conf, 'bittrex')
+    exchange = get_patched_exchange(mocker, default_conf, id='bittrex')
     with pytest.raises(OperationalException, match=r"stoploss is not implemented .*"):
         exchange.stoploss(pair='ETH/BTC', amount=1, stop_price=220, order_types={})
 


### PR DESCRIPTION
## Summary
Use limit parameter for fetch_ohlcv to avoid failures for some exchanges which requrire this parameter.
By setting `ohlcv_candle_limit` to the correct value, there is no downside (by increasing this to 1000 for binance, data-download will even be sped up). 
There are no "holes" left in the data due to this change (explicitly tested against this).

closes #3993

## Quick changelog

- Add limit parameter to `fetch_ohlcv()` call
- set "ohclv_candle_limit" correctly for supported exchanges
- subclass exchange for ByBit - as it allows only 200 candles per call