### PR TITLE
Docker Quick start grammatical error

### DIFF
--- a/docs/docker_quickstart.md
+++ b/docs/docker_quickstart.md
@@ -10,7 +10,7 @@ Start by downloading and installing Docker CE for your platform:
 * [Windows](https://docs.docker.com/docker-for-windows/install/)
 * [Linux](https://docs.docker.com/install/)
 
-To simplify running freqtrade, please install [`docker-compose`](https://docs.docker.com/compose/install/) should be installed and available to follow the below [docker quick start guide](#docker-quick-start).
+To simplify running freqtrade, [`docker-compose`](https://docs.docker.com/compose/install/) should be installed and available to follow the below [docker quick start guide](#docker-quick-start).
 
 ## Freqtrade with docker-compose
 


### PR DESCRIPTION
please install docker-compose should be installed
 does not make grammatical sense

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Simple typo fix

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?

`please install docker-compose should be installed` does not make sense