### PR TITLE
test-pairlist: remove non-JSON headline from JSON output

### DIFF
--- a/freqtrade/commands/pairlist_commands.py
+++ b/freqtrade/commands/pairlist_commands.py
@@ -31,7 +31,7 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
         results[curr] = pairlists.whitelist
 
     for curr, pairlist in results.items():
-        if not args.get('print_one_column', False):
+        if not args.get('print_one_column', False) and not args.get('list_pairs_print_json', False):
             print(f"Pairs for {curr}: ")
 
         if args.get('print_one_column', False):

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1,3 +1,4 @@
+import json
 import re
 from io import BytesIO
 from pathlib import Path
@@ -914,8 +915,15 @@ def test_start_test_pairlist(mocker, caplog, tickers, default_conf, capsys):
     ]
     start_test_pairlist(get_args(args))
     captured = capsys.readouterr()
-    assert re.match(r'Pairs for BTC: \n\["ETH/BTC","TKN/BTC","BLK/BTC","LTC/BTC","XRP/BTC"\]\n',
-                    captured.out)
+    try:
+        json_pairs = json.loads(captured.out)
+        assert 'ETH/BTC' in json_pairs
+        assert 'TKN/BTC' in json_pairs
+        assert 'BLK/BTC' in json_pairs
+        assert 'LTC/BTC' in json_pairs
+        assert 'XRP/BTC' in json_pairs
+    except json.decoder.JSONDecodeError:
+        pytest.fail(f'Expected well formed JSON, but failed to parse: {captured.out}')
 
 
 def test_hyperopt_list(mocker, capsys, caplog, saved_hyperopt_results,


### PR DESCRIPTION
## Summary
Removing non-JSON headline for `test-pairlist --print-json` command, in order to improve processing of JSON output.

## Quick changelog

- `test-pairlist --print-json` command returns well-formed JSON

## What's new?
Before, the out isn't valid JSON:
```
$ freqtrade test-pairlist -c config_bittrex.json.example --print-json
Pairs for BTC:
["ETH/BTC","TKN/BTC","BLK/BTC","LTC/BTC","XRP/BTC"]
```

After:
```
$ freqtrade test-pairlist -c config_bittrex.json.example --print-json
["ETH/BTC","TKN/BTC","BLK/BTC","LTC/BTC","XRP/BTC"]
```
Which is valid JSON and can be directly further processed by tools.