### PR TITLE
day/week options for Telegram '/profit' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Telegram is not mandatory. However, this is a great way to control your bot. Mor
 - `/stop`: Stops the trader.
 - `/stopbuy`: Stop entering new trades.
 - `/status <trade_id>|[table]`: Lists all or specific open trades.
-- `/profit`: Lists cumulative profit from all finished trades
+- `/profit [day]|[week]`: Lists cumulative profit from all finished trades
 - `/forcesell <trade_id>|all`: Instantly sells the given trade (Ignoring `minimum_roi`).
 - `/performance`: Show performance of each finished trade grouped by pair
 - `/balance`: Show account balance per currency.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Telegram is not mandatory. However, this is a great way to control your bot. Mor
 - `/stop`: Stops the trader.
 - `/stopbuy`: Stop entering new trades.
 - `/status <trade_id>|[table]`: Lists all or specific open trades.
-- `/profit [day]|[week]`: Lists cumulative profit from all finished trades
+- `/profit [<n>]`: Lists cumulative profit from all finished trades, over the last n days.
 - `/forcesell <trade_id>|all`: Instantly sells the given trade (Ignoring `minimum_roi`).
 - `/performance`: Show performance of each finished trade grouped by pair
 - `/balance`: Show account balance per currency.

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -130,7 +130,7 @@ You can create your own keyboard in `config.json`:
 !!! Note "Supported Commands"
     Only the following commands are allowed. Command arguments are not supported!
 
-    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
+    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/profit day`, `/profit week`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
 
 ## Telegram commands
 
@@ -154,7 +154,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/count` | Displays number of trades used and available
 | `/locks` | Show currently locked pairs.
 | `/unlock <pair or lock_id>` | Remove the lock for this pair (or for this lock id).
-| `/profit` | Display a summary of your profit/loss from close trades and some stats about your performance
+| `/profit [day]|[week]` | Display a summary of your profit/loss from close trades and some stats about your performance
 | `/forcesell <trade_id>` | Instantly sells the given trade  (Ignoring `minimum_roi`).
 | `/forcesell all` | Instantly sells all open trades (Ignoring `minimum_roi`).
 | `/forcebuy <pair> [rate]` | Instantly buys the given pair. Rate is optional. (`forcebuy_enable` must be set to True)

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -130,7 +130,7 @@ You can create your own keyboard in `config.json`:
 !!! Note "Supported Commands"
     Only the following commands are allowed. Command arguments are not supported!
 
-    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/profit day`, `/profit week`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
+    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopbuy`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
 
 ## Telegram commands
 
@@ -154,7 +154,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/count` | Displays number of trades used and available
 | `/locks` | Show currently locked pairs.
 | `/unlock <pair or lock_id>` | Remove the lock for this pair (or for this lock id).
-| `/profit [day]|[week]` | Display a summary of your profit/loss from close trades and some stats about your performance
+| `/profit [<n>]` | Display a summary of your profit/loss from close trades and some stats about your performance, over the last n days (all trades by default)
 | `/forcesell <trade_id>` | Instantly sells the given trade  (Ignoring `minimum_roi`).
 | `/forcesell all` | Instantly sells all open trades (Ignoring `minimum_roi`).
 | `/forcebuy <pair> [rate]` | Instantly buys the given pair. Rate is optional. (`forcebuy_enable` must be set to True)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -352,9 +352,10 @@ class RPC:
         return {'sell_reasons': sell_reasons, 'durations': durations}
 
     def _rpc_trade_statistics(
-            self, stake_currency: str, fiat_display_currency: str) -> Dict[str, Any]:
+            self, stake_currency: str, fiat_display_currency: str,
+            start_date: datetime = datetime.fromtimestamp(0)) -> Dict[str, Any]:
         """ Returns cumulative profit statistics """
-        trades = Trade.get_trades().order_by(Trade.id).all()
+        trades = Trade.get_trades([Trade.open_date >= start_date]).order_by(Trade.id).all()
 
         profit_all_coin = []
         profit_all_ratio = []

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -206,13 +206,14 @@ class Telegram(RPCHandler):
         msg['emoji'] = self._get_sell_emoji(msg)
 
         message = ("{emoji} *{exchange}:* Selling {pair} (#{trade_id})\n"
+                   "*Profit:* `{profit_percent:.2f}%`\n"
+                   "*Sell Reason:* `{sell_reason}`\n"
+                   "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
                    "*Amount:* `{amount:.8f}`\n"
                    "*Open Rate:* `{open_rate:.8f}`\n"
                    "*Current Rate:* `{current_rate:.8f}`\n"
-                   "*Close Rate:* `{limit:.8f}`\n"
-                   "*Sell Reason:* `{sell_reason}`\n"
-                   "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
-                   "*Profit:* `{profit_percent:.2f}%`").format(**msg)
+                   "*Close Rate:* `{limit:.8f}`"
+                   ).format(**msg)
 
         # Check if all sell properties are available.
         # This might not be the case if the message origin is triggered by /forcesell
@@ -423,11 +424,11 @@ class Telegram(RPCHandler):
         fiat_disp_cur = self._config.get('fiat_display_currency', '')
 
         start_date = datetime.fromtimestamp(0)
-        if context.args:
-            if 'day' in context.args:
-                start_date = datetime.combine(date.today(), datetime.min.time())
-            elif 'week' in context.args:
-                start_date = datetime.combine(date.today(), datetime.min.time()) - timedelta(days=7)
+        try:
+            timescale = int(context.args[0]) if context.args else None
+            start_date = datetime.combine(date.today(), datetime.min.time()) - timedelta(days=timescale)
+        except (TypeError, ValueError, IndexError):
+            pass
 
         stats = self._rpc._rpc_trade_statistics(
             stake_cur,

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -206,14 +206,13 @@ class Telegram(RPCHandler):
         msg['emoji'] = self._get_sell_emoji(msg)
 
         message = ("{emoji} *{exchange}:* Selling {pair} (#{trade_id})\n"
-                   "*Profit:* `{profit_percent:.2f}%`\n"
-                   "*Sell Reason:* `{sell_reason}`\n"
-                   "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
                    "*Amount:* `{amount:.8f}`\n"
                    "*Open Rate:* `{open_rate:.8f}`\n"
                    "*Current Rate:* `{current_rate:.8f}`\n"
-                   "*Close Rate:* `{limit:.8f}`"
-                   ).format(**msg)
+                   "*Close Rate:* `{limit:.8f}`\n"
+                   "*Sell Reason:* `{sell_reason}`\n"
+                   "*Duration:* `{duration} ({duration_min:.1f} min)`\n"
+                   "*Profit:* `{profit_percent:.2f}%`").format(**msg)
 
         # Check if all sell properties are available.
         # This might not be the case if the message origin is triggered by /forcesell

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -5,7 +5,7 @@ This module manage Telegram communication
 """
 import json
 import logging
-from datetime import datetime, date, timedelta
+from datetime import date, datetime, timedelta
 from html import escape
 from itertools import chain
 from typing import Any, Callable, Dict, List, Union

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -427,6 +427,7 @@ class Telegram(RPCHandler):
         fiat_disp_cur = self._config.get('fiat_display_currency', '')
 
         start_date = datetime.fromtimestamp(0)
+        timescale = None
         try:
             if context.args:
                 timescale = int(context.args[0])
@@ -466,16 +467,18 @@ class Telegram(RPCHandler):
             else:
                 markdown_msg = "`No closed trade` \n"
 
-            markdown_msg += (f"*ROI:* All trades\n"
-                             f"∙ `{round_coin_value(profit_all_coin, stake_cur)} "
-                             f"({profit_all_percent_mean:.2f}%) "
-                             f"({profit_all_percent_sum} \N{GREEK CAPITAL LETTER SIGMA}%)`\n"
-                             f"∙ `{round_coin_value(profit_all_fiat, fiat_disp_cur)}`\n"
-                             f"*Total Trade Count:* `{trade_count}`\n"
-                             f"*First Trade opened:* `{first_trade_date}`\n"
-                             f"*Latest Trade opened:* `{latest_trade_date}\n`"
-                             f"*Win / Loss:* `{stats['winning_trades']} / {stats['losing_trades']}`"
-                             )
+            markdown_msg += (
+                f"*ROI:* All trades\n"
+                f"∙ `{round_coin_value(profit_all_coin, stake_cur)} "
+                f"({profit_all_percent_mean:.2f}%) "
+                f"({profit_all_percent_sum} \N{GREEK CAPITAL LETTER SIGMA}%)`\n"
+                f"∙ `{round_coin_value(profit_all_fiat, fiat_disp_cur)}`\n"
+                f"*Total Trade Count:* `{trade_count}`\n"
+                f"*{'First Trade opened' if not timescale else 'Showing Profit since'}:* "
+                f"`{first_trade_date}`\n"
+                f"*Latest Trade opened:* `{latest_trade_date}\n`"
+                f"*Win / Loss:* `{stats['winning_trades']} / {stats['losing_trades']}`"
+                )
             if stats['closed_trade_count'] > 0:
                 markdown_msg += (f"\n*Avg. Duration:* `{avg_duration}`\n"
                                  f"*Best Performing:* `{best_pair}: {best_rate:.2f}%`")

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -910,7 +910,7 @@ class Telegram(RPCHandler):
                    "                `pending buy orders are marked with an asterisk (*)`\n"
                    "                `pending sell orders are marked with a double asterisk (**)`\n"
                    "*/trades [limit]:* `Lists last closed trades (limited to 10 by default)`\n"
-                   "*/profit [day]|[week]:* `Lists cumulative profit from all finished trades`\n"
+                   "*/profit [<n>]:* `Lists cumulative profit from all finished trades, over the last n days`\n"
                    "*/forcesell <trade_id>|all:* `Instantly sells the given trade or all trades, "
                    "regardless of profit`\n"
                    f"{forcebuy_text if self._config.get('forcebuy_enable', False) else ''}"

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -425,7 +425,8 @@ class Telegram(RPCHandler):
         start_date = datetime.fromtimestamp(0)
         try:
             timescale = int(context.args[0]) if context.args else None
-            start_date = datetime.combine(date.today(), datetime.min.time()) - timedelta(days=timescale)
+            today_start = datetime.combine(date.today(), datetime.min.time())
+            start_date = today_start - timedelta(days=timescale)
         except (TypeError, ValueError, IndexError):
             pass
 
@@ -910,7 +911,8 @@ class Telegram(RPCHandler):
                    "                `pending buy orders are marked with an asterisk (*)`\n"
                    "                `pending sell orders are marked with a double asterisk (**)`\n"
                    "*/trades [limit]:* `Lists last closed trades (limited to 10 by default)`\n"
-                   "*/profit [<n>]:* `Lists cumulative profit from all finished trades, over the last n days`\n"
+                   "*/profit [<n>]:* `Lists cumulative profit from all finished trades, "
+                   "over the last n days`\n"
                    "*/forcesell <trade_id>|all:* `Instantly sells the given trade or all trades, "
                    "regardless of profit`\n"
                    f"{forcebuy_text if self._config.get('forcebuy_enable', False) else ''}"

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -5,7 +5,7 @@ This module manage Telegram communication
 """
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, date, timedelta
 from html import escape
 from itertools import chain
 from typing import Any, Callable, Dict, List, Union
@@ -425,9 +425,9 @@ class Telegram(RPCHandler):
         start_date = datetime.fromtimestamp(0)
         if context.args:
             if 'day' in context.args:
-                start_date = datetime.utcnow().date()
+                start_date = datetime.combine(date.today(), datetime.min.time())
             elif 'week' in context.args:
-                start_date = datetime.utcnow().date() - timedelta(days=7)
+                start_date = datetime.combine(date.today(), datetime.min.time()) - timedelta(days=7)
 
         stats = self._rpc._rpc_trade_statistics(
             stake_cur,

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -424,9 +424,10 @@ class Telegram(RPCHandler):
 
         start_date = datetime.fromtimestamp(0)
         try:
-            timescale = int(context.args[0]) if context.args else None
-            today_start = datetime.combine(date.today(), datetime.min.time())
-            start_date = today_start - timedelta(days=timescale)
+            if context.args:
+                timescale = int(context.args[0])
+                today_start = datetime.combine(date.today(), datetime.min.time())
+                start_date = today_start - timedelta(days=timescale)
         except (TypeError, ValueError, IndexError):
             pass
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1568,7 +1568,7 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
                          ['/count', '/start', '/stop', '/help']]
     default_keyboard = ReplyKeyboardMarkup(default_keys_list)
 
-    custom_keys_list = [['/daily', '/stats', '/balance', '/profit'],
+    custom_keys_list = [['/daily', '/stats', '/balance', '/profit', '/profit 5'],
                         ['/count', '/start', '/reload_config', '/help']]
     custom_keyboard = ReplyKeyboardMarkup(custom_keys_list)
 
@@ -1602,5 +1602,5 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     used_keyboard = bot.send_message.call_args[1]['reply_markup']
     assert used_keyboard == custom_keyboard
     assert log_has("using custom keyboard from config.json: "
-                   "[['/daily', '/stats', '/balance', '/profit'], ['/count', "
+                   "[['/daily', '/stats', '/balance', '/profit', '/profit 5'], ['/count', "
                    "'/start', '/reload_config', '/help']]", caplog)


### PR DESCRIPTION
## Summary
Allows to show profit not for all trades but for today/last 7 days trades only with Telegram '/profit' command

## What's new?
Existing '/profit' Telegram command shows statistics for all trades
This change adds two new commands '/profit day' and '/profit week' which show statistics for today/last 7 days trades only
