### PR TITLE
allow list-strategies to show if params are hyperoptable

### DIFF
--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -273,11 +273,12 @@ class HyperStrategyMixin(object):
         for par in params:
             yield par.name, par
 
-    def _detect_parameters(self, category: str) -> Iterator[Tuple[str, BaseParameter]]:
+    @classmethod
+    def detect_parameters(cls, category: str) -> Iterator[Tuple[str, BaseParameter]]:
         """ Detect all parameters for 'category' """
-        for attr_name in dir(self):
+        for attr_name in dir(cls):
             if not attr_name.startswith('__'):  # Ignore internals, not strictly necessary.
-                attr = getattr(self, attr_name)
+                attr = getattr(cls, attr_name)
                 if issubclass(attr.__class__, BaseParameter):
                     if (attr_name.startswith(category + '_')
                             and attr.category is not None and attr.category != category):
@@ -286,6 +287,19 @@ class HyperStrategyMixin(object):
                     if (category == attr.category or
                             (attr_name.startswith(category + '_') and attr.category is None)):
                         yield attr_name, attr
+
+    @classmethod
+    def detect_all_parameters(cls) -> Dict:
+        """ Detect all parameters and return them as a list"""
+        params: Dict = {
+            'buy': list(cls.detect_parameters('buy')),
+            'sell': list(cls.detect_parameters('sell')),
+        }
+        params.update({
+            'count': len(params['buy'] + params['sell'])
+        })
+
+        return params
 
     def _load_hyper_params(self, hyperopt: bool = False) -> None:
         """
@@ -303,7 +317,7 @@ class HyperStrategyMixin(object):
             logger.info(f"No params for {space} found, using default values.")
         param_container: List[BaseParameter] = getattr(self, f"ft_{space}_params")
 
-        for attr_name, attr in self._detect_parameters(space):
+        for attr_name, attr in self.detect_parameters(space):
             attr.name = attr_name
             attr.in_space = hyperopt and HyperoptTools.has_space(self.config, space)
             if not attr.category:

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -667,8 +667,13 @@ def test_auto_hyperopt_interface(default_conf):
 
     # Parameter is disabled - so value from sell_param dict will NOT be used.
     assert strategy.sell_minusdi.value == 0.5
+    all_params = strategy.detect_all_parameters()
+    assert isinstance(all_params, dict)
+    assert len(all_params['buy']) == 2
+    assert len(all_params['sell']) == 2
+    assert all_params['count'] == 4
 
-    strategy.sell_rsi = IntParameter([0, 10], default=5, space='buy')
+    strategy.__class__.sell_rsi = IntParameter([0, 10], default=5, space='buy')
 
     with pytest.raises(OperationalException, match=r"Inconclusive parameter.*"):
-        [x for x in strategy._detect_parameters('sell')]
+        [x for x in strategy.detect_parameters('sell')]


### PR DESCRIPTION
## Summary
allow list-strategies to show if params are hyperoptable

Allow to easily detect if a strategy has hyperoptable parameters via `list-strategy` command.


```
+--------------------------------+-----------------------------------+-------------+----------------+--------------+---------------+     
|                           name |                          location |      status |   hyperoptable |   buy-Params |   sell-Params |     
|--------------------------------+-----------------------------------+-------------+----------------+--------------+---------------|     
|                        BinHV45 |                        BinHV45.py |          OK |             No |            0 |             0 |     
|           SwingHighIHYPERSTRAT |           SwingHighIHYPERSTRAT.py |          OK |            Yes |            2 |             3 |
+--------------------------------+-----------------------------------+-------------+----------------+--------------+---------------+

```