### PR TITLE
pass data and config to loss function

### DIFF
--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -40,6 +40,11 @@ For the sample below, you then need to add the command line parameter `--hyperop
 A sample of this can be found below, which is identical to the Default Hyperopt loss implementation. A full sample can be found in [userdata/hyperopts](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/templates/sample_hyperopt_loss.py).
 
 ``` python
+from datetime import datetime
+from typing import Dict
+
+from pandas import DataFrame
+
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 TARGET_TRADES = 600
@@ -54,6 +59,7 @@ class SuperDuperHyperOptLoss(IHyperOptLoss):
     @staticmethod
     def hyperopt_loss_function(results: DataFrame, trade_count: int,
                                min_date: datetime, max_date: datetime,
+                               processed: Dict[str, DataFrame],
                                *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for better results
@@ -81,6 +87,7 @@ Currently, the arguments are:
 * `trade_count`: Amount of trades (identical to `len(results)`)
 * `min_date`: Start date of the timerange used
 * `min_date`: End date of the timerange used
+* `processed`: Dict of Dataframes with the pair as keys containing the data used for backtesting.
 
 This function needs to return a floating point number (`float`). Smaller numbers will be interpreted as better results. The parameters and balancing for this is up to you.
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -546,10 +546,11 @@ class Hyperopt:
 
         )
         return self._get_results_dict(backtesting_results, min_date, max_date,
-                                      params_dict, params_details)
+                                      params_dict, params_details,
+                                      processed=processed)
 
     def _get_results_dict(self, backtesting_results, min_date, max_date,
-                          params_dict, params_details):
+                          params_dict, params_details, processed: Dict):
         results_metrics = self._calculate_results_metrics(backtesting_results)
         results_explanation = self._format_results_explanation_string(results_metrics)
 
@@ -563,7 +564,8 @@ class Hyperopt:
         loss: float = MAX_LOSS
         if trade_count >= self.config['hyperopt_min_trades']:
             loss = self.calculate_loss(results=backtesting_results, trade_count=trade_count,
-                                       min_date=min_date.datetime, max_date=max_date.datetime)
+                                       min_date=min_date.datetime, max_date=max_date.datetime,
+                                       config=self.config, processed=processed)
         return {
             'loss': loss,
             'params_dict': params_dict,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -550,7 +550,7 @@ class Hyperopt:
                                       processed=processed)
 
     def _get_results_dict(self, backtesting_results, min_date, max_date,
-                          params_dict, params_details, processed: Dict):
+                          params_dict, params_details, processed: Dict[str, DataFrame]):
         results_metrics = self._calculate_results_metrics(backtesting_results)
         results_explanation = self._format_results_explanation_string(results_metrics)
 

--- a/freqtrade/templates/sample_hyperopt_loss.py
+++ b/freqtrade/templates/sample_hyperopt_loss.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from math import exp
+from typing import Dict
 
 from pandas import DataFrame
 
@@ -35,6 +36,7 @@ class SampleHyperOptLoss(IHyperOptLoss):
     @staticmethod
     def hyperopt_loss_function(results: DataFrame, trade_count: int,
                                min_date: datetime, max_date: datetime,
+                               processed: Dict[str, DataFrame],
                                *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for better results


### PR DESCRIPTION
## Summary
Me again :) In this PR i want to add some small changes mainly for the hyperopt loss function. I did some more extended loss function. Which does some kind of cross validation over the the hole timeframe, to prevent overfitting.
So what i did for now is, i read it in by myself:
`Path("user_data") / 'hyperopt_results' / 'hyperopt_tickerdata.pkl'`
But I think that is an ugly workaround :(
So I think I just needed to pass the processed timeframe to the loss function to, to do that.
The same applies for backtesting stats. I want to analyze some splits of the timeframe and combine that to a more meaningfull score.

## Quick changelog

- pass processed timeframe to hyperopt loss function
- pass processed timeframe to backtest result stats