### PR TITLE
Allow changing the order_type for forcesell

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -49,6 +49,7 @@
         "buy": "limit",
         "sell": "limit",
         "emergencysell": "market",
+        "forcesell": "market",
         "stoploss": "market",
         "stoploss_on_exchange": false,
         "stoploss_on_exchange_interval": 60

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,7 @@ For example, if your strategy is using a 1h timeframe, and you only want to buy 
 
 ### Understand order_types
 
-The `order_types` configuration parameter maps actions (`buy`, `sell`, `stoploss`, `emergencysell`) to order-types (`market`, `limit`, ...) as well as configures stoploss to be on the exchange and defines stoploss on exchange update interval in seconds.
+The `order_types` configuration parameter maps actions (`buy`, `sell`, `stoploss`, `emergencysell`, `forcesell`) to order-types (`market`, `limit`, ...) as well as configures stoploss to be on the exchange and defines stoploss on exchange update interval in seconds.
 
 This allows to buy using limit orders, sell using
 limit-orders, and create stoplosses using market orders. It also allows to set the
@@ -287,7 +287,7 @@ the buy order is fulfilled.
 If this is configured, the following 4 values (`buy`, `sell`, `stoploss` and
 `stoploss_on_exchange`) need to be present, otherwise the bot will fail to start.
 
-For information on (`emergencysell`,`stoploss_on_exchange`,`stoploss_on_exchange_interval`,`stoploss_on_exchange_limit_ratio`) please see stop loss documentation [stop loss on exchange](stoploss.md)
+For information on (`emergencysell`,`forcesell`, `stoploss_on_exchange`,`stoploss_on_exchange_interval`,`stoploss_on_exchange_limit_ratio`) please see stop loss documentation [stop loss on exchange](stoploss.md)
 
 Syntax for Strategy:
 
@@ -296,6 +296,7 @@ order_types = {
     "buy": "limit",
     "sell": "limit",
     "emergencysell": "market",
+    "forcesell": "market",
     "stoploss": "market",
     "stoploss_on_exchange": False,
     "stoploss_on_exchange_interval": 60,
@@ -310,6 +311,7 @@ Configuration:
     "buy": "limit",
     "sell": "limit",
     "emergencysell": "market",
+    "forcesell": "market",
     "stoploss": "market",
     "stoploss_on_exchange": false,
     "stoploss_on_exchange_interval": 60

--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -51,6 +51,10 @@ The bot cannot do these every 5 seconds (at each iteration), otherwise it would 
 So this parameter will tell the bot how often it should update the stoploss order. The default value is 60 (1 minute).
 This same logic will reapply a stoploss order on the exchange should you cancel it accidentally.
 
+### forcesell
+
+`forcesell` is an optional value, which defaults to the same value as `sell` and is used when sending a `/forcesell` command from Telegram or from the Rest API.
+
 ### emergencysell
 
 `emergencysell` is an optional value, which defaults to `market` and is used when creating stop loss on exchange orders fails.

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1157,7 +1157,8 @@ class FreqtradeBot(LoggingMixin):
             # Emergency sells (default to market!)
             order_type = self.strategy.order_types.get("emergencysell", "market")
         if sell_reason == SellType.FORCE_SELL:
-            # Force sells (default to the sell_type defined in the strategy, but we allow this value to be changed)
+            # Force sells (default to the sell_type defined in the strategy,
+            # but we allow this value to be changed)
             order_type = self.strategy.order_types.get("forcesell", order_type)
 
         amount = self._safe_sell_amount(trade.pair, trade.amount)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1156,6 +1156,9 @@ class FreqtradeBot(LoggingMixin):
         if sell_reason == SellType.EMERGENCY_SELL:
             # Emergency sells (default to market!)
             order_type = self.strategy.order_types.get("emergencysell", "market")
+        if sell_reason == SellType.FORCE_SELL:
+            # Force sells (default to the sell_type defined in the strategy, but we allow this value to be changed)
+            order_type = self.strategy.order_types.get("forcesell", order_type)
 
         amount = self._safe_sell_amount(trade.pair, trade.amount)
         time_in_force = self.strategy.order_time_in_force['sell']


### PR DESCRIPTION
## Summary
Allow specifying a different `order_type` for `forcesell`

closes: #3199

## Quick changelog

- Update `freqtrade/freqtradebot.py` to load a specific `order_type` for `forcesell` from the config file if present. If this value is missing, defaults to the same behavior as before (uses the `order_type` of `sell`)
- Update Docs to specify that this settings is optional

## What's new?
This will allow using a different `order_type` for `forcesell` than the one defined for `sell`
