### PR TITLE
Create event loop manually if uvloop is available

### DIFF
--- a/freqtrade/rpc/api_server/uvicorn_threaded.py
+++ b/freqtrade/rpc/api_server/uvicorn_threaded.py
@@ -8,12 +8,33 @@ import uvicorn
 class UvicornServer(uvicorn.Server):
     """
     Multithreaded server - as found in https://github.com/encode/uvicorn/issues/742
+
+    Removed install_signal_handlers() override based on changes from this commit:
+        https://github.com/encode/uvicorn/commit/ce2ef45a9109df8eae038c0ec323eb63d644cbc6
+
+    Cannot rely on asyncio.get_event_loop() to create new event loop because of this check:
+        https://github.com/python/cpython/blob/4d7f11e05731f67fd2c07ec2972c6cb9861d52be/Lib/asyncio/events.py#L638
+
+    Fix by overriding run() and forcing creation of new event loop if uvloop is available
     """
-    def install_signal_handlers(self):
+
+    def run(self, sockets=None):
+        import asyncio
+
         """
-        In the parent implementation, this starts the thread, therefore we must patch it away here.
+        Parent implementation calls self.config.setup_event_loop(),
+            but we need to create uvloop event loop manually
         """
-        pass
+        try:
+            import uvloop  # noqa
+        except ImportError:  # pragma: no cover
+            from uvicorn.loops.asyncio import asyncio_setup
+            asyncio_setup()
+        else:
+            asyncio.set_event_loop(uvloop.new_event_loop())
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.serve(sockets=sockets))
 
     @contextlib.contextmanager
     def run_in_thread(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from datetime import datetime
 from functools import reduce
 from pathlib import Path
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import arrow
 import numpy as np
@@ -62,6 +62,14 @@ def log_has_re(line, logs):
 
 def get_args(args):
     return Arguments(args).get_parsed_arg()
+
+
+# Source: https://stackoverflow.com/questions/29881236/how-to-mock-asyncio-coroutines
+def get_mock_coro(return_value):
+    async def mock_coro(*args, **kwargs):
+        return return_value
+
+    return Mock(wraps=mock_coro)
 
 
 def patched_configuration_load_config_file(mocker, config) -> None:
@@ -1736,7 +1744,7 @@ def import_fails() -> None:
     realimport = builtins.__import__
 
     def mockedimport(name, *args, **kwargs):
-        if name in ["filelock", 'systemd.journal']:
+        if name in ["filelock", 'systemd.journal', 'uvloop']:
             raise ImportError(f"No module named '{name}'")
         return realimport(name, *args, **kwargs)
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -18,19 +18,11 @@ from freqtrade.exchange.exchange import (market_is_active, timeframe_to_minutes,
                                          timeframe_to_next_date, timeframe_to_prev_date,
                                          timeframe_to_seconds)
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
-from tests.conftest import get_patched_exchange, log_has, log_has_re
+from tests.conftest import get_mock_coro, get_patched_exchange, log_has, log_has_re
 
 
 # Make sure to always keep one exchange here which is NOT subclassed!!
 EXCHANGES = ['bittrex', 'binance', 'kraken', 'ftx']
-
-
-# Source: https://stackoverflow.com/questions/29881236/how-to-mock-asyncio-coroutines
-def get_mock_coro(return_value):
-    async def mock_coro(*args, **kwargs):
-        return return_value
-
-    return Mock(wraps=mock_coro)
 
 
 def ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,


### PR DESCRIPTION
## Summary
When `uvloop` is available, create event loop manually so `rpc.api_server` can start successfully.

## Quick changelog

- Override `Server.run()` to manually create event loop when using `uvloop`
- Remove override of `Server.install_signal_handlers()`

## What's new?
I cannot get the `rpc.api_server` to run when `uvloop` is available; instead, I get the following RuntimeError:
```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.9/site-packages/uvicorn/server.py", line 47, in run
    self.config.setup_event_loop()
  File "/usr/lib/python3.9/site-packages/uvicorn/config.py", line 356, in setup_event_loop
    loop_setup()
  File "/usr/lib/python3.9/site-packages/uvicorn/loops/auto.py", line 11, in auto_loop_setup
    uvloop_setup()
  File "/usr/lib/python3.9/site-packages/uvicorn/loops/uvloop.py", line 8, in uvloop_setup
    asyncio.get_event_loop()
  File "/usr/lib/python3.9/asyncio/events.py", line 642, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'Thread-1'.
```

If I manually specify `loop='asyncio'` in `webserver.py` it runs OK, but is not ideal if `uvloop` is available.

We cannot rely on `asyncio.get_event_loop()` to create a new event loop because of this check: https://github.com/python/cpython/blob/4d7f11e05731f67fd2c07ec2972c6cb9861d52be/Lib/asyncio/events.py#L636-L639
```python
        if (self._local._loop is None and
                not self._local._set_called and
                threading.current_thread() is threading.main_thread()):
            self.set_event_loop(self.new_event_loop())
```

To resolve this issue, we override `Server.run()` and force creation of new event loop when using `uvloop`. Parent implementation of `run()` calls `self.config.setup_event_loop()`, but we need to create `uvloop` event loop manually because `asyncio.get_event_loop()` does not call `new_event_loop()` if `current_thread() != main_thread()`.

I also removed `install_signal_handlers()` override based on changes from this commit: https://github.com/encode/uvicorn/commit/ce2ef45a9109df8eae038c0ec323eb63d644cbc6