### PR TITLE
max-value change filter

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -112,6 +112,7 @@ The `PriceFilter` allows filtering of pairs by price. Currently the following pr
 
 * `min_price`
 * `max_price`
+* `max_value`
 * `low_price_ratio`
 
 The `min_price` setting removes pairs where the price is below the specified price. This is useful if you wish to avoid trading very low-priced pairs.
@@ -119,6 +120,11 @@ This option is disabled by default, and will only apply if set to > 0.
 
 The `max_price` setting removes pairs where the price is above the specified price. This is useful if you wish to trade only low-priced pairs.
 This option is disabled by default, and will only apply if set to > 0.
+
+The `max_value` setting removes pairs where the minimum value change is above a specified value.
+This is useful when an exchange has unbalanced limits. For example, if step-size = 1 (so you can only buy 1, or 2, or 3, but not 1.1 Coins) - and the price is pretty high (like 20$) as the coin has risen sharply since the last limit adaption.
+As a result of the above, you can only buy for 20$, or 40$ - but not for 25$.
+On exchanges that deduct fees from the receiving currency (e.g. FTX) - this can result in high value coins / amounts that are unsellable as the amount is slightly below the limit.
 
 The `low_price_ratio` setting removes pairs where a raise of 1 price unit (pip) is above the `low_price_ratio` ratio.
 This option is disabled by default, and will only apply if set to > 0.

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any, Dict, List
 
 from freqtrade.exceptions import OperationalException
-from freqtrade.exchange import market_is_active
+from freqtrade.exchange import Exchange, market_is_active
 from freqtrade.mixins import LoggingMixin
 
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class IPairList(LoggingMixin, ABC):
 
-    def __init__(self, exchange, pairlistmanager,
+    def __init__(self, exchange: Exchange, pairlistmanager,
                  config: Dict[str, Any], pairlistconfig: Dict[str, Any],
                  pairlist_pos: int) -> None:
         """
@@ -28,7 +28,7 @@ class IPairList(LoggingMixin, ABC):
         """
         self._enabled = True
 
-        self._exchange = exchange
+        self._exchange: Exchange = exchange
         self._pairlistmanager = pairlistmanager
         self._config = config
         self._pairlistconfig = pairlistconfig

--- a/freqtrade/plugins/pairlist/PriceFilter.py
+++ b/freqtrade/plugins/pairlist/PriceFilter.py
@@ -33,7 +33,7 @@ class PriceFilter(IPairList):
         self._enabled = ((self._low_price_ratio > 0) or
                          (self._min_price > 0) or
                          (self._max_price > 0) or
-                         (self._max_value))
+                         (self._max_value > 0))
 
     @property
     def needstickers(self) -> bool:

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -407,6 +407,9 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
     ([{"method": "VolumePairList", "number_assets": 20, "sort_key": "quoteVolume"},
       {"method": "PriceFilter", "low_price_ratio": 0.02}],
         "USDT", ['ETH/USDT', 'NANO/USDT']),
+    ([{"method": "VolumePairList", "number_assets": 20, "sort_key": "quoteVolume"},
+      {"method": "PriceFilter", "max_value": 0.000001}],
+        "USDT", ['NANO/USDT']),
     ([{"method": "StaticPairList"},
       {"method": "RangeStabilityFilter", "lookback_days": 10,
        "min_rate_of_change": 0.01, "refresh_period": 1440}],
@@ -489,6 +492,8 @@ def test_VolumePairList_whitelist_gen(mocker, whitelist_conf, shitcoinmarkets, t
                                    r'because last price < .*%$', caplog) or
                         log_has_re(r'^Removed .* from whitelist, '
                                    r'because last price > .*%$', caplog) or
+                        log_has_re(r'^Removed .* from whitelist, '
+                                   r'because min value change of .*', caplog) or
                         log_has_re(r"^Removed .* from whitelist, because ticker\['last'\] "
                                    r"is empty.*", caplog))
             if pairlist['method'] == 'VolumePairList':

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -800,6 +800,10 @@ def test_spreadfilter_invalid_data(mocker, default_conf, markets, tickers, caplo
      "[{'PriceFilter': 'PriceFilter - Filtering pairs priced below 0.00002000.'}]",
      None
      ),
+    ({"method": "PriceFilter", "max_value": 0.00002000},
+     "[{'PriceFilter': 'PriceFilter - Filtering pairs priced Value above 0.00002000.'}]",
+     None
+     ),
     ({"method": "PriceFilter"},
      "[{'PriceFilter': 'PriceFilter - No price filters configured.'}]",
      None
@@ -815,6 +819,10 @@ def test_spreadfilter_invalid_data(mocker, default_conf, markets, tickers, caplo
     ({"method": "PriceFilter", "max_price": -1.00010000},
      None,
      "PriceFilter requires max_price to be >= 0"
+     ),  # OperationalException expected
+    ({"method": "PriceFilter", "max_value": -1.00010000},
+     None,
+     "PriceFilter requires max_value to be >= 0"
      ),  # OperationalException expected
     ({"method": "RangeStabilityFilter", "lookback_days": 10, "min_rate_of_change": 0.01},
      "[{'RangeStabilityFilter': 'RangeStabilityFilter - Filtering pairs with rate of change below "


### PR DESCRIPTION
## Summary
Add max-value change option to Pricefilter.
This can be useful on some exchanges (e.g. FTX) - where some coins have unbalanced limits (e.g. YFI on FTX, which has a minimum amount limit of 0.001 - and a price of 60.000$ - which results in a minimum tradable step-size of 60$.
This is problematic because FTX removes fees from the receiving currency - so when buying 0.001 YFI, we'd receive 0.00099 YFI - which are unsellable based on current limits.


## Quick changelog

- Add max-value filter option