### PR TITLE
add tests to verify exchange compatibility with ccxt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
     - name: Tests
       run: |
         pytest --random-order --cov=freqtrade --cov-config=.coveragerc
+      if: matrix.python-version != '3.9'
+
+    - name: Tests incl. ccxt compatibility tests
+      run: |
+        pytest --random-order --cov=freqtrade --cov-config=.coveragerc --longrun
+      if: matrix.python-version == '3.9'
 
     - name: Coveralls
       if: (startsWith(matrix.os, 'ubuntu-20') && matrix.python-version == '3.8')

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -242,6 +242,8 @@ The `IProtection` parent class provides a helper method for this in `calculate_l
 
 Most exchanges supported by CCXT should work out of the box.
 
+To quickly test the public endpoints of an exchange, add a configuration for your exchange to `test_ccxt_compat.py` and run these tests with `pytest --longrun`.
+
 ### Stoploss On Exchange
 
 Check if the new exchange supports Stoploss on Exchange orders through their API.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -242,7 +242,8 @@ The `IProtection` parent class provides a helper method for this in `calculate_l
 
 Most exchanges supported by CCXT should work out of the box.
 
-To quickly test the public endpoints of an exchange, add a configuration for your exchange to `test_ccxt_compat.py` and run these tests with `pytest --longrun`.
+To quickly test the public endpoints of an exchange, add a configuration for your exchange to `test_ccxt_compat.py` and run these tests with `pytest --longrun tests/exchange/test_ccxt_compat.py`.
+Completing these tests successfully a good basis point (it's a requirement, actually), however these won't guarantee correct exchange functioning, as this only tests public endpoints, but no private endpoint (like generate order or similar).
 
 ### Stoploss On Exchange
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,19 @@ logging.getLogger('').setLevel(logging.INFO)
 np.seterr(all='raise')
 
 
+def pytest_addoption(parser):
+    parser.addoption('--longrun', action='store_true', dest="longrun",
+                     default=False, help="Enable long-run tests (ccxt compat)")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "longrun: mark test that is running slowly and should not be run regularily"
+    )
+    if not config.option.longrun:
+        setattr(config.option, 'markexpr', 'not longrun')
+
+
 def log_has(line, logs):
     # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
     # and we want to match line against foobar in the tuple

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,11 @@ def init_persistence(default_conf):
 
 
 @pytest.fixture(scope="function")
-def default_conf(testdatadir):
+def default_conf():
+    return get_default_conf()
+
+
+def get_default_conf(testdatadir):
     """ Returns validated configuration suitable for most tests """
     configuration = {
         "max_open_trades": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,8 +223,8 @@ def init_persistence(default_conf):
 
 
 @pytest.fixture(scope="function")
-def default_conf():
-    return get_default_conf()
+def default_conf(testdatadir):
+    return get_default_conf(testdatadir)
 
 
 def get_default_conf(testdatadir):

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -50,6 +50,7 @@ def exchange(request, exchange_conf):
     yield exchange, request.param
 
 
+@pytest.mark.longrun
 class TestCCXTExchange():
 
     def test_load_markets(self, exchange):

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -100,8 +100,12 @@ class TestCCXTExchange():
                 assert len(l2['bids']) == val
             else:
                 next_limit = exchange.get_next_limit_in_list(val, exchange._ft_has['l2_limit_range'])
-                assert len(l2['asks']) == next_limit
-                assert len(l2['asks']) == next_limit
+                if next_limit > 200:
+                    assert len(l2['asks']) > 200
+                    assert len(l2['asks']) > 200
+                else:
+                    assert len(l2['asks']) == next_limit
+                    assert len(l2['asks']) == next_limit
 
     def test_fetch_ohlcv(self, exchange):
         exchange, exchangename = exchange
@@ -116,7 +120,7 @@ class TestCCXTExchange():
         exchange, exchangename = exchange
         pair = EXCHANGES[exchangename]['pair']
 
-        assert exchange.get_fee(pair, 'limit', 'buy') > 0 < 1
-        assert exchange.get_fee(pair, 'limit', 'sell') > 0 < 1
-        assert exchange.get_fee(pair, 'market', 'buy') > 0 < 1
-        assert exchange.get_fee(pair, 'market', 'sell') > 0 < 1
+        assert 0 < exchange.get_fee(pair, 'limit', 'buy') < 1
+        assert 0 < exchange.get_fee(pair, 'limit', 'sell') < 1
+        assert 0 < exchange.get_fee(pair, 'market', 'buy') < 1
+        assert 0 < exchange.get_fee(pair, 'market', 'sell') < 1

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -88,12 +88,13 @@ class TestCCXTExchange():
 
     def test_ccxt_fetch_l2_orderbook(self, exchange):
         exchange, exchangename = exchange
-        l2 = exchange.fetch_l2_order_book('BTC/USDT')
+        pair = EXCHANGES[exchangename]['pair']
+        l2 = exchange.fetch_l2_order_book(pair)
         assert 'asks' in l2
         assert 'bids' in l2
 
         for val in [1, 2, 5, 25, 100]:
-            l2 = exchange.fetch_l2_order_book('BTC/USDT', val)
+            l2 = exchange.fetch_l2_order_book(pair, val)
             if not exchange._ft_has['l2_limit_range'] or val in exchange._ft_has['l2_limit_range']:
                 assert len(l2['asks']) == val
                 assert len(l2['bids']) == val

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -92,15 +92,16 @@ class TestCCXTExchange():
         l2 = exchange.fetch_l2_order_book(pair)
         assert 'asks' in l2
         assert 'bids' in l2
-
+        l2_limit_range = exchange._ft_has['l2_limit_range']
         for val in [1, 2, 5, 25, 100]:
             l2 = exchange.fetch_l2_order_book(pair, val)
-            if not exchange._ft_has['l2_limit_range'] or val in exchange._ft_has['l2_limit_range']:
+            if not l2_limit_range or val in l2_limit_range:
                 assert len(l2['asks']) == val
                 assert len(l2['bids']) == val
             else:
-                next_limit = exchange.get_next_limit_in_list(val, exchange._ft_has['l2_limit_range'])
+                next_limit = exchange.get_next_limit_in_list(val, l2_limit_range)
                 if next_limit > 200:
+                    # Large orderbook sizes can be a problem for some exchanges (bitrex ...)
                     assert len(l2['asks']) > 200
                     assert len(l2['asks']) > 200
                 else:
@@ -115,6 +116,8 @@ class TestCCXTExchange():
         ohlcv = exchange.refresh_latest_ohlcv([pair_tf])
         assert isinstance(ohlcv, list)
         assert len(exchange.klines(pair_tf)) > 200
+
+    # TODO: tests fetch_trades (?)
 
     def test_ccxt_get_fee(self, exchange):
         exchange, exchangename = exchange

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -3,7 +3,6 @@ Tests in this file do NOT mock network calls, so they are expected to be fluky a
 
 However, these tests should give a good idea to determine if a new exchange is
 suitable to run with freqtrade.
-
 """
 
 import pytest
@@ -16,19 +15,23 @@ from tests.conftest import get_default_conf
 EXCHANGES = {
     'bittrex': {
         'pair': 'BTC/USDT',
-        'hasQuoteVolume': False
+        'hasQuoteVolume': False,
+        'timeframe': '5m',
     },
     'binance': {
         'pair': 'BTC/USDT',
-        'hasQuoteVolume': True
+        'hasQuoteVolume': True,
+        'timeframe': '5m',
     },
     'kraken': {
         'pair': 'BTC/USDT',
-        'hasQuoteVolume': True
+        'hasQuoteVolume': True,
+        'timeframe': '5m',
     },
     'ftx': {
         'pair': 'BTC/USDT',
-        'hasQuoteVolume': True
+        'hasQuoteVolume': True,
+        'timeframe': '5m',
     }
 }
 
@@ -100,8 +103,13 @@ class TestCCXTExchange():
                 assert len(l2['asks']) == next_limit
 
     def test_fetch_ohlcv(self, exchange):
-        # TODO: Implement me
-        pass
+        exchange, exchangename = exchange
+        pair = EXCHANGES[exchangename]['pair']
+        timeframe = EXCHANGES[exchangename]['timeframe']
+        pair_tf = (pair, timeframe)
+        ohlcv = exchange.refresh_latest_ohlcv([pair_tf])
+        assert isinstance(ohlcv, list)
+        assert len(exchange.klines(pair_tf)) > 200
 
     def test_ccxt_get_fee(self, exchange):
         exchange, exchangename = exchange

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -115,7 +115,8 @@ class TestCCXTExchange():
         timeframe = EXCHANGES[exchangename]['timeframe']
         pair_tf = (pair, timeframe)
         ohlcv = exchange.refresh_latest_ohlcv([pair_tf])
-        assert isinstance(ohlcv, list)
+        assert isinstance(ohlcv, dict)
+        assert len(ohlcv[pair_tf]) == len(exchange.klines(pair_tf))
         assert len(exchange.klines(pair_tf)) > 200
 
     # TODO: tests fetch_trades (?)

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -99,6 +99,10 @@ class TestCCXTExchange():
                 assert len(l2['asks']) == next_limit
                 assert len(l2['asks']) == next_limit
 
+    def test_fetch_ohlcv(self, exchange):
+        # TODO: Implement me
+        pass
+
     def test_ccxt_get_fee(self, exchange):
         exchange, exchangename = exchange
         pair = EXCHANGES[exchangename]['pair']

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -98,3 +98,12 @@ class TestCCXTExchange():
                 next_limit = exchange.get_next_limit_in_list(val, exchange._ft_has['l2_limit_range'])
                 assert len(l2['asks']) == next_limit
                 assert len(l2['asks']) == next_limit
+
+    def test_ccxt_get_fee(self, exchange):
+        exchange, exchangename = exchange
+        pair = EXCHANGES[exchangename]['pair']
+
+        assert exchange.get_fee(pair, 'limit', 'buy') > 0 < 1
+        assert exchange.get_fee(pair, 'limit', 'sell') > 0 < 1
+        assert exchange.get_fee(pair, 'market', 'buy') > 0 < 1
+        assert exchange.get_fee(pair, 'market', 'sell') > 0 < 1

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -5,8 +5,10 @@ However, these tests should give a good idea to determine if a new exchange is
 suitable to run with freqtrade.
 """
 
-import pytest
 from pathlib import Path
+
+import pytest
+
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import get_default_conf
 

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -1,0 +1,43 @@
+"""
+Tests in this file do NOT mock network calls, so they are expected to be fluky at times.
+
+However, these tests should give a good idea to determine if a new exchange is
+suitable to run with freqtrade.
+
+"""
+
+from freqtrade.resolvers.exchange_resolver import ExchangeResolver
+import pytest
+
+# Exchanges that should be tested
+EXCHANGES = ['bittrex', 'binance', 'kraken', 'ftx']
+
+
+@pytest.fixture
+def exchange_conf(default_conf):
+    default_conf['exchange']['pair_whitelist'] = []
+    return default_conf
+
+
+@pytest.mark.parametrize('exchange', EXCHANGES)
+def test_ccxt_fetch_l2_orderbook(exchange_conf, exchange):
+
+    exchange_conf['exchange']['name'] = exchange
+    exchange_conf['exchange']['name'] = exchange
+
+    exchange = ExchangeResolver.load_exchange(exchange, exchange_conf)
+    l2 = exchange.fetch_l2_order_book('BTC/USDT')
+    assert 'asks' in l2
+    assert 'bids' in l2
+
+    for val in [1, 2, 5, 25, 100]:
+        l2 = exchange.fetch_l2_order_book('BTC/USDT', val)
+        if not exchange._ft_has['l2_limit_range'] or val in exchange._ft_has['l2_limit_range']:
+            assert len(l2['asks']) == val
+            assert len(l2['bids']) == val
+        else:
+            next_limit = exchange.get_next_limit_in_list(val, exchange._ft_has['l2_limit_range'])
+            assert len(l2['asks']) == next_limit
+            assert len(l2['asks']) == next_limit
+
+

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -48,7 +48,8 @@ def exchange_conf():
 @pytest.fixture(params=EXCHANGES, scope="class")
 def exchange(request, exchange_conf):
     exchange_conf['exchange']['name'] = request.param
-    exchange = ExchangeResolver.load_exchange(request.param, exchange_conf, validate=False)
+    exchange = ExchangeResolver.load_exchange(request.param, exchange_conf, validate=True)
+
     yield exchange, request.param
 
 


### PR DESCRIPTION
## Summary
This will prevent verision incomatibilities.
The tests will only run when explicitly enabled (via `pytest --longrun`) - and run in ci only once.

This can also serve as a quick method to verify a unsupported exchange's public methods.

## Quick changelog

- Add compatibility tests with ccxt
- Allow quick testing of new exchanges