### PR TITLE
Data provider support in backtesting

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -60,7 +60,8 @@ from freqtrade.strategy import IStrategy, timeframe_to_prev_date
 
 class AwesomeStrategy(IStrategy):
     def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,
-                    current_profit: float, dataframe: DataFrame, **kwargs):
+                    current_profit: float, **kwargs):
+        dataframe = self.dp.get_analyzed_dataframe(pair, self.timeframe)
         trade_open_date = timeframe_to_prev_date(self.timeframe, trade.open_date_utc)
         trade_row = dataframe.loc[dataframe['date'] == trade_open_date].squeeze()
 
@@ -105,8 +106,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
         """
         Custom stoploss logic, returning the new distance relative to current_rate (as ratio).
         e.g. returning -0.05 would create a stoploss 5% below current_rate.
@@ -156,8 +156,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
 
         # Make sure you have the longest interval first - these conditions are evaluated from top to bottom.
         if current_time - timedelta(minutes=120) > trade.open_date_utc:
@@ -183,8 +182,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
 
         if pair in ('ETH/BTC', 'XRP/BTC'):
             return -0.10
@@ -210,8 +208,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
 
         if current_profit < 0.04:
             return -1 # return a value bigger than the inital stoploss to keep using the inital stoploss
@@ -250,8 +247,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
 
         # evaluate highest to lowest, so that highest possible stop is used
         if current_profit > 0.40:
@@ -293,8 +289,7 @@ class AwesomeStrategy(IStrategy):
     use_custom_stoploss = True
 
     def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                        current_rate: float, current_profit: float, dataframe: DataFrame,
-                        **kwargs) -> float:
+                        current_rate: float, current_profit: float, **kwargs) -> float:
 
         # Default return value
         result = 1
@@ -302,6 +297,7 @@ class AwesomeStrategy(IStrategy):
             # Using current_time directly would only work in backtesting. Live/dry runs need time to
             # be rounded to previous candle to be used as dataframe index. Rounding must also be 
             # applied to `trade.open_date(_utc)` if it is used for `dataframe` indexing.
+            dataframe = self.dp.get_analyzed_dataframe(pair, self.timeframe)
             current_time = timeframe_to_prev_date(self.timeframe, current_time)
             current_row = dataframe.loc[dataframe['date'] == current_time].squeeze()
             if 'atr' in current_row:

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -61,7 +61,7 @@ from freqtrade.strategy import IStrategy, timeframe_to_prev_date
 class AwesomeStrategy(IStrategy):
     def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,
                     current_profit: float, **kwargs):
-        dataframe = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+        dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
         trade_open_date = timeframe_to_prev_date(self.timeframe, trade.open_date_utc)
         trade_row = dataframe.loc[dataframe['date'] == trade_open_date].squeeze()
 
@@ -290,7 +290,7 @@ class AwesomeStrategy(IStrategy):
             # Using current_time directly would only work in backtesting. Live/dry runs need time to
             # be rounded to previous candle to be used as dataframe index. Rounding must also be 
             # applied to `trade.open_date(_utc)` if it is used for `dataframe` indexing.
-            dataframe = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+            dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
             current_candle = dataframe.loc[-1].squeeze()
             if 'atr' in current_candle:
                 # new stoploss relative to current_rate

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -422,10 +422,6 @@ if self.dp:
     Returns an empty dataframe if the requested pair was not cached.
     This should not happen when using whitelisted pairs.
 
-
-!!! Warning "Warning about backtesting"
-    This method will return an empty dataframe during backtesting.
-
 ### *orderbook(pair, maximum)*
 
 ``` python

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -631,8 +631,7 @@ Stoploss values returned from `custom_stoploss` must specify a percentage relati
         use_custom_stoploss = True
 
         def custom_stoploss(self, pair: str, trade: 'Trade', current_time: datetime,
-                            current_rate: float, current_profit: float, dataframe: DataFrame,
-                            **kwargs) -> float:
+                            current_rate: float, current_profit: float, **kwargs) -> float:
 
             # once the profit has risen above 10%, keep the stoploss at 7% above the open price
             if current_profit > 0.10:

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -173,3 +173,6 @@ class DataProvider:
             return self._pairlists.whitelist.copy()
         else:
             raise OperationalException("Dataprovider was not initialized with a pairlist provider.")
+
+    def clear_cache(self):
+        self.__cached_pairs = {}

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -24,7 +24,7 @@ NO_EXCHANGE_EXCEPTION = 'Exchange is not available to DataProvider.'
 
 class DataProvider:
 
-    def __init__(self, config: dict, exchange: Exchange, pairlists=None) -> None:
+    def __init__(self, config: dict, exchange: Optional[Exchange], pairlists=None) -> None:
         self._config = config
         self._exchange = exchange
         self._pairlists = pairlists

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -19,6 +19,8 @@ from freqtrade.state import RunMode
 
 logger = logging.getLogger(__name__)
 
+NO_EXCHANGE_EXCEPTION = 'Exchange is not available to DataProvider.'
+
 
 class DataProvider:
 
@@ -126,7 +128,7 @@ class DataProvider:
         Refresh data, called with each cycle
         """
         if self._exchange is None:
-            raise OperationalException('Exchange is not available to DataProvider.')
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         if helping_pairs:
             self._exchange.refresh_latest_ohlcv(pairlist + helping_pairs)
         else:
@@ -139,7 +141,7 @@ class DataProvider:
         Should be whitelist + open trades.
         """
         if self._exchange is None:
-            raise OperationalException('Exchange is not available to DataProvider.')
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         return list(self._exchange._klines.keys())
 
     def ohlcv(self, pair: str, timeframe: str = None, copy: bool = True) -> DataFrame:
@@ -151,6 +153,8 @@ class DataProvider:
         :param copy: copy dataframe before returning if True.
                      Use False only for read-only operations (where the dataframe is not modified)
         """
+        if self._exchange is None:
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE):
             return self._exchange.klines((pair, timeframe or self._config['timeframe']),
                                          copy=copy)
@@ -164,7 +168,7 @@ class DataProvider:
         :return: Market data dict from ccxt or None if market info is not available for the pair
         """
         if self._exchange is None:
-            raise OperationalException('Exchange is not available to DataProvider.')
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         return self._exchange.markets.get(pair)
 
     def ticker(self, pair: str):
@@ -174,7 +178,7 @@ class DataProvider:
         :return: Ticker dict from exchange or empty dict if ticker is not available for the pair
         """
         if self._exchange is None:
-            raise OperationalException('Exchange is not available to DataProvider.')
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         try:
             return self._exchange.fetch_ticker(pair)
         except ExchangeError:
@@ -189,5 +193,5 @@ class DataProvider:
         :return: dict including bids/asks with a total of `maximum` entries.
         """
         if self._exchange is None:
-            raise OperationalException('Exchange is not available to DataProvider.')
+            raise OperationalException(NO_EXCHANGE_EXCEPTION)
         return self._exchange.fetch_l2_order_book(pair, maximum)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -552,7 +552,7 @@ class FreqtradeBot(LoggingMixin):
 
         if not strategy_safe_wrapper(self.strategy.confirm_trade_entry, default_retval=True)(
                 pair=pair, order_type=order_type, amount=amount, rate=buy_limit_requested,
-                time_in_force=time_in_force, current_time=datetime.utcnow()):
+                time_in_force=time_in_force, current_time=datetime.now(timezone.utc)):
             logger.info(f"User requested abortion of buying {pair}")
             return False
         amount = self.exchange.amount_to_precision(pair, amount)
@@ -1191,7 +1191,7 @@ class FreqtradeBot(LoggingMixin):
         if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=True)(
                 pair=trade.pair, trade=trade, order_type=order_type, amount=amount, rate=limit,
                 time_in_force=time_in_force, sell_reason=sell_reason.sell_reason,
-                current_time=datetime.utcnow()):
+                current_time=datetime.now(timezone.utc)):
             logger.info(f"User requested abortion of selling {trade.pair}")
             return False
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -552,7 +552,7 @@ class FreqtradeBot(LoggingMixin):
 
         if not strategy_safe_wrapper(self.strategy.confirm_trade_entry, default_retval=True)(
                 pair=pair, order_type=order_type, amount=amount, rate=buy_limit_requested,
-                time_in_force=time_in_force):
+                time_in_force=time_in_force, current_time=datetime.utcnow()):
             logger.info(f"User requested abortion of buying {pair}")
             return False
         amount = self.exchange.amount_to_precision(pair, amount)
@@ -1190,8 +1190,8 @@ class FreqtradeBot(LoggingMixin):
 
         if not strategy_safe_wrapper(self.strategy.confirm_trade_exit, default_retval=True)(
                 pair=trade.pair, trade=trade, order_type=order_type, amount=amount, rate=limit,
-                time_in_force=time_in_force,
-                sell_reason=sell_reason.sell_reason):
+                time_in_force=time_in_force, sell_reason=sell_reason.sell_reason,
+                current_time=datetime.utcnow()):
             logger.info(f"User requested abortion of selling {trade.pair}")
             return False
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional
 
 import arrow
 from cachetools import TTLCache
-from pandas import DataFrame
 
 from freqtrade import __version__, constants
 from freqtrade.configuration import validate_config_consistency
@@ -784,10 +783,10 @@ class FreqtradeBot(LoggingMixin):
 
         config_ask_strategy = self.config.get('ask_strategy', {})
 
-        analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
-                                                                  self.strategy.timeframe)
         if (config_ask_strategy.get('use_sell_signal', True) or
                 config_ask_strategy.get('ignore_roi_if_buy_signal', False)):
+            analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
+                                                                      self.strategy.timeframe)
 
             (buy, sell) = self.strategy.get_signal(trade.pair, self.strategy.timeframe, analyzed_df)
 
@@ -814,13 +813,13 @@ class FreqtradeBot(LoggingMixin):
                 # resulting in outdated RPC messages
                 self._sell_rate_cache[trade.pair] = sell_rate
 
-                if self._check_and_execute_sell(analyzed_df, trade, sell_rate, buy, sell):
+                if self._check_and_execute_sell(trade, sell_rate, buy, sell):
                     return True
 
         else:
             logger.debug('checking sell')
             sell_rate = self.get_sell_rate(trade.pair, True)
-            if self._check_and_execute_sell(analyzed_df, trade, sell_rate, buy, sell):
+            if self._check_and_execute_sell(trade, sell_rate, buy, sell):
                 return True
 
         logger.debug('Found no sell signal for %s.', trade)
@@ -951,13 +950,13 @@ class FreqtradeBot(LoggingMixin):
                     logger.warning(f"Could not create trailing stoploss order "
                                    f"for pair {trade.pair}.")
 
-    def _check_and_execute_sell(self, dataframe: DataFrame, trade: Trade, sell_rate: float,
+    def _check_and_execute_sell(self, trade: Trade, sell_rate: float,
                                 buy: bool, sell: bool) -> bool:
         """
         Check and execute sell
         """
         should_sell = self.strategy.should_sell(
-            dataframe, trade, sell_rate, datetime.now(timezone.utc), buy, sell,
+            trade, sell_rate, datetime.now(timezone.utc), buy, sell,
             force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0
         )
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -353,6 +353,7 @@ class Backtesting:
         # Update dataprovider cache
         for pair, dataframe in processed.items():
             self.dataprovider._set_cached_df(pair, self.timeframe, dataframe)
+        self.strategy.dp = self.dataprovider
 
         # Use dict of lists with data for performance
         # (looping lists is a lot faster than pandas DataFrames)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -373,8 +373,9 @@ class Backtesting:
             open_trade_count_start = open_trade_count
 
             for i, pair in enumerate(data):
+                row_index = indexes[pair]
                 try:
-                    row = data[pair][indexes[pair]]
+                    row = data[pair][row_index]
                 except IndexError:
                     # missing Data for one pair at the end.
                     # Warnings for this are shown during data loading
@@ -383,7 +384,10 @@ class Backtesting:
                 # Waits until the time-counter reaches the start of the data for this pair.
                 if row[DATE_IDX] > tmp:
                     continue
-                indexes[pair] += 1
+
+                row_index += 1
+                self.dataprovider._set_dataframe_max_index(row_index)   # noqa
+                indexes[pair] = row_index
 
                 # without positionstacking, we can only have one open trade per pair.
                 # max_open_trades must be respected

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -63,9 +63,7 @@ class Backtesting:
         self.all_results: Dict[str, Dict] = {}
 
         self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
-
         self.dataprovider = DataProvider(self.config, self.exchange)
-        IStrategy.dp = self.dataprovider
 
         if self.config.get('strategy_list', None):
             for strat in list(self.config['strategy_list']):
@@ -132,6 +130,7 @@ class Backtesting:
         Load strategy into backtesting
         """
         self.strategy: IStrategy = strategy
+        strategy.dp = self.dataprovider
         # Set stoploss_on_exchange to false for backtesting,
         # since a "perfect" stoploss-sell is assumed anyway
         # And the regular "stoploss" function would not apply to that case
@@ -353,7 +352,6 @@ class Backtesting:
         # Update dataprovider cache
         for pair, dataframe in processed.items():
             self.dataprovider._set_cached_df(pair, self.timeframe, dataframe)
-        self.strategy.dp = self.dataprovider
 
         # Use dict of lists with data for performance
         # (looping lists is a lot faster than pandas DataFrames)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -386,7 +386,7 @@ class Backtesting:
                     continue
 
                 row_index += 1
-                self.dataprovider._set_dataframe_max_index(row_index)   # noqa
+                self.dataprovider._set_dataframe_max_index(row_index)
                 indexes[pair] = row_index
 
                 # without positionstacking, we can only have one open trade per pair.

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -63,7 +63,7 @@ class Backtesting:
         self.all_results: Dict[str, Dict] = {}
 
         self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
-        self.dataprovider = DataProvider(self.config, self.exchange)
+        self.dataprovider = DataProvider(self.config, None)
 
         if self.config.get('strategy_list', None):
             for strat in list(self.config['strategy_list']):

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -110,8 +110,6 @@ class Backtesting:
         PairLocks.timeframe = self.config['timeframe']
         PairLocks.use_db = False
         PairLocks.reset_locks()
-        if self.config.get('enable_protections', False):
-            self.protections = ProtectionManager(self.config)
 
         self.wallets = Wallets(self.config, self.exchange, log=False)
 
@@ -135,6 +133,12 @@ class Backtesting:
         # since a "perfect" stoploss-sell is assumed anyway
         # And the regular "stoploss" function would not apply to that case
         self.strategy.order_types['stoploss_on_exchange'] = False
+        if self.config.get('enable_protections', False):
+            conf = self.config
+            if hasattr(strategy, 'protections'):
+                conf = deepcopy(conf)
+                conf['protections'] = strategy.protections
+            self.protections = ProtectionManager(conf)
 
     def load_bt_data(self) -> Tuple[Dict[str, DataFrame], TimeRange]:
         """

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -247,10 +247,9 @@ class Backtesting:
         else:
             return sell_row[OPEN_IDX]
 
-    def _get_sell_trade_entry(self, dataframe: DataFrame, trade: LocalTrade,
-                              sell_row: Tuple) -> Optional[LocalTrade]:
+    def _get_sell_trade_entry(self, trade: LocalTrade, sell_row: Tuple) -> Optional[LocalTrade]:
 
-        sell = self.strategy.should_sell(dataframe, trade, sell_row[OPEN_IDX],  # type: ignore
+        sell = self.strategy.should_sell(trade, sell_row[OPEN_IDX],  # type: ignore
                                          sell_row[DATE_IDX].to_pydatetime(), sell_row[BUY_IDX],
                                          sell_row[SELL_IDX],
                                          low=sell_row[LOW_IDX], high=sell_row[HIGH_IDX])
@@ -398,7 +397,7 @@ class Backtesting:
 
                 for trade in open_trades[pair]:
                     # also check the buying candle for sell conditions.
-                    trade_entry = self._get_sell_trade_entry(processed[pair], trade, row)
+                    trade_entry = self._get_sell_trade_entry(trade, row)
                     # Sell occured
                     if trade_entry:
                         # logger.debug(f"{pair} - Backtesting sell {trade}")

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -31,7 +31,6 @@ from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F4
 from freqtrade.optimize.hyperopt_tools import HyperoptTools
 from freqtrade.optimize.optimize_reports import generate_strategy_stats
 from freqtrade.resolvers.hyperopt_resolver import HyperOptLossResolver, HyperOptResolver
-from freqtrade.strategy import IStrategy
 
 
 # Suppress scikit-learn FutureWarnings from skopt

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -372,8 +372,6 @@ class Hyperopt:
         self.backtesting.exchange._api_async = None  # type: ignore
         # self.backtesting.exchange = None  # type: ignore
         self.backtesting.pairlists = None  # type: ignore
-        self.backtesting.strategy.dp = None  # type: ignore
-        IStrategy.dp = None  # type: ignore
 
         cpus = cpu_count()
         logger.info(f"Found {cpus} CPU cores. Let's make them scream!")

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -296,7 +296,6 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_time: datetime object, containing the current datetime
         :param current_rate: Rate, calculated based on pricing settings in ask_strategy.
         :param current_profit: Current profit (as ratio), calculated based on current_rate.
-        :param dataframe: Analyzed dataframe for this pair. Can contain future data in backtesting.
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return float: New stoploss value, relative to the currentrate
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -229,7 +229,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         pass
 
     def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                            time_in_force: str, **kwargs) -> bool:
+                            time_in_force: str, current_time: datetime, **kwargs) -> bool:
         """
         Called right before placing a buy order.
         Timing for this function is critical, so avoid doing heavy computations or
@@ -244,6 +244,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param amount: Amount in target (quote) currency that's going to be traded.
         :param rate: Rate that's going to be used when using limit orders
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
+        :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return bool: When True is returned, then the buy-order is placed on the exchange.
             False aborts the process
@@ -251,7 +252,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         return True
 
     def confirm_trade_exit(self, pair: str, trade: Trade, order_type: str, amount: float,
-                           rate: float, time_in_force: str, sell_reason: str, **kwargs) -> bool:
+                           rate: float, time_in_force: str, sell_reason: str,
+                           current_time: datetime, **kwargs) -> bool:
         """
         Called right before placing a regular sell order.
         Timing for this function is critical, so avoid doing heavy computations or
@@ -270,6 +272,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param sell_reason: Sell reason.
             Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',
                            'sell_signal', 'force_sell', 'emergency_sell']
+        :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return bool: When True is returned, then the sell-order is placed on the exchange.
             False aborts the process

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -39,7 +39,7 @@ def custom_stoploss(self, pair: str, trade: 'Trade', current_time: 'datetime',
     return self.stoploss
 
 def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                        time_in_force: str, **kwargs) -> bool:
+                        time_in_force: str, current_time: 'datetime', **kwargs) -> bool:
     """
     Called right before placing a buy order.
     Timing for this function is critical, so avoid doing heavy computations or
@@ -54,6 +54,7 @@ def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: f
     :param amount: Amount in target (quote) currency that's going to be traded.
     :param rate: Rate that's going to be used when using limit orders
     :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
+    :param current_time: datetime object, containing the current datetime
     :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
     :return bool: When True is returned, then the buy-order is placed on the exchange.
         False aborts the process
@@ -61,7 +62,8 @@ def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: f
     return True
 
 def confirm_trade_exit(self, pair: str, trade: 'Trade', order_type: str, amount: float,
-                       rate: float, time_in_force: str, sell_reason: str, **kwargs) -> bool:
+                       rate: float, time_in_force: str, sell_reason: str,
+                       current_time: 'datetime', **kwargs) -> bool:
     """
     Called right before placing a regular sell order.
     Timing for this function is critical, so avoid doing heavy computations or
@@ -80,6 +82,7 @@ def confirm_trade_exit(self, pair: str, trade: 'Trade', order_type: str, amount:
     :param sell_reason: Sell reason.
         Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',
                         'sell_signal', 'force_sell', 'emergency_sell']
+    :param current_time: datetime object, containing the current datetime
     :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
     :return bool: When True is returned, then the sell-order is placed on the exchange.
         False aborts the process

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -247,6 +247,25 @@ def test_get_analyzed_dataframe(mocker, default_conf, ohlcv_history):
     assert isinstance(time, datetime)
     assert time == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
+    # Test backtest mode
+    default_conf["runmode"] = RunMode.BACKTEST
+    dp._set_dataframe_max_index(1)
+    dataframe, time = dp.get_analyzed_dataframe("XRP/BTC", timeframe)
+
+    assert len(dataframe) == 1
+
+    dp._set_dataframe_max_index(2)
+    dataframe, time = dp.get_analyzed_dataframe("XRP/BTC", timeframe)
+    assert len(dataframe) == 2
+
+    dp._set_dataframe_max_index(3)
+    dataframe, time = dp.get_analyzed_dataframe("XRP/BTC", timeframe)
+    assert len(dataframe) == 3
+
+    dp._set_dataframe_max_index(500)
+    dataframe, time = dp.get_analyzed_dataframe("XRP/BTC", timeframe)
+    assert len(dataframe) == len(ohlcv_history)
+
 
 def test_no_exchange_mode(default_conf):
     dp = DataProvider(default_conf, None)
@@ -267,3 +286,6 @@ def test_no_exchange_mode(default_conf):
 
     with pytest.raises(OperationalException, match=message):
         dp.orderbook('XRP/USDT', 20)
+
+    with pytest.raises(OperationalException, match=message):
+        dp.available_pairs()

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -246,3 +246,24 @@ def test_get_analyzed_dataframe(mocker, default_conf, ohlcv_history):
     assert dataframe.empty
     assert isinstance(time, datetime)
     assert time == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def test_no_exchange_mode(default_conf):
+    dp = DataProvider(default_conf, None)
+
+    message = "Exchange is not available to DataProvider."
+
+    with pytest.raises(OperationalException, match=message):
+        dp.refresh([()])
+
+    with pytest.raises(OperationalException, match=message):
+        dp.ohlcv('XRP/USDT', '5m')
+
+    with pytest.raises(OperationalException, match=message):
+        dp.market('XRP/USDT')
+
+    with pytest.raises(OperationalException, match=message):
+        dp.ticker('XRP/USDT')
+
+    with pytest.raises(OperationalException, match=message):
+        dp.orderbook('XRP/USDT', 20)

--- a/tests/strategy/test_default_strategy.py
+++ b/tests/strategy/test_default_strategy.py
@@ -36,9 +36,11 @@ def test_default_strategy(result, fee):
     )
 
     assert strategy.confirm_trade_entry(pair='ETH/BTC', order_type='limit', amount=0.1,
-                                        rate=20000, time_in_force='gtc') is True
+                                        rate=20000, time_in_force='gtc',
+                                        current_time=datetime.utcnow()) is True
     assert strategy.confirm_trade_exit(pair='ETH/BTC', trade=trade, order_type='limit', amount=0.1,
-                                       rate=20000, time_in_force='gtc', sell_reason='roi') is True
+                                       rate=20000, time_in_force='gtc', sell_reason='roi',
+                                       current_time=datetime.utcnow()) is True
 
     assert strategy.custom_stoploss(pair='ETH/BTC', trade=trade, current_time=datetime.now(),
                                     current_rate=20_000, current_profit=0.05) == strategy.stoploss

--- a/tests/strategy/test_default_strategy.py
+++ b/tests/strategy/test_default_strategy.py
@@ -41,5 +41,4 @@ def test_default_strategy(result, fee):
                                        rate=20000, time_in_force='gtc', sell_reason='roi') is True
 
     assert strategy.custom_stoploss(pair='ETH/BTC', trade=trade, current_time=datetime.now(),
-                                    current_rate=20_000, current_profit=0.05, dataframe=None
-                                    ) == strategy.stoploss
+                                    current_rate=20_000, current_profit=0.05) == strategy.stoploss

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -360,7 +360,7 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
     now = arrow.utcnow().datetime
     sl_flag = strategy.stop_loss_reached(current_rate=trade.open_rate * (1 + profit), trade=trade,
                                          current_time=now, current_profit=profit,
-                                         force_stoploss=0, high=None, dataframe=None)
+                                         force_stoploss=0, high=None)
     assert isinstance(sl_flag, SellCheckTuple)
     assert sl_flag.sell_type == expected
     if expected == SellType.NONE:
@@ -371,7 +371,7 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
 
     sl_flag = strategy.stop_loss_reached(current_rate=trade.open_rate * (1 + profit2), trade=trade,
                                          current_time=now, current_profit=profit2,
-                                         force_stoploss=0, high=None, dataframe=None)
+                                         force_stoploss=0, high=None)
     assert sl_flag.sell_type == expected2
     if expected2 == SellType.NONE:
         assert sl_flag.sell_flag is False

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -399,27 +399,27 @@ def test_custom_sell(default_conf, fee, caplog) -> None:
     )
 
     now = arrow.utcnow().datetime
-    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    res = strategy.should_sell(trade, 1, now, False, False, None, None, 0)
 
     assert res.sell_flag is False
     assert res.sell_type == SellType.NONE
 
     strategy.custom_sell = MagicMock(return_value=True)
-    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    res = strategy.should_sell(trade, 1, now, False, False, None, None, 0)
     assert res.sell_flag is True
     assert res.sell_type == SellType.CUSTOM_SELL
     assert res.sell_reason == 'custom_sell'
 
     strategy.custom_sell = MagicMock(return_value='hello world')
 
-    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    res = strategy.should_sell(trade, 1, now, False, False, None, None, 0)
     assert res.sell_type == SellType.CUSTOM_SELL
     assert res.sell_flag is True
     assert res.sell_reason == 'hello world'
 
     caplog.clear()
     strategy.custom_sell = MagicMock(return_value='h' * 100)
-    res = strategy.should_sell(None, trade, 1, now, False, False, None, None, 0)
+    res = strategy.should_sell(trade, 1, now, False, False, None, None, 0)
     assert res.sell_type == SellType.CUSTOM_SELL
     assert res.sell_flag is True
     assert res.sell_reason == 'h' * 64


### PR DESCRIPTION
## Quick changelog

- Fix `self.dp.get_analyzed_dataframe()` not working in backtesting.
- Remove `dataframe` parameter from `custom_stoploss` and `custom_sell`.
- Add `current_time` parameter to `confirm_trade_entry`/`confirm_trade_exit`.

## What's new?

Seems like i went the wrong way adding `dataframe` as a parameter to `custom_sell` and `custom_stoploss`. After all dataframe is useful in other methods as well. One such very practical usecase i bumped into is blocking roi sells and riding an uptrend.

```py
    def confirm_trade_exit(self, pair: str, trade: 'Trade', order_type: str, amount: float,
                           rate: float, time_in_force: str, sell_reason: str,
                           current_time: 'datetime', **kwargs) -> bool:
        current_time = timeframe_to_prev_date(self.timeframe, current_time)
        dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
        # dataframe = self.dataframe
        current_candle = dataframe.loc[dataframe['date'] == current_time]
        if current_candle is not None and sell_reason == 'roi':
            current_candle = current_candle.squeeze()
            if current_candle['rsi'] > 50:
                return False

        return True
```

Adding dataframe as a parameter to all these methods gets complicated real fast. Since we can use `self.dp` in live, i figured we could also make it work in backtesting.
