### PR TITLE
Correct get_min_pair_stake_amount formula

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,7 @@ This exchange has also a limit on USD - where all orders must be > 10$ - which h
 
 To guarantee safe execution, freqtrade will not allow buying with a stake-amount of 10.1$, instead, it'll make sure that there's enough space to place a stoploss below the pair (+ an offset, defined by `amount_reserve_percent`, which defaults to 5%).
 
-With a stoploss of 10% - we'd therefore end up with a value of ~13.8$ (`12 * (1 + 0.05 + 0.1)`).
+With a reserve of 5%, the minimum stake amount would be ~12.6$ (`12 * (1 + 0.05)`). If we take in account a stoploss of 10% on top of that - we'd end up with a value of ~14$ (`12.6 / (1 - 0.1)`).
 
 To limit this calculation in case of large stoploss values, the calculated minimum stake-limit will never be more than 50% above the real limit.
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -541,7 +541,7 @@ class Exchange:
                                                         DEFAULT_AMOUNT_RESERVE_PERCENT)
         amount_reserve_percent = (
           amount_reserve_percent / (1 - abs(stoploss)) if abs(stoploss) != 1 else 1.5
-        )     
+        )
         # it should not be more than 50%
         amount_reserve_percent = max(min(amount_reserve_percent, 1.5), 1)
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -539,7 +539,9 @@ class Exchange:
         # reserve some percent defined in config (5% default) + stoploss
         amount_reserve_percent = 1.0 + self._config.get('amount_reserve_percent',
                                                         DEFAULT_AMOUNT_RESERVE_PERCENT)
-        amount_reserve_percent += abs(stoploss)
+        amount_reserve_percent = (
+          amount_reserve_percent / (1 - abs(stoploss)) if abs(stoploss) != 1 else 1.5
+        )     
         # it should not be more than 50%
         amount_reserve_percent = max(min(amount_reserve_percent, 1.5), 1)
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -410,7 +410,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     assert isclose(result, max(8, 2 * 2) * (1+0.05) / (1-abs(stoploss)))
 
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4)
-    assert isclose(result, max(8, 2 * 2) * (1+0.05) / (1-abs(-0.4)))
+    assert isclose(result, max(8, 2 * 2) * 1.5)
 
     # Really big stoploss
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1)

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -371,7 +371,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 1, stoploss)
-    assert isclose(result, 2 * 1.1)
+    assert isclose(result, 2 * (1+0.05) / (1-abs(stoploss)))
 
     # min amount is set
     markets["ETH/BTC"]["limits"] = {
@@ -383,7 +383,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, 2 * 2 * 1.1)
+    assert isclose(result, 2 * 2 * (1+0.05) / (1-abs(stoploss)))
 
     # min amount and cost are set (cost is minimal)
     markets["ETH/BTC"]["limits"] = {
@@ -395,7 +395,7 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, max(2, 2 * 2) * 1.1)
+    assert isclose(result, max(2, 2 * 2) * (1+0.05) / (1-abs(stoploss)))
 
     # min amount and cost are set (amount is minial)
     markets["ETH/BTC"]["limits"] = {
@@ -407,10 +407,10 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
-    assert isclose(result, max(8, 2 * 2) * 1.1)
+    assert isclose(result, max(8, 2 * 2) * (1+0.05) / (1-abs(stoploss)))
 
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4)
-    assert isclose(result, max(8, 2 * 2) * 1.45)
+    assert isclose(result, max(8, 2 * 2) * (1+0.05) / (1-abs(-0.4)))
 
     # Really big stoploss
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1)
@@ -432,7 +432,7 @@ def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss)
-    assert round(result, 8) == round(max(0.0001, 0.001 * 0.020405) * 1.1, 8)
+    assert round(result, 8) == round(max(0.0001, 0.001 * 0.020405) * (1+0.05) / (1-abs(stoploss)), 8)
 
 
 def test_set_sandbox(default_conf, mocker):

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -432,7 +432,10 @@ def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
         PropertyMock(return_value=markets)
     )
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss)
-    assert round(result, 8) == round(max(0.0001, 0.001 * 0.020405) * (1+0.05) / (1-abs(stoploss)), 8)
+    assert round(result, 8) == round(
+        max(0.0001, 0.001 * 0.020405) * (1+0.05) / (1-abs(stoploss)),
+        8
+    )
 
 
 def test_set_sandbox(default_conf, mocker):


### PR DESCRIPTION
## Summary
Fix get_min_pair_stake_amount formula.

## What's new?
If I understand well, the goal is to have stoploss price above the minimum required by the exchange + a reserve, which is not what has been achieved so far.
Only if `amount_reserve_percent = (1 + pad) / (1 - abs(stoploss))` we get `final stake amount * (1 - abs(stoploss)) > minimum required`.

The maths:
The reserve of 5% above the minimum stake amount required by the exchange: `reserve = config['amount_reserve_percent']`
The minimum stake amount required by the exchange: `min_required_by_exchange = max(markets['limits']['cost']['min'], markets['limits']['amount']['min'] * price)`
We want the stake amount of the stoploss to be above the minimum + the reserve: `min_stoploss_stake_amount > min_required_by_exchange * (1 + reserve)`
We know that, for a stoploss expressed with a positive float:`min_stoploss_stake_amount = min_buy_stake_amount * (1 - stoploss)`
So, `min_buy_stake_amount * (1 - stoploss) > min_required_by_exchange * (1 + reserve)`
Then `min_buy_stake_amount > min_required_by_exchange * (1 + reserve) / (1 - stoploss)`


Here is a code example, with numbers from the example in the doc for this function:
```
# Inputs
markets = {
    'limits': {
        'cost': {
            'min': 10
        },
        'amount': {
            'min': 20
        }
    }
}

price = 0.6
config = {
    'amount_reserve_percent': 0.05
}

stoploss = -0.1

# Common to both old and new logic
min_required_by_exchange = max(markets['limits']['cost']['min'], 
                               markets['limits']['amount']['min'] * price)

# We want both the stoploss stake amount and the buy order stake amount to be above this value
min_required_by_exchange_with_reserve = min_required_by_exchange * (1 + config['amount_reserve_percent'])

# OLD LOGIC (min_stake_amount would be the value returned by get_min_pair_stake_amount formula)
min_stake_amount =  min_required_by_exchange *\
                    (1 + config['amount_reserve_percent'] + abs(stoploss))
stoploss_stake_amount = min_stake_amount * (1 + stoploss)
assert stoploss_stake_amount >= round(min_required_by_exchange_with_reserve, 8), 'Stoploss should be >= min stake amount required by exchange + pad'

# NEW LOGIC
min_stake_amount = min_required_by_exchange *\
                    ((1 + config['amount_reserve_percent']) / (1 - abs(stoploss)))
stoploss_stake_amount = min_stake_amount * (1 + stoploss)
assert stoploss_stake_amount >= round(min_required_by_exchange_with_reserve, 8), 'Stoploss should be >= min stake amount required by exchange + pad'
```
