### PR TITLE
Allow ask_strategy.sell_profit_offset negative value

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -176,7 +176,7 @@ CONF_SCHEMA = {
                 'order_book_max': {'type': 'integer', 'minimum': 1, 'maximum': 50},
                 'use_sell_signal': {'type': 'boolean'},
                 'sell_profit_only': {'type': 'boolean'},
-                'sell_profit_offset': {'type': 'number', 'minimum': -100},
+                'sell_profit_offset': {'type': 'number'},
                 'ignore_roi_if_buy_signal': {'type': 'boolean'}
             }
         },

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -176,7 +176,7 @@ CONF_SCHEMA = {
                 'order_book_max': {'type': 'integer', 'minimum': 1, 'maximum': 50},
                 'use_sell_signal': {'type': 'boolean'},
                 'sell_profit_only': {'type': 'boolean'},
-                'sell_profit_offset': {'type': 'number', 'minimum': 0.0},
+                'sell_profit_offset': {'type': 'number', 'minimum': -100},
                 'ignore_roi_if_buy_signal': {'type': 'boolean'}
             }
         },


### PR DESCRIPTION
## Summary
`ask_strategy.sell_profit_offset` currently has a minimal value of 0. Setting it to -100 allows negative values.

Solve the issue: #4664 

## Quick changelog

- Allow parameter `ask_strategy.sell_profit_offset` to get negative value.
