### PR TITLE
Fixed syntax error in the example

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -204,7 +204,7 @@ The below example blacklists `BNB/BTC`, uses `VolumePairList` with `20` assets, 
     {
         "method": "VolumePairList",
         "number_assets": 20,
-        "sort_key": "quoteVolume",
+        "sort_key": "quoteVolume"
     },
     {"method": "AgeFilter", "min_days_listed": 10},
     {"method": "PrecisionFilter"},


### PR DESCRIPTION
Removed extra comma in the "Full example of Pairlist Handlers" section.