### PR TITLE
Add backoff timer for coingecko API

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -58,6 +58,13 @@ class CryptoToFiatConverter:
                     "Too many requests for Coingecko API, backing off and trying again later.")
                 # Set backoff timestamp to 60 seconds in the future
                 self._backoff = datetime.datetime.now().timestamp() + 60
+                return
+            # If the request is not a 429 error we want to raise the normal error
+            logger.error(
+                "Could not load FIAT Cryptocurrency map for the following problem: {}".format(
+                  request_exception
+                )
+            )
         except (Exception) as exception:
             logger.error(
                 f"Could not load FIAT Cryptocurrency map for the following problem: {exception}")

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -143,10 +143,13 @@ class CryptoToFiatConverter:
         if crypto_symbol == fiat_symbol:
             return 1.0
 
-        if self._cryptomap == {} and self._backoff <= datetime.datetime.now().timestamp():
-            self._load_cryptomap()
-            # return 0.0 if we still dont have data to check, no reason to proceed
-            if self._cryptomap == {}:
+        if self._cryptomap == {}:
+            if self._backoff <= datetime.datetime.now().timestamp():
+                self._load_cryptomap()
+                # return 0.0 if we still dont have data to check, no reason to proceed
+                if self._cryptomap == {}:
+                    return 0.0
+            else:
                 return 0.0
 
         if crypto_symbol not in self._cryptomap:

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -54,7 +54,8 @@ class CryptoToFiatConverter:
             self._cryptomap = {x['symbol']: x['id'] for x in coinlistings}
         except RequestException as request_exception:
             if "429" in str(request_exception):
-                logger.warning("Too many requests for Coingecko API, backing off and trying again later.")
+                logger.warning(
+                    "Too many requests for Coingecko API, backing off and trying again later.")
                 # Set backoff timestamp to 60 seconds in the future
                 self._backoff = datetime.datetime.now().timestamp() + 60
         except (Exception) as exception:

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -145,6 +145,9 @@ class CryptoToFiatConverter:
 
         if self._cryptomap == {} and self._backoff <= datetime.datetime.now().timestamp():
             self._load_cryptomap()
+            # return 0.0 if we still dont have data to check, no reason to proceed
+            if self._cryptomap == {}:
+                return 0.0
 
         if crypto_symbol not in self._cryptomap:
             # return 0 for unsupported stake currencies (fiat-convert should not break the bot)

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -4,10 +4,12 @@ e.g BTC to USD
 """
 
 import logging
-from typing import Dict
+import datetime
 
+from typing import Dict
 from cachetools.ttl import TTLCache
 from pycoingecko import CoinGeckoAPI
+from requests.exceptions import RequestException
 
 from freqtrade.constants import SUPPORTED_FIAT
 
@@ -25,6 +27,7 @@ class CryptoToFiatConverter:
     _coingekko: CoinGeckoAPI = None
 
     _cryptomap: Dict = {}
+    _backoff = int
 
     def __new__(cls):
         """
@@ -47,8 +50,13 @@ class CryptoToFiatConverter:
     def _load_cryptomap(self) -> None:
         try:
             coinlistings = self._coingekko.get_coins_list()
-            # Create mapping table from synbol to coingekko_id
+            # Create mapping table from symbol to coingekko_id
             self._cryptomap = {x['symbol']: x['id'] for x in coinlistings}
+        except RequestException as request_exception:
+            if "429" in str(request_exception):
+                logger.warning("Too many requests for Coingecko API, backing off and trying again later.")
+                # Set backoff timestamp to 60 seconds in the future
+                self._backoff = datetime.datetime.now().timestamp() + 60
         except (Exception) as exception:
             logger.error(
                 f"Could not load FIAT Cryptocurrency map for the following problem: {exception}")
@@ -126,6 +134,9 @@ class CryptoToFiatConverter:
         # No need to convert if both crypto and fiat are the same
         if crypto_symbol == fiat_symbol:
             return 1.0
+
+        if self._cryptomap == {} and self._backoff <= datetime.datetime.now().timestamp():
+            self._load_cryptomap()
 
         if crypto_symbol not in self._cryptomap:
             # return 0 for unsupported stake currencies (fiat-convert should not break the bot)

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -27,7 +27,7 @@ class CryptoToFiatConverter:
     _coingekko: CoinGeckoAPI = None
 
     _cryptomap: Dict = {}
-    _backoff = int
+    _backoff: int = 0
 
     def __new__(cls):
         """

--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -3,10 +3,10 @@ Module that define classes to convert Crypto-currency to FIAT
 e.g BTC to USD
 """
 
-import logging
 import datetime
-
+import logging
 from typing import Dict
+
 from cachetools.ttl import TTLCache
 from pycoingecko import CoinGeckoAPI
 from requests.exceptions import RequestException
@@ -27,7 +27,7 @@ class CryptoToFiatConverter:
     _coingekko: CoinGeckoAPI = None
 
     _cryptomap: Dict = {}
-    _backoff: int = 0
+    _backoff: float = 0.0
 
     def __new__(cls):
         """

--- a/tests/rpc/test_fiat_convert.py
+++ b/tests/rpc/test_fiat_convert.py
@@ -1,9 +1,9 @@
 # pragma pylint: disable=missing-docstring, too-many-arguments, too-many-ancestors,
 # pragma pylint: disable=protected-access, C0103
 
+import datetime
 from unittest.mock import MagicMock
 
-import datetime
 import pytest
 from requests.exceptions import RequestException
 

--- a/tests/rpc/test_fiat_convert.py
+++ b/tests/rpc/test_fiat_convert.py
@@ -138,7 +138,11 @@ def test_fiat_too_many_requests_response(mocker, caplog):
     length_cryptomap = len(fiat_convert._cryptomap)
     assert length_cryptomap == 0
     assert fiat_convert._backoff > datetime.datetime.now().timestamp()
-    assert log_has('Too many requests for Coingecko API, backing off and trying again later.', caplog)
+    assert log_has(
+              'Too many requests for Coingecko API, backing off and trying again later.',
+              caplog
+            )
+
 
 def test_fiat_invalid_response(mocker, caplog):
     # Because CryptoToFiatConverter is a Singleton we reset the listings
@@ -156,6 +160,7 @@ def test_fiat_invalid_response(mocker, caplog):
     assert length_cryptomap == 0
     assert log_has_re('Could not load FIAT Cryptocurrency map for the following problem: .*',
                       caplog)
+
 
 def test_convert_amount(mocker):
     mocker.patch('freqtrade.rpc.fiat_convert.CryptoToFiatConverter.get_price', return_value=12345.0)


### PR DESCRIPTION
## Summary
This fixes conversion from stake to fiat when running multiple bots by setting a future timestamp for retrying to get data.

## Quick changelog
- Set a timestamp in fiat_converter for retrying to get coingecko data

## What's new?
By accepting the possibility for 429 errors when trying to get data from Coingecko API we can enhance the ability to run multiple freqtrade instances on one machine. As all instances will fetch data from Coingecko in a short timeframe we will receive an `429 Too Many Requests` error, which results in no fiat conversion for the rest of the instances runtime. By retrying to fetch the data later, we can fetch the data for any number of instance that might run after some iterations.

## TODO
- [ ] Discuss the settting of a timestamp. Right place, right name?
- [x] Unit test?
- [x] Different warning when `self._cryptomap == {}`, to indicate that this will be fine in a couple of minutes?

