### PR TITLE
Add show Pairlists Whitelist on RFC and Telegram

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -716,6 +716,8 @@ class RPC:
                'length': len(self._freqtrade.active_pair_whitelist),
                'whitelist': self._freqtrade.active_pair_whitelist
                }
+        if self._freqtrade.pairlists.whitelist:
+            res['pairlistsWhitelist'] = self._freqtrade.pairlists.whitelist
         return res
 
     def _rpc_blacklist(self, add: List[str] = None) -> Dict:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -853,6 +853,8 @@ class Telegram(RPCHandler):
 
             message = f"Using whitelist `{whitelist['method']}` with {whitelist['length']} pairs\n"
             message += f"`{', '.join(whitelist['whitelist'])}`"
+            if whitelist['pairlistsWhitelist']:
+                message += f"`from current pairlists whitelist {', '.join(whitelist['pairlistsWhitelist'])}`"
 
             logger.debug(message)
             self._send_msg(message)

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -854,7 +854,7 @@ class Telegram(RPCHandler):
             message = f"Using whitelist `{whitelist['method']}` with {whitelist['length']} pairs\n"
             message += f"`{', '.join(whitelist['whitelist'])}`"
             if whitelist['pairlistsWhitelist']:
-                message += f"`from current pairlists whitelist {', '.join(whitelist['pairlistsWhitelist'])}`"
+                message += f"`\nfrom current pairlists whitelist {', '.join(whitelist['pairlistsWhitelist'])}`"
 
             logger.debug(message)
             self._send_msg(message)

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -959,6 +959,9 @@ def test_rpc_whitelist_dynamic(mocker, default_conf) -> None:
     assert ret['length'] == 4
     assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']
 
+    api_whitelist = ['ETH/BTC', 'LTC/BTC', 'XRP/BTC', 'NEO/BTC']
+    assert api_whitelist == ret['pairlistsWhitelist']
+
 
 def test_rpc_blacklist(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())


### PR DESCRIPTION
Because the whitelist command only shows active whitelists.

## Summary

to make the RFC whitelist API response pairlistsWhitelist from dynamic pairlists

```JSON

{
    "whitelist": ["ETH/BTC"],
    "length": 1,
    "method": [{
		"method": "VolumePairList",
        "number_assets": 4,
	}],
	"pairlistsWhitelist": ["ETH/BTC", "LTC/BTC", "XRP/BTC", "NEO/BTC"]
}

```

and add telegram bot showing pairlists whitelist in the line after `/whitelist`

## Quick changelog

- Add pairlists whitelist (API whitelist) response from RFC API
- Add bot telegram output current pairlists whitelist

## What's new?

Add showing current API whitelist after filters.