### PR TITLE
Fix wallet unlimited

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -472,8 +472,7 @@ class FreqtradeBot(LoggingMixin):
         (buy, sell) = self.strategy.get_signal(pair, self.strategy.timeframe, analyzed_df)
 
         if buy and not sell:
-            stake_amount = self.wallets.get_trade_stake_amount(pair, self.get_free_open_trades(),
-                                                               self.edge)
+            stake_amount = self.wallets.get_trade_stake_amount(pair, self.edge)
             if not stake_amount:
                 logger.debug(f"Stake amount is 0, ignoring possible trade for {pair}.")
                 return False

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -273,11 +273,9 @@ class Backtesting:
 
         return None
 
-    def _enter_trade(self, pair: str, row: List, max_open_trades: int,
-                     open_trade_count: int) -> Optional[LocalTrade]:
+    def _enter_trade(self, pair: str, row: List) -> Optional[LocalTrade]:
         try:
-            stake_amount = self.wallets.get_trade_stake_amount(
-                pair, max_open_trades - open_trade_count, None)
+            stake_amount = self.wallets.get_trade_stake_amount(pair, None)
         except DependencyException:
             return None
         min_stake_amount = self.exchange.get_min_pair_stake_amount(pair, row[OPEN_IDX], -0.05)
@@ -388,7 +386,7 @@ class Backtesting:
                         and tmp != end_date
                         and row[BUY_IDX] == 1 and row[SELL_IDX] != 1
                         and not PairLocks.is_pair_locked(pair, row[DATE_IDX])):
-                    trade = self._enter_trade(pair, row, max_open_trades, open_trade_count_start)
+                    trade = self._enter_trade(pair, row)
                     if trade:
                         # TODO: hacky workaround to avoid opening > max_open_trades
                         # This emulates previous behaviour - not sure if this is correct

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -603,8 +603,7 @@ class RPC:
             raise RPCException(f'position for {pair} already open - id: {trade.id}')
 
         # gen stake amount
-        stakeamount = self._freqtrade.wallets.get_trade_stake_amount(
-            pair, self._freqtrade.get_free_open_trades())
+        stakeamount = self._freqtrade.wallets.get_trade_stake_amount(pair)
 
         # execute buy
         if self._freqtrade.execute_buy(pair, stakeamount, price, forcebuy=True):

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -145,13 +145,13 @@ class Wallets:
                             self._config['tradable_balance_ratio']) - val_tied_up
         return available_amount
 
-    def _calculate_unlimited_stake_amount(self, free_open_trades: int, available_amount: float,
+    def _calculate_unlimited_stake_amount(self, available_amount: float,
                                           val_tied_up: float) -> float:
         """
         Calculate stake amount for "unlimited" stake amount
         :return: 0 if max number of trades reached, else stake_amount to use.
         """
-        if not free_open_trades or self._config['max_open_trades'] == 0:
+        if self._config['max_open_trades'] == 0:
             return 0
 
         possible_stake = (available_amount + val_tied_up) / self._config['max_open_trades']
@@ -182,7 +182,7 @@ class Wallets:
 
         return stake_amount
 
-    def get_trade_stake_amount(self, pair: str, free_open_trades: int, edge=None) -> float:
+    def get_trade_stake_amount(self, pair: str, edge=None) -> float:
         """
         Calculate stake amount for the trade
         :return: float: Stake amount
@@ -205,6 +205,6 @@ class Wallets:
             stake_amount = self._config['stake_amount']
             if stake_amount == UNLIMITED_STAKE_AMOUNT:
                 stake_amount = self._calculate_unlimited_stake_amount(
-                    free_open_trades, available_amount, val_tied_up)
+                    available_amount, val_tied_up)
 
         return self._check_available_stake_amount(stake_amount, available_amount)

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -156,7 +156,9 @@ class Wallets:
         val_tied_up = Trade.total_open_trades_stakes()
         available_amount = self._get_available_stake_amount(val_tied_up)
 
-        return (available_amount + val_tied_up) / self._config['max_open_trades']
+        # Theoretical amount can be above available amount - therefore limit to available amount!
+        return min((available_amount + val_tied_up) / self._config['max_open_trades'],
+                   available_amount)
 
     def _check_available_stake_amount(self, stake_amount: float) -> float:
         """

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -457,7 +457,7 @@ def test_backtesting_pairlist_list(default_conf, mocker, caplog, testdatadir, ti
         Backtesting(default_conf)
 
 
-def test_backtest__enter_trade(default_conf, fee, mocker, testdatadir) -> None:
+def test_backtest__enter_trade(default_conf, fee, mocker) -> None:
     default_conf['ask_strategy']['use_sell_signal'] = False
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
     mocker.patch("freqtrade.exchange.Exchange.get_min_pair_stake_amount", return_value=0.00001)
@@ -474,24 +474,24 @@ def test_backtest__enter_trade(default_conf, fee, mocker, testdatadir) -> None:
         0.00099,  # Low
         0.0012,  # High
     ]
-    trade = backtesting._enter_trade(pair, row=row, max_open_trades=2, open_trade_count=0)
+    trade = backtesting._enter_trade(pair, row=row)
     assert isinstance(trade, LocalTrade)
     assert trade.stake_amount == 495
 
-    trade = backtesting._enter_trade(pair, row=row, max_open_trades=2, open_trade_count=2)
+    trade = backtesting._enter_trade(pair, row=row)
     assert trade is None
 
     # Stake-amount too high!
     mocker.patch("freqtrade.exchange.Exchange.get_min_pair_stake_amount", return_value=600.0)
 
-    trade = backtesting._enter_trade(pair, row=row, max_open_trades=2, open_trade_count=0)
+    trade = backtesting._enter_trade(pair, row=row)
     assert trade is None
 
     # Stake-amount too high!
     mocker.patch("freqtrade.wallets.Wallets.get_trade_stake_amount",
                  side_effect=DependencyException)
 
-    trade = backtesting._enter_trade(pair, row=row, max_open_trades=2, open_trade_count=0)
+    trade = backtesting._enter_trade(pair, row=row)
     assert trade is None
 
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -160,8 +160,7 @@ def test_get_trade_stake_amount(default_conf, ticker, mocker) -> None:
 
     freqtrade = FreqtradeBot(default_conf)
 
-    result = freqtrade.wallets.get_trade_stake_amount(
-        'ETH/BTC', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('ETH/BTC')
     assert result == default_conf['stake_amount']
 
 
@@ -197,14 +196,12 @@ def test_check_available_stake_amount(default_conf, ticker, mocker, fee, limit_b
 
         if expected[i] is not None:
             limit_buy_order_open['id'] = str(i)
-            result = freqtrade.wallets.get_trade_stake_amount('ETH/BTC',
-                                                              freqtrade.get_free_open_trades())
+            result = freqtrade.wallets.get_trade_stake_amount('ETH/BTC')
             assert pytest.approx(result) == expected[i]
             freqtrade.execute_buy('ETH/BTC', result)
         else:
             with pytest.raises(DependencyException):
-                freqtrade.wallets.get_trade_stake_amount('ETH/BTC',
-                                                         freqtrade.get_free_open_trades())
+                freqtrade.wallets.get_trade_stake_amount('ETH/BTC')
 
 
 def test_edge_called_in_process(mocker, edge_conf) -> None:
@@ -230,9 +227,9 @@ def test_edge_overrides_stake_amount(mocker, edge_conf) -> None:
     freqtrade = FreqtradeBot(edge_conf)
 
     assert freqtrade.wallets.get_trade_stake_amount(
-        'NEO/BTC', freqtrade.get_free_open_trades(), freqtrade.edge) == (999.9 * 0.5 * 0.01) / 0.20
+        'NEO/BTC', freqtrade.edge) == (999.9 * 0.5 * 0.01) / 0.20
     assert freqtrade.wallets.get_trade_stake_amount(
-        'LTC/BTC', freqtrade.get_free_open_trades(), freqtrade.edge) == (999.9 * 0.5 * 0.01) / 0.21
+        'LTC/BTC', freqtrade.edge) == (999.9 * 0.5 * 0.01) / 0.21
 
 
 def test_edge_overrides_stoploss(limit_buy_order, fee, caplog, mocker, edge_conf) -> None:
@@ -448,8 +445,7 @@ def test_create_trade_limit_reached(default_conf, ticker, limit_buy_order_open,
     patch_get_signal(freqtrade)
 
     assert not freqtrade.create_trade('ETH/BTC')
-    assert freqtrade.wallets.get_trade_stake_amount('ETH/BTC', freqtrade.get_free_open_trades(),
-                                                    freqtrade.edge) == 0
+    assert freqtrade.wallets.get_trade_stake_amount('ETH/BTC', freqtrade.edge) == 0
 
 
 def test_enter_positions_no_pairs_left(default_conf, ticker, limit_buy_order_open, fee,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -177,8 +177,7 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
 
     trades = Trade.query.all()
     assert len(trades) == 4
-    assert freqtrade.wallets.get_trade_stake_amount(
-        'XRP/BTC', freqtrade.get_free_open_trades()) == result1
+    assert freqtrade.wallets.get_trade_stake_amount('XRP/BTC') == result1
 
     rpc._rpc_forcebuy('TKN/BTC', None)
 
@@ -199,8 +198,7 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, limit_buy_order, moc
     # One trade sold
     assert len(trades) == 4
     # stake-amount should now be reduced, since one trade was sold at a loss.
-    assert freqtrade.wallets.get_trade_stake_amount(
-        'XRP/BTC', freqtrade.get_free_open_trades()) < result1
+    assert freqtrade.wallets.get_trade_stake_amount('XRP/BTC') < result1
     # Validate that balance of sold trade is not in dry-run balances anymore.
     bals2 = freqtrade.wallets.get_all_balances()
     assert bals != bals2

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -118,7 +118,7 @@ def test_get_trade_stake_amount_no_stake_amount(default_conf, mocker) -> None:
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
 
     with pytest.raises(DependencyException, match=r'.*stake amount.*'):
-        freqtrade.wallets.get_trade_stake_amount('ETH/BTC', freqtrade.get_free_open_trades())
+        freqtrade.wallets.get_trade_stake_amount('ETH/BTC')
 
 
 @pytest.mark.parametrize("balance_ratio,result1,result2", [
@@ -145,28 +145,28 @@ def test_get_trade_stake_amount_unlimited_amount(default_conf, ticker, balance_r
     freqtrade = get_patched_freqtradebot(mocker, conf)
 
     # no open trades, order amount should be 'balance / max_open_trades'
-    result = freqtrade.wallets.get_trade_stake_amount('ETH/USDT', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('ETH/USDT')
     assert result == result1
 
     # create one trade, order amount should be 'balance / (max_open_trades - num_open_trades)'
     freqtrade.execute_buy('ETH/USDT', result)
 
-    result = freqtrade.wallets.get_trade_stake_amount('LTC/USDT', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('LTC/USDT')
     assert result == result1
 
     # create 2 trades, order amount should be None
     freqtrade.execute_buy('LTC/BTC', result)
 
-    result = freqtrade.wallets.get_trade_stake_amount('XRP/USDT', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('XRP/USDT')
     assert result == 0
 
     freqtrade.config['max_open_trades'] = 3
     freqtrade.config['dry_run_wallet'] = 200
     freqtrade.wallets.start_cap = 200
-    result = freqtrade.wallets.get_trade_stake_amount('XRP/USDT', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('XRP/USDT')
     assert round(result, 4) == round(result2, 4)
 
     # set max_open_trades = None, so do not trade
     freqtrade.config['max_open_trades'] = 0
-    result = freqtrade.wallets.get_trade_stake_amount('NEO/USDT', freqtrade.get_free_open_trades())
+    result = freqtrade.wallets.get_trade_stake_amount('NEO/USDT')
     assert result == 0


### PR DESCRIPTION
## Summary
Change calculation of unlimited_stake amount.

By using the full stake (open trades + available stake), and dividing by "max_open_trades", we'll get evenly spaced stakes even if the wallet balance is increased with open trades.

closes #4642 
closes #4200 (reduces impact)

## Quick changelog

- change stake-amount calculation
- Simplify interface for get_stake_amount