### PR TITLE
fix the rpc for balance which returns incorrect est. balance 

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -451,7 +451,7 @@ class RPC:
                     pair = self._freqtrade.exchange.get_valid_pair_combination(coin, stake_currency)
                     rate = tickers.get(pair, {}).get('bid', None)
                     if rate:
-                        if pair.startswith(stake_currency) and not pair.endswith(stake_currency):
+                        if pair.startswith(stake_currency + "/") and not pair.endswith(stake_currency):
                             rate = 1.0 / rate
                         est_stake = rate * balance.total
                 except (ExchangeError):


### PR DESCRIPTION
## Summary
fix the rpc for balance which returns incorrect est. balance for BTC pairs that starts with BTC such as BTCST/BTC

Solve the issue: #4345 

## Quick changelog

- Updated the function to include the '/' when performing a startswith comparison.