### PR TITLE
Extending the Telegram Bot command /status with the possibility to query specific trade_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Telegram is not mandatory. However, this is a great way to control your bot. Mor
 - `/start`: Starts the trader.
 - `/stop`: Stops the trader.
 - `/stopbuy`: Stop entering new trades.
-- `/status [table]`: Lists all open trades.
+- `/status <trade_id>|[table]`: Lists all or specific open trades.
 - `/profit`: Lists cumulative profit from all finished trades
 - `/forcesell <trade_id>|all`: Instantly sells the given trade (Ignoring `minimum_roi`).
 - `/performance`: Show performance of each finished trade grouped by pair

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -137,6 +137,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/show_config` | Shows part of the current configuration with relevant settings to operation
 | `/logs [limit]` | Show last log messages.
 | `/status` | Lists all open trades
+| `/status <trade_id>` | Lists one or more specific trade. Separate multiple <trade_id> with a blank space.
 | `/status table` | List all open trades in a table format. Pending buy orders are marked with an asterisk (*) Pending sell orders are marked with a double asterisk (**)
 | `/trades [limit]` | List all recently closed trades in a table format.
 | `/delete <trade_id>` | Delete a specific trade from the Database. Tries to close open orders. Requires manual handling of this trade on the exchange.

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -144,7 +144,7 @@ class RPC:
         }
         return val
 
-    def _rpc_trade_status(self, trade_ids=None) -> List[Dict[str, Any]]:
+    def _rpc_trade_status(self, trade_ids: List[int] = []) -> List[Dict[str, Any]]:
         """
         Below follows the RPC backend it is prefixed with rpc_ to raise awareness that it is
         a remotely exposed function

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -151,7 +151,7 @@ class RPC:
         """
         # Fetch open trades
         if trade_ids:
-            trades = Trade.get_trades(trade_filter=Trade.id.in_(trade_ids))
+            trades = Trade.get_trades(trade_filter=Trade.id.in_(trade_ids)).all()
         else:
             trades = Trade.get_open_trades()
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -144,13 +144,17 @@ class RPC:
         }
         return val
 
-    def _rpc_trade_status(self) -> List[Dict[str, Any]]:
+    def _rpc_trade_status(self, trade_ids=None) -> List[Dict[str, Any]]:
         """
         Below follows the RPC backend it is prefixed with rpc_ to raise awareness that it is
         a remotely exposed function
         """
-        # Fetch open trade
-        trades = Trade.get_open_trades()
+        # Fetch open trades
+        if trade_ids:
+            trades = Trade.get_trades(trade_filter=Trade.id.in_(trade_ids))
+        else:
+            trades = Trade.get_open_trades()
+
         if not trades:
             raise RPCException('no active trade')
         else:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -278,7 +278,8 @@ class Telegram(RPCHandler):
 
         try:
 
-            # Check if there's at least one numerical ID provided. If so, try to get only these trades.
+            # Check if there's at least one numerical ID provided.
+            # If so, try to get only these trades.
             trade_ids = None
             if context.args and len(context.args) > 0:
                 trade_ids = [i for i in context.args if i.isnumeric()]

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -821,7 +821,9 @@ class Telegram(RPCHandler):
                          "Optionally takes a rate at which to buy.` \n")
         message = ("*/start:* `Starts the trader`\n"
                    "*/stop:* `Stops the trader`\n"
-                   "*/status [table]:* `Lists all open trades`\n"
+                   "*/status <trade_id>|[table]:* `Lists all open trades`\n"
+                   "         *<trade_id> :* `Lists one or more specific trades.`\n"
+                   "                        `Separate multiple <trade_id> with a blank space.`\n"
                    "         *table :* `will display trades in a table`\n"
                    "                `pending buy orders are marked with an asterisk (*)`\n"
                    "                `pending sell orders are marked with a double asterisk (**)`\n"

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -280,9 +280,9 @@ class Telegram(RPCHandler):
 
             # Check if there's at least one numerical ID provided.
             # If so, try to get only these trades.
-            trade_ids = None
+            trade_ids = []
             if context.args and len(context.args) > 0:
-                trade_ids = [i for i in context.args if i.isnumeric()]
+                trade_ids = [int(i) for i in context.args if i.isnumeric()]
 
             results = self._rpc._rpc_trade_status(trade_ids=trade_ids)
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -277,7 +277,13 @@ class Telegram(RPCHandler):
             return
 
         try:
-            results = self._rpc._rpc_trade_status()
+
+            # Check if there's at least one numerical ID provided. If so, try to get only these trades.
+            trade_ids = None
+            if context.args and len(context.args) > 0:
+                trade_ids = [i for i in context.args if i.isnumeric()]
+
+            results = self._rpc._rpc_trade_status(trade_ids=trade_ids)
 
             messages = []
             for r in results:


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Extending the Telegram Bot command /status with the possibility to query specific trade_ids

Solve the issue: #___

## Quick changelog

- In module `telegram.py` extend the `_status` method with verifying provided arguments as numbers, and provide these numbers as an array to `_rpc._rpc_trade_status`
- In module `rpc.py` extend the `_rpc_trade_status` with an additional argument for the trade_ids and query these trade_ids if provided.
- Extend the docs and the Telegram `/help` command.

## What's new?
New is the possibility to query via Telegram status details of specific trades.
![unknown](https://user-images.githubusercontent.com/26668031/104855189-9c7ecc80-590b-11eb-9af0-d9f184b21710.png)

