### PR TITLE
Fix hyperopt trim to empty dataframe

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -192,8 +192,8 @@ class Backtesting:
         # Create dict with data
         for pair, pair_data in processed.items():
             if not pair_data.empty:
-              pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
-              pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
+                pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
+                pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
 
             df_analyzed = self.strategy.advise_sell(
                 self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -191,8 +191,9 @@ class Backtesting:
         data: Dict = {}
         # Create dict with data
         for pair, pair_data in processed.items():
-            pair_data['buy'] = 0  # cleanup from previous run
-            pair_data['sell'] = 0  # cleanup from previous run
+            if not pair_data.empty:
+              pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
+              pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
 
             df_analyzed = self.strategy.advise_sell(
                 self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -191,8 +191,8 @@ class Backtesting:
         data: Dict = {}
         # Create dict with data
         for pair, pair_data in processed.items():
-            pair_data.loc[:, 'buy'] = 0  # cleanup from previous run
-            pair_data.loc[:, 'sell'] = 0  # cleanup from previous run
+            pair_data['buy'] = 0  # cleanup from previous run
+            pair_data['sell'] = 0  # cleanup from previous run
 
             df_analyzed = self.strategy.advise_sell(
                 self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -357,9 +357,9 @@ class Hyperopt:
             trimed_df = trim_dataframe(df, timerange,
                                        startup_candles=self.backtesting.required_startup)
             if not trimed_df.empty:
-              processed[pair] = trimed_df
+                processed[pair] = trimed_df
             else:
-              logger.warn(f'Pair {pair} got removed because triming dataframe left nothing')
+                logger.warn(f'Pair {pair} got removed because triming dataframe left nothing')
 
         self.min_date, self.max_date = get_timerange(processed)
 


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

I try to run freqtrade on my local machine (MacOS) I always get `cannot set a frame with no defined index and a scalar` error on latest develop.

After debugging, I found root cause when hyperopt do trim dataframe cause dataframe to be empty and cause the problem.

## Quick changelog

- none

## What's new?

*Explain in details what this PR solve or improve. You can include visuals.* 

### Reference

1. https://stackoverflow.com/questions/38886080/python-pandas-series-why-use-loc
2. #3644
