### PR TITLE
plot-profit: Make "auto-open" HTML result optional

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -275,6 +275,7 @@ optional arguments:
                         (backtest file)) Default: file
   -i TIMEFRAME, --timeframe TIMEFRAME, --ticker-interval TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
+  --auto-open           Automatically open generated plot.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -69,7 +69,7 @@ ARGS_PLOT_DATAFRAME = ["pairs", "indicators1", "indicators2", "plot_limit",
                        "timerange", "timeframe", "no_trades"]
 
 ARGS_PLOT_PROFIT = ["pairs", "timerange", "export", "exportfilename", "db_url",
-                    "trade_source", "timeframe"]
+                    "trade_source", "timeframe", "plot_auto_open"]
 
 ARGS_INSTALL_UI = ["erase_ui_only"]
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -433,6 +433,11 @@ AVAILABLE_CLI_OPTIONS = {
         metavar='INT',
         default=750,
     ),
+    "plot_auto_open": Arg(
+        '--auto-open',
+        help='Automatically open generated plot.',
+        action='store_true',
+    ),
     "no_trades": Arg(
         '--no-trades',
         help='Skip using trades from backtesting file and DB.',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -375,6 +375,9 @@ class Configuration:
         self._args_to_config(config, argname='plot_limit',
                              logstring='Limiting plot to: {}')
 
+        self._args_to_config(config, argname='plot_auto_open',
+                             logstring='Parameter --auto-open detected.')
+
         self._args_to_config(config, argname='trade_source',
                              logstring='Using trades from: {}')
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -602,4 +602,5 @@ def plot_profit(config: Dict[str, Any]) -> None:
                                 trades, config.get('timeframe', '5m'),
                                 config.get('stake_currency', ''))
     store_plot_file(fig, filename='freqtrade-profit-plot.html',
-                    directory=config['user_data_dir'] / 'plot', auto_open=True)
+                    directory=config['user_data_dir'] / 'plot',
+                    auto_open=config.get('plot_auto_open', False))

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -186,18 +186,22 @@ def test_plot_dataframe_options() -> None:
     assert pargs['pairs'] == ['UNITTEST/BTC']
 
 
-def test_plot_profit_options() -> None:
+@pytest.mark.parametrize('auto_open_arg', [True, False])
+def test_plot_profit_options(auto_open_arg: bool) -> None:
     args = [
         'plot-profit',
         '-p', 'UNITTEST/BTC',
         '--trade-source', 'DB',
         '--db-url', 'sqlite:///whatever.sqlite',
     ]
+    if auto_open_arg:
+        args.append('--auto-open')
     pargs = Arguments(args).get_parsed_arg()
 
     assert pargs['trade_source'] == 'DB'
     assert pargs['pairs'] == ['UNITTEST/BTC']
     assert pargs['db_url'] == 'sqlite:///whatever.sqlite'
+    assert pargs['plot_auto_open'] == auto_open_arg
 
 
 def test_config_notallowed(mocker) -> None:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -460,7 +460,7 @@ def test_plot_profit(default_conf, mocker, testdatadir):
     assert store_mock.call_count == 1
 
     assert profit_mock.call_args_list[0][0][0] == default_conf['pairs']
-    assert store_mock.call_args_list[0][1]['auto_open'] is True
+    assert store_mock.call_args_list[0][1]['auto_open'] is False
 
 
 @pytest.mark.parametrize("ind1,ind2,plot_conf,exp", [


### PR DESCRIPTION
## Summary
For better tool processing, make the "auto-open" function of the `freqtrade plot-profit` result optional

## Quick changelog

- Auto-open HTML result of `plot-profit` sub-command is now optional
- `plot-profit --auto-open` argument added to substitute the original behavior

## What's new?
For tool processing of the result of `plot-profit`, it is disadvantageous to automatically open the generated HTML file.

Before:
`freqtrade plot-profit` -> opens generated HTML file in system application (browser).
After:
`freqtrade plot-profit` -> just generates the HTML result, doesn't open
`freqtrade plot-profit --auto-open` -> opens generated HTML file in system application (browser). (original behavior)