### PR TITLE
Implementing end time in data-download

### DIFF
--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -34,10 +34,6 @@ class TimeRange:
         return (self.starttype == other.starttype and self.stoptype == other.stoptype
                 and self.startts == other.startts and self.stopts == other.stopts)
 
-    def to_datetime(self) -> (datetime, datetime):
-        return datetime.fromtimestamp(self.startts, timezone.utc), \
-               datetime.fromtimestamp(self.stopts, timezone.utc)
-
     def subtract_start(self, seconds: int) -> None:
         """
         Subtracts <seconds> from startts if startts is set.

--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -4,6 +4,7 @@ This module contains the argument manager class
 import logging
 import re
 from typing import Optional
+from datetime import datetime, timezone
 
 import arrow
 
@@ -32,6 +33,10 @@ class TimeRange:
         """Override the default Equals behavior"""
         return (self.starttype == other.starttype and self.stoptype == other.stoptype
                 and self.startts == other.startts and self.stopts == other.stopts)
+
+    def to_datetime(self) -> (datetime, datetime):
+        return datetime.fromtimestamp(self.startts, timezone.utc), \
+               datetime.fromtimestamp(self.stopts, timezone.utc)
 
     def subtract_start(self, seconds: int) -> None:
         """

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -287,9 +287,12 @@ def refresh_backtest_ohlcv_data(exchange: Exchange, pairs: List[str], timeframes
                         f'Deleting existing data for pair {pair}, interval {timeframe}.')
 
             logger.info(f'Downloading pair {pair}, interval {timeframe}.')
+            # What happens when until should be None?
+            since, until = timerange.to_datetime()
             _download_pair_history(datadir=datadir, exchange=exchange,
                                    pair=pair, timeframe=str(timeframe),
-                                   timerange=timerange, data_handler=data_handler)
+                                   since=since, until=until,
+                                   data_handler=data_handler)
     return pairs_not_available
 
 

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -184,7 +184,7 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                      if cached_start else 'None')
         logger.debug("Cached End: %s",
                      f"{cached.iloc[-1]['date']:%Y-%m-%d %H:%M:%S}"
-                     if not cached_end else 'None')
+                     if cached_end else 'None')
 
         # Set the bounds for downloading
         since_ms, until_ms = None, None

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -196,9 +196,6 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                 if since < cached_start:
                     since_ms = since.timestamp() * 1000
                 elif cached_start <= since < cached_end:
-                    logger.warning("The timerange overlaps with cached data."
-                                   " This may lead to unexpected outcomes "
-                                   "including overwriting existing data!")
                     since_ms = since.timestamp() * 1000
                 else:
                     since_ms = cached_end.timestamp() * 1000
@@ -208,9 +205,6 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                 if until < cached_start:
                     until_ms = cached_start.timestamp() * 1000
                 elif cached_start < until <= cached_end:
-                    logger.warning("The timerange overlaps with cached data."
-                                   " This may lead to unexpected outcomes "
-                                   "including overwriting existing data!")
                     until_ms = until.timestamp() * 1000
                 else:
                     until_ms = until.timestamp()

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -176,8 +176,8 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
 
         cached_start, cached_end = None, None
         if not cached.empty:
-            cached_start = cached.iloc[0]['date'].timestamp()
-            cached_end = cached.iloc[-1]['date'].timestamp()
+            cached_start = int(cached.iloc[0]['date'].timestamp())
+            cached_end = int(cached.iloc[-1]['date'].timestamp())
 
         logger.debug("Cached Start: %s",
                      f"{cached.iloc[0]['date']:%Y-%m-%d %H:%M:%S}"
@@ -190,9 +190,9 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
         since_ms, until_ms = None, None
         if cached.empty:
             since_ms = (since if since else
-                        arrow.utcnow().shift(days=-30).timestamp()) * 1000
+                        arrow.utcnow().shift(days=-30).int_timestamp) * 1000
             until_ms = (until if until else
-                        datetime.now(timezone.utc).timestamp()) * 1000
+                        arrow.utcnow().int_timestamp) * 1000
         else:
             # Determine lower bound
             if since:
@@ -207,7 +207,7 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                            * 1000
             else:
                 # Default upper-bound is the current time.
-                until_ms = datetime.now(timezone.utc).timestamp() * 1000
+                until_ms = arrow.utcnow().int_timestamp * 1000
 
         new_data = exchange.get_historic_ohlcv(pair=pair,
                                                timeframe=timeframe,

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -154,12 +154,16 @@ def _load_cached_data_for_updating(pair: str, timeframe: str, timerange: Optiona
 
 def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                            timeframe: str = '5m',
-                           since: datetime = None, until: datetime = None,
+                           timerange: Optional[TimeRange] = None,
                            data_handler: IDataHandler = None) -> bool:
 
     data_handler = get_datahandler(datadir, data_handler=data_handler)
 
     try:
+        since, until = None, None
+        if timerange:
+            since, until = timerange.to_datetime()
+
         logger.info(
             f'Downloading history data for par: "{pair}", timeframe: '
             f'{timeframe} and storing in "{datadir}"'
@@ -273,11 +277,9 @@ def refresh_backtest_ohlcv_data(exchange: Exchange, pairs: List[str], timeframes
                         f'Deleting existing data for pair {pair}, interval {timeframe}.')
 
             logger.info(f'Downloading pair {pair}, interval {timeframe}.')
-            # What happens when until should be None?
-            since, until = timerange.to_datetime()
             _download_pair_history(datadir=datadir, exchange=exchange,
                                    pair=pair, timeframe=str(timeframe),
-                                   since=since, until=until,
+                                   timerange=timerange,
                                    data_handler=data_handler)
     return pairs_not_available
 

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -180,18 +180,22 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
         logger.debug("Cached End: %s",
                      f"{cached_end:%Y-%m-%d %H:%M:%S}" if not cached_end else 'None')
 
+        # Set the bounds for downloading
         since_ms, until_ms = None, None
         if cached.empty:
             if since:
                 since_ms = since.timestamp() * 1000
             else:
+                # The default lower-bound is 30 days before the current time.
                 since_ms = arrow.utcnow().shift(days=-30).float_timestamp * \
                            1000
             if until:
                 until_ms = until.timestamp() * 1000
             else:
+                # Default upper-bound is the current time.
                 until_ms = datetime.now(timezone.utc).timestamp() * 1000
         else:
+            # Determine lower bound
             if since:
                 if since < cached_start:
                     since_ms = since.timestamp() * 1000
@@ -200,7 +204,10 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                 else:
                     since_ms = cached_end.timestamp() * 1000
             else:
+                # Set lower-bound to the end of the cache if not provided
                 since_ms = cached_end.timestamp() * 1000
+
+            # Determine upper bound
             if until:
                 if until < cached_start:
                     until_ms = cached_start.timestamp() * 1000
@@ -209,6 +216,7 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                 else:
                     until_ms = until.timestamp()
             else:
+                # Default upper-bound is the current time.
                 until_ms = datetime.now(timezone.utc).timestamp() * 1000
 
         new_data = exchange.get_historic_ohlcv(pair=pair,

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -153,10 +153,9 @@ def _load_cached_data_for_updating(pair: str, timeframe: str, timerange: Optiona
 
 
 def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
-                               timeframe: str = '5m',
-                               since: datetime = None, until: datetime = None,
-                               data_handler: IDataHandler = None,
-                               fill_gaps: bool = False) -> bool:
+                           timeframe: str = '5m',
+                           since: datetime = None, until: datetime = None,
+                           data_handler: IDataHandler = None) -> bool:
 
     data_handler = get_datahandler(datadir, data_handler=data_handler)
 
@@ -182,7 +181,6 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                      f"{cached_end:%Y-%m-%d %H:%M:%S}" if not cached_end else 'None')
 
         since_ms, until_ms = None, None
-
         if cached.empty:
             if since:
                 since_ms = since.timestamp() * 1000
@@ -203,26 +201,12 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
                                    "including overwriting existing data!")
                     since_ms = since.timestamp() * 1000
                 else:
-                    if fill_gaps:
-                        since_ms = cached_end.timestamp() * 1000
-                    else:
-                        logger.warning("The timerange starts after cached "
-                                       "data. There will be a gap in the "
-                                       "saved data! Use --fill-gaps to "
-                                       "prevent this!")
-                        since_ms = since.timestamp() * 1000
+                    since_ms = cached_end.timestamp() * 1000
             else:
                 since_ms = cached_end.timestamp() * 1000
             if until:
                 if until < cached_start:
-                    if fill_gaps:
-                        until_ms = cached_start.timestamp() * 1000
-                    else:
-                        logger.warning("The timerange ends before the cached "
-                                       "data. There will be a gap in the "
-                                       "saved data! Use --fill-gaps to "
-                                       "prevent this!")
-                        until_ms = until.timestamp() * 1000
+                    until_ms = cached_start.timestamp() * 1000
                 elif cached_start < until <= cached_end:
                     logger.warning("The timerange overlaps with cached data."
                                    " This may lead to unexpected outcomes "

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -165,7 +165,7 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
             since, until = timerange.startts, timerange.stopts
 
         logger.info(
-            f'Downloading history data for par: "{pair}", timeframe: '
+            f'Downloading history data for pair: "{pair}", timeframe: '
             f'{timeframe} and storing in "{datadir}"'
         )
 
@@ -234,7 +234,7 @@ def _download_pair_history(datadir: Path, exchange: Exchange, pair: str, *,
 
     except Exception:
         logger.exception(
-            f'Failed to download history data for pari: "{pair}", '
+            f'Failed to download history data for pair: "{pair}", '
             f'timeframe: {timeframe}.'
         )
         return False

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -739,7 +739,7 @@ class Exchange:
         """
 
         if not until_ms:
-            until_ms = datetime.now(timezone.utc).timestamp() * 1000
+            until_ms = arrow.utcnow().int_timestamp * 1000
 
         return asyncio.get_event_loop().run_until_complete(
             self._async_get_historic_ohlcv(pair=pair, timeframe=timeframe,

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -90,8 +90,8 @@ def test_load_data_1min_timeframe(ohlcv_history, mocker, caplog, testdatadir) ->
     load_data(datadir=testdatadir, timeframe='1m', pairs=['UNITTEST/BTC'])
     assert file.is_file()
     assert not log_has(
-        'Download history data for pair: "UNITTEST/BTC", interval: 1m '
-        'and store in None.', caplog
+        'Downloading history data for pair: "UNITTEST/BTC", interval: 1m '
+        'and storing in None.', caplog
     )
     _clean_test_file(file)
 
@@ -135,8 +135,8 @@ def test_load_data_with_new_pair_1min(ohlcv_history_list, mocker, caplog,
     load_pair_history(datadir=testdatadir, timeframe='1m', pair='MEME/BTC')
     assert file.is_file()
     assert log_has_re(
-        'Download history data for pair: "MEME/BTC", timeframe: 1m '
-        'and store in .*', caplog
+        'Downloading history data for pair: "MEME/BTC", timeframe: 1m '
+        'and storing in .*', caplog
     )
     _clean_test_file(file)
 


### PR DESCRIPTION
## Summary
The goal of this PR is to implement end times in data downloading functions so that timeranges with the data-download command work as expected.

Solve the issue: #4412 

This is a work-in-progress change; however, I wanted to draft a PR in order to get some feedback on this.

## Current Changes
- Added `until` parameters to functions for downloading OHLCV data
- Ensure that downloading stops once the `until` time has been reached
- Added a `to_datetime` method to the `TimeRange` object

## Planned Changes
- Implement `until` on functions for downloading trade data
- Update unit tests
- ~Add parameter `--fill-gaps` to prevent gaps in data which would occur in certain cases~
- ~Add parameter `--no-overwrite` to prevent new downloads from overwriting already saved data~

## Potential Changes
- ~Replace `--timerange` parameter with parameters `from` and `to`~
