### PR TITLE
Fix incorrect message when protection is fired

### DIFF
--- a/freqtrade/plugins/protections/max_drawdown_protection.py
+++ b/freqtrade/plugins/protections/max_drawdown_protection.py
@@ -61,7 +61,7 @@ class MaxDrawdown(IProtection):
 
         if drawdown > self._max_allowed_drawdown:
             self.log_once(
-                f"Trading stopped due to Max Drawdown {drawdown:.2f} < {self._max_allowed_drawdown}"
+                f"Trading stopped due to Max Drawdown {drawdown:.2f} > {self._max_allowed_drawdown}"
                 f" within {self.lookback_period_str}.", logger.info)
             until = self.calculate_lock_end(trades, self._stop_duration)
 


### PR DESCRIPTION
## Summary
max_drawdown_protection.py prints an invalid message when it fires.
