### PR TITLE
Sort pair lists by total profit

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -110,6 +110,9 @@ def generate_pair_metrics(data: Dict[str, Dict], stake_currency: str, starting_b
 
         tabular_data.append(_generate_result_line(result, starting_balance, pair))
 
+    # Sort by total profit %:
+    tabular_data = sorted(tabular_data, key=lambda k: k['profit_total_abs'], reverse=True)
+
     # Append Total
     tabular_data.append(_generate_result_line(results, starting_balance, 'TOTAL'))
     return tabular_data


### PR DESCRIPTION
## Summary
Sort backtest pair lists results by total profit %:

<img width="1137" alt="Screen Shot 2021-04-04 at 1 20 11" src="https://user-images.githubusercontent.com/17566570/113492933-e8d9b180-94e3-11eb-90e3-7feb2ea4b6cc.png">