### PR TITLE
Change rate back to "open" for custom_sell

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -573,6 +573,10 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         sell_signal = SellType.NONE
         custom_reason = ''
+        # use provided rate in backtesting, not high/low.
+        current_rate = rate
+        current_profit = trade.calc_profit_ratio(current_rate)
+
         if (ask_strategy.get('sell_profit_only', False)
                 and current_profit <= ask_strategy.get('sell_profit_offset', 0)):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal


### PR DESCRIPTION


## Summary
Rate should be changed back to the provided rate (if it was different -> we're in backtesting).
Otherwise, we'll be providing high to custom_sell (and profit calculated based on high) - which would result in different sell-prices than what the signal was based on.

closes #4920

## Quick changelog

- don't use "high" for `custom_sell` callback