### PR TITLE
Add IStrategy.custom_sell method which allows per-trade sell signal evaluation

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -69,6 +69,20 @@ class AwesomeStrategy(IStrategy):
 
 See `custom_stoploss` examples below on how to access the saved dataframe columns
 
+## Custom sell signal
+
+It is possible to define custom sell signals. This is very useful when we need to customize sell conditions for each individual trade.
+
+An example of how we can sell trades that were open longer than 1 day:
+
+``` python
+class AwesomeStrategy(IStrategy):
+    def custom_sell(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
+                    current_profit: float, **kwargs) -> bool:
+        time_delta = datetime.datetime.utcnow() - trade.open_date_utc
+        return time_delta.days >= 1
+```
+
 ## Custom stoploss
 
 The stoploss price can only ever move upwards - if the stoploss value returned from `custom_stoploss` would result in a lower stoploss price than was previously set, it will be ignored. The traditional `stoploss` value serves as an absolute lower level and will be instated as the initial stoploss.

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -52,8 +52,8 @@ An example of how we can set stop-loss and take-profit targets in the dataframe 
 class AwesomeStrategy(IStrategy):
     def custom_sell(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
                     current_profit: float, dataframe: Dataframe, **kwargs) -> bool:
-        trade_row = dataframe.loc[timeframe_to_prev_date(trade.open_date_utc)]
-        
+        trade_row = dataframe.loc[dataframe['date'] == timeframe_to_prev_date(trade.open_date_utc)].squeeze()
+
         # Sell when price falls below value in stoploss column of taken buy signal.
         if 'stop_loss' in trade_row:
             if current_rate <= trade_row['stop_loss'] < trade.open_rate:
@@ -292,7 +292,7 @@ class AwesomeStrategy(IStrategy):
             # be rounded to previous candle to be used as dataframe index. Rounding must also be 
             # applied to `trade.open_date(_utc)` if it is used for `dataframe` indexing.
             current_time = timeframe_to_prev_date(self.timeframe, current_time)
-            current_row = dataframe.loc[current_time]
+            current_row = dataframe.loc[dataframe['date'] == current_time].squeeze()
             if 'atr' in current_row:
                 # new stoploss relative to current_rate
                 new_stoploss = (current_rate - current_row['atr']) / current_rate

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -270,10 +270,10 @@ Imagine you want to use `custom_stoploss()` to use a trailing indicator like e.g
     see [Common mistakes when developing strategies](strategy-customization.md#common-mistakes-when-developing-strategies) for more info.
 
 !!! Note
-    `dataframe` is indexed by candle date. During dry/live runs `current_time` and
-    `trade.open_date_utc` will not match candle dates precisely and using them as indices will throw
-    an error. Use `date = timeframe_to_prev_date(self.timeframe, date)` to round a date to previous
-    candle before using it as a `dataframe` index.
+    `dataframe['date']` contains the candle's open date. During dry/live runs `current_time` and
+    `trade.open_date_utc` will not match the candle date precisely and using them directly will throw
+    an error. Use `date = timeframe_to_prev_date(self.timeframe, date)` to round a date to the candle's open date
+    before using it to access `dataframe`.
 
 ``` python
 from freqtrade.exchange import timeframe_to_prev_date

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -631,9 +631,10 @@ Stoploss values returned from `custom_stoploss` must specify a percentage relati
         use_custom_stoploss = True
 
         def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                            current_rate: float, current_profit: float, **kwargs) -> float:
+                            current_rate: float, current_profit: float, dataframe: DataFrame,
+                            **kwargs) -> float:
 
-            # once the profit has risin above 10%, keep the stoploss at 7% above the open price
+            # once the profit has risen above 10%, keep the stoploss at 7% above the open price
             if current_profit > 0.10:
                 return stoploss_from_open(0.07, current_profit)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -961,7 +961,7 @@ class FreqtradeBot(LoggingMixin):
 
         if should_sell.sell_flag:
             logger.info(f'Executing Sell for {trade.pair}. Reason: {should_sell.sell_type}')
-            self.execute_sell(trade, sell_rate, should_sell.sell_type)
+            self.execute_sell(trade, sell_rate, should_sell.sell_type, should_sell.sell_reason)
             return True
         return False
 
@@ -1150,12 +1150,15 @@ class FreqtradeBot(LoggingMixin):
             raise DependencyException(
                 f"Not enough amount to sell. Trade-amount: {amount}, Wallet: {wallet_amount}")
 
-    def execute_sell(self, trade: Trade, limit: float, sell_reason: SellType) -> bool:
+    def execute_sell(self, trade: Trade, limit: float, sell_reason: SellType,
+                     custom_reason: Optional[str] = None) -> bool:
         """
         Executes a limit sell for the given trade and limit
         :param trade: Trade instance
         :param limit: limit rate for the sell order
-        :param sellreason: Reason the sell was triggered
+        :param sell_reason: Reason the sell was triggered
+        :param custom_reason: A custom sell reason. Provided only if
+        sell_reason == SellType.CUSTOM_SELL,
         :return: True if it succeeds (supported) False (not supported)
         """
         sell_type = 'sell'
@@ -1213,7 +1216,7 @@ class FreqtradeBot(LoggingMixin):
         trade.open_order_id = order['id']
         trade.sell_order_status = ''
         trade.close_rate_requested = limit
-        trade.sell_reason = sell_reason.value
+        trade.sell_reason = custom_reason or sell_reason.value
         # In case of market sell orders the order can be closed immediately
         if order.get('status', 'unknown') == 'closed':
             self.update_trade_state(trade, trade.open_order_id, order)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 import arrow
 from cachetools import TTLCache
+from pandas import DataFrame
 
 from freqtrade import __version__, constants
 from freqtrade.configuration import validate_config_consistency
@@ -783,10 +784,10 @@ class FreqtradeBot(LoggingMixin):
 
         config_ask_strategy = self.config.get('ask_strategy', {})
 
+        analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
+                                                                  self.strategy.timeframe)
         if (config_ask_strategy.get('use_sell_signal', True) or
                 config_ask_strategy.get('ignore_roi_if_buy_signal', False)):
-            analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
-                                                                      self.strategy.timeframe)
 
             (buy, sell) = self.strategy.get_signal(trade.pair, self.strategy.timeframe, analyzed_df)
 
@@ -813,13 +814,13 @@ class FreqtradeBot(LoggingMixin):
                 # resulting in outdated RPC messages
                 self._sell_rate_cache[trade.pair] = sell_rate
 
-                if self._check_and_execute_sell(trade, sell_rate, buy, sell):
+                if self._check_and_execute_sell(analyzed_df, trade, sell_rate, buy, sell):
                     return True
 
         else:
             logger.debug('checking sell')
             sell_rate = self.get_sell_rate(trade.pair, True)
-            if self._check_and_execute_sell(trade, sell_rate, buy, sell):
+            if self._check_and_execute_sell(analyzed_df, trade, sell_rate, buy, sell):
                 return True
 
         logger.debug('Found no sell signal for %s.', trade)
@@ -950,13 +951,13 @@ class FreqtradeBot(LoggingMixin):
                     logger.warning(f"Could not create trailing stoploss order "
                                    f"for pair {trade.pair}.")
 
-    def _check_and_execute_sell(self, trade: Trade, sell_rate: float,
+    def _check_and_execute_sell(self, dataframe: DataFrame, trade: Trade, sell_rate: float,
                                 buy: bool, sell: bool) -> bool:
         """
         Check and execute sell
         """
         should_sell = self.strategy.should_sell(
-            trade, sell_rate, datetime.now(timezone.utc), buy, sell,
+            dataframe, trade, sell_rate, datetime.now(timezone.utc), buy, sell,
             force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0
         )
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1194,7 +1194,7 @@ class FreqtradeBot(LoggingMixin):
         if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=True)(
                 pair=trade.pair, trade=trade, order_type=order_type, amount=amount, rate=limit,
                 time_in_force=time_in_force,
-                sell_reason=sell_reason.sell_type.value):
+                sell_reason=sell_reason.sell_reason):
             logger.info(f"User requested abortion of selling {trade.pair}")
             return False
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -851,7 +851,7 @@ class FreqtradeBot(LoggingMixin):
             logger.error(f'Unable to place a stoploss order on exchange. {e}')
             logger.warning('Selling the trade forcefully')
             self.execute_sell(trade, trade.stop_loss, sell_reason=SellCheckTuple(
-                sell_flag=True, sell_type=SellType.EMERGENCY_SELL))
+                sell_type=SellType.EMERGENCY_SELL))
 
         except ExchangeError:
             trade.stoploss_order_id = None

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1158,8 +1158,6 @@ class FreqtradeBot(LoggingMixin):
         :param trade: Trade instance
         :param limit: limit rate for the sell order
         :param sell_reason: Reason the sell was triggered
-        :param custom_reason: A custom sell reason. Provided only if
-        sell_reason == SellType.CUSTOM_SELL,
         :return: True if it succeeds (supported) False (not supported)
         """
         sell_type = 'sell'

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -255,7 +255,7 @@ class Backtesting:
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
 
         if sell.sell_flag:
-            trade.close_date = sell_row[DATE_IDX]
+            trade.close_date = sell_row[DATE_IDX].to_pydatetime()
             trade.sell_reason = sell.sell_reason
             trade_dur = int((trade.close_date_utc - trade.open_date_utc).total_seconds() // 60)
             closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
@@ -294,7 +294,7 @@ class Backtesting:
             trade = LocalTrade(
                 pair=pair,
                 open_rate=row[OPEN_IDX],
-                open_date=row[DATE_IDX],
+                open_date=row[DATE_IDX].to_pydatetime(),
                 stake_amount=stake_amount,
                 amount=round(stake_amount / row[OPEN_IDX], 8),
                 fee_open=self.fee,
@@ -316,7 +316,7 @@ class Backtesting:
                 for trade in open_trades[pair]:
                     sell_row = data[pair][-1]
 
-                    trade.close_date = sell_row[DATE_IDX]
+                    trade.close_date = sell_row[DATE_IDX].to_pydatetime()
                     trade.sell_reason = SellType.FORCE_SELL.value
                     trade.close(sell_row[OPEN_IDX], show_msg=False)
                     LocalTrade.close_bt_trade(trade)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -247,9 +247,10 @@ class Backtesting:
         else:
             return sell_row[OPEN_IDX]
 
-    def _get_sell_trade_entry(self, trade: LocalTrade, sell_row: Tuple) -> Optional[LocalTrade]:
+    def _get_sell_trade_entry(self, dataframe: DataFrame, trade: LocalTrade,
+                              sell_row: Tuple) -> Optional[LocalTrade]:
 
-        sell = self.strategy.should_sell(trade, sell_row[OPEN_IDX],  # type: ignore
+        sell = self.strategy.should_sell(dataframe, trade, sell_row[OPEN_IDX],  # type: ignore
                                          sell_row[DATE_IDX], sell_row[BUY_IDX], sell_row[SELL_IDX],
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
 
@@ -396,7 +397,7 @@ class Backtesting:
 
                 for trade in open_trades[pair]:
                     # also check the buying candle for sell conditions.
-                    trade_entry = self._get_sell_trade_entry(trade, row)
+                    trade_entry = self._get_sell_trade_entry(processed[pair], trade, row)
                     # Sell occured
                     if trade_entry:
                         # logger.debug(f"{pair} - Backtesting sell {trade}")

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -251,7 +251,8 @@ class Backtesting:
                               sell_row: Tuple) -> Optional[LocalTrade]:
 
         sell = self.strategy.should_sell(dataframe, trade, sell_row[OPEN_IDX],  # type: ignore
-                                         sell_row[DATE_IDX], sell_row[BUY_IDX], sell_row[SELL_IDX],
+                                         sell_row[DATE_IDX].to_pydatetime(), sell_row[BUY_IDX],
+                                         sell_row[SELL_IDX],
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
 
         if sell.sell_flag:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -255,7 +255,7 @@ class Backtesting:
 
         if sell.sell_flag:
             trade.close_date = sell_row[DATE_IDX]
-            trade.sell_reason = sell.sell_type.value
+            trade.sell_reason = sell.sell_reason or sell.sell_type.value
             trade_dur = int((trade.close_date_utc - trade.open_date_utc).total_seconds() // 60)
             closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -256,7 +256,7 @@ class Backtesting:
 
         if sell.sell_flag:
             trade.close_date = sell_row[DATE_IDX]
-            trade.sell_reason = sell.sell_reason or sell.sell_type.value
+            trade.sell_reason = sell.sell_reason
             trade_dur = int((trade.close_date_utc - trade.open_date_utc).total_seconds() // 60)
             closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
 
@@ -266,7 +266,7 @@ class Backtesting:
                     pair=trade.pair, trade=trade, order_type='limit', amount=trade.amount,
                     rate=closerate,
                     time_in_force=time_in_force,
-                    sell_reason=sell.sell_type.value):
+                    sell_reason=sell.sell_reason):
                 return None
 
             trade.close(closerate, show_msg=False)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -24,7 +24,7 @@ from freqtrade.persistence.models import PairLock
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.state import State
-from freqtrade.strategy.interface import SellType
+from freqtrade.strategy.interface import SellCheckTuple, SellType
 
 
 logger = logging.getLogger(__name__)
@@ -554,7 +554,8 @@ class RPC:
             if not fully_canceled:
                 # Get current rate and execute sell
                 current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
-                self._freqtrade.execute_sell(trade, current_rate, SellType.FORCE_SELL)
+                sell_reason = SellCheckTuple(sell_flag=True, sell_type=SellType.FORCE_SELL)
+                self._freqtrade.execute_sell(trade, current_rate, sell_reason)
         # ---- EOF def _exec_forcesell ----
 
         if self._freqtrade.state != State.RUNNING:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -554,7 +554,7 @@ class RPC:
             if not fully_canceled:
                 # Get current rate and execute sell
                 current_rate = self._freqtrade.get_sell_rate(trade.pair, False)
-                sell_reason = SellCheckTuple(sell_flag=True, sell_type=SellType.FORCE_SELL)
+                sell_reason = SellCheckTuple(sell_type=SellType.FORCE_SELL)
                 self._freqtrade.execute_sell(trade, current_rate, sell_reason)
         # ---- EOF def _exec_forcesell ----
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -579,7 +579,8 @@ class IStrategy(ABC, HyperStrategyMixin):
                 sell_signal = SellType.SELL_SIGNAL
             else:
                 custom_reason = strategy_safe_wrapper(self.custom_sell, default_retval=False)(
-                    trade.pair, trade, date, current_rate, current_profit, dataframe)
+                    pair=trade.pair, trade=trade, current_time=date, current_rate=current_rate,
+                    current_profit=current_profit, dataframe=dataframe)
                 if custom_reason:
                     sell_signal = SellType.CUSTOM_SELL
                     if isinstance(custom_reason, str):
@@ -598,8 +599,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         # Sell-signal
         # Stoploss
         if roi_reached and stoplossflag.sell_type != SellType.STOP_LOSS:
-            logger.debug(f"{trade.pair} - Required profit reached. "
-                         f"sell_type=SellType.ROI")
+            logger.debug(f"{trade.pair} - Required profit reached. sell_type=SellType.ROI")
             return SellCheckTuple(sell_type=SellType.ROI)
 
         if sell_signal != SellType.NONE:
@@ -610,8 +610,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         if stoplossflag.sell_flag:
 
-            logger.debug(f"{trade.pair} - Stoploss hit. "
-                         f"sell_type={stoplossflag.sell_type}")
+            logger.debug(f"{trade.pair} - Stoploss hit. sell_type={stoplossflag.sell_type}")
             return stoplossflag
 
         # This one is noisy, commented out...

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -290,6 +290,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_time: datetime object, containing the current datetime
         :param current_rate: Rate, calculated based on pricing settings in ask_strategy.
         :param current_profit: Current profit (as ratio), calculated based on current_rate.
+        :param dataframe: Analyzed dataframe for this pair. Can contain future data in backtesting.
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return float: New stoploss value, relative to the currentrate
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -572,12 +572,14 @@ class IStrategy(ABC, HyperStrategyMixin):
                     trade.pair, trade, date, current_rate, current_profit)
                 if custom_reason:
                     sell_signal = SellType.CUSTOM_SELL
-                    if isinstance(custom_reason, bool):
-                        custom_reason = None
-                    elif isinstance(custom_reason, str):
+                    if isinstance(custom_reason, str):
                         if len(custom_reason) > CUSTOM_SELL_MAX_LENGTH:
-                            raise OperationalException('Custom sell reason returned '
-                                                       'from custom_sell is too long.')
+                            logger.warning(f'Custom sell reason returned from custom_sell is too '
+                                           f'long and was trimmed to {CUSTOM_SELL_MAX_LENGTH} '
+                                           f'characters.')
+                            custom_reason = custom_reason[:CUSTOM_SELL_MAX_LENGTH]
+                    else:
+                        custom_reason = None
             # TODO: return here if sell-signal should be favored over ROI
 
         # Start evaluations

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -59,9 +59,9 @@ class SellCheckTuple(object):
     NamedTuple for Sell type + reason
     """
     sell_type: SellType
-    sell_reason: Optional[str]
+    sell_reason: str = ''
 
-    def __init__(self, sell_type: SellType, sell_reason: Optional[str] = None):
+    def __init__(self, sell_type: SellType, sell_reason: str = ''):
         self.sell_type = sell_type
         self.sell_reason = sell_reason or sell_type.value
 
@@ -568,7 +568,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                                                 current_time=date))
 
         sell_signal = SellType.NONE
-        custom_reason = None
+        custom_reason = ''
         if (ask_strategy.get('sell_profit_only', False)
                 and current_profit <= ask_strategy.get('sell_profit_offset', 0)):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -274,7 +274,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         return True
 
     def custom_stoploss(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
-                        current_profit: float, **kwargs) -> float:
+                        current_profit: float, dataframe: DataFrame, **kwargs) -> float:
         """
         Custom stoploss logic, returning the new distance relative to current_rate (as ratio).
         e.g. returning -0.05 would create a stoploss 5% below current_rate.
@@ -296,7 +296,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         return self.stoploss
 
     def custom_sell(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
-                    current_profit: float, **kwargs) -> Optional[Union[str, bool]]:
+                    current_profit: float, dataframe: DataFrame,
+                    **kwargs) -> Optional[Union[str, bool]]:
         """
         Custom sell signal logic indicating that specified position should be sold. Returning a
         string or True from this method is equal to setting sell signal on a candle at specified
@@ -534,8 +535,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         else:
             return False
 
-    def should_sell(self, trade: Trade, rate: float, date: datetime, buy: bool,
-                    sell: bool, low: float = None, high: float = None,
+    def should_sell(self, dataframe: DataFrame, trade: Trade, rate: float, date: datetime,
+                    buy: bool, sell: bool, low: float = None, high: float = None,
                     force_stoploss: float = 0) -> SellCheckTuple:
         """
         This function evaluates if one of the conditions required to trigger a sell
@@ -551,8 +552,9 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         trade.adjust_min_max_rates(high or current_rate)
 
-        stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade,
-                                              current_time=date, current_profit=current_profit,
+        stoplossflag = self.stop_loss_reached(dataframe=dataframe, current_rate=current_rate,
+                                              trade=trade, current_time=date,
+                                              current_profit=current_profit,
                                               force_stoploss=force_stoploss, high=high)
 
         # Set current rate to high for backtesting sell
@@ -576,7 +578,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                 sell_signal = SellType.SELL_SIGNAL
             else:
                 custom_reason = strategy_safe_wrapper(self.custom_sell, default_retval=False)(
-                    trade.pair, trade, date, current_rate, current_profit)
+                    trade.pair, trade, date, current_rate, current_profit, dataframe)
                 if custom_reason:
                     sell_signal = SellType.CUSTOM_SELL
                     if isinstance(custom_reason, str):
@@ -615,7 +617,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         # logger.debug(f"{trade.pair} - No sell signal.")
         return SellCheckTuple(sell_type=SellType.NONE)
 
-    def stop_loss_reached(self, current_rate: float, trade: Trade,
+    def stop_loss_reached(self, dataframe: DataFrame, current_rate: float, trade: Trade,
                           current_time: datetime, current_profit: float,
                           force_stoploss: float, high: float = None) -> SellCheckTuple:
         """
@@ -633,7 +635,8 @@ class IStrategy(ABC, HyperStrategyMixin):
                                                     )(pair=trade.pair, trade=trade,
                                                       current_time=current_time,
                                                       current_rate=current_rate,
-                                                      current_profit=current_profit)
+                                                      current_profit=current_profit,
+                                                      dataframe=dataframe)
             # Sanity check - error cases will return None
             if stop_loss_value:
                 # logger.info(f"{trade.pair} {stop_loss_value=} {current_profit=}")

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -557,7 +557,8 @@ class IStrategy(ABC, HyperStrategyMixin):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal
             sell_signal = False
         elif ask_strategy.get('use_sell_signal', True):
-            sell = sell or self.custom_sell(trade.pair, trade, date, current_rate, current_profit)
+            sell = sell or strategy_safe_wrapper(self.custom_sell, default_retval=False)(
+                trade.pair, trade, date, current_rate, current_profit)
             sell_signal = sell and not buy
             # TODO: return here if sell-signal should be favored over ROI
         else:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -7,7 +7,7 @@ import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import arrow
 from pandas import DataFrame
@@ -54,13 +54,18 @@ class SellType(Enum):
         return self.value
 
 
-class SellCheckTuple(NamedTuple):
+class SellCheckTuple(object):
     """
     NamedTuple for Sell type + reason
     """
-    sell_flag: bool
+    sell_flag: bool     # TODO: Remove?
     sell_type: SellType
-    sell_reason: Optional[str] = None
+    sell_reason: Optional[str]
+
+    def __init__(self, sell_flag: bool, sell_type: SellType, sell_reason: Optional[str] = None):
+        self.sell_flag = sell_flag
+        self.sell_type = sell_type
+        self.sell_reason = sell_reason or sell_type.value
 
 
 class IStrategy(ABC, HyperStrategyMixin):
@@ -594,7 +599,8 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         if sell_signal != SellType.NONE:
             logger.debug(f"{trade.pair} - Sell signal received. sell_flag=True, "
-                         f"sell_type={sell_signal}, custom_reason={custom_reason}")
+                         f"sell_type=SellType.{sell_signal.name}" +
+                         (f", custom_reason={custom_reason}" if custom_reason else ""))
             return SellCheckTuple(sell_flag=True, sell_type=sell_signal, sell_reason=custom_reason)
 
         if stoplossflag.sell_flag:

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -14,8 +14,9 @@ def bot_loop_start(self, **kwargs) -> None:
 
 use_custom_stoploss = True
 
-def custom_stoploss(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,
-                    current_profit: float, **kwargs) -> float:
+def custom_stoploss(self, pair: str, trade: 'Trade', current_time: 'datetime',
+                    current_rate: float, current_profit: float, dataframe: DataFrame,
+                    **kwargs) -> float:
     """
     Custom stoploss logic, returning the new distance relative to current_rate (as ratio).
     e.g. returning -0.05 would create a stoploss 5% below current_rate.
@@ -31,6 +32,7 @@ def custom_stoploss(self, pair: str, trade: 'Trade', current_time: 'datetime', c
     :param current_time: datetime object, containing the current datetime
     :param current_rate: Rate, calculated based on pricing settings in ask_strategy.
     :param current_profit: Current profit (as ratio), calculated based on current_rate.
+    :param dataframe: Analyzed dataframe for this pair. Can contain future data in backtesting.
     :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
     :return float: New stoploss value, relative to the currentrate
     """

--- a/tests/strategy/test_default_strategy.py
+++ b/tests/strategy/test_default_strategy.py
@@ -41,4 +41,5 @@ def test_default_strategy(result, fee):
                                        rate=20000, time_in_force='gtc', sell_reason='roi') is True
 
     assert strategy.custom_stoploss(pair='ETH/BTC', trade=trade, current_time=datetime.now(),
-                                    current_rate=20_000, current_profit=0.05) == strategy.stoploss
+                                    current_rate=20_000, current_profit=0.05, dataframe=None
+                                    ) == strategy.stoploss

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -360,7 +360,7 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
     now = arrow.utcnow().datetime
     sl_flag = strategy.stop_loss_reached(current_rate=trade.open_rate * (1 + profit), trade=trade,
                                          current_time=now, current_profit=profit,
-                                         force_stoploss=0, high=None)
+                                         force_stoploss=0, high=None, dataframe=None)
     assert isinstance(sl_flag, SellCheckTuple)
     assert sl_flag.sell_type == expected
     if expected == SellType.NONE:
@@ -371,7 +371,7 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
 
     sl_flag = strategy.stop_loss_reached(current_rate=trade.open_rate * (1 + profit2), trade=trade,
                                          current_time=now, current_profit=profit2,
-                                         force_stoploss=0, high=None)
+                                         force_stoploss=0, high=None, dataframe=None)
     assert sl_flag.sell_type == expected2
     if expected2 == SellType.NONE:
         assert sl_flag.sell_flag is False

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -382,6 +382,50 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
     strategy.custom_stoploss = original_stopvalue
 
 
+def test_custom_sell(default_conf, fee, caplog) -> None:
+
+    default_conf.update({'strategy': 'DefaultStrategy'})
+
+    strategy = StrategyResolver.load_strategy(default_conf)
+    trade = Trade(
+        pair='ETH/BTC',
+        stake_amount=0.01,
+        amount=1,
+        open_date=arrow.utcnow().shift(hours=-1).datetime,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        exchange='binance',
+        open_rate=1,
+    )
+
+    now = arrow.utcnow().datetime
+    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+
+    assert res.sell_flag is False
+    assert res.sell_type == SellType.NONE
+
+    strategy.custom_sell = MagicMock(return_value=True)
+    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    assert res.sell_flag is True
+    assert res.sell_type == SellType.CUSTOM_SELL
+    assert res.sell_reason == 'custom_sell'
+
+    strategy.custom_sell = MagicMock(return_value='hello world')
+
+    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    assert res.sell_type == SellType.CUSTOM_SELL
+    assert res.sell_flag is True
+    assert res.sell_reason == 'hello world'
+
+    caplog.clear()
+    strategy.custom_sell = MagicMock(return_value='h' * 100)
+    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    assert res.sell_type == SellType.CUSTOM_SELL
+    assert res.sell_flag is True
+    assert res.sell_reason == 'h' * 64
+    assert log_has_re('Custom sell reason returned from custom_sell is too long.*', caplog)
+
+
 def test_analyze_ticker_default(ohlcv_history, mocker, caplog) -> None:
     caplog.set_level(logging.DEBUG)
     ind_mock = MagicMock(side_effect=lambda x, meta: x)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1973,7 +1973,7 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order_open,
     # if ROI is reached we must sell
     patch_get_signal(freqtrade, value=(False, True))
     assert freqtrade.handle_trade(trade)
-    assert log_has("ETH/BTC - Required profit reached. sell_flag=True, sell_type=SellType.ROI",
+    assert log_has("ETH/BTC - Required profit reached. sell_type=SellType.ROI",
                    caplog)
 
 
@@ -2002,7 +2002,7 @@ def test_handle_trade_use_sell_signal(
 
     patch_get_signal(freqtrade, value=(False, True))
     assert freqtrade.handle_trade(trade)
-    assert log_has("ETH/BTC - Sell signal received. sell_flag=True, sell_type=SellType.SELL_SIGNAL",
+    assert log_has("ETH/BTC - Sell signal received. sell_type=SellType.SELL_SIGNAL",
                    caplog)
 
 
@@ -2607,7 +2607,7 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, mocker) -> N
     )
     # Prevented sell ...
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.ROI))
+                           sell_reason=SellCheckTuple(sell_type=SellType.ROI))
     assert rpc_mock.call_count == 0
     assert freqtrade.strategy.confirm_trade_exit.call_count == 1
 
@@ -2615,7 +2615,7 @@ def test_execute_sell_up(default_conf, ticker, fee, ticker_sell_up, mocker) -> N
     freqtrade.strategy.confirm_trade_exit = MagicMock(return_value=True)
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.ROI))
+                           sell_reason=SellCheckTuple(sell_type=SellType.ROI))
     assert freqtrade.strategy.confirm_trade_exit.call_count == 1
 
     assert rpc_mock.call_count == 1
@@ -2667,7 +2667,7 @@ def test_execute_sell_down(default_conf, ticker, fee, ticker_sell_down, mocker) 
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_down()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.STOP_LOSS))
+                           sell_reason=SellCheckTuple(sell_type=SellType.STOP_LOSS))
 
     assert rpc_mock.call_count == 2
     last_msg = rpc_mock.call_args_list[-1][0][0]
@@ -2724,7 +2724,7 @@ def test_execute_sell_down_stoploss_on_exchange_dry_run(default_conf, ticker, fe
 
     trade.stop_loss = 0.00001099 * 0.99
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_down()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.STOP_LOSS))
+                           sell_reason=SellCheckTuple(sell_type=SellType.STOP_LOSS))
 
     assert rpc_mock.call_count == 2
     last_msg = rpc_mock.call_args_list[-1][0][0]
@@ -2776,7 +2776,7 @@ def test_execute_sell_sloe_cancel_exception(mocker, default_conf, ticker, fee, c
     trade.stoploss_order_id = "abcd"
 
     freqtrade.execute_sell(trade=trade, limit=1234,
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.STOP_LOSS))
+                           sell_reason=SellCheckTuple(sell_type=SellType.STOP_LOSS))
     assert sellmock.call_count == 1
     assert log_has('Could not cancel stoploss order abcd', caplog)
 
@@ -2826,7 +2826,7 @@ def test_execute_sell_with_stoploss_on_exchange(default_conf, ticker, fee, ticke
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.STOP_LOSS))
+                           sell_reason=SellCheckTuple(sell_type=SellType.STOP_LOSS))
 
     trade = Trade.query.first()
     assert trade
@@ -2932,7 +2932,7 @@ def test_execute_sell_market_order(default_conf, ticker, fee,
     freqtrade.config['order_types']['sell'] = 'market'
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.ROI))
+                           sell_reason=SellCheckTuple(sell_type=SellType.ROI))
 
     assert not trade.is_open
     assert trade.close_profit == 0.0620716
@@ -2986,7 +2986,7 @@ def test_execute_sell_insufficient_funds_error(default_conf, ticker, fee,
         fetch_ticker=ticker_sell_up
     )
 
-    sell_reason = SellCheckTuple(sell_flag=True, sell_type=SellType.ROI)
+    sell_reason = SellCheckTuple(sell_type=SellType.ROI)
     assert not freqtrade.execute_sell(trade=trade, limit=ticker_sell_up()['bid'],
                                       sell_reason=sell_reason)
     assert mock_insuf.call_count == 1
@@ -3081,7 +3081,7 @@ def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, limit_buy_o
     freqtrade = FreqtradeBot(default_conf)
     patch_get_signal(freqtrade)
     freqtrade.strategy.stop_loss_reached = MagicMock(return_value=SellCheckTuple(
-        sell_flag=False, sell_type=SellType.NONE))
+        sell_type=SellType.NONE))
     freqtrade.enter_positions()
 
     trade = Trade.query.first()
@@ -3230,7 +3230,7 @@ def test_locked_pairs(default_conf, ticker, fee, ticker_sell_down, mocker, caplo
     )
 
     freqtrade.execute_sell(trade=trade, limit=ticker_sell_down()['bid'],
-                           sell_reason=SellCheckTuple(sell_flag=True, sell_type=SellType.STOP_LOSS))
+                           sell_reason=SellCheckTuple(sell_type=SellType.STOP_LOSS))
     trade.close(ticker_sell_down()['bid'])
     assert freqtrade.strategy.is_pair_locked(trade.pair)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -51,8 +51,8 @@ def test_may_execute_sell_stoploss_on_exchange_multi(default_conf, ticker, fee,
         side_effect=[stoploss_order_closed, stoploss_order_open, stoploss_order_open])
     # Sell 3rd trade (not called for the first trade)
     should_sell_mock = MagicMock(side_effect=[
-        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
-        SellCheckTuple(sell_flag=True, sell_type=SellType.SELL_SIGNAL)]
+        SellCheckTuple(sell_type=SellType.NONE),
+        SellCheckTuple(sell_type=SellType.SELL_SIGNAL)]
     )
     cancel_order_mock = MagicMock()
     mocker.patch('freqtrade.exchange.Binance.stoploss', stoploss)
@@ -156,11 +156,11 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
         _notify_sell=MagicMock(),
     )
     should_sell_mock = MagicMock(side_effect=[
-        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
-        SellCheckTuple(sell_flag=True, sell_type=SellType.SELL_SIGNAL),
-        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
-        SellCheckTuple(sell_flag=False, sell_type=SellType.NONE),
-        SellCheckTuple(sell_flag=None, sell_type=SellType.NONE)]
+        SellCheckTuple(sell_type=SellType.NONE),
+        SellCheckTuple(sell_type=SellType.SELL_SIGNAL),
+        SellCheckTuple(sell_type=SellType.NONE),
+        SellCheckTuple(sell_type=SellType.NONE),
+        SellCheckTuple(sell_type=SellType.NONE)]
     )
     mocker.patch("freqtrade.strategy.interface.IStrategy.should_sell", should_sell_mock)
 


### PR DESCRIPTION
Implementing `custom_sell()` in a strategy is conceptually equal to setting `sell` signal in dataframe.


closes #4276