### PR TITLE
Add API endpoint for getting a specific trade

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -182,7 +182,7 @@ count
 	Return the amount of open trades.
 
 daily
-	Return the amount of open trades.
+	Return the profits for each day, and amount of trades.
 
 delete_lock
 	Delete (disable) lock from the database.
@@ -215,7 +215,7 @@ locks
 logs
 	Show latest logs.
 
-        :param limit: Limits log messages to the last <limit> logs. No limit to get all the trades.
+        :param limit: Limits log messages to the last <limit> logs. No limit to get the entire log.
 
 pair_candles
 	Return live dataframe for <pair><timeframe>.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -235,6 +235,9 @@ pair_history
 performance
 	Return the performance of the different coins.
 
+ping
+	simple ping
+
 plot_config
 	Return plot configuration if the strategy defines one.
 
@@ -271,14 +274,15 @@ strategy
 
         :param strategy: Strategy class name
 
+trade
+	Return specific trade
+
+        :param trade_id: Specify which trade to get.
+
 trades
 	Return trades history.
 
         :param limit: Limits trades to the X last trades. No limit to get all the trades.
-
-trade
-	Return specific trade.
-        :param tradeid: Specify which trade to get.
 
 version
 	Return the version of the bot.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -125,6 +125,7 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `stopbuy` | Stops the trader from opening new trades. Gracefully closes open trades according to their rules.
 | `reload_config` | Reloads the configuration file.
 | `trades` | List last trades.
+| `trade/<tradeid>` | Get specific trade.
 | `delete_trade <trade_id>` | Remove trade from the database. Tries to close open orders. Requires manual handling of this trade on the exchange.
 | `show_config` | Shows part of the current configuration with relevant settings to operation.
 | `logs` | Shows last log messages.
@@ -274,6 +275,10 @@ trades
 	Return trades history.
 
         :param limit: Limits trades to the X last trades. No limit to get all the trades.
+
+trade
+	Return specific trade.
+        :param tradeid: Specify which trade to get.
 
 version
 	Return the version of the bot.

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -90,7 +90,10 @@ def trades(limit: int = 0, rpc: RPC = Depends(get_rpc)):
 
 @router.get('/trade/{tradeid}', response_model=OpenTradeSchema, tags=['info', 'trading'])
 def trade(tradeid: int = 0, rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_trade_status([tradeid])[0]
+    try:
+        return rpc._rpc_trade_status([tradeid])[0]
+    except (RPCException, KeyError):
+        raise HTTPException(status_code=404, detail='Trade not found.')
 
 
 @router.delete('/trades/{tradeid}', response_model=DeleteTrade, tags=['info', 'trading'])

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -88,6 +88,11 @@ def trades(limit: int = 0, rpc: RPC = Depends(get_rpc)):
     return rpc._rpc_trade_history(limit)
 
 
+@router.get('/trade/{tradeid}', response_model=OpenTradeSchema, tags=['info', 'trading'])
+def trade(tradeid: int = 0, rpc: RPC = Depends(get_rpc)):
+    return rpc._rpc_trade_status([tradeid])[0]
+
+
 @router.delete('/trades/{tradeid}', response_model=DeleteTrade, tags=['info', 'trading'])
 def trades_delete(tradeid: int, rpc: RPC = Depends(get_rpc)):
     return rpc._rpc_delete(tradeid)

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -127,7 +127,7 @@ class FtRestClient():
         return self._delete("locks/{}".format(lock_id))
 
     def daily(self, days=None):
-        """Return the amount of open trades.
+        """Return the profits for each day, and amount of trades.
 
         :return: json object
         """
@@ -195,7 +195,7 @@ class FtRestClient():
     def logs(self, limit=None):
         """Show latest logs.
 
-        :param limit: Limits log messages to the last <limit> logs. No limit to get all the trades.
+        :param limit: Limits log messages to the last <limit> logs. No limit to get the entire log.
         :return: json object
         """
         return self._get("logs", params={"limit": limit} if limit else 0)
@@ -207,6 +207,14 @@ class FtRestClient():
         :return: json object
         """
         return self._get("trades", params={"limit": limit} if limit else 0)
+
+    def trade(self, trade_id):
+        """Return specific trade
+
+        :param trade_id: Specify which trade to get.
+        :return: json object
+        """
+        return self._get("trade/{}".format(trade_id))
 
     def delete_trade(self, trade_id):
         """Delete trade from the database.

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -522,6 +522,26 @@ def test_api_trades(botclient, mocker, fee, markets):
     assert rc.json()['trades_count'] == 1
 
 
+def test_api_trade_single(botclient, mocker, fee, ticker, markets):
+    ftbot, client = botclient
+    patch_get_signal(ftbot, (True, False))
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        markets=PropertyMock(return_value=markets),
+        fetch_ticker=ticker,
+    )
+    rc = client_get(client, f"{BASE_URI}/trade/3")
+    assert_response(rc, 404)
+    assert rc.json()['detail'] == 'Trade not found.'
+
+    create_mock_trades(fee)
+    Trade.query.session.flush()
+
+    rc = client_get(client, f"{BASE_URI}/trade/3")
+    assert_response(rc)
+    assert rc.json()['trade_id'] == 3
+
+
 def test_api_delete_trade(botclient, mocker, fee, markets):
     ftbot, client = botclient
     patch_get_signal(ftbot, (True, False))


### PR DESCRIPTION
## Summary
This will allow calling the endpoint `GET /api/v1/trade/<id>` to get infomation about a specific trade.

It will return the standard trade schema.

I have added it to the docs, and changed some that were ninja-copy-pasted haha.