### PR TITLE
fix IStrategy: abstract methods still need to pass through return value

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -161,6 +161,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param metadata: Additional information, like the currently traded pair
         :return: a Dataframe with all mandatory indicators for the strategies
         """
+        return dataframe
 
     @abstractmethod
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
@@ -170,6 +171,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param metadata: Additional information, like the currently traded pair
         :return: DataFrame with buy column
         """
+        return dataframe
 
     @abstractmethod
     def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
@@ -179,6 +181,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param metadata: Additional information, like the currently traded pair
         :return: DataFrame with sell column
         """
+        return dataframe
 
     def check_buy_timeout(self, pair: str, trade: Trade, order: dict, **kwargs) -> bool:
         """


### PR DESCRIPTION

## Summary

abstract methods still need to pass through return value
otherwise doing something like:
```py
dataframe = super().populate_indicators(dataframe, ...)
```

won't work, because `dataframe` becomes `None`.

This is needed if one of those methods uses `dataframe.copy()` instead of
just working on reference. e.g. using `merge_informative` in
`populate_indicator` in a nested class hierarchy
