### PR TITLE
Add confirm_trade_exit and confirm_trade_entry to backtesting

### DIFF
--- a/docs/bot-basics.md
+++ b/docs/bot-basics.md
@@ -53,6 +53,7 @@ This loop will be repeated again and again until the bot is stopped.
 * Calls `bot_loop_start()` once.
 * Calculate indicators (calls `populate_indicators()` once per pair).
 * Calculate buy / sell signals (calls `populate_buy_trend()` and `populate_sell_trend()` once per pair)
+* Confirm trade buy / sell (calls `confirm_trade_entry()` and `confirm_trade_exit()` if implemented in the strategy)
 * Loops per candle simulating entry and exit points.
 * Generate backtest report output
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -253,7 +253,6 @@ class Backtesting:
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
 
         time_in_force = self.strategy.order_time_in_force['sell']
-
         # confirm_trade_exit
         if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=False)(
                 pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount, rate=sell_row[LOW_IDX],

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -30,7 +30,6 @@ from freqtrade.strategy.interface import IStrategy, SellCheckTuple, SellType
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets
 
-
 logger = logging.getLogger(__name__)
 
 # Indexes for backtest tuples
@@ -252,8 +251,17 @@ class Backtesting:
         sell = self.strategy.should_sell(trade, sell_row[OPEN_IDX],  # type: ignore
                                          sell_row[DATE_IDX], sell_row[BUY_IDX], sell_row[SELL_IDX],
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
-        if sell.sell_flag:
 
+        time_in_force = self.strategy.order_time_in_force['sell']
+
+        # confirm_trade_exit
+        if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=False)(
+                pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount, rate=sell_row[LOW_IDX],
+                time_in_force=time_in_force,
+                sell_reason=sell.sell_type.value):
+            return None
+
+        if sell.sell_flag:
             trade.close_date = sell_row[DATE_IDX]
             trade.sell_reason = sell.sell_type.value
             trade_dur = int((trade.close_date_utc - trade.open_date_utc).total_seconds() // 60)
@@ -271,6 +279,15 @@ class Backtesting:
         except DependencyException:
             return None
         min_stake_amount = self.exchange.get_min_pair_stake_amount(pair, row[OPEN_IDX], -0.05)
+
+        order_type = self.strategy.order_types['buy']
+        time_in_force = self.strategy.order_time_in_force['sell']
+        # confirm_trade_entry
+        if not strategy_safe_wrapper(self.strategy.confirm_trade_entry, default_retval=True)(
+                pair=pair, order_type=order_type, amount=stake_amount, rate=row[OPEN_IDX],
+                time_in_force=time_in_force):
+            return None
+
         if stake_amount and (not min_stake_amount or stake_amount > min_stake_amount):
             # Enter trade
             trade = LocalTrade(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -30,6 +30,7 @@ from freqtrade.strategy.interface import IStrategy, SellCheckTuple, SellType
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets
 
+
 logger = logging.getLogger(__name__)
 
 # Indexes for backtest tuples

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -255,7 +255,8 @@ class Backtesting:
         time_in_force = self.strategy.order_time_in_force['sell']
         # confirm_trade_exit
         if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=True)(
-                pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount, rate=sell_row[LOW_IDX],
+                pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount,
+                rate=sell_row[LOW_IDX],
                 time_in_force=time_in_force,
                 sell_reason=sell.sell_type.value):
             return None

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -254,7 +254,7 @@ class Backtesting:
 
         time_in_force = self.strategy.order_time_in_force['sell']
         # confirm_trade_exit
-        if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=False)(
+        if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=True)(
                 pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount, rate=sell_row[LOW_IDX],
                 time_in_force=time_in_force,
                 sell_reason=sell.sell_type.value):


### PR DESCRIPTION
## Summary
Add confirm_trade_exit and confirm_trade_entry to backtesting

Solve the issue: #___

## Quick changelog

- backtesting.py

## What's new?
Add confirm_trade_exit and confirm_trade_entry to backtesting