### PR TITLE
Allow protections to be set in the strategy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `edge.*` | Please refer to [edge configuration document](edge.md) for detailed explanation.
 | `experimental.block_bad_exchanges` | Block exchanges known to not work with freqtrade. Leave on default unless you want to test if that exchange works now. <br>*Defaults to `true`.* <br> **Datatype:** Boolean
 | `pairlists` | Define one or more pairlists to be used. [More information below](#pairlists-and-pairlist-handlers). <br>*Defaults to `StaticPairList`.*  <br> **Datatype:** List of Dicts
-| `protections` | Define one or more protections to be used. [More information below](#protections). <br> **Datatype:** List of Dicts
+| `protections` | Define one or more protections to be used. [More information below](#protections). [Strategy Override](#parameters-in-the-strategy). <br> **Datatype:** List of Dicts
 | `telegram.enabled` | Enable the usage of Telegram. <br> **Datatype:** Boolean
 | `telegram.token` | Your Telegram bot token. Only required if `telegram.enabled` is `true`. <br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
 | `telegram.chat_id` | Your personal Telegram account id. Only required if `telegram.enabled` is `true`. <br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
@@ -141,6 +141,7 @@ Values set in the configuration file always overwrite values set in the strategy
 * `stake_amount`
 * `unfilledtimeout`
 * `disable_dataframe_checks`
+* `protections`
 * `use_sell_signal` (ask_strategy)
 * `sell_profit_only` (ask_strategy)
 * `ignore_roi_if_buy_signal` (ask_strategy)

--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -7,7 +7,8 @@ Protections will protect your strategy from unexpected events and market conditi
 All protection end times are rounded up to the next candle to avoid sudden, unexpected intra-candle buys.
 
 !!! Note
-    Not all Protections will work for all strategies, and parameters will need to be tuned for your strategy to improve performance.
+    Not all Protections will work for all strategies, and parameters will need to be tuned for your strategy to improve performance.  
+    To align your protection with your strategy, you can define protections in the strategy.
 
 !!! Tip
     Each Protection can be configured multiple times with different parameters, to allow different levels of protection (short-term / long-term).
@@ -166,4 +167,48 @@ The below example assumes a timeframe of 1 hour:
         "required_profit": 0.01
     }
     ],
+```
+
+You can use the same in your strategy, the syntax is only slightly different:
+
+``` python
+from freqtrade.strategy import IStrategy
+
+class AwesomeStrategy(IStrategy)
+    timeframe = '1h'
+    protections = [
+        {
+            "method": "CooldownPeriod",
+            "stop_duration_candles": 5
+        },
+        {
+            "method": "MaxDrawdown",
+            "lookback_period_candles": 48,
+            "trade_limit": 20,
+            "stop_duration_candles": 4,
+            "max_allowed_drawdown": 0.2
+        },
+        {
+            "method": "StoplossGuard",
+            "lookback_period_candles": 24,
+            "trade_limit": 4,
+            "stop_duration_candles": 2,
+            "only_per_pair": False
+        },
+        {
+            "method": "LowProfitPairs",
+            "lookback_period_candles": 6,
+            "trade_limit": 2,
+            "stop_duration_candles": 60,
+            "required_profit": 0.02
+        },
+        {
+            "method": "LowProfitPairs",
+            "lookback_period_candles": 24,
+            "trade_limit": 4,
+            "stop_duration_candles": 2,
+            "required_profit": 0.01
+        }
+    ]
+    # ...
 ```

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -73,6 +73,7 @@ class StrategyResolver(IResolver):
                       ("order_time_in_force",             None,        None),
                       ("stake_currency",                  None,        None),
                       ("stake_amount",                    None,        None),
+                      ("protections",                     None,        None),
                       ("startup_candle_count",            None,        None),
                       ("unfilledtimeout",                 None,        None),
                       ("use_sell_signal",                 True,        'ask_strategy'),

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -119,6 +119,9 @@ class IStrategy(ABC):
     # Count of candles the strategy requires before producing valid signals
     startup_candle_count: int = 0
 
+    # Protections
+    protections: List
+
     # Class level variables (intentional) containing
     # the dataprovider (dp) (access to other candles, historic data, ...)
     # and wallets - access to the current balance.


### PR DESCRIPTION
## Summary
Allow protections to be set in the strategy

Having them in the configuration can hinder experimenting with multiple strategies that require different protections.

## Quick changelog

- load protections from strategy
- Document this method