### PR TITLE
Implement environment variable substitution within configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Per default, the bot loads the configuration from the `config.json` file, locate
 
 You can specify a different configuration file used by the bot with the `-c/--config` command line option.
 
-In some advanced use cases, multiple configuration files can be specified and used by the bot or the bot can read its configuration parameters from the process standard input stream.
+In some advanced use cases, multiple configuration files can be specified and used by the bot or the bot can read its configuration parameters from the process standard input stream. Furthermore, the bot substitutes environment variables in the form of `${VARIABLE_NAME}`.
 
 If you used the [Quick start](installation.md/#quick-start) method for installing 
 the bot, the installation script should have already created the default configuration file (`config.json`) for you.
@@ -524,6 +524,9 @@ API Keys are usually only required for live trading (trading for real money, bot
 ```
 
 You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
+
+!!! Note
+    You can also store your secrets in environment variables and let the bot substitute them (`"key" : "${EXCHANGE_KEY}"`).
 
 ### Using proxy with Freqtrade
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Per default, the bot loads the configuration from the `config.json` file, locate
 
 You can specify a different configuration file used by the bot with the `-c/--config` command line option.
 
-In some advanced use cases, multiple configuration files can be specified and used by the bot or the bot can read its configuration parameters from the process standard input stream. Furthermore, the bot substitutes environment variables in the form of `${VARIABLE_NAME}`.
+In some advanced use cases, multiple configuration files can be specified and used by the bot or the bot can read its configuration parameters from the process standard input stream. Furthermore, the bot substitutes environment variables in the form of `${FREQTRADE_VARIABLE_NAME}`. Please note that the prefix `FREQTRADE_` must be present for this to work.
 
 If you used the [Quick start](installation.md/#quick-start) method for installing 
 the bot, the installation script should have already created the default configuration file (`config.json`) for you.
@@ -526,7 +526,7 @@ API Keys are usually only required for live trading (trading for real money, bot
 You should also make sure to read the [Exchanges](exchanges.md) section of the documentation to be aware of potential configuration details specific to your exchange.
 
 !!! Note
-    You can also store your secrets in environment variables and let the bot substitute them (`"key" : "${EXCHANGE_KEY}"`).
+    You can also store your secrets in environment variables and let the bot substitute them (`"key" : "${FREQTRADE_EXCHANGE_KEY}"`).
 
 ### Using proxy with Freqtrade
 

--- a/freqtrade/configuration/load_config.py
+++ b/freqtrade/configuration/load_config.py
@@ -4,6 +4,7 @@ This module contain functions to load the configuration file
 import logging
 import re
 import sys
+from os import environ
 from pathlib import Path
 from typing import Any, Dict
 
@@ -14,28 +15,55 @@ from freqtrade.exceptions import OperationalException
 
 logger = logging.getLogger(__name__)
 
-
 CONFIG_PARSE_MODE = rapidjson.PM_COMMENTS | rapidjson.PM_TRAILING_COMMAS
 
 
-def log_config_error_range(path: str, errmsg: str) -> str:
+class SubstitutionException(Exception):
     """
-    Parses configuration file and prints range around error
+    Indicates that a variable within the configuration couldn't be substituted.
     """
-    if path != '-':
-        offsetlist = re.findall(r'(?<=Parse\serror\sat\soffset\s)\d+', errmsg)
-        if offsetlist:
-            offset = int(offsetlist[0])
-            text = Path(path).read_text()
-            # Fetch an offset of 80 characters around the error line
-            subtext = text[offset-min(80, offset):offset+80]
-            segments = subtext.split('\n')
-            if len(segments) > 3:
-                # Remove first and last lines, to avoid odd truncations
-                return '\n'.join(segments[1:-1])
-            else:
-                return subtext
+
+    def __init__(self, key: str, offset: int):
+        self.offset = offset
+        self.err = f'Environment variable {key} was requested for substitution, but is not set.'
+        super().__init__(self.err)
+
+
+def log_config_error_range(path: str, offset: int) -> str:
+    """
+    Parses configuration file and prints range around the specified offset
+    """
+    if path != '-' and offset != -1:
+        text = Path(path).read_text()
+        # Fetch an offset of 80 characters around the error line
+        subtext = text[offset - min(80, offset):offset + 80]
+        segments = subtext.split('\n')
+        if len(segments) > 3:
+            # Remove first and last lines, to avoid odd truncations
+            return '\n'.join(segments[1:-1])
+        else:
+            return subtext
+
     return ''
+
+
+def substitute_environment_variable(match: re.Match) -> str:
+    """
+    Substitutes a matched environment variable with its value
+    """
+    key = match.group(1).strip()
+    if key not in environ:
+        raise SubstitutionException(key, match.start(0))
+
+    return environ[key]
+
+
+def extract_error_offset(errmsg: str) -> int:
+    offsetlist = re.findall(r'(?<=Parse\serror\sat\soffset\s)\d+', errmsg)
+    if offsetlist:
+        return int(offsetlist[0])
+
+    return -1
 
 
 def load_config_file(path: str) -> Dict[str, Any]:
@@ -47,13 +75,22 @@ def load_config_file(path: str) -> Dict[str, Any]:
     try:
         # Read config from stdin if requested in the options
         with open(path) if path != '-' else sys.stdin as file:
-            config = rapidjson.load(file, parse_mode=CONFIG_PARSE_MODE)
+            content = re.sub(r'\${(.*?)}', substitute_environment_variable, file.read())
+            config = rapidjson.loads(content, parse_mode=CONFIG_PARSE_MODE)
     except FileNotFoundError:
         raise OperationalException(
             f'Config file "{path}" not found!'
             ' Please create a config file or check whether it exists.')
     except rapidjson.JSONDecodeError as e:
-        err_range = log_config_error_range(path, str(e))
+        err_offset = extract_error_offset(str(e))
+        err_range = log_config_error_range(path, err_offset)
+        raise OperationalException(
+            f'{e}\n'
+            f'Please verify the following segment of your configuration:\n{err_range}'
+            if err_range else 'Please verify your configuration file for syntax errors.'
+        )
+    except SubstitutionException as e:
+        err_range = log_config_error_range(path, e.offset)
         raise OperationalException(
             f'{e}\n'
             f'Please verify the following segment of your configuration:\n{err_range}'

--- a/tests/config_test_environment.json
+++ b/tests/config_test_environment.json
@@ -1,0 +1,127 @@
+{
+    /* Single-line C-style comment */
+    "max_open_trades": 3,
+    /*
+     * Multi-line C-style comment
+     */
+    "stake_currency": "BTC",
+    "stake_amount": 0.05,
+    "fiat_display_currency": "USD",             // C++-style comment
+    "amount_reserve_percent" : 0.05,		// And more, tabs before this comment
+    "dry_run": false,
+    "timeframe": "5m",
+    "trailing_stop": false,
+    "trailing_stop_positive": 0.005,
+    "trailing_stop_positive_offset": 0.0051,
+    "trailing_only_offset_is_reached": false,
+    "minimal_roi": {
+        "40":  0.0,
+        "30":  0.01,
+        "20":  0.02,
+        "0":  0.04
+    },
+    "stoploss": -0.10,
+    "unfilledtimeout": {
+        "buy": 10,
+        "sell": 30,				// Trailing comma should also be accepted now
+    },
+    "bid_strategy": {
+        "use_order_book": false,
+        "ask_last_balance": 0.0,
+        "order_book_top": 1,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+    "ask_strategy":{
+        "use_order_book": false,
+        "order_book_min": 1,
+        "order_book_max": 9
+    },
+    "order_types": {
+        "buy": "limit",
+        "sell": "limit",
+        "stoploss": "market",
+        "stoploss_on_exchange": false,
+        "stoploss_on_exchange_interval": 60
+    },
+    "order_time_in_force": {
+        "buy": "gtc",
+        "sell": "gtc"
+    },
+    "pairlist": {
+        "method": "VolumePairList",
+        "config": {
+            "number_assets": 20,
+            "sort_key": "quoteVolume",
+            "precision_filter": false
+        }
+    },
+    "exchange": {
+        "name": "bittrex",
+        "sandbox": false,
+        "key": "your_exchange_key",
+        "secret": "your_exchange_secret",
+        "password": "",
+        "ccxt_config": {"enableRateLimit": true},
+        "ccxt_async_config": {
+            "enableRateLimit": false,
+            "rateLimit": 500,
+            "aiohttp_trust_env": false
+        },
+        "pair_whitelist": [
+            "ETH/BTC",
+            "LTC/BTC",
+            "ETC/BTC",
+            "DASH/BTC",
+            "ZEC/BTC",
+            "XLM/BTC",
+            "NXT/BTC",
+            "TRX/BTC",
+            "ADA/BTC",
+            "XMR/BTC"
+        ],
+        "pair_blacklist": [
+            "DOGE/BTC"
+        ],
+        "outdated_offset": 5,
+        "markets_refresh_interval": 60
+    },
+    "edge": {
+        "enabled": false,
+        "process_throttle_secs": 3600,
+        "calculate_since_number_of_days": 7,
+        "allowed_risk": 0.01,
+        "stoploss_range_min": -0.01,
+        "stoploss_range_max": -0.1,
+        "stoploss_range_step": -0.01,
+        "minimum_winrate": 0.60,
+        "minimum_expectancy": 0.20,
+        "min_trade_number": 10,
+        "max_trade_duration_minute": 1440,
+        "remove_pumps": false
+    },
+    "telegram": {
+// We can now comment out some settings
+//        "enabled": true,
+        "enabled": false,
+        "token": "${TELEGRAM_TOKEN}",
+        "chat_id": "${TELEGRAM_CHAT}"
+    },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "username": "freqtrader",
+        "password": "SuperSecurePassword"
+    },
+    "db_url": "sqlite:///tradesv3.sqlite",
+    "initial_state": "running",
+    "forcebuy_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    },
+    "strategy": "DefaultStrategy",
+    "strategy_path": "user_data/strategies/"
+}

--- a/tests/config_test_environment_invalid.json
+++ b/tests/config_test_environment_invalid.json
@@ -106,8 +106,8 @@
 // We can now comment out some settings
 //        "enabled": true,
         "enabled": false,
-        "token": "${FREQTRADE_TELEGRAM_TOKEN}",
-        "chat_id": "${FREQTRADE_TELEGRAM_CHAT}"
+        "token": "${TELEGRAM_TOKEN}",
+        "chat_id": "${TELEGRAM_CHAT}"
     },
     "api_server": {
         "enabled": false,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -919,7 +919,10 @@ def test_load_config_test_env_variables(mocker) -> None:
     token = "17264728:eW91dHUuYmUvMDAwYWw3cnUzbXMg"
     chat_id = "17263827"
 
-    mocker.patch.dict(os.environ, {'TELEGRAM_TOKEN': token, 'TELEGRAM_CHAT': chat_id})
+    mocker.patch.dict(os.environ, {
+        'FREQTRADE_TELEGRAM_TOKEN': token,
+        'FREQTRADE_TELEGRAM_CHAT': chat_id
+    })
     config_file = Path(__file__).parents[0] / "config_test_environment.json"
     conf = load_config_file(str(config_file))
 
@@ -932,9 +935,18 @@ def test_load_config_test_substitution_error() -> None:
     """
     Load config with environment variables without setting them
     """
-
     config_file = Path(__file__).parents[0] / "config_test_environment.json"
-    with pytest.raises(OperationalException, match=r'.*Environment variable TELEGRAM_TOKEN*'):
+    with pytest.raises(OperationalException, match=r'.*variable FREQTRADE_TELEGRAM_TOKEN*'):
+        load_config_file(str(config_file))
+
+
+def test_load_config_test_prefix_error() -> None:
+    """
+    Load config with environment variables without setting them
+    """
+
+    config_file = Path(__file__).parents[0] / "config_test_environment_invalid.json"
+    with pytest.raises(OperationalException, match=r'.*must be prefixed*'):
         load_config_file(str(config_file))
 
 


### PR DESCRIPTION
## Summary
This PR adds the capability to use environment variables ~in the form of `${SECRET}`~ in the form of `${FREQTRADE_SECRET}` within the configuration where the prefix `FREQTRADE_` **must** be present. It does not alter the behavior of parsing configuration files without environment variables.

Solves issue #4385 

## Quick changelog

- Implement environment variable substitution within configuration file

## What's new?

  * Environment variables can now be specified within the configuration, which will be replaced accordingly. A good place to use this are exchange API keys or the Telegram token. This can especially be useful in environments where secrets are injected into environment variables (like Kubernetes etc.).

    ```
    "telegram" : {
        "token"   : "${FREQTRADE_TELEGRAM_TOKEN}",
        "chat_id" : "${FREQTRADE_TELEGRAM_CHAT}",
    }
    ```

  * A small easter egg. Look for a base64 encoded string in the contributed tests :stuck_out_tongue_winking_eye:
