### PR TITLE
Refactor RPC dependency tree

### DIFF
--- a/freqtrade/rpc/__init__.py
+++ b/freqtrade/rpc/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
-from .rpc import RPC, RPCException, RPCMessageType
+from .rpc import RPC, RPCException, RPCHandler, RPCMessageType
 from .rpc_manager import RPCManager

--- a/freqtrade/rpc/api_server.py
+++ b/freqtrade/rpc/api_server.py
@@ -20,7 +20,6 @@ from freqtrade.__init__ import __version__
 from freqtrade.constants import DATETIME_PRINT_FORMAT, USERPATH_STRATEGIES
 from freqtrade.exceptions import OperationalException
 from freqtrade.persistence import Trade
-from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.rpc.rpc import RPC, RPCException
 
 
@@ -116,9 +115,6 @@ class ApiServer(RPC):
 
         # Register application handling
         self.register_rest_rpc_urls()
-
-        if self._config.get('fiat_display_currency', None):
-            self._fiat_converter = CryptoToFiatConverter()
 
         thread = threading.Thread(target=self.run, daemon=True)
         thread.start()

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -69,7 +69,7 @@ class RPC:
     """
     RPC class can be used to have extra feature, like bot data, and access to DB data
     """
-    # Bind _fiat_converter if needed in each RPC handler
+    # Bind _fiat_converter if needed
     _fiat_converter: Optional[CryptoToFiatConverter] = None
 
     def __init__(self, freqtrade) -> None:
@@ -80,6 +80,8 @@ class RPC:
         """
         self._freqtrade = freqtrade
         self._config: Dict[str, Any] = freqtrade.config
+        if self._config.get('fiat_display_currency', None):
+            self._fiat_converter = CryptoToFiatConverter()
 
     @property
     def name(self) -> str:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -65,6 +65,32 @@ class RPCException(Exception):
         }
 
 
+class RPCHandler:
+
+    def __init__(self, rpc: 'RPC', config: Dict[str, Any]) -> None:
+        """
+        Initializes RPCHandlers
+        :param rpc: instance of RPC Helper class
+        :param config: Configuration object
+        :return: None
+        """
+        self._rpc = rpc
+        self._config: Dict[str, Any] = config
+
+    @property
+    def name(self) -> str:
+        """ Returns the lowercase name of the implementation """
+        return self.__class__.__name__.lower()
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        """ Cleanup pending module resources """
+
+    @abstractmethod
+    def send_msg(self, msg: Dict[str, str]) -> None:
+        """ Sends a message to all registered rpc modules """
+
+
 class RPC:
     """
     RPC class can be used to have extra feature, like bot data, and access to DB data
@@ -82,19 +108,6 @@ class RPC:
         self._config: Dict[str, Any] = freqtrade.config
         if self._config.get('fiat_display_currency', None):
             self._fiat_converter = CryptoToFiatConverter()
-
-    @property
-    def name(self) -> str:
-        """ Returns the lowercase name of the implementation """
-        return self.__class__.__name__.lower()
-
-    @abstractmethod
-    def cleanup(self) -> None:
-        """ Cleanup pending module resources """
-
-    @abstractmethod
-    def send_msg(self, msg: Dict[str, str]) -> None:
-        """ Sends a message to all registered rpc modules """
 
     @staticmethod
     def _rpc_show_config(config, botstate: State) -> Dict[str, Any]:

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -4,7 +4,7 @@ This module contains class to manage RPC communications (Telegram, Slack, ...)
 import logging
 from typing import Any, Dict, List
 
-from freqtrade.rpc import RPC, RPCMessageType
+from freqtrade.rpc import RPC, RPCHandler, RPCMessageType
 
 
 logger = logging.getLogger(__name__)
@@ -16,25 +16,26 @@ class RPCManager:
     """
     def __init__(self, freqtrade) -> None:
         """ Initializes all enabled rpc modules """
-        self.registered_modules: List[RPC] = []
-
+        self.registered_modules: List[RPCHandler] = []
+        self._rpc = RPC(freqtrade)
+        config = freqtrade.config
         # Enable telegram
-        if freqtrade.config.get('telegram', {}).get('enabled', False):
+        if config.get('telegram', {}).get('enabled', False):
             logger.info('Enabling rpc.telegram ...')
             from freqtrade.rpc.telegram import Telegram
-            self.registered_modules.append(Telegram(freqtrade))
+            self.registered_modules.append(Telegram(self._rpc, config))
 
         # Enable Webhook
-        if freqtrade.config.get('webhook', {}).get('enabled', False):
+        if config.get('webhook', {}).get('enabled', False):
             logger.info('Enabling rpc.webhook ...')
             from freqtrade.rpc.webhook import Webhook
-            self.registered_modules.append(Webhook(freqtrade))
+            self.registered_modules.append(Webhook(self._rpc, config))
 
         # Enable local rest api server for cmd line control
-        if freqtrade.config.get('api_server', {}).get('enabled', False):
+        if config.get('api_server', {}).get('enabled', False):
             logger.info('Enabling rpc.api_server')
             from freqtrade.rpc.api_server import ApiServer
-            self.registered_modules.append(ApiServer(freqtrade))
+            self.registered_modules.append(ApiServer(self._rpc, config))
 
     def cleanup(self) -> None:
         """ Stops all enabled rpc modules """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -19,7 +19,6 @@ from telegram.utils.helpers import escape_markdown
 from freqtrade.__init__ import __version__
 from freqtrade.exceptions import OperationalException
 from freqtrade.rpc import RPC, RPCException, RPCMessageType
-from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 
 
 logger = logging.getLogger(__name__)
@@ -77,8 +76,6 @@ class Telegram(RPC):
         self._updater: Updater
         self._init_keyboard()
         self._init()
-        if self._config.get('fiat_display_currency', None):
-            self._fiat_converter = CryptoToFiatConverter()
 
     def _init_keyboard(self) -> None:
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -18,7 +18,7 @@ from telegram.utils.helpers import escape_markdown
 
 from freqtrade.__init__ import __version__
 from freqtrade.exceptions import OperationalException
-from freqtrade.rpc import RPC, RPCException, RPCMessageType
+from freqtrade.rpc import RPC, RPCException, RPCHandler, RPCMessageType
 
 
 logger = logging.getLogger(__name__)
@@ -62,16 +62,18 @@ def authorized_only(command_handler: Callable[..., None]) -> Callable[..., Any]:
     return wrapper
 
 
-class Telegram(RPC):
+class Telegram(RPCHandler):
     """  This class handles all telegram communication """
 
-    def __init__(self, freqtrade) -> None:
+    def __init__(self, rpc: RPC, config: Dict[str, Any]) -> None:
+
         """
-        Init the Telegram call, and init the super class RPC
-        :param freqtrade: Instance of a freqtrade bot
+        Init the Telegram call, and init the super class RPCHandler
+        :param rpc: instance of RPC Helper class
+        :param config: Configuration object
         :return: None
         """
-        super().__init__(freqtrade)
+        super().__init__(rpc, config)
 
         self._updater: Updater
         self._init_keyboard()
@@ -181,8 +183,8 @@ class Telegram(RPC):
             return
 
         if msg['type'] == RPCMessageType.BUY_NOTIFICATION:
-            if self._fiat_converter:
-                msg['stake_amount_fiat'] = self._fiat_converter.convert_amount(
+            if self._rpc._fiat_converter:
+                msg['stake_amount_fiat'] = self._rpc._fiat_converter.convert_amount(
                     msg['stake_amount'], msg['stake_currency'], msg['fiat_currency'])
             else:
                 msg['stake_amount_fiat'] = 0
@@ -222,8 +224,8 @@ class Telegram(RPC):
             # Check if all sell properties are available.
             # This might not be the case if the message origin is triggered by /forcesell
             if (all(prop in msg for prop in ['gain', 'fiat_currency', 'stake_currency'])
-                    and self._fiat_converter):
-                msg['profit_fiat'] = self._fiat_converter.convert_amount(
+                    and self._rpc._fiat_converter):
+                msg['profit_fiat'] = self._rpc._fiat_converter.convert_amount(
                     msg['profit_amount'], msg['stake_currency'], msg['fiat_currency'])
                 message += (' `({gain}: {profit_amount:.8f} {stake_currency}'
                             ' / {profit_fiat:.3f} {fiat_currency})`').format(**msg)
@@ -275,7 +277,7 @@ class Telegram(RPC):
             return
 
         try:
-            results = self._rpc_trade_status()
+            results = self._rpc._rpc_trade_status()
 
             messages = []
             for r in results:
@@ -325,8 +327,9 @@ class Telegram(RPC):
         :return: None
         """
         try:
-            statlist, head = self._rpc_status_table(self._config['stake_currency'],
-                                                    self._config.get('fiat_display_currency', ''))
+            statlist, head = self._rpc._rpc_status_table(
+                self._config['stake_currency'], self._config.get('fiat_display_currency', ''))
+
             message = tabulate(statlist, headers=head, tablefmt='simple')
             self._send_msg(f"<pre>{message}</pre>", parse_mode=ParseMode.HTML)
         except RPCException as e:
@@ -348,7 +351,7 @@ class Telegram(RPC):
         except (TypeError, ValueError, IndexError):
             timescale = 7
         try:
-            stats = self._rpc_daily_profit(
+            stats = self._rpc._rpc_daily_profit(
                 timescale,
                 stake_cur,
                 fiat_disp_cur
@@ -382,7 +385,7 @@ class Telegram(RPC):
         stake_cur = self._config['stake_currency']
         fiat_disp_cur = self._config.get('fiat_display_currency', '')
 
-        stats = self._rpc_trade_statistics(
+        stats = self._rpc._rpc_trade_statistics(
             stake_cur,
             fiat_disp_cur)
         profit_closed_coin = stats['profit_closed_coin']
@@ -433,7 +436,7 @@ class Telegram(RPC):
         Handler for /stats
         Show stats of recent trades
         """
-        stats = self._rpc_stats()
+        stats = self._rpc._rpc_stats()
 
         reason_map = {
             'roi': 'ROI',
@@ -473,8 +476,8 @@ class Telegram(RPC):
     def _balance(self, update: Update, context: CallbackContext) -> None:
         """ Handler for /balance """
         try:
-            result = self._rpc_balance(self._config['stake_currency'],
-                                       self._config.get('fiat_display_currency', ''))
+            result = self._rpc._rpc_balance(self._config['stake_currency'],
+                                            self._config.get('fiat_display_currency', ''))
 
             output = ''
             if self._config['dry_run']:
@@ -517,7 +520,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        msg = self._rpc_start()
+        msg = self._rpc._rpc_start()
         self._send_msg('Status: `{status}`'.format(**msg))
 
     @authorized_only
@@ -529,7 +532,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        msg = self._rpc_stop()
+        msg = self._rpc._rpc_stop()
         self._send_msg('Status: `{status}`'.format(**msg))
 
     @authorized_only
@@ -541,7 +544,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        msg = self._rpc_reload_config()
+        msg = self._rpc._rpc_reload_config()
         self._send_msg('Status: `{status}`'.format(**msg))
 
     @authorized_only
@@ -553,7 +556,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        msg = self._rpc_stopbuy()
+        msg = self._rpc._rpc_stopbuy()
         self._send_msg('Status: `{status}`'.format(**msg))
 
     @authorized_only
@@ -571,7 +574,7 @@ class Telegram(RPC):
             self._send_msg("You must specify a trade-id or 'all'.")
             return
         try:
-            msg = self._rpc_forcesell(trade_id)
+            msg = self._rpc._rpc_forcesell(trade_id)
             self._send_msg('Forcesell Result: `{result}`'.format(**msg))
 
         except RPCException as e:
@@ -590,7 +593,7 @@ class Telegram(RPC):
             pair = context.args[0]
             price = float(context.args[1]) if len(context.args) > 1 else None
             try:
-                self._rpc_forcebuy(pair, price)
+                self._rpc._rpc_forcebuy(pair, price)
             except RPCException as e:
                 self._send_msg(str(e))
 
@@ -609,7 +612,7 @@ class Telegram(RPC):
         except (TypeError, ValueError, IndexError):
             nrecent = 10
         try:
-            trades = self._rpc_trade_history(
+            trades = self._rpc._rpc_trade_history(
                 nrecent
             )
             trades_tab = tabulate(
@@ -642,7 +645,7 @@ class Telegram(RPC):
             if not context.args or len(context.args) == 0:
                 raise RPCException("Trade-id not set.")
             trade_id = int(context.args[0])
-            msg = self._rpc_delete(trade_id)
+            msg = self._rpc._rpc_delete(trade_id)
             self._send_msg((
                 '`{result_msg}`\n'
                 'Please make sure to take care of this asset on the exchange manually.'
@@ -661,7 +664,7 @@ class Telegram(RPC):
         :return: None
         """
         try:
-            trades = self._rpc_performance()
+            trades = self._rpc._rpc_performance()
             stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
                 index=i + 1,
                 pair=trade['pair'],
@@ -683,7 +686,7 @@ class Telegram(RPC):
         :return: None
         """
         try:
-            counts = self._rpc_count()
+            counts = self._rpc._rpc_count()
             message = tabulate({k: [v] for k, v in counts.items()},
                                headers=['current', 'max', 'total stake'],
                                tablefmt='simple')
@@ -700,7 +703,7 @@ class Telegram(RPC):
         Returns the currently active locks
         """
         try:
-            locks = self._rpc_locks()
+            locks = self._rpc._rpc_locks()
             message = tabulate([[
                 lock['pair'],
                 lock['lock_end_time'],
@@ -720,7 +723,7 @@ class Telegram(RPC):
         Shows the currently active whitelist
         """
         try:
-            whitelist = self._rpc_whitelist()
+            whitelist = self._rpc._rpc_whitelist()
 
             message = f"Using whitelist `{whitelist['method']}` with {whitelist['length']} pairs\n"
             message += f"`{', '.join(whitelist['whitelist'])}`"
@@ -738,7 +741,7 @@ class Telegram(RPC):
         """
         try:
 
-            blacklist = self._rpc_blacklist(context.args)
+            blacklist = self._rpc._rpc_blacklist(context.args)
             errmsgs = []
             for pair, error in blacklist['errors'].items():
                 errmsgs.append(f"Error adding `{pair}` to blacklist: `{error['error_msg']}`")
@@ -792,7 +795,7 @@ class Telegram(RPC):
         Shows information related to Edge
         """
         try:
-            edge_pairs = self._rpc_edge()
+            edge_pairs = self._rpc._rpc_edge()
             edge_pairs_tab = tabulate(edge_pairs, headers='keys', tablefmt='simple')
             message = f'<b>Edge only validated following pairs:</b>\n<pre>{edge_pairs_tab}</pre>'
             self._send_msg(message, parse_mode=ParseMode.HTML)
@@ -862,7 +865,7 @@ class Telegram(RPC):
         :param update: message update
         :return: None
         """
-        val = RPC._rpc_show_config(self._freqtrade.config, self._freqtrade.state)
+        val = RPC._rpc_show_config(self._config, self._rpc._freqtrade.state)
 
         if val['trailing_stop']:
             sl_info = (

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from requests import RequestException, post
 
-from freqtrade.rpc import RPC, RPCMessageType
+from freqtrade.rpc import RPC, RPCHandler, RPCMessageType
 
 
 logger = logging.getLogger(__name__)
@@ -14,16 +14,17 @@ logger = logging.getLogger(__name__)
 logger.debug('Included module rpc.webhook ...')
 
 
-class Webhook(RPC):
+class Webhook(RPCHandler):
     """  This class handles all webhook communication """
 
-    def __init__(self, freqtrade) -> None:
+    def __init__(self, rpc: RPC, config: Dict[str, Any]) -> None:
         """
-        Init the Webhook class, and init the super class RPC
-        :param freqtrade: Instance of a freqtrade bot
+        Init the Webhook class, and init the super class RPCHandler
+        :param rpc: instance of RPC Helper class
+        :param config: Configuration object
         :return: None
         """
-        super().__init__(freqtrade)
+        super().__init__(rpc, config)
 
         self._url = self._config['webhook']['url']
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -185,7 +185,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
         fetch_ticker=ticker,
         get_fee=fee,
     )
-
+    del default_conf['fiat_display_currency']
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from requests import RequestException
 
-from freqtrade.rpc import RPCMessageType
+from freqtrade.rpc import RPC, RPCMessageType
 from freqtrade.rpc.webhook import Webhook
 from freqtrade.strategy.interface import SellType
 from tests.conftest import get_patched_freqtradebot, log_has
@@ -45,7 +45,7 @@ def get_webhook_dict() -> dict:
 
 def test__init__(mocker, default_conf):
     default_conf['webhook'] = {'enabled': True, 'url': "https://DEADBEEF.com"}
-    webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
     assert webhook._config == default_conf
 
 
@@ -53,7 +53,7 @@ def test_send_msg(default_conf, mocker):
     default_conf["webhook"] = get_webhook_dict()
     msg_mock = MagicMock()
     mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
-    webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
     # Test buy
     msg_mock = MagicMock()
     mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
@@ -172,7 +172,7 @@ def test_exception_send_msg(default_conf, mocker, caplog):
     default_conf["webhook"] = get_webhook_dict()
     del default_conf["webhook"]["webhookbuy"]
 
-    webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
     webhook.send_msg({'type': RPCMessageType.BUY_NOTIFICATION})
     assert log_has(f"Message type '{RPCMessageType.BUY_NOTIFICATION}' not configured for webhooks",
                    caplog)
@@ -181,7 +181,7 @@ def test_exception_send_msg(default_conf, mocker, caplog):
     default_conf["webhook"]["webhookbuy"]["value1"] = "{DEADBEEF:8f}"
     msg_mock = MagicMock()
     mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
-    webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
     msg = {
         'type': RPCMessageType.BUY_NOTIFICATION,
         'exchange': 'Bittrex',
@@ -209,7 +209,7 @@ def test_exception_send_msg(default_conf, mocker, caplog):
 
 def test__send_msg(default_conf, mocker, caplog):
     default_conf["webhook"] = get_webhook_dict()
-    webhook = Webhook(get_patched_freqtradebot(mocker, default_conf))
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
     msg = {'value1': 'DEADBEEF',
            'value2': 'ALIVEBEEF',
            'value3': 'FREQTRADE'}


### PR DESCRIPTION
## Summary
Deconstruct RPC dependencies, so handlers (Telegram, api, webhook) don't inherit RPC, but are passed an instance of RPC.
This way, we'll not have the a child of the same instance around 2-3 times, but can use the same RPC instance.

## Quick changelog

- Change inheritance of RPC methods