### PR TITLE
Telegram rpc: split too long /locks messages

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -6,7 +6,7 @@ import logging
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator, List
 from typing.io import IO
 
 import rapidjson
@@ -202,3 +202,14 @@ def render_template_with_fallback(templatefile: str, templatefallbackfile: str,
         return render_template(templatefile, arguments)
     except TemplateNotFound:
         return render_template(templatefallbackfile, arguments)
+
+
+def chunks(lst: List[Any], n: int) -> Iterator[List[Any]]:
+    """
+    Split lst into chunks of the size n.
+    :param lst: list to split into chunks
+    :param n: number of max elements per chunk
+    :return: None
+    """
+    for chunk in range(0, len(lst), n):
+        yield (lst[chunk:chunk + n])


### PR DESCRIPTION
## Summary
Partly addressing #4519, I think it is easier to split arrays into equally sized parts before they go into tabulate, producing better readable (instead of super long) messages. Implemented for /locks as that list was too long for telegram. I think the same approach could be used for all telegram messages that use tabulate and produce a long output. Other ideas/suggestions welcome, I'd be happy to update the PR.

## Quick changelog

- Add a misc.chunks function to split arrays into chunks
- Split the /locks message for Telegram into chunks of 25 lines per message.

