### PR TITLE
Specify which versions of Python Freqtrade successfully builds on.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,7 +38,7 @@ These requirements apply to both [Script Installation](#script-installation) and
 
 ### Install guide
 
-* [Python >= 3.7.x](http://docs.python-guide.org/en/latest/starting/installation/)
+* [Python == 3.7.*, == 3.8.*](http://docs.python-guide.org/en/latest/starting/installation/)
 * [pip](https://pip.pypa.io/en/stable/installing/)
 * [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [virtualenv](https://virtualenv.pypa.io/en/stable/installation.html) (Recommended)


### PR DESCRIPTION
## Summary
This is just a small change to the docs to specify the versions that Freqtrade builds on.

At this time, a wheel for the "tables" dependency is not available for python 3.9 on pypi. This prevents a user from installing freqtrade with python 3.9.