### PR TITLE
Fixes FTX stoploss on echange throwing an error

### DIFF
--- a/freqtrade/exchange/ftx.py
+++ b/freqtrade/exchange/ftx.py
@@ -63,10 +63,11 @@ class Ftx(Exchange):
                 # set orderPrice to place limit order, otherwise it's a market order
                 params['orderPrice'] = limit_rate
 
+            params['stopPrice'] = stop_price
             amount = self.amount_to_precision(pair, amount)
 
             order = self._api.create_order(symbol=pair, type=ordertype, side='sell',
-                                           amount=amount, price=stop_price, params=params)
+                                           amount=amount, params=params)
             logger.info('stoploss order added for %s. '
                         'stop price: %s.', pair, stop_price)
             return order

--- a/tests/exchange/test_ftx.py
+++ b/tests/exchange/test_ftx.py
@@ -39,8 +39,9 @@ def test_stoploss_order_ftx(default_conf, mocker):
     assert api_mock.create_order.call_args_list[0][1]['type'] == STOPLOSS_ORDERTYPE
     assert api_mock.create_order.call_args_list[0][1]['side'] == 'sell'
     assert api_mock.create_order.call_args_list[0][1]['amount'] == 1
-    assert api_mock.create_order.call_args_list[0][1]['price'] == 190
     assert 'orderPrice' not in api_mock.create_order.call_args_list[0][1]['params']
+    assert 'stopPrice' in api_mock.create_order.call_args_list[0][1]['params']
+    assert api_mock.create_order.call_args_list[0][1]['params']['stopPrice'] == 190
 
     assert api_mock.create_order.call_count == 1
 
@@ -55,8 +56,8 @@ def test_stoploss_order_ftx(default_conf, mocker):
     assert api_mock.create_order.call_args_list[0][1]['type'] == STOPLOSS_ORDERTYPE
     assert api_mock.create_order.call_args_list[0][1]['side'] == 'sell'
     assert api_mock.create_order.call_args_list[0][1]['amount'] == 1
-    assert api_mock.create_order.call_args_list[0][1]['price'] == 220
     assert 'orderPrice' not in api_mock.create_order.call_args_list[0][1]['params']
+    assert api_mock.create_order.call_args_list[0][1]['params']['stopPrice'] == 220
 
     api_mock.create_order.reset_mock()
     order = exchange.stoploss(pair='ETH/BTC', amount=1, stop_price=220,
@@ -69,9 +70,9 @@ def test_stoploss_order_ftx(default_conf, mocker):
     assert api_mock.create_order.call_args_list[0][1]['type'] == STOPLOSS_ORDERTYPE
     assert api_mock.create_order.call_args_list[0][1]['side'] == 'sell'
     assert api_mock.create_order.call_args_list[0][1]['amount'] == 1
-    assert api_mock.create_order.call_args_list[0][1]['price'] == 220
     assert 'orderPrice' in api_mock.create_order.call_args_list[0][1]['params']
     assert api_mock.create_order.call_args_list[0][1]['params']['orderPrice'] == 217.8
+    assert api_mock.create_order.call_args_list[0][1]['params']['stopPrice'] == 220
 
     # test exception handling
     with pytest.raises(DependencyException):


### PR DESCRIPTION
## Summary
Stoploss price should be set as param instead of passing it as price according to ccxt
