### PR TITLE
Fix a rare error during hyperopt

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -163,7 +163,7 @@ class Hyperopt:
         :param epoch: result dictionary for this epoch.
         """
         with self.results_file.open('a') as f:
-            rapidjson.dump(epoch, f, default=str, number_mode=rapidjson.NM_NATIVE)
+            rapidjson.dump(epoch, f, default=str, number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)
             f.write("\n")
 
         self.num_epochs_saved += 1

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -163,7 +163,8 @@ class Hyperopt:
         :param epoch: result dictionary for this epoch.
         """
         with self.results_file.open('a') as f:
-            rapidjson.dump(epoch, f, default=str, number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)
+            rapidjson.dump(epoch, f, default=str,
+                           number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)
             f.write("\n")
 
         self.num_epochs_saved += 1


### PR DESCRIPTION
Solve an error when saving epoch 
```
freqtrade/freqtrade/optimize/hyperopt.py", line 166, in _save_result
    rapidjson.dump(epoch, f, default=str, number_mode=rapidjson.NM_NATIVE)
ValueError: Out of range float values are not JSON compliant
```


