### PR TITLE
update conda dependencies to make compatible with tables package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 # - defaults
 dependencies:
 # 1/4 req main
-    - python>=3.7
+    - python>=3.7,<3.9
     - numpy
     - pandas
     - pip


### PR DESCRIPTION
## Summary
restrict python version in conda's environment.yml to fix installation issues due to current incompatibility of tables package with python 3.9

## Quick changelog

- restrict python version in environment.yml for conda to be <3.9

## What's new?
Conda environment creation fixed 