### PR TITLE
Fix: custom_stoploss returns typo

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -176,7 +176,7 @@ class AwesomeStrategy(IStrategy):
         if current_profit > 0.25:
             return (-0.15 + current_profit)
         if current_profit > 0.20:
-            return (-0.7 + current_profit)
+            return (-0.07 + current_profit)
         return 1
 ```
 


### PR DESCRIPTION
Afaik it should return -0.07 for 7% instead of -0.7.

As a side note, really interesting would also be an example for greater than 100% profits. especially when trailing stoploss, like
* Once profit is > 200% - stoploss will be set to 150%.

I assume it could be as simple as
```py
if current_profit > 2:
            return (-1.50 + current_profit)
````
to achieve it

But I'm not quite confident, if the bot can handle stuff smaller than `-1`, since `1` and `-1` seem to have some special meaning and are often used to disable stoploss etc.

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
