### PR TITLE
Correct get_min_pair_stake_amount formula

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -539,7 +539,7 @@ class Exchange:
         # reserve some percent defined in config (5% default) + stoploss
         amount_reserve_percent = 1.0 + self._config.get('amount_reserve_percent',
                                                         DEFAULT_AMOUNT_RESERVE_PERCENT)
-        amount_reserve_percent += abs(stoploss)
+        amount_reserve_percent /= 1 - abs(stoploss)
         # it should not be more than 50%
         amount_reserve_percent = max(min(amount_reserve_percent, 1.5), 1)
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -539,7 +539,7 @@ class Exchange:
         # reserve some percent defined in config (5% default) + stoploss
         amount_reserve_percent = 1.0 + self._config.get('amount_reserve_percent',
                                                         DEFAULT_AMOUNT_RESERVE_PERCENT)
-        amount_reserve_percent /= 1 - abs(stoploss)
+        amount_reserve_percent /= 1 - abs(stoploss) if abs(stoploss) < 1 else 1.5
         # it should not be more than 50%
         amount_reserve_percent = max(min(amount_reserve_percent, 1.5), 1)
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -383,7 +383,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, 2 * 2 * 1.1)
+    assert isclose(result, (2 * 2)*((1+0.5)/1-0.1))
 
     # min amount and cost are set (cost is minimal)
     markets["ETH/BTC"]["limits"] = {
@@ -395,7 +395,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, max(2, 2 * 2) * 1.1)
+    assert isclose(result, max(2, 2 * 2) * ((1+0.5)/1-0.1))
 
     # min amount and cost are set (amount is minial)
     markets["ETH/BTC"]["limits"] = {
@@ -407,10 +407,10 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, max(8, 2 * 2) * 1.1)
+    assert isclose(result, max(8, 2 * 2) * ((1+0.5)/1-0.1))
 
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4)
-    assert isclose(result, max(8, 2 * 2) * 1.45)
+    assert isclose(result, max(8, 2 * 2) * ((1+0.5)/1-0.4))
 
     # Really big stoploss
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1)
@@ -432,7 +432,7 @@ def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss)
-    assert round(result, 8) == round(max(0.0001, 0.001 * 0.020405) * 1.1, 8)
+    assert round(result, 8) == round(max(0.0001, 0.001 * 0.020405) * ((1+0.5)/1-0.05), 8)
 
 
 def test_set_sandbox(default_conf, mocker):


### PR DESCRIPTION
## Summary
Fix get_min_pair_stake_amount formula.

## What's new?
If I understand well, the goal is to have stoploss price above the minimum required by the exchange, which is not what has been achieved so far.
Only if amount_reserve_percent = (1 + pad) / (1 - abs(stoploss)) we get final stake amount * (1 - abs(stoploss)) > minimum required.

Here is a code example, with numbers from the example in the doc for this function:
```
stoploss = 0.1
padding = 0.05
min_required_exchange_cost = 10
min_required_exchange_amount = 12
min_required_exchange = max(min_required_exchange_cost, min_required_exchange_amount)
min_required_with_padding = min_required_exchange * (1 + padding)

min_stake_amount = min_required_exchange * max(min(padding + stoploss + 1, 1.5), 1)
stoploss_price = min_stake_amount*(1-stoploss)
print(f'[OLD LOGIC] stoploss_price ({stoploss_price}) < min_required_with_padding ({min_required_with_padding})')

min_stake_amount = min_required_exchange * max(min((1+padding) / (1-stoploss), 1.5), 1)
stoploss_price = min_stake_amount*(1-stoploss)
print(f'[NEW LOGIC] stoploss_price ({stoploss_price}) > min_required_with_padding ({min_required_with_padding})')
```
