### PR TITLE
Improve merge_informative_pairs to properly merge correct timeframes

### DIFF
--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -24,15 +24,24 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
     :param timeframe: Timeframe of the original pair sample.
     :param timeframe_inf: Timeframe of the informative pair sample.
     :param ffill: Forwardfill missing values - optional but usually required
+    :return: Merged dataframe
+    :raise: ValueError if the secondary timeframe is shorter than the dataframe timeframe
     """
 
     minutes_inf = timeframe_to_minutes(timeframe_inf)
     minutes = timeframe_to_minutes(timeframe)
-    if minutes >= minutes_inf:
+    if minutes == minutes_inf:
         # No need to forwardshift if the timeframes are identical
         informative['date_merge'] = informative["date"]
+    elif minutes < minutes_inf:
+        # Subtract "small" timeframe so merging is not delayed by 1 small candle
+        # Detailed explanation in https://github.com/freqtrade/freqtrade/issues/4073
+        informative['date_merge'] = (
+            informative["date"] + pd.to_timedelta(minutes_inf, 'm') - pd.to_timedelta(minutes, 'm')
+            )
     else:
-        informative['date_merge'] = informative["date"] + pd.to_timedelta(minutes_inf, 'm')
+        raise ValueError("Tried to merge a faster timeframe to a slower timeframe."
+                         "This would create new rows, and can throw off your regular indicators.")
 
     # Rename columns to be unique
     informative.columns = [f"{col}_{timeframe_inf}" for col in informative.columns]


### PR DESCRIPTION
## Summary
Fix slightly wrong merging strategy for merge_informative_pairs.

Full explanation in #4073, closes #4073

## Quick changelog

- Fix calculation of merge_informative_pairs to consider that both timeframes are candle OPEN times.
 
## What's new?
Example: (notice Line 3 - as 11:55 is the Candle's Open date, it's available at 12:00 - so the hourly candle from 11:00-12:00 is also available at this time.
```
987 2021-01-04 11:45:00+00:00   5690.087 2021-01-04 10:00:00+00:00  19376.831179
988 2021-01-04 11:50:00+00:00   3276.061 2021-01-04 10:00:00+00:00  19376.831179
989 2021-01-04 11:55:00+00:00   6351.362 2021-01-04 11:00:00+00:00   9413.490067
990 2021-01-04 12:00:00+00:00  10748.958 2021-01-04 11:00:00+00:00   9413.490067
991 2021-01-04 12:05:00+00:00   2265.807 2021-01-04 11:00:00+00:00   9413.490067

```