### PR TITLE
Standardize CRLF throughout repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=crlf


### PR DESCRIPTION
Whilst creating a fresh fork, I experienced all files being instantly marked as modified by git when i launched the devcontainer. Turns out it somewhy wanted to change CRLF to LF.

This will standardize it, so we can avoid having 200+ "changed files" in a fresh devcontainer.

This works by the editor (and git) looking in the file, and obeying whatever it defines.

Example : 
![image](https://user-images.githubusercontent.com/16370656/113607308-58b57c80-9649-11eb-8290-ec5ff4141ff9.png)


Other example: https://github.com/microsoft/vscode-remote-release/issues/302

Solution: https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files