### PR TITLE
Don't fail API calls when live price is not available

### DIFF
--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -2,6 +2,7 @@ import logging
 from ipaddress import IPv4Address
 from typing import Any, Dict
 
+import rapidjson
 import uvicorn
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +13,17 @@ from freqtrade.rpc.rpc import RPC, RPCException, RPCHandler
 
 
 logger = logging.getLogger(__name__)
+
+
+class FTJSONResponse(JSONResponse):
+    media_type = "application/json"
+
+    def render(self, content: Any) -> bytes:
+        """
+        Use rapidjson for responses
+        Handles NaN and Inf / -Inf in a javascript way by default.
+        """
+        return rapidjson.dumps(content).encode("utf-8")
 
 
 class ApiServer(RPCHandler):
@@ -32,6 +44,7 @@ class ApiServer(RPCHandler):
         self.app = FastAPI(title="Freqtrade API",
                            docs_url='/docs' if api_config.get('enable_openapi', False) else None,
                            redoc_url=None,
+                           default_response_class=FTJSONResponse,
                            )
         self.configure_app(self.app, self._config)
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -11,6 +11,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.exceptions import HTTPException
 from fastapi.testclient import TestClient
+from numpy import isnan
 from requests.auth import _basic_auth_str
 
 from freqtrade.__init__ import __version__
@@ -797,7 +798,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
     assert_response(rc)
     resp_values = rc.json()
     assert len(resp_values) == 1
-    assert resp_values[0]['profit_abs'] is None
+    assert isnan(resp_values[0]['profit_abs'])
 
 
 def test_api_version(botclient):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 from requests.auth import _basic_auth_str
 
 from freqtrade.__init__ import __version__
+from freqtrade.exceptions import ExchangeError
 from freqtrade.loggers import setup_logging, setup_logging_pre
 from freqtrade.persistence import PairLocks, Trade
 from freqtrade.rpc import RPC
@@ -788,6 +789,15 @@ def test_api_status(botclient, mocker, ticker, fee, markets):
         'timeframe': 5,
         'exchange': 'bittrex',
     }]
+
+    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.get_sell_rate',
+                 MagicMock(side_effect=ExchangeError("Pair 'ETH/BTC' not available")))
+
+    rc = client_get(client, f"{BASE_URI}/status")
+    assert_response(rc)
+    resp_values = rc.json()
+    assert len(resp_values) == 1
+    assert resp_values[0]['profit_abs'] is None
 
 
 def test_api_version(botclient):


### PR DESCRIPTION
## Summary
Don't fail API calls when live price is not available

closes #4405

## Quick changelog

- Properly format NaN and infinity values, without failing the conversion.