### PR TITLE
/balance should use cached tickers when possible

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -86,7 +86,7 @@ class Exchange:
         self._last_markets_refresh: int = 0
 
         # Cache for 10 minutes ...
-        self._fetch_tickers_cache = TTLCache(maxsize=1, ttl=60 * 10)
+        self._fetch_tickers_cache: TTLCache = TTLCache(maxsize=1, ttl=60 * 10)
 
         # Holds candles
         self._klines: Dict[Tuple[str, str], DataFrame] = {}

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -442,7 +442,7 @@ class RPC:
         output = []
         total = 0.0
         try:
-            tickers = self._freqtrade.exchange.get_tickers()
+            tickers = self._freqtrade.exchange.get_tickers(cached=True)
         except (ExchangeError):
             raise RPCException('Error getting current tickers.')
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1319,6 +1319,14 @@ def test_get_tickers(default_conf, mocker, exchange_name):
     assert tickers['ETH/BTC']['ask'] == 1
     assert tickers['BCH/BTC']['bid'] == 0.6
     assert tickers['BCH/BTC']['ask'] == 0.5
+    assert api_mock.fetch_tickers.call_count == 1
+
+    api_mock.fetch_tickers.reset_mock()
+
+    # Cached ticker should not call api again
+    tickers2 = exchange.get_tickers(cached=True)
+    assert tickers2 == tickers
+    assert api_mock.fetch_tickers.call_count == 0
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
                            "get_tickers", "fetch_tickers")

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1327,6 +1327,8 @@ def test_get_tickers(default_conf, mocker, exchange_name):
     tickers2 = exchange.get_tickers(cached=True)
     assert tickers2 == tickers
     assert api_mock.fetch_tickers.call_count == 0
+    tickers2 = exchange.get_tickers(cached=False)
+    assert api_mock.fetch_tickers.call_count == 1
 
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
                            "get_tickers", "fetch_tickers")

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -569,6 +569,8 @@ def test_rpc_balance_handle(default_conf, mocker, tickers):
     result = rpc._rpc_balance(default_conf['stake_currency'], default_conf['fiat_display_currency'])
     assert prec_satoshi(result['total'], 12.309096315)
     assert prec_satoshi(result['value'], 184636.44472997)
+    assert tickers.call_count == 1
+    assert tickers.call_args.kwargs['cached'] is True
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -570,7 +570,7 @@ def test_rpc_balance_handle(default_conf, mocker, tickers):
     assert prec_satoshi(result['total'], 12.309096315)
     assert prec_satoshi(result['value'], 184636.44472997)
     assert tickers.call_count == 1
-    assert tickers.call_args.kwargs['cached'] is True
+    assert tickers.call_args[1]['cached'] is True
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -570,7 +570,7 @@ def test_rpc_balance_handle(default_conf, mocker, tickers):
     assert prec_satoshi(result['total'], 12.309096315)
     assert prec_satoshi(result['value'], 184636.44472997)
     assert tickers.call_count == 1
-    assert tickers.call_args[1]['cached'] is True
+    assert tickers.call_args_list[0][1]['cached'] is True
     assert 'USD' == result['symbol']
     assert result['currencies'] == [
         {'currency': 'BTC',


### PR DESCRIPTION
## Summary
/balance should use cached tickers when possible

This will speed up subsequent answers, and uptotheminute conversion rates are not really required.