### PR TITLE
fix: startup_candle trim doesn't work with informative pairs

### DIFF
--- a/freqtrade/data/converter.py
+++ b/freqtrade/data/converter.py
@@ -132,13 +132,12 @@ def trim_dataframe(df: DataFrame, timerange, df_date_col: str = 'date',
     :param startup_candles: When not 0, is used instead the timerange start date
     :return: trimmed dataframe
     """
+    if timerange.starttype == 'date':
+        start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
+        df = df.loc[df[df_date_col] >= start, :]
     if startup_candles:
         # Trim candles instead of timeframe in case of given startup_candle count
         df = df.iloc[startup_candles:, :]
-    else:
-        if timerange.starttype == 'date':
-            start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
-            df = df.loc[df[df_date_col] >= start, :]
     if timerange.stoptype == 'date':
         stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc)
         df = df.loc[df[df_date_col] <= stop, :]


### PR DESCRIPTION
## Summary
when using `informative_pairs` trimming the startup candles results in trimming it from the whole of historical data. so this PR trims it after start date was subtracted

Solve the issue: see below
## Issue description
when I enter this freqtrade backtesting --strategy RSIDivergence  --timerange 20210301- -c user_data/config.json --export trades
it detects it right, but still backtest from the beginning of time (2017-11-26):
```bash
021-04-07 22:05:21,143 - freqtrade.optimize.backtesting - INFO - Loading data from 2021-02-28 15:40:00 up to 2021-04-06 22:05:00 (37 days)..
2021-04-07 22:05:21,143 - freqtrade.optimize.backtesting - INFO - Running backtesting for Strategy RSIDivergence
2021-04-07 22:06:54,309 - freqtrade.optimize.backtesting - INFO - Backtesting with data from 2017-11-26 08:20:00 up to 2021-04-06 21:20:00 (1227 days)..
```

this is how I load `informative_pairs`
```py
    def informative_pairs(self):
        """
        Define additional, informative pair/interval combinations to be cached from the exchange.
        These pair/interval combinations are non-tradeable, unless they are part
        of the whitelist as well.
        For more information, please consult the documentation
        :return: List of tuples in the format (pair, interval)
            Sample: return [("ETH/USDT", "5m"),
                            ("BTC/USDT", "15m"),
                            ]
        """
        # get access to all pairs available in whitelist.
        pairs = self.dp.current_whitelist()
        pairs += ["BTC/USDT"]
        # Assign tf to each pair so they can be downloaded and cached for strategy.
        informative_pairs = [(pair, '4h') for pair in pairs]
        informative_pairs = [(pair, '1h') for pair in pairs]
        # Optionally Add additional "static" pairs
        informative_pairs += [("BTC/USDT", self.timeframe)]
        return informative_pairs
```

and then merge them:
```py
    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        inf_long_tf = '1h'
        inf_tf = self.timeframe
        inf_pair = 'BTC/USDT'

        informative = self.dp.get_pair_dataframe(pair=inf_pair, timeframe=inf_long_tf)
        # Get the 14 day rsi
        informative['rsi'] = ta.ADX(informative)
        informative = merge_informative_pair(
            self.dp.get_pair_dataframe(pair=inf_pair, timeframe=inf_tf), informative, self.timeframe, inf_long_tf, ffill=True)

        informative['rsi'] = ta.RSI(dataframe)
        informative = findDivergences(informative)
        dataframe = merge_informative_pair(
            informative, informative[['date', 'found_divergence_regular', 'found_divergence_hidden', 'found_divergence_marker']].copy(),  self.timeframe, inf_long_tf, ffill=True)

```
