### PR TITLE
Improve Kraken-specific config description.

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -44,6 +44,10 @@ Due to the heavy rate-limiting applied by Kraken, the following configuration se
     Downloading kraken data will require significantly more memory (RAM) than any other exchange, as the trades-data needs to be converted into candles on your machine.
     It will also take a long time, as freqtrade will need to download every single trade that happened on the exchange for the pair / timerange combination, therefore please be patient.
 
+!!! Warning "rateLimit tuning"
+    Please pay attention that rateLimit configuration entry holds delay in milliseconds between requests, NOT requests\sec rate.
+    So, in order to mitigate Kraken API "Rate limit exceeded" exception, this configuration should be increased, NOT decreased.
+
 ## Bittrex
 
 ### Order types


### PR DESCRIPTION
Added Warning after Kraken rate limit config in order to clearly highlight that it holds delay between requests instead of req\sec rate.

## Summary
Clearly highlight in docs that ccxt rateLimit is in milliseconds instead of req\sec

## Quick changelog
New warning in Exchanges documentation section

