### PR TITLE
Indicator plotting improvement

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -170,8 +170,14 @@ Additional features when using plot_config include:
 * Specify additional subplots
 * Specify indicator pairs to fill area in between 
 
-The sample plot configuration below specifies fixed colors for the indicators. Otherwise consecutive plots may produce different colorschemes each time, making comparisons difficult.
+The sample plot configuration below specifies fixed colors for the indicators. Otherwise, consecutive plots may produce different color schemes each time, making comparisons difficult.
 It also allows multiple subplots to display both MACD and RSI at the same time.
+
+Plot type can be configured using `type` key. Possible types are:
+* `scatter` corresponding to `plotly.graph_objects.Scatter` class (default).
+* `bar` corresponding to `plotly.graph_objects.Bar` class.
+
+Extra parameters to `plotly.graph_objects.*` constructor can be specified in `plotly` dict.
 
 Sample configuration with inline comments explaining the process:
 
@@ -198,7 +204,8 @@ Sample configuration with inline comments explaining the process:
             # Create subplot MACD
             "MACD": {
                 'macd': {'color': 'blue', 'fill_to': 'macdhist'},
-                'macdsignal': {'color': 'orange'}
+                'macdsignal': {'color': 'orange'},
+                'macdhist': {'type': 'bar', 'plotly': {'opacity': 0.9}}
             },
             # Additional subplot RSI
             "RSI": {
@@ -212,6 +219,9 @@ Sample configuration with inline comments explaining the process:
 !!! Note
     The above configuration assumes that `ema10`, `ema50`, `senkou_a`, `senkou_b`,
     `macd`, `macdsignal`, `macdhist` and `rsi` are columns in the DataFrame created by the strategy.
+
+!!! Warning
+    `plotly` arguments are only supported with plotly library and will not work with freq-ui.
 
 ## Plot profit
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -96,20 +96,34 @@ def add_indicators(fig, row, indicators: Dict[str, Dict], data: pd.DataFrame) ->
                        Dict key must correspond to dataframe column.
     :param data: candlestick DataFrame
     """
+    plot_kinds = {
+        'scatter': go.Scatter,
+        'bar': go.Bar,
+    }
     for indicator, conf in indicators.items():
         logger.debug(f"indicator {indicator} with config {conf}")
         if indicator in data:
             kwargs = {'x': data['date'],
                       'y': data[indicator].values,
-                      'mode': 'lines',
                       'name': indicator
                       }
-            if 'color' in conf:
-                kwargs.update({'line': {'color': conf['color']}})
-            scatter = go.Scatter(
-                **kwargs
-            )
-            fig.add_trace(scatter, row, 1)
+
+            plot_type = conf.get('type', 'scatter')
+            color = conf.get('color')
+            if plot_type == 'bar':
+                kwargs.update({'marker_color': color or 'DarkSlateGrey',
+                               'marker_line_color': color or 'DarkSlateGrey'})
+            else:
+                if color:
+                    kwargs.update({'line': {'color': color}})
+                kwargs['mode'] = 'lines'
+                if plot_type != 'scatter':
+                    logger.warning(f'Indicator {indicator} has hnknown plot trace kind {plot_type}'
+                                   f', assuming "scatter".')
+
+            kwargs.update(conf.get('plotly', {}))
+            trace = plot_kinds[plot_type](**kwargs)
+            fig.add_trace(trace, row, 1)
         else:
             logger.info(
                 'Indicator "%s" ignored. Reason: This indicator is not found '

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -118,7 +118,7 @@ def add_indicators(fig, row, indicators: Dict[str, Dict], data: pd.DataFrame) ->
                     kwargs.update({'line': {'color': color}})
                 kwargs['mode'] = 'lines'
                 if plot_type != 'scatter':
-                    logger.warning(f'Indicator {indicator} has hnknown plot trace kind {plot_type}'
+                    logger.warning(f'Indicator {indicator} has unknown plot trace kind {plot_type}'
                                    f', assuming "scatter".')
 
             kwargs.update(conf.get('plotly', {}))


### PR DESCRIPTION
- Added a way to specify plot type. Still defaults to "scatter", but we can also specify "bar". Great for MACD histogram 👍🏻 
- Added a way to pass extra arguments to plotly trace constructor. Now we can customize appearance of plotted objects. For example displaying parabolic sar is now possible as we can override `mode` and set `marker_symbol`.