### PR TITLE
Improvement for timerange parser

### DIFF
--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -103,5 +103,7 @@ class TimeRange:
                         stop = int(stops) // 1000
                     else:
                         stop = int(stops)
+                if start > stop > 0:
+                    raise Exception('Start date is after stop date for timerange "%s"' % text)
                 return TimeRange(stype[0], stype[1], start, stop)
         raise Exception('Incorrect syntax for timerange "%s"' % text)

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -30,6 +30,9 @@ def test_parse_timerange_incorrect():
     with pytest.raises(Exception, match=r'Incorrect syntax.*'):
         TimeRange.parse_timerange('-')
 
+    with pytest.raises(Exception, match=r'Start date is after stop date for timerange.*'):
+        TimeRange.parse_timerange('20100523-20100522')
+
 
 def test_subtract_start():
     x = TimeRange('date', 'date', 1274486400, 1438214400)


### PR DESCRIPTION
## Summary
When users run for example back testing and their start date is AFTER their stop date, the syntax is OK, but they get an error that data has not been found. I decided include a nice error message for this case, because the error is a bit cryptic when you overlook your error. 

Solve the issue: Not an existing issue on Github.

## Quick changelog
-Added a small snippet to give users a descent error message, when their start date is after the stop date. (timerange.py)
-Added test for the exception (test_timerange.py)

## What's new?
Users now get the message "Start date is after stop date for timerange" when they make the above mistake.
