### PR TITLE
setting resize_keyboard=True for slightly smaller Telegram buttons

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -910,7 +910,7 @@ class Telegram(RPCHandler):
         :param parse_mode: telegram parse mode
         :return: None
         """
-        reply_markup = ReplyKeyboardMarkup(self._keyboard)
+        reply_markup = ReplyKeyboardMarkup(self._keyboard, resize_keyboard=True)
         try:
             try:
                 self._updater.bot.send_message(


### PR DESCRIPTION
## Summary
Telegram button are just slightly smaller.
Existing tests are passing, no tests about button size present (because testing an external library is out of scope).

## Quick changelog
- set resize_keyboard=True on ReplyKeyboardMarkup

