### PR TITLE
Have Edge support informative pairs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from freqtrade.exchange import Exchange
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import LocalTrade, Trade, init_db
 from freqtrade.resolvers import ExchangeResolver
+from freqtrade.state import RunMode
 from freqtrade.worker import Worker
 from tests.conftest_trades import (mock_trade_1, mock_trade_2, mock_trade_3, mock_trade_4,
                                    mock_trade_5, mock_trade_6)
@@ -1677,6 +1678,7 @@ def buy_order_fee():
 @pytest.fixture(scope="function")
 def edge_conf(default_conf):
     conf = deepcopy(default_conf)
+    conf['runmode'] = RunMode.DRY_RUN
     conf['max_open_trades'] = -1
     conf['tradable_balance_ratio'] = 0.5
     conf['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -344,6 +344,8 @@ def test_edge_process_no_trades(mocker, edge_conf, caplog):
 
 def test_edge_process_no_pairs(mocker, edge_conf, caplog):
     edge_conf['exchange']['pair_whitelist'] = []
+    mocker.patch('freqtrade.freqtradebot.validate_config_consistency')
+
     freqtrade = get_patched_freqtradebot(mocker, edge_conf)
     fee_mock = mocker.patch('freqtrade.exchange.Exchange.get_fee', return_value=0.001)
     mocker.patch('freqtrade.edge.edge_positioning.refresh_data')


### PR DESCRIPTION
## Summary
Edge should support and download informative-pairs as well.

closes #4868 

## Quick changelog

- Download informative pairs
- Have edge respect startup_candle_count when downloading data
- Switch run-mode to edge while "edging" - so informative-pairs are loaded correctly.