### PR TITLE
restore plot-profit command functionality

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -347,7 +347,12 @@ def create_cum_profit(df: pd.DataFrame, trades: pd.DataFrame, col_name: str,
     # Resample to timeframe to make sure trades match candles
     _trades_sum = trades.resample(f'{timeframe_minutes}min', on='close_date'
                                   )[['profit_percent']].sum()
-    df.loc[:, col_name] = _trades_sum.cumsum()
+
+    _trades_sum.rename(columns={"profit_percent": col_name}, inplace=True)
+
+    cp = _trades_sum.cumsum()
+    df = pd.merge(df, cp, how='left', left_index=True, right_index=True)
+
     # Set first value to 0
     df.loc[df.iloc[0].name, col_name] = 0
     # FFill to get continuous


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Restoring the plot-profit command functionality

Solve the issue: #4316

## Quick changelog

- Restored the plot-profit functionality

## What's new?
The problem was here:
```
    freqtrade/data/btanalysis.py@350
    df.loc[:, col_name] = _trades_sum.cumsum()
```
Somehow this copies an empty column.