### PR TITLE
Reduce verbosity of missing data if less than 1% of data is missing

### DIFF
--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -110,8 +110,15 @@ def ohlcv_fill_up_missing_data(dataframe: DataFrame, timeframe: str, pair: str) 
     df.reset_index(inplace=True)
     len_before = len(dataframe)
     len_after = len(df)
+    pct_missing = (len_after - len_before) / len_before if len_before > 0 else 0
     if len_before != len_after:
-        logger.info(f"Missing data fillup for {pair}: before: {len_before} - after: {len_after}")
+        message = (f"Missing data fillup for {pair}: before: {len_before} - after: {len_after}"
+                   f" - {round(pct_missing * 100, 2)} %")
+        if pct_missing > 0.01:
+            logger.info(message)
+        else:
+            # Don't be verbose if only a small amount is missing
+            logger.debug(message)
     return df
 
 

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -10,7 +10,7 @@ from freqtrade.data.converter import (convert_ohlcv_format, convert_trades_forma
                                       trades_to_ohlcv, trim_dataframe)
 from freqtrade.data.history import (get_timerange, load_data, load_pair_history,
                                     validate_backtest_data)
-from tests.conftest import log_has
+from tests.conftest import log_has, log_has_re
 from tests.data.test_history import _backup_file, _clean_test_file
 
 
@@ -62,8 +62,8 @@ def test_ohlcv_fill_up_missing_data(testdatadir, caplog):
     # Column names should not change
     assert (data.columns == data2.columns).all()
 
-    assert log_has(f"Missing data fillup for UNITTEST/BTC: before: "
-                   f"{len(data)} - after: {len(data2)}", caplog)
+    assert log_has_re(f"Missing data fillup for UNITTEST/BTC: before: "
+                      f"{len(data)} - after: {len(data2)}.*", caplog)
 
     # Test fillup actually fixes invalid backtest data
     min_date, max_date = get_timerange({'UNITTEST/BTC': data})
@@ -125,8 +125,8 @@ def test_ohlcv_fill_up_missing_data2(caplog):
     # Column names should not change
     assert (data.columns == data2.columns).all()
 
-    assert log_has(f"Missing data fillup for UNITTEST/BTC: before: "
-                   f"{len(data)} - after: {len(data2)}", caplog)
+    assert log_has_re(f"Missing data fillup for UNITTEST/BTC: before: "
+                      f"{len(data)} - after: {len(data2)}.*", caplog)
 
 
 def test_ohlcv_drop_incomplete(caplog):


### PR DESCRIPTION
## Summary
Reduce verbosity of missing data fillup message if less than 1% of data is missing, which is usually the case on / after exchange downtimes.