### PR TITLE
setup.sh: Install libpython3-dev on Debian/Ubuntu

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -138,7 +138,7 @@ function install_macos() {
 # Install bot Debian_ubuntu
 function install_debian() {
     sudo apt-get update
-    sudo apt-get install -y build-essential autoconf libtool pkg-config make wget git
+    sudo apt-get install -y build-essential autoconf libtool pkg-config make wget git libpython3-dev
     install_talib
 }
 


### PR DESCRIPTION
## Summary
Python.h is required to build c modules for Python. Install libpython3-dev on Debian/Ubuntu.

## Quick changelog

- Ensure Python c modules can be build from setup.sh/pip3