### PR TITLE
correct math used in examples and clarify some terminology regarding …

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -181,17 +181,9 @@ class AwesomeStrategy(IStrategy):
 
 #### Calculating stoploss relative to open price
 
-Stoploss values returned from `custom_stoploss` always specify a percentage relative to `current_rate`.  In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
+Stoploss values returned from `custom_stoploss()` always specify a percentage relative to `current_rate`.  In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
 
-This can be calculated as:
-
-``` python
-def stoploss_from_open(open_relative_stop: float, current_profit: float) -> float:
-    return 1-((1+open_relative_stop)/(1+current_profit))
-
-```
-
-For example, say our open price was $100, and `current_price` is $121 (`current_profit` will be `0.21`).  If we want a stop price at 7% above the open price we can call `stoploss_from_open(0.07, 0.21)` which will return `0.1157024793`.  11.57% below $121 is $107, which is the same as 7% above $100.
+The helper function [`stoploss_from_open()`](strategy-customization.md#stoploss_from_open) can be used to convert from an open price relative stop, to a current price relative stop which can be returned from `custom_stoploss()`.
 
 #### Trailing stoploss with positive offset
 
@@ -201,9 +193,7 @@ Use the initial stoploss until the profit is above 4%, then use a trailing stopl
 ``` python
 from datetime import datetime, timedelta
 from freqtrade.persistence import Trade
-
-def stoploss_from_open(open_relative_stop: float, current_profit: float) -> float:
-    return 1-((1+open_relative_stop)/(1+current_profit))
+from freqtrade.strategy import stoploss_from_open
 
 class AwesomeStrategy(IStrategy):
 
@@ -237,9 +227,7 @@ Instead of continuously trailing behind the current price, this example sets fix
 ``` python
 from datetime import datetime
 from freqtrade.persistence import Trade
-
-def stoploss_from_open(open_relative_stop: float, current_profit: float) -> float:
-    return 1-((1+open_relative_stop)/(1+current_profit))
+from freqtrade.strategy import stoploss_from_open
 
 class AwesomeStrategy(IStrategy):
 
@@ -290,7 +278,7 @@ class AwesomeStrategy(IStrategy):
             # using current_time directly (like below) will only work in backtesting.
             # so check "runmode" to make sure that it's only used in backtesting/hyperopt
             if self.dp and self.dp.runmode.value in ('backtest', 'hyperopt'):
-              relative_sl = self.custom_info[pair].loc[current_time]['atr]
+              relative_sl = self.custom_info[pair].loc[current_time]['atr']
             # in live / dry-run, it'll be really the current time
             else:
               # but we can just use the last entry from an already analyzed dataframe instead

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -178,17 +178,15 @@ class AwesomeStrategy(IStrategy):
         return -0.15
 ```
 
-
 #### Calculating stoploss relative to open price
 
-Stoploss values returned from `custom_stoploss()` always specify a percentage relative to `current_rate`.  In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
+Stoploss values returned from `custom_stoploss()` always specify a percentage relative to `current_rate`. In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
 
 The helper function [`stoploss_from_open()`](strategy-customization.md#stoploss_from_open) can be used to convert from an open price relative stop, to a current price relative stop which can be returned from `custom_stoploss()`.
 
 #### Trailing stoploss with positive offset
 
 Use the initial stoploss until the profit is above 4%, then use a trailing stoploss of 50% of the current profit with a minimum of 2.5% and a maximum of 5%.
-
 
 ``` python
 from datetime import datetime, timedelta

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -204,7 +204,7 @@ class AwesomeStrategy(IStrategy):
         desired_stoploss = current_profit / 2
 
         # Use a minimum of 2.5% and a maximum of 5%
-        return max(min(desired_stoploss, 0.05), 0.025
+        return max(min(desired_stoploss, 0.05), 0.025)
 ```
 
 #### Calculating stoploss relative to open price

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -178,20 +178,15 @@ class AwesomeStrategy(IStrategy):
         return -0.15
 ```
 
-#### Calculating stoploss relative to open price
-
-Stoploss values returned from `custom_stoploss()` always specify a percentage relative to `current_rate`. In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
-
-The helper function [`stoploss_from_open()`](strategy-customization.md#stoploss_from_open) can be used to convert from an open price relative stop, to a current price relative stop which can be returned from `custom_stoploss()`.
-
 #### Trailing stoploss with positive offset
 
 Use the initial stoploss until the profit is above 4%, then use a trailing stoploss of 50% of the current profit with a minimum of 2.5% and a maximum of 5%.
 
+Please note that the stoploss can only increase, values lower than the current stoploss are ignored.
+
 ``` python
 from datetime import datetime, timedelta
 from freqtrade.persistence import Trade
-from freqtrade.strategy import stoploss_from_open
 
 class AwesomeStrategy(IStrategy):
 
@@ -203,14 +198,20 @@ class AwesomeStrategy(IStrategy):
                         current_rate: float, current_profit: float, **kwargs) -> float:
 
         if current_profit < 0.04:
-            return 1 # return a value bigger than the inital stoploss to keep using the inital stoploss
+            return -1 # return a value bigger than the inital stoploss to keep using the inital stoploss
 
         # After reaching the desired offset, allow the stoploss to trail by half the profit
-        # Use a minimum of 2.5% and a maximum of 5%
-        desired_stop_from_open = max(min(current_profit / 2, 0.05), 0.025)
+        desired_stoploss = current_profit / 2
 
-        return stoploss_from_open(desired_stop_from_open, current_profit)
+        # Use a minimum of 2.5% and a maximum of 5%
+        return max(min(desired_stoploss, 0.05), 0.025
 ```
+
+#### Calculating stoploss relative to open price
+
+Stoploss values returned from `custom_stoploss()` always specify a percentage relative to `current_rate`. In order to set a stoploss relative to the *open* price, we need to use `current_profit` to calculate what percentage relative to the `current_rate` will give you the same result as if the percentage was specified from the open price.
+
+The helper function [`stoploss_from_open()`](strategy-customization.md#stoploss_from_open) can be used to convert from an open price relative stop, to a current price relative stop which can be returned from `custom_stoploss()`.
 
 #### Stepped stoploss
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -600,9 +600,9 @@ Stoploss values returned from `custom_stoploss` must specify a percentage relati
 
     ``` python
 
-    from freqtrade.strategy import IStrategy, stoploss_from_open
     from datetime import datetime
     from freqtrade.persistence import Trade
+    from freqtrade.strategy import IStrategy, stoploss_from_open
 
     class AwesomeStrategy(IStrategy):
 
@@ -621,6 +621,7 @@ Stoploss values returned from `custom_stoploss` must specify a percentage relati
 
     ```
 
+    Full examples can be found in the [Custom stoploss](strategy-advanced.md#custom-stoploss) section of the Documentation.
 
 
 ## Additional data (Wallets)

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -587,6 +587,42 @@ All columns of the informative dataframe will be available on the returning data
 
 ***
 
+### *stoploss_from_open()*
+
+Stoploss values returned from `custom_stoploss` must specify a percentage relative to `current_rate`, but sometimes you may want to specify a stoploss relative to the open price instead. `stoploss_from_open()` is a helper function to calculate a stoploss value that can be returned from `custom_stoploss` which will be equivalent to the desired percentage above the open price.
+
+??? Example "Returning a stoploss relative to the open price from the custom stoploss function"
+
+    Say the open price was $100, and `current_price` is $121 (`current_profit` will be `0.21`).  
+
+    If we want a stop price at 7% above the open price we can call `stoploss_from_open(0.07, current_profit)` which will return `0.1157024793`.  11.57% below $121 is $107, which is the same as 7% above $100.
+
+
+    ``` python
+
+    from freqtrade.strategy import IStrategy, stoploss_from_open
+    from datetime import datetime
+    from freqtrade.persistence import Trade
+
+    class AwesomeStrategy(IStrategy):
+
+        # ... populate_* methods
+
+        use_custom_stoploss = True
+
+        def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
+                            current_rate: float, current_profit: float, **kwargs) -> float:
+
+            # once the profit has risin above 10%, keep the stoploss at 7% above the open price
+            if current_profit > 0.10:
+                return stoploss_from_open(0.07, current_profit)
+
+            return 1
+
+    ```
+
+
+
 ## Additional data (Wallets)
 
 The strategy provides access to the `Wallets` object. This contains the current balances on the exchange.

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -3,3 +3,4 @@ from freqtrade.exchange import (timeframe_to_minutes, timeframe_to_msecs, timefr
                                 timeframe_to_prev_date, timeframe_to_seconds)
 from freqtrade.strategy.interface import IStrategy
 from freqtrade.strategy.strategy_helper import merge_informative_pair
+from freqtrade.strategy.strategy_helper import stoploss_from_open

--- a/freqtrade/strategy/__init__.py
+++ b/freqtrade/strategy/__init__.py
@@ -2,5 +2,4 @@
 from freqtrade.exchange import (timeframe_to_minutes, timeframe_to_msecs, timeframe_to_next_date,
                                 timeframe_to_prev_date, timeframe_to_seconds)
 from freqtrade.strategy.interface import IStrategy
-from freqtrade.strategy.strategy_helper import merge_informative_pair
-from freqtrade.strategy.strategy_helper import stoploss_from_open
+from freqtrade.strategy.strategy_helper import merge_informative_pair, stoploss_from_open

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -65,12 +65,21 @@ def stoploss_from_open(open_relative_stop: float, current_profit: float) -> floa
     return a stop loss value that is relative to the current price, and which can be
     returned from `custom_stoploss`.
 
-    :param open_relative_stop: Desired stop loss value relative to open price
+    The requested stop can be positive for a stop above the open price, or negative for
+    a stop below the open price. The return value is always >= 0.
+
+    Returns 0 if the resulting stop price would be above the current price.
+
+    :param open_relative_stop: Desired stop loss percentage relative to open price
     :param current_profit: The current profit percentage
-    :return: Stop loss value relative to current price
+    :return: Positive stop loss value relative to current price
     """
 
+    # formula is undefined for current_profit -1, return maximum value
     if current_profit == -1:
         return 1
 
-    return 1-((1+open_relative_stop)/(1+current_profit))
+    stoploss = 1-((1+open_relative_stop)/(1+current_profit))
+
+    # negative stoploss values indicate the requested stop price is higher than the current price
+    return max(stoploss, 0.0)

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -56,3 +56,21 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
         dataframe = dataframe.ffill()
 
     return dataframe
+
+
+def stoploss_from_open(open_relative_stop: float, current_profit: float) -> float:
+    """
+
+    Given the current profit, and a desired stop loss value relative to the open price,
+    return a stop loss value that is relative to the current price, and which can be
+    returned from `custom_stoploss`.
+
+    :param open_relative_stop: Desired stop loss value relative to open price
+    :param current_profit: The current profit percentage
+    :return: Stop loss value relative to current price
+    """
+
+    if current_profit == -1:
+        return 1
+
+    return 1-((1+open_relative_stop)/(1+current_profit))


### PR DESCRIPTION
…custom stoploss functions

## Summary
Correct the math used in the custom stoploss example documentation, and clarify a few points of terminology.

An example utility function `stoploss_from_open` is introduced which can be used to calculate stop loss values which are relative to the open price, instead of the current price.  This is something that is shown several times in the example documentation, but the math used previously was incorrect. In some cases the results were *close*, especially when dealing with very small percentages, however as the current profit increases, the previous math used becomes increasingly inaccurate.