### PR TITLE
Trades pagination

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -290,8 +290,6 @@ version
 
 whitelist
 	Show the current whitelist.
-
-
 ```
 
 ### OpenAPI interface

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -124,7 +124,7 @@ python3 scripts/rest_client.py --config rest_config.json <command> [optional par
 | `stop` | Stops the trader.
 | `stopbuy` | Stops the trader from opening new trades. Gracefully closes open trades according to their rules.
 | `reload_config` | Reloads the configuration file.
-| `trades` | List last trades.
+| `trades` | List last trades. Limited to 500 trades per call.
 | `trade/<tradeid>` | Get specific trade.
 | `delete_trade <trade_id>` | Remove trade from the database. Tries to close open orders. Requires manual handling of this trade on the exchange.
 | `show_config` | Shows part of the current configuration with relevant settings to operation.
@@ -280,15 +280,17 @@ trade
         :param trade_id: Specify which trade to get.
 
 trades
-	Return trades history.
+	Return trades history, sorted by id
 
-        :param limit: Limits trades to the X last trades. No limit to get all the trades.
+        :param limit: Limits trades to the X last trades. Max 500 trades.
+        :param offset: Offset by this amount of trades.
 
 version
 	Return the version of the bot.
 
 whitelist
 	Show the current whitelist.
+
 
 ```
 

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -199,6 +199,7 @@ class OpenTradeSchema(TradeSchema):
 class TradeResponse(BaseModel):
     trades: List[TradeSchema]
     trades_count: int
+    total_trades: int
 
 
 class ForceBuyResponse(BaseModel):

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -86,7 +86,7 @@ def status(rpc: RPC = Depends(get_rpc)):
 # on big databases. Correct response model: response_model=TradeResponse,
 @router.get('/trades', tags=['info', 'trading'])
 def trades(limit: int = 500, offset: int = 0, rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_trade_history(min(limit, 500), offset=offset, order_by_id=True)
+    return rpc._rpc_trade_history(limit, offset=offset, order_by_id=True)
 
 
 @router.get('/trade/{tradeid}', response_model=OpenTradeSchema, tags=['info', 'trading'])

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -85,8 +85,8 @@ def status(rpc: RPC = Depends(get_rpc)):
 # Using the responsemodel here will cause a ~100% increase in response time (from 1s to 2s)
 # on big databases. Correct response model: response_model=TradeResponse,
 @router.get('/trades', tags=['info', 'trading'])
-def trades(limit: int = 0, rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_trade_history(limit)
+def trades(limit: int = 500, offset: int = 0, rpc: RPC = Depends(get_rpc)):
+    return rpc._rpc_trade_history(min(limit, 500), offset=offset, order_by_id=True)
 
 
 @router.get('/trade/{tradeid}', response_model=OpenTradeSchema, tags=['info', 'trading'])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -300,11 +300,12 @@ class RPC:
             'data': data
         }
 
-    def _rpc_trade_history(self, limit: int) -> Dict:
+    def _rpc_trade_history(self, limit: int, offset: int = 0, order_by_id: bool = False) -> Dict:
         """ Returns the X last trades """
-        if limit > 0:
+        order_by = Trade.id if order_by_id else Trade.close_date.desc()
+        if limit:
             trades = Trade.get_trades([Trade.is_open.is_(False)]).order_by(
-                Trade.close_date.desc()).limit(limit)
+                order_by).limit(limit).offset(offset)
         else:
             trades = Trade.get_trades([Trade.is_open.is_(False)]).order_by(
                 Trade.close_date.desc()).all()
@@ -313,7 +314,8 @@ class RPC:
 
         return {
             "trades": output,
-            "trades_count": len(output)
+            "trades_count": len(output),
+            "total_trades": Trade.get_trades([Trade.is_open.is_(False)]).count(),
         }
 
     def _rpc_stats(self) -> Dict[str, Any]:

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -200,13 +200,19 @@ class FtRestClient():
         """
         return self._get("logs", params={"limit": limit} if limit else 0)
 
-    def trades(self, limit=None):
-        """Return trades history.
+    def trades(self, limit=None, offset=None):
+        """Return trades history, sorted by id
 
-        :param limit: Limits trades to the X last trades. No limit to get all the trades.
+        :param limit: Limits trades to the X last trades. Max 500 trades.
+        :param offset: Offset by this amount of trades.
         :return: json object
         """
-        return self._get("trades", params={"limit": limit} if limit else 0)
+        params = {}
+        if limit:
+            params['limit'] = limit
+        if offset:
+            params['offset'] = offset
+        return self._get("trades", params)
 
     def trade(self, trade_id):
         """Return specific trade

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -508,6 +508,7 @@ def test_api_trades(botclient, mocker, fee, markets):
     assert_response(rc)
     assert len(rc.json()) == 3
     assert rc.json()['trades_count'] == 0
+    assert rc.json()['total_trades'] == 0
 
     create_mock_trades(fee)
     Trade.query.session.flush()
@@ -516,10 +517,12 @@ def test_api_trades(botclient, mocker, fee, markets):
     assert_response(rc)
     assert len(rc.json()['trades']) == 2
     assert rc.json()['trades_count'] == 2
+    assert rc.json()['total_trades'] == 2
     rc = client_get(client, f"{BASE_URI}/trades?limit=1")
     assert_response(rc)
     assert len(rc.json()['trades']) == 1
     assert rc.json()['trades_count'] == 1
+    assert rc.json()['total_trades'] == 2
 
 
 def test_api_trade_single(botclient, mocker, fee, ticker, markets):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -506,7 +506,7 @@ def test_api_trades(botclient, mocker, fee, markets):
     )
     rc = client_get(client, f"{BASE_URI}/trades")
     assert_response(rc)
-    assert len(rc.json()) == 2
+    assert len(rc.json()) == 3
     assert rc.json()['trades_count'] == 0
 
     create_mock_trades(fee)


### PR DESCRIPTION

## Summary
Use Pagination for Trades response.
With big databases (4000+ trades), results can get huge.

## Quick changelog

- paginate /trades endpoint