### PR TITLE
config - add argument 'strategy_params'

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -188,6 +188,7 @@
     "disable_dataframe_checks": false,
     "strategy": "DefaultStrategy",
     "strategy_path": "user_data/strategies/",
+    "strategy_param": "{'param1': 5, 'param2': 'something'}",
     "dataformat_ohlcv": "json",
     "dataformat_trades": "jsongz"
 }

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -10,8 +10,8 @@ To learn how to get data for the pairs and exchange you're interested in, head o
 ```
 usage: freqtrade backtesting [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                              [-d PATH] [--userdir PATH] [-s NAME]
-                             [--strategy-path PATH] [-i TIMEFRAME]
-                             [--timerange TIMERANGE]
+                             [--strategy-path PATH] [--strategy-params JSON]
+                             [-i TIMEFRAME] [--timerange TIMERANGE]
                              [--data-format-ohlcv {json,jsongz,hdf5}]
                              [--max-open-trades INT]
                              [--stake-amount STAKE_AMOUNT] [--fee FLOAT]
@@ -85,6 +85,8 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
+  --strategy-params JSON
+                        Specify additional strategy parameters.
 
 ```
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -54,7 +54,7 @@ optional arguments:
 
 ```
 usage: freqtrade trade [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
-                       [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                       [--userdir PATH] [-s NAME] [--strategy-path PATH] [--strategy-params JSON]
                        [--db-url PATH] [--sd-notify] [--dry-run]
 
 optional arguments:
@@ -85,9 +85,10 @@ Common arguments:
 
 Strategy arguments:
   -s NAME, --strategy NAME
-                        Specify strategy class name which will be used by the
-                        bot.
-  --strategy-path PATH  Specify additional strategy lookup path.
+                          Specify strategy class name which will be used by the
+                          bot.
+  --strategy-path PATH    Specify additional strategy lookup path.
+  --strategy-params JSON  Specify additional strategy params.
 
 ```
 
@@ -187,6 +188,14 @@ checked before the default locations (The passed path must be a directory!):
 
 ```bash
 freqtrade trade --strategy AwesomeStrategy --strategy-path /some/directory
+```
+
+### How to use **--strategy-params**?
+
+This parameter allows you to add parameters of your strategy:
+
+```bash
+freqtrade trade --strategy AwesomeStrategy --strategy-params "{'param1': 5, 'param2': 'something'}"
 ```
 
 #### How to install a strategy?

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `disable_dataframe_checks` | Disable checking the OHLCV dataframe returned from the strategy methods for correctness. Only use when intentionally changing the dataframe and understand what you are doing. [Strategy Override](#parameters-in-the-strategy).<br> *Defaults to `False`*. <br> **Datatype:** Boolean
 | `strategy` | **Required** Defines Strategy class to use. Recommended to be set via `--strategy NAME`. <br> **Datatype:** ClassName
 | `strategy_path` | Adds an additional strategy lookup path (must be a directory). <br> **Datatype:** String
+| `strategy_params` | Adds an additional strategy parameters. <br> **Datatype:** JSON
 | `internals.process_throttle_secs` | Set the process throttle, or minimum loop duration for one bot iteration loop. Value in second. <br>*Defaults to `5` seconds.* <br> **Datatype:** Positive Integer
 | `internals.heartbeat_interval` | Print heartbeat message every N seconds. Set to 0 to disable heartbeat messages. <br>*Defaults to `60` seconds.* <br> **Datatype:** Positive Integer or 0
 | `internals.sd_notify` | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](installation.md#7-optional-configure-freqtrade-as-a-systemd-service) for more details. <br> **Datatype:** Boolean

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -214,6 +214,7 @@ Let's say the stake currency is **ETH** and there is $10$ **ETH** on the wallet.
 ```
 usage: freqtrade edge [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                       [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                      [--strategy-params JSON]
                       [-i TIMEFRAME] [--timerange TIMERANGE]
                       [--max-open-trades INT] [--stake-amount STAKE_AMOUNT]
                       [--fee FLOAT] [--stoplosses STOPLOSS_RANGE]
@@ -260,6 +261,8 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
+  --strategy-params JSON
+                        Specify additional strategy parameters.
 
 ```
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -38,6 +38,7 @@ pip install -r requirements-hyperopt.txt
 ```
 usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                           [--userdir PATH] [-s NAME] [--strategy-path PATH]
+                          [--strategy-params JSON]
                           [-i TIMEFRAME] [--timerange TIMERANGE]
                           [--data-format-ohlcv {json,jsongz,hdf5}]
                           [--max-open-trades INT]
@@ -130,6 +131,8 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
+  --strategy-params JSON
+                        Specify additional strategy parameters.
 
 ```
 

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -25,7 +25,8 @@ Possible arguments:
 ```
 usage: freqtrade plot-dataframe [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                                 [-d PATH] [--userdir PATH] [-s NAME]
-                                [--strategy-path PATH] [-p PAIRS [PAIRS ...]]
+                                [--strategy-path PATH] [--strategy-params JSON]
+                                [-p PAIRS [PAIRS ...]]
                                 [--indicators1 INDICATORS1 [INDICATORS1 ...]]
                                 [--indicators2 INDICATORS2 [INDICATORS2 ...]]
                                 [--plot-limit INT] [--db-url PATH]
@@ -91,6 +92,8 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
+  --strategy-params JSON
+                        Specify additional strategy parameters.
 ```
 
 Example:
@@ -237,7 +240,8 @@ Possible options for the `freqtrade plot-profit` subcommand:
 ```
 usage: freqtrade plot-profit [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                              [-d PATH] [--userdir PATH] [-s NAME]
-                             [--strategy-path PATH] [-p PAIRS [PAIRS ...]]
+                             [--strategy-path PATH] [--strategy-params JSON]
+                             [-p PAIRS [PAIRS ...]]
                              [--timerange TIMERANGE] [--export EXPORT]
                              [--export-filename PATH] [--db-url PATH]
                              [--trade-source {DB,file}] [-i TIMEFRAME]
@@ -288,6 +292,8 @@ Strategy arguments:
                         Specify strategy class name which will be used by the
                         bot.
   --strategy-path PATH  Specify additional strategy lookup path.
+  --strategy-params JSON
+                        Specify additional strategy parameters.
 ```
 
 The `-p/--pairs`  argument, can be used to limit the pairs that are considered for this calculation.

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -12,7 +12,7 @@ from freqtrade.constants import DEFAULT_CONFIG
 
 ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_data_dir"]
 
-ARGS_STRATEGY = ["strategy", "strategy_path"]
+ARGS_STRATEGY = ["strategy", "strategy_path", "strategy_params"]
 
 ARGS_TRADE = ["db_url", "sd_notify", "dry_run"]
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -93,6 +93,11 @@ AVAILABLE_CLI_OPTIONS = {
         help='Specify additional strategy lookup path.',
         metavar='PATH',
     ),
+    "strategy_params": Arg(
+        '--strategy-params',
+        help='Specify additional strategy parameters.',
+        metavar='JSON',
+    ),
     "db_url": Arg(
         '--db-url',
         help=f'Override trades database URL, this is useful in custom deployments '

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -109,6 +109,18 @@ def test_parse_args_strategy_path_invalid() -> None:
         Arguments(['--strategy-path']).get_parsed_arg()
 
 
+def test_parse_args_strategy_params() -> None:
+    args = Arguments([
+        'trade', '--strategy-params', '{"param1": 5, "param2": "something"}'
+        ]).get_parsed_arg()
+    assert args['strategy_params'] == '{"param1": 5, "param2": "something"}'
+
+
+def test_parse_args_strategy_params_invalid() -> None:
+    with pytest.raises(SystemExit, match=r'2'):
+        Arguments(['--strategy-params']).get_parsed_arg()
+
+
 def test_parse_args_backtesting_invalid() -> None:
     with pytest.raises(SystemExit, match=r'2'):
         Arguments(['backtesting --ticker-interval']).get_parsed_arg()


### PR DESCRIPTION
## Summary
This PR add the possibility to add own strategy parameters with cli or config.json.
That is helpful to prevent any modification in the strategy file, and it's more convenient to pass strategy parameters over the configuration instead of modifying the strategy file every time.

## What's new?
* new parameter argument "strategy_params"
* also possible to add in the config.json
* strategy_params is able to parse JSON notation