### PR TITLE
Add strategy name to HyperOpt results filename

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -77,8 +77,9 @@ class Hyperopt:
         self.custom_hyperoptloss = HyperOptLossResolver.load_hyperoptloss(self.config)
         self.calculate_loss = self.custom_hyperoptloss.hyperopt_loss_function
         time_now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        strategy = str(self.config['strategy'])
         self.results_file = (self.config['user_data_dir'] /
-                             'hyperopt_results' / f'hyperopt_results_{time_now}.pickle')
+                             'hyperopt_results' / f'strategy_{strategy}_' f'hyperopt_results_{time_now}.pickle')
         self.data_pickle_file = (self.config['user_data_dir'] /
                                  'hyperopt_results' / 'hyperopt_tickerdata.pkl')
         self.total_epochs = config.get('epochs', 0)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -79,7 +79,8 @@ class Hyperopt:
         time_now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         strategy = str(self.config['strategy'])
         self.results_file = (self.config['user_data_dir'] /
-                             'hyperopt_results' / f'strategy_{strategy}_' f'hyperopt_results_{time_now}.pickle')
+                             'hyperopt_results' /
+                             f'strategy_{strategy}_hyperopt_results_{time_now}.pickle')
         self.data_pickle_file = (self.config['user_data_dir'] /
                                  'hyperopt_results' / 'hyperopt_tickerdata.pkl')
         self.total_epochs = config.get('epochs', 0)


### PR DESCRIPTION
## Summary
This extends the HyperOpt result filename by adding the strategy name. 

Solve the issue: #___

## Quick changelog

- Added filename to HyperOpt filename in HyperOpt Class Init.

## What's new?
This allows analysis of HyperOpt results folder with no additional necessary context. An alternative idea would be to expand the result dict, but the additional static copies are non value added.
