### PR TITLE
fix: Use now() to match timezone of download data

### DIFF
--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -706,7 +706,7 @@ def test_download_data_timerange(mocker, caplog, markets):
     start_download_data(get_args(args))
     assert dl_mock.call_count == 1
     # 20days ago
-    days_ago = arrow.get(arrow.utcnow().shift(days=-20).date()).int_timestamp
+    days_ago = arrow.get(arrow.now().shift(days=-20).date()).int_timestamp
     assert dl_mock.call_args_list[0][1]['timerange'].startts == days_ago
 
     dl_mock.reset_mock()


### PR DESCRIPTION
## Summary
Fix `test_download_data_timerange()` in cases when download data is not timestamped for UTC

Solve the issue: #4532

## Quick changelog

- Use `arrow.now()` instead of `arrow.utcnow()`
## What's new?
Since the downloaded data timestamp is local time, the test will only pass if it is compared to local time. For times when this test case is ran where there is a date discrepancy between UTC and local time, the test will fail.

This PR fixes the issue by comparing the timestamp of the downloaded data with the local date.