### PR TITLE
Fix(docs/data-download): use wording specific for `data-download`

### DIFF
--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -30,7 +30,7 @@ usage: freqtrade download-data [-h] [-v] [--logfile FILE] [-V] [-c PATH]
 optional arguments:
   -h, --help            show this help message and exit
   -p PAIRS [PAIRS ...], --pairs PAIRS [PAIRS ...]
-                        Show profits for only these pairs. Pairs are space-
+                        Only download data for these pairs. Pairs are space-
                         separated.
   --pairs-file FILE     File containing a list of pairs to download.
   --days INT            Download data for given number of days.


### PR DESCRIPTION
Just a small lapse I noticed while reading the docs

`Show profits for only these pairs` -> `Only download data for these pairs[...]`