### PR TITLE
patch: add Helper functions for dataframe access via datetime

### DIFF
--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -115,18 +115,18 @@ def get_buy_candle(dataframe, trade: Trade, timeframe: str, now: datetime = None
 
 def find_candle_datetime(dataframe: pd.DataFrame, timeframe: str, query_date: datetime, pair: str, now: datetime = None):
     result = None
-    candle = find_candle_datetime_safer(dataframe, query_date)
-    # candle = find_candle_datetime_faster(dataframe, timeframe, query_date, now)
-    result = candle if candle.empty else candle.squeeze()
+    try:
+        candle = find_candle_datetime_safer(dataframe, query_date)
+        result = candle if candle.empty else candle.squeeze()
+    # query_date may not exist yet, e.g. if using trade.open_date
+    except KeyError:
+        result = None
     return result
 
 
 def find_candle_datetime_safer(dataframe: pd.DataFrame, query_date: datetime):
     df = dataframe[['date']].set_index('date')
 
-    try:
-        date_mask = df.index.unique().get_loc(query_date, method='ffill')
-        candle = dataframe.iloc[date_mask]  # use iloc because date_mask maybe :int
-    except KeyError:  # trade.open_date may not exist yet
-        candle = pd.DataFrame(index=dataframe.index)
+    date_mask = df.index.unique().get_loc(query_date, method='ffill')
+    candle = dataframe.iloc[date_mask]  # use iloc because date_mask maybe :int
     return candle

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -1,7 +1,7 @@
+from datetime import datetime, timedelta
 import pandas as pd
 
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
-from datetime import datetime, timedelta
 from freqtrade.persistence import Trade
 
 

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -105,12 +105,12 @@ def get_buy_candle(dataframe, trade: Trade, timeframe: str, now: datetime = None
     """
     trade_open = trade.open_date_utc
     one_frame = timedelta(minutes=timeframe_to_minutes(timeframe))
-    trade_candle = find_candle_datetime(dataframe,
-                                        timeframe,
-                                        query_date=trade_open - one_frame,
-                                        pair=trade.pair,
-                                        now=now)
-    return trade_candle
+    buy_candle = find_candle_datetime(dataframe,
+                                      timeframe,
+                                      query_date=trade_open - one_frame,
+                                      pair=trade.pair,
+                                      now=now)
+    return buy_candle
 
 
 def find_candle_datetime(dataframe: pd.DataFrame, timeframe: str, query_date: datetime, pair: str, now: datetime = None):

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -1,6 +1,9 @@
 import pandas as pd
 
-from freqtrade.exchange import timeframe_to_minutes
+from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
+from freqtrade.strategy import IStrategy
+from datetime import datetime
+from freqtrade.persistence import Trade
 
 
 def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
@@ -83,3 +86,46 @@ def stoploss_from_open(open_relative_stop: float, current_profit: float) -> floa
 
     # negative stoploss values indicate the requested stop price is higher than the current price
     return max(stoploss, 0.0)
+
+
+class HelperMixin(IStrategy):
+    custom_stoploss_config = {}
+
+    def get_custom_dataframe(self, pair: str):
+        dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+        return dataframe
+
+    def get_trade_candle(self, trade: 'Trade'):
+        """
+        search for nearest row of trade.open_date
+        """
+        trade_candle = self.find_candle_datetime(trade.open_date_utc, pair=trade.pair, now=None)
+        return trade_candle
+
+    def find_candle_datetime(self, query_date: datetime, pair: str, now: datetime):
+        result = None
+        dataframe = self.get_custom_dataframe(pair)
+        candle = self.find_candle_datetime_safer(query_date, now, dataframe,)
+        result = candle if candle.empty else candle.squeeze()
+        return result
+
+    def find_candle_datetime_faster(self, query_date: datetime, now: datetime, dataframe):
+        if(now and now == query_date):
+            candle = dataframe.iloc[-1]
+        else:
+            candle_date = timeframe_to_prev_date(self.timeframe, query_date)
+            candle = dataframe.loc[dataframe.date == candle_date]
+        return candle
+
+    def find_candle_datetime_safer(self, query_date: datetime, now: datetime, dataframe):
+        df = dataframe[['date']].set_index('date')
+
+        try:
+            date_mask = df.index.unique().get_loc(query_date, method='ffill')
+            candle = dataframe.iloc[date_mask]  # use iloc because date_mask maybe :int
+        except KeyError:  # trade.open_date may not exist yet
+            candle = pd.DataFrame(index=dataframe.index)
+        return candle
+
+    def __init__(self, config: dict) -> None:
+        super().__init__(config)

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
-from freqtrade.strategy import IStrategy
 from datetime import datetime, timedelta
 from freqtrade.persistence import Trade
 
@@ -107,7 +106,7 @@ def get_buy_candle(self, trade: 'Trade', timeframe="5m"):
     """
     trade_candle = find_candle_datetime(
         self,
-        trade.open_date_utc-timedelta(minutes=timeframe_to_minutes(self.timeframe)),
+        trade.open_date_utc - timedelta(minutes=timeframe_to_minutes(self.timeframe)),
         pair=trade.pair,
         now=None)
     return trade_candle

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -121,15 +121,6 @@ def find_candle_datetime(dataframe: pd.DataFrame, timeframe: str, query_date: da
     return result
 
 
-def find_candle_datetime_faster(dataframe: pd.DataFrame, timeframe: str, query_date: datetime, now: datetime = None):
-    if(now and now == query_date):
-        candle = dataframe.iloc[-1]
-    else:
-        candle_date = timeframe_to_prev_date(timeframe, query_date)
-        candle = dataframe.loc[dataframe.date == candle_date]
-    return candle
-
-
 def find_candle_datetime_safer(dataframe: pd.DataFrame, query_date: datetime):
     df = dataframe[['date']].set_index('date')
 

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -125,7 +125,7 @@ def find_candle_datetime_faster(dataframe: pd.DataFrame, timeframe: str, query_d
     if(now and now == query_date):
         candle = dataframe.iloc[-1]
     else:
-        candle_date = timeframe_to_prev_date(self.timeframe, query_date)
+        candle_date = timeframe_to_prev_date(timeframe, query_date)
         candle = dataframe.loc[dataframe.date == candle_date]
     return candle
 


### PR DESCRIPTION
adds following public facing helper functions:

`def get_trade_candle(self, trade: 'Trade'):` -> gets candle of `trade.open_date`


`def get_buy_candle(self, trade: 'Trade', timeframe="5m"):` -> gets the candle where the buy decision happend (basically `shift(1)` of open_date)


`find_candle_datetime(self, query_date: datetime, pair: str, now: datetime)` -> finds candle of the given `query_date`

I'm not married to the names. Just tried to keep it somewhat short. 

> There are two hard things in computer science: cache invalidation, naming things​, and off-by-one errors