### PR TITLE
IntParameter should not calculate indicators if it's not being optimized

### DIFF
--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -4,7 +4,7 @@ import logging
 from collections import OrderedDict
 from pathlib import Path
 from pprint import pformat
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import rapidjson
 import tabulate
@@ -20,6 +20,17 @@ logger = logging.getLogger(__name__)
 
 
 class HyperoptTools():
+
+    @staticmethod
+    def has_space(config: Dict[str, Any], space: str) -> bool:
+        """
+        Tell if the space value is contained in the configuration
+        """
+        # The 'trailing' space is not included in the 'default' set of spaces
+        if space == 'trailing':
+            return any(s in config['spaces'] for s in [space, 'all'])
+        else:
+            return any(s in config['spaces'] for s in [space, 'all', 'default'])
 
     @staticmethod
     def _read_results(results_file: Path) -> List:

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -284,7 +284,7 @@ class HyperStrategyMixin(object):
         if not params:
             logger.info(f"No params for {space} found, using default values.")
 
-        for attr_name, attr in self.enumerate_parameters():
+        for attr_name, attr in self.enumerate_parameters(space):
             attr.hyperopt = hyperopt
             if params and attr_name in params:
                 if attr.load:

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -503,10 +503,10 @@ def test_format_results(hyperopt):
     (['default', 'buy'],
      {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
 ])
-def test_has_space(hyperopt, spaces, expected_results):
+def test_has_space(hyperopt_conf, spaces, expected_results):
     for s in ['buy', 'sell', 'roi', 'stoploss', 'trailing']:
-        hyperopt.config.update({'spaces': spaces})
-        assert hyperopt.has_space(s) == expected_results[s]
+        hyperopt_conf.update({'spaces': spaces})
+        assert HyperoptTools.has_space(hyperopt_conf, s) == expected_results[s]
 
 
 def test_populate_indicators(hyperopt, testdatadir) -> None:

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -1108,7 +1108,7 @@ def test_in_strategy_auto_hyperopt(mocker, hyperopt_conf, tmpdir, fee) -> None:
     assert isinstance(hyperopt.custom_hyperopt, HyperOptAuto)
     assert isinstance(hyperopt.backtesting.strategy.buy_rsi, IntParameter)
 
-    assert hyperopt.backtesting.strategy.buy_rsi.hyperopt is True
+    assert hyperopt.backtesting.strategy.buy_rsi.in_space is True
     assert hyperopt.backtesting.strategy.buy_rsi.value == 35
     buy_rsi_range = hyperopt.backtesting.strategy.buy_rsi.range
     assert isinstance(buy_rsi_range, range)

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -636,7 +636,7 @@ def test_hyperopt_parameters():
     assert len(list(intpar.range)) == 1
     # Range contains ONLY the default / value.
     assert list(intpar.range) == [intpar.value]
-    intpar.hyperopt = True
+    intpar.in_space = True
 
     assert len(list(intpar.range)) == 6
     assert list(intpar.range) == [0, 1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
Optimize performance of `.range` provider for hyperoptparameters

## Quick changelog

- IntParameter should be aware if it's being optimized - and not calculate indicators if it's not.