### PR TITLE
remove `copy()` from `custom_info` example

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -57,7 +57,7 @@ class AwesomeStrategy(IStrategy):
         dataframe['atr'] = ta.ATR(dataframe)
         if self.dp.runmode.value in ('backtest', 'hyperopt'):
           # add indicator mapped to correct DatetimeIndex to custom_info
-          self.custom_info[metadata['pair']] = dataframe[['date', 'atr']].copy().set_index('date')
+          self.custom_info[metadata['pair']] = dataframe[['date', 'atr']].set_index('date')
         return dataframe
 ```
 


### PR DESCRIPTION
`set_index` automatically copies if not stated otherwise with `inplace=True`
> inplacebool, default False
If True, modifies the DataFrame in place (do not create a new object).

from: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.set_index.html?highlight=set_index#pandas.DataFrame.set_index
