### PR TITLE
Add bot_name setting

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -85,6 +85,7 @@
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },
+    "bot_name": "freqtrade",
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/config_binance.json.example
+++ b/config_binance.json.example
@@ -90,6 +90,7 @@
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },
+    "bot_name": "freqtrade",
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -177,6 +177,7 @@
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },
+    "bot_name": "freqtrade",
     "db_url": "sqlite:///tradesv3.sqlite",
     "initial_state": "running",
     "forcebuy_enable": false,

--- a/config_kraken.json.example
+++ b/config_kraken.json.example
@@ -95,6 +95,7 @@
         "username": "freqtrader",
         "password": "SuperSecurePassword"
     },
+    "bot_name": "freqtrade",
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `api_server.verbosity` | Logging verbosity. `info` will print all RPC Calls, while "error" will only display errors. <br>**Datatype:** Enum, either `info` or `error`. Defaults to `info`.
 | `api_server.username` | Username for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
 | `api_server.password` | Password for API server. See the [API Server documentation](rest-api.md) for more details. <br>**Keep it in secret, do not disclose publicly.**<br> **Datatype:** String
+| `bot_name` | Name of the bot. Passed via API to a client - can be shown to distinguish / name bots.<br> *Defaults to `freqtrade`*<br> **Datatype:** String
 | `db_url` | Declares database URL to use. NOTE: This defaults to `sqlite:///tradesv3.dryrun.sqlite` if `dry_run` is `true`, and to `sqlite:///tradesv3.sqlite` for production instances. <br> **Datatype:** String, SQLAlchemy connect string
 | `initial_state` | Defines the initial application state. More information below. <br>*Defaults to `stopped`.* <br> **Datatype:** Enum, either `stopped` or `running`
 | `forcebuy_enable` | Enables the RPC Commands to force a buy. More information below. <br> **Datatype:** Boolean

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -116,6 +116,7 @@ CONF_SCHEMA = {
         'trailing_stop_positive': {'type': 'number', 'minimum': 0, 'maximum': 1},
         'trailing_stop_positive_offset': {'type': 'number', 'minimum': 0, 'maximum': 1},
         'trailing_only_offset_is_reached': {'type': 'boolean'},
+        'bot_name': {'type': 'string'},
         'unfilledtimeout': {
             'type': 'object',
             'properties': {

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -131,6 +131,7 @@ class ShowConfig(BaseModel):
     forcebuy_enabled: bool
     ask_strategy: Dict[str, Any]
     bid_strategy: Dict[str, Any]
+    bot_name: str
     state: str
     runmode: str
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -129,6 +129,7 @@ class RPC:
             'trailing_stop_positive': config.get('trailing_stop_positive'),
             'trailing_stop_positive_offset': config.get('trailing_stop_positive_offset'),
             'trailing_only_offset_is_reached': config.get('trailing_only_offset_is_reached'),
+            'bot_name': config.get('bot_name', 'freqtrade'),
             'timeframe': config.get('timeframe'),
             'timeframe_ms': timeframe_to_msecs(config['timeframe']
                                                ) if 'timeframe' in config else '',

--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -63,6 +63,7 @@
         "username": "",
         "password": ""
     },
+    "bot_name": "freqtrade",
     "initial_state": "running",
     "forcebuy_enable": false,
     "internals": {

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -414,6 +414,7 @@ def test_api_show_config(botclient, mocker):
     assert rc.json()['timeframe_ms'] == 300000
     assert rc.json()['timeframe_min'] == 5
     assert rc.json()['state'] == 'running'
+    assert rc.json()['bot_name'] == 'freqtrade'
     assert not rc.json()['trailing_stop']
     assert 'bid_strategy' in rc.json()
     assert 'ask_strategy' in rc.json()


### PR DESCRIPTION
## Summary
Add bot_name setting

allows naming the bot to simply differentiate when running different
bots.

## Quick changelog

- Add bot_name setting - which is passed via show_config to the API - allowing the UI to differentiate between bots.