### PR TITLE
backtest proposal: less optimistic trailing stops

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -224,6 +224,13 @@ class Backtesting:
                 # sell at open price.
                 return sell_row[OPEN_IDX]
 
+            if sell.sell_type == SellType.TRAILING_STOP_LOSS:
+                # trailing stop could potentially occur at any price between
+                # trade.stop_loss and candle low, so use the mid point
+                # to prevent extremely optimistic results with tight stops
+                stop_price = (trade.stop_loss + sell_row[LOW_IDX]) / 2
+                return stop_price
+
             # Set close_rate to stoploss
             return trade.stop_loss
         elif sell.sell_type == (SellType.ROI):


### PR DESCRIPTION
## Summary

in backtesting, calculate trailing stop sell price as being half way between the stop loss and low, preventing extremely optimistic results when using tight stop loss values

## What's new?

Before
![20210527-202710-msedge](https://user-images.githubusercontent.com/323682/119824966-6d1f4280-bf31-11eb-9f1c-34dc76c2be62.png)

After

![20210527-202941-msedge](https://user-images.githubusercontent.com/323682/119824982-727c8d00-bf31-11eb-9f91-9b05b2e41b24.png)

