### PR TITLE
add "cfg" argument for overriding any config from command line

### DIFF
--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -10,7 +10,7 @@ from freqtrade.commands.cli_options import AVAILABLE_CLI_OPTIONS
 from freqtrade.constants import DEFAULT_CONFIG
 
 
-ARGS_COMMON = ["verbosity", "logfile", "version", "config", "datadir", "user_data_dir"]
+ARGS_COMMON = ["verbosity", "logfile", "version", "config", "cfg", "datadir", "user_data_dir"]
 
 ARGS_STRATEGY = ["strategy", "strategy_path"]
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -49,8 +49,10 @@ class SetDictFromArgAction(argparse.Action):
         for key_value in values:
             try:
                 (k, v) = key_value.split("=", 2)
-            except ValueError as ex:
-                raise argparse.ArgumentError(self, f"could not parse argument \"{values[0]}\" as k=v format")
+            except ValueError:
+                raise argparse.ArgumentError(
+                    self,
+                    f"could not parse argument \"{values[0]}\" as k=v format")
             d = self.set_dict_path_value(getattr(args, self.dest) or {}, k, v)
             setattr(args, self.dest, d)
 
@@ -76,7 +78,9 @@ class SetDictFromArgAction(argparse.Action):
             elif value == "False" or value == "false" or value == "0":
                 value = False
             else:
-                raise ArgumentTypeError(f"Argument '{key}' has unknown value '{value}'. Must be (true|false|True|False|1|0)")
+                raise ArgumentTypeError(
+                    f"Argument '{key}' has unknown value '{value}'. "
+                    f"Must be (true|false|True|False|1|0)")
         else:
             raise Exception(f"Unsupported arg type '{value_type}'")
         obj[latest_key] = value

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -93,6 +93,9 @@ class Configuration:
         # Load all configs
         config: Dict[str, Any] = self.load_from_files(self.args.get("config", []))
 
+        if 'cfg' in self.args:
+            config = deep_merge_dicts(self.args['cfg'] or {}, config)
+
         # Keep a copy of the original configuration file
         config['original_config'] = deepcopy(config)
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -35,6 +35,30 @@ def test_setup_utils_configuration():
     assert config['exchange']['secret'] == ''
 
 
+def test_cfg_argument_replaces_configuration():
+    args = [
+        'list-exchanges', '--config', 'config_bittrex.json.example',
+    ]
+
+    # Check original config
+    config = setup_utils_configuration(get_args(args), RunMode.OTHER)
+    assert config['dry_run'] is True
+    assert config['exchange']['key'] == ''
+    assert config['stake_amount'] == 0.05
+    assert config['timeframe'] == '5m'
+
+    args = [
+        'list-exchanges', '--config', 'config_bittrex.json.example',
+        '--cfg', 'stake_amount:float=0.1', 'timeframe=15m', 'exchange.sandbox:bool=true',
+    ]
+
+    # Check original config
+    config = setup_utils_configuration(get_args(args), RunMode.OTHER)
+    assert config['stake_amount'] == 0.1
+    assert config['timeframe'] == '15m'
+    assert config['exchange']['sandbox'] is True
+
+
 def test_start_trading_fail(mocker, caplog):
 
     mocker.patch("freqtrade.worker.Worker.run", MagicMock(side_effect=OperationalException))


### PR DESCRIPTION
## Summary
Add universal argument "--cfg" for overriding any config value

## Common Syntax:
```
--cfg key=value [key.subkey.subsubkey...:type=value]
```

## Usage and Examples
Now you have you create a new argument configuration if you want to set some new config from command line. With this small improvement you can easily override any config value. 

```
freqtrade trade --cfg timeframe=15m stake_amount:float=0.1 exchange.sandbox:bool=true
```

Because all data in arguments is string you must specify the type of a value (default: string). Also you can use "path" of the key with "." to set the value at any level of the config.

Now we support only 4 types:
```
key:str=value - String
key:int=1
key:float=0.99
key:bool=0|1|false|true|False|True
```