### PR TITLE
Remove candle_count from dataframe 

### DIFF
--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -115,17 +115,23 @@ def ohlcv_fill_up_missing_data(dataframe: DataFrame, timeframe: str, pair: str) 
     return df
 
 
-def trim_dataframe(df: DataFrame, timerange, df_date_col: str = 'date') -> DataFrame:
+def trim_dataframe(df: DataFrame, timerange, df_date_col: str = 'date',
+                   startup_candles: int = 0) -> DataFrame:
     """
     Trim dataframe based on given timerange
     :param df: Dataframe to trim
     :param timerange: timerange (use start and end date if available)
-    :param: df_date_col: Column in the dataframe to use as Date column
+    :param df_date_col: Column in the dataframe to use as Date column
+    :param startup_candles: When not 0, is used instead the timerange start date
     :return: trimmed dataframe
     """
-    if timerange.starttype == 'date':
-        start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
-        df = df.loc[df[df_date_col] >= start, :]
+    if startup_candles:
+        # Trim candles instead of timeframe in case of given startup_candle count
+        df = df.iloc[startup_candles:, :]
+    else:
+        if timerange.starttype == 'date':
+            start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
+            df = df.loc[df[df_date_col] >= start, :]
     if timerange.stoptype == 'date':
         stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc)
         df = df.loc[df[df_date_col] <= stop, :]

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -443,7 +443,8 @@ class Backtesting:
 
         # Trim startup period from analyzed dataframe
         for pair, df in preprocessed.items():
-            preprocessed[pair] = trim_dataframe(df, timerange)
+            preprocessed[pair] = trim_dataframe(df, timerange,
+                                                startup_candles=self.required_startup)
         min_date, max_date = history.get_timerange(preprocessed)
 
         logger.info(f'Backtesting with data from {min_date.strftime(DATETIME_PRINT_FORMAT)} '

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -379,7 +379,8 @@ class Hyperopt:
 
         # Trim startup period from analyzed dataframe
         for pair, df in preprocessed.items():
-            preprocessed[pair] = trim_dataframe(df, timerange)
+            preprocessed[pair] = trim_dataframe(df, timerange,
+                                                startup_candles=self.backtesting.required_startup)
         min_date, max_date = get_timerange(preprocessed)
 
         logger.info(f'Hyperopting with data from {min_date.strftime(DATETIME_PRINT_FORMAT)} '

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -198,6 +198,16 @@ def test_trim_dataframe(testdatadir) -> None:
     assert all(data_modify.iloc[0] == data.iloc[30])
 
     data_modify = data.copy()
+    tr = TimeRange('date', None, min_date + 1800, 0)
+    # Remove first 20 candles - ignores min date
+    data_modify = trim_dataframe(data_modify, tr, startup_candles=20)
+    assert not data_modify.equals(data)
+    assert len(data_modify) < len(data)
+    assert len(data_modify) == len(data) - 20
+    assert all(data_modify.iloc[-1] == data.iloc[-1])
+    assert all(data_modify.iloc[0] == data.iloc[20])
+
+    data_modify = data.copy()
     # Remove last 30 minutes (1800 s)
     tr = TimeRange(None, 'date', 0, max_date - 1800)
     data_modify = trim_dataframe(data_modify, tr)


### PR DESCRIPTION
## Summary
Remove candle_count from dataframe before backtesting.
Otherwise, the startup candle count is ignored if pair-data starts after the backtesting data.

closes #3754

## Quick changelog

- Remove candle-count index-wise while trimming dataframe