### PR TITLE
Retry accessing the database, if it's too busy. Applicable when the UI pummels large databases.

### DIFF
--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -15,6 +15,7 @@ from freqtrade.exceptions import OperationalException, TemporaryError
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.state import State
 
+from sqlalchemy.exc import OperationalError
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,9 @@ class Worker:
 
             logger.exception('OperationalException. Stopping trader ...')
             self.freqtrade.state = State.STOPPED
+        except OperationalError as error:
+            logger.warning(f"Warning: {error}, retrying in half a second...")
+            time.sleep(0.5)
 
     def _reconfigure(self) -> None:
         """


### PR DESCRIPTION
## Summary of the purpose of the PR
This solidifies solving #4653 once and for all, because we determined that FT is most probably perfectly thread safe and handles SQLAlchemy session creation well (because every session has its unique ID on each thread), however it appears normal for the sqlite file itself to be locked at the sqlite library level when thousands of old trades are requested at the same time (I can not reproduce the problem on a small database but I can do it easily on a database of thousands of old trades by pummeling the reload button of the Trade tab of the UI even on a relatively fast PC).

## Detailed justification
This is justified for the following reasons:

1. We have determined that FT does nothing wrong with thread safety or SQLAlchemy session handling because each thread has its own unique session ID during debugging; however:
2. The SQLite database file may be busy during very lengthy operations when it is big enough and the entire length of a table is requested at the same time; so it should be retried:
3. Every backtrace involves self.freqtrade.process() at worker.py which already includes similar exception handling so it's elegant and simple and very short to do it there.

## Expected behavior
Step1: Get a large database of thousands of old trades and keep pummeling the Reload button of the Trade tab of the UI

Step2: The software may catch the problem:
```
freqtrade.worker - INFO - Bot heartbeat. PID=25401, version='develop-8b102f457', state='RUNNING'
freqtrade.worker - WARNING - Warning: [..] (sqlite3.OperationalError) database is locked[..], retrying in half a second...
freqtrade.worker - INFO - Bot heartbeat. PID=25401, version='develop-8b102f457', state='RUNNING'
```
Step 3: Success; the trading continues as normal in half a second; it affected nothing and it does not affect those without the issue.