### PR TITLE
Enums own package

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -8,11 +8,11 @@ from freqtrade.configuration import TimeRange, setup_utils_configuration
 from freqtrade.data.converter import convert_ohlcv_format, convert_trades_format
 from freqtrade.data.history import (convert_trades_to_ohlcv, refresh_backtest_ohlcv_data,
                                     refresh_backtest_trades_data)
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.resolvers import ExchangeResolver
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/deploy_commands.py
+++ b/freqtrade/commands/deploy_commands.py
@@ -8,9 +8,9 @@ import requests
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.configuration.directory_operations import copy_sample_files, create_userdata_dir
 from freqtrade.constants import USERPATH_HYPEROPTS, USERPATH_STRATEGIES
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import render_template, render_template_with_fallback
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -6,9 +6,9 @@ from colorama import init as colorama_init
 
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.data.btanalysis import get_latest_hyperopt_file
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.optimize_reports import show_backtest_result
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/list_commands.py
+++ b/freqtrade/commands/list_commands.py
@@ -12,11 +12,11 @@ from tabulate import tabulate
 
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.constants import USERPATH_HYPEROPTS, USERPATH_STRATEGIES
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import market_is_active, validate_exchanges
 from freqtrade.misc import plural
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/optimize_commands.py
+++ b/freqtrade/commands/optimize_commands.py
@@ -3,9 +3,9 @@ from typing import Any, Dict
 
 from freqtrade import constants
 from freqtrade.configuration import setup_utils_configuration
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import round_coin_value
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/pairlist_commands.py
+++ b/freqtrade/commands/pairlist_commands.py
@@ -4,8 +4,8 @@ from typing import Any, Dict
 import rapidjson
 
 from freqtrade.configuration import setup_utils_configuration
+from freqtrade.enums import RunMode
 from freqtrade.resolvers import ExchangeResolver
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/commands/plot_commands.py
+++ b/freqtrade/commands/plot_commands.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
 
 from freqtrade.configuration import setup_utils_configuration
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
-from freqtrade.state import RunMode
 
 
 def validate_plot_args(args: Dict[str, Any]) -> None:

--- a/freqtrade/configuration/check_exchange.py
+++ b/freqtrade/configuration/check_exchange.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Dict
 
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import (available_exchanges, is_exchange_known_ccxt,
                                 is_exchange_officially_supported, validate_exchange)
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/configuration/config_setup.py
+++ b/freqtrade/configuration/config_setup.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict
 
-from freqtrade.state import RunMode
+from freqtrade.enums import RunMode
 
 from .check_exchange import remove_credentials
 from .config_validation import validate_config_consistency

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -6,8 +6,8 @@ from jsonschema import Draft4Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
 
 from freqtrade import constants
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -12,10 +12,10 @@ from freqtrade.configuration.check_exchange import check_exchange
 from freqtrade.configuration.deprecated_settings import process_temporary_deprecated_settings
 from freqtrade.configuration.directory_operations import create_datadir, create_userdata_dir
 from freqtrade.configuration.load_config import load_config_file, load_file
+from freqtrade.enums import NON_UTIL_MODES, TRADING_MODES, RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.loggers import setup_logging
 from freqtrade.misc import deep_merge_dicts
-from freqtrade.state import NON_UTIL_MODES, TRADING_MODES, RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -12,9 +12,9 @@ from pandas import DataFrame
 
 from freqtrade.constants import ListPairsWithTimeframes, PairWithTimeframe
 from freqtrade.data.history import load_pair_history
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import ExchangeError, OperationalException
 from freqtrade.exchange import Exchange
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -13,11 +13,12 @@ from pandas import DataFrame
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import DATETIME_PRINT_FORMAT, UNLIMITED_STAKE_AMOUNT
 from freqtrade.data.history import get_timerange, load_data, refresh_data
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange.exchange import timeframe_to_seconds
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.state import RunMode
-from freqtrade.strategy.interface import IStrategy, SellType
+from freqtrade.strategy.interface import IStrategy
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/edge/edge_positioning.py
+++ b/freqtrade/edge/edge_positioning.py
@@ -13,11 +13,10 @@ from pandas import DataFrame
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import DATETIME_PRINT_FORMAT, UNLIMITED_STAKE_AMOUNT
 from freqtrade.data.history import get_timerange, load_data, refresh_data
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange.exchange import timeframe_to_seconds
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
-from freqtrade.state import RunMode
 from freqtrade.strategy.interface import IStrategy
 
 

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,3 +1,5 @@
 # flake8: noqa: F401
+from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODES, RunMode
 from freqtrade.enums.selltype import SellType
 from freqtrade.enums.signaltype import SignalType
+from freqtrade.enums.state import State

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+from freqtrade.enums.rpcmessagetype import RPCMessageType
 from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODES, RunMode
 from freqtrade.enums.selltype import SellType
 from freqtrade.enums.signaltype import SignalType

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from freqtrade.enums.selltype import SellType
+from freqtrade.enums.signaltype import SignalType

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from freqtrade.enums.selltype import SellType

--- a/freqtrade/enums/rpcmessagetype.py
+++ b/freqtrade/enums/rpcmessagetype.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class RPCMessageType(Enum):
+    STATUS = 'status'
+    WARNING = 'warning'
+    STARTUP = 'startup'
+    BUY = 'buy'
+    BUY_FILL = 'buy_fill'
+    BUY_CANCEL = 'buy_cancel'
+    SELL = 'sell'
+    SELL_FILL = 'sell_fill'
+    SELL_CANCEL = 'sell_cancel'
+
+    def __repr__(self):
+        return self.value
+
+    def __str__(self):
+        return self.value

--- a/freqtrade/enums/runmode.py
+++ b/freqtrade/enums/runmode.py
@@ -1,8 +1,3 @@
-# pragma pylint: disable=too-few-public-methods
-
-"""
-Bot state constant
-"""
 from enum import Enum
 
 

--- a/freqtrade/enums/runmode.py
+++ b/freqtrade/enums/runmode.py
@@ -6,18 +6,6 @@ Bot state constant
 from enum import Enum
 
 
-class State(Enum):
-    """
-    Bot application states
-    """
-    RUNNING = 1
-    STOPPED = 2
-    RELOAD_CONFIG = 3
-
-    def __str__(self):
-        return f"{self.name.lower()}"
-
-
 class RunMode(Enum):
     """
     Bot running mode (backtest, hyperopt, ...)

--- a/freqtrade/enums/selltype.py
+++ b/freqtrade/enums/selltype.py
@@ -1,4 +1,3 @@
-
 from enum import Enum
 
 

--- a/freqtrade/enums/selltype.py
+++ b/freqtrade/enums/selltype.py
@@ -1,0 +1,21 @@
+
+from enum import Enum
+
+
+class SellType(Enum):
+    """
+    Enum to distinguish between sell reasons
+    """
+    ROI = "roi"
+    STOP_LOSS = "stop_loss"
+    STOPLOSS_ON_EXCHANGE = "stoploss_on_exchange"
+    TRAILING_STOP_LOSS = "trailing_stop_loss"
+    SELL_SIGNAL = "sell_signal"
+    FORCE_SELL = "force_sell"
+    EMERGENCY_SELL = "emergency_sell"
+    CUSTOM_SELL = "custom_sell"
+    NONE = ""
+
+    def __str__(self):
+        # explicitly convert to String to help with exporting data.
+        return self.value

--- a/freqtrade/enums/signaltype.py
+++ b/freqtrade/enums/signaltype.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SignalType(Enum):
+    """
+    Enum to distinguish between buy and sell signals
+    """
+    BUY = "buy"
+    SELL = "sell"

--- a/freqtrade/enums/state.py
+++ b/freqtrade/enums/state.py
@@ -1,0 +1,18 @@
+# pragma pylint: disable=too-few-public-methods
+
+"""
+Bot state constant
+"""
+from enum import Enum
+
+
+class State(Enum):
+    """
+    Bot application states
+    """
+    RUNNING = 1
+    STOPPED = 2
+    RELOAD_CONFIG = 3
+
+    def __str__(self):
+        return f"{self.name.lower()}"

--- a/freqtrade/enums/state.py
+++ b/freqtrade/enums/state.py
@@ -1,8 +1,3 @@
-# pragma pylint: disable=too-few-public-methods
-
-"""
-Bot state constant
-"""
 from enum import Enum
 
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -16,6 +16,7 @@ from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
+from freqtrade.enums import SellType
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, PricingError)
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
@@ -27,7 +28,7 @@ from freqtrade.plugins.protectionmanager import ProtectionManager
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.rpc import RPCManager, RPCMessageType
 from freqtrade.state import State
-from freqtrade.strategy.interface import IStrategy, SellCheckTuple, SellType
+from freqtrade.strategy.interface import IStrategy, SellCheckTuple
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets
 
@@ -337,7 +338,7 @@ class FreqtradeBot(LoggingMixin):
                         # Assume this as the open order
                         trade.open_order_id = order.order_id
                 if fo:
-                    logger.info(f"Found {order} for trade {trade}.jj")
+                    logger.info(f"Found {order} for trade {trade}.")
                     self.update_trade_state(trade, order.order_id, fo,
                                             stoploss_order=order.ft_order_side == 'stoploss')
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -16,7 +16,7 @@ from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
-from freqtrade.enums import SellType, State
+from freqtrade.enums import RPCMessageType, SellType, State
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, PricingError)
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
@@ -26,7 +26,7 @@ from freqtrade.persistence import Order, PairLocks, Trade, cleanup_db, init_db
 from freqtrade.plugins.pairlistmanager import PairListManager
 from freqtrade.plugins.protectionmanager import ProtectionManager
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
-from freqtrade.rpc import RPCManager, RPCMessageType
+from freqtrade.rpc import RPCManager
 from freqtrade.strategy.interface import IStrategy, SellCheckTuple
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -16,7 +16,7 @@ from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
-from freqtrade.enums import SellType
+from freqtrade.enums import SellType, State
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, PricingError)
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
@@ -27,7 +27,6 @@ from freqtrade.plugins.pairlistmanager import PairListManager
 from freqtrade.plugins.protectionmanager import ProtectionManager
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
 from freqtrade.rpc import RPCManager, RPCMessageType
-from freqtrade.state import State
 from freqtrade.strategy.interface import IStrategy, SellCheckTuple
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -17,6 +17,7 @@ from freqtrade.data import history
 from freqtrade.data.btanalysis import trade_list_to_dataframe
 from freqtrade.data.converter import trim_dataframes
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.enums import SellType
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.mixins import LoggingMixin
@@ -26,7 +27,7 @@ from freqtrade.persistence import LocalTrade, PairLocks, Trade
 from freqtrade.plugins.pairlistmanager import PairListManager
 from freqtrade.plugins.protectionmanager import ProtectionManager
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
-from freqtrade.strategy.interface import IStrategy, SellCheckTuple, SellType
+from freqtrade.strategy.interface import IStrategy, SellCheckTuple
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets
 

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -14,6 +14,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.schema import UniqueConstraint
 
 from freqtrade.constants import DATETIME_PRINT_FORMAT
+from freqtrade.enums import SellType
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.misc import safe_value_fallback
 from freqtrade.persistence.migrations import check_migrate
@@ -430,6 +431,7 @@ class LocalTrade():
         elif order_type in ('stop_loss_limit', 'stop-loss', 'stop-loss-limit', 'stop'):
             self.stoploss_order_id = None
             self.close_rate_requested = self.stop_loss
+            self.sell_reason = SellType.STOPLOSS_ON_EXCHANGE.value
             if self.is_open:
                 logger.info(f'{order_type.upper()} is hit for {self}.')
             self.close(safe_value_fallback(order, 'average', 'price'))

--- a/freqtrade/plugins/protections/stoploss_guard.py
+++ b/freqtrade/plugins/protections/stoploss_guard.py
@@ -3,9 +3,9 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict
 
+from freqtrade.enums import SellType
 from freqtrade.persistence import Trade
 from freqtrade.plugins.protections import IProtection, ProtectionReturn
-from freqtrade.strategy.interface import SellType
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/rpc/__init__.py
+++ b/freqtrade/rpc/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
-from .rpc import RPC, RPCException, RPCHandler, RPCMessageType
+from .rpc import RPC, RPCException, RPCHandler
 from .rpc_manager import RPCManager

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -15,6 +15,7 @@ from pandas import DataFrame
 from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CANCEL_REASON, DATETIME_PRINT_FORMAT
 from freqtrade.data.history import load_data
+from freqtrade.enums import SellType
 from freqtrade.exceptions import ExchangeError, PricingError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_msecs
 from freqtrade.loggers import bufferHandler
@@ -24,7 +25,7 @@ from freqtrade.persistence.models import PairLock
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
 from freqtrade.state import State
-from freqtrade.strategy.interface import SellCheckTuple, SellType
+from freqtrade.strategy.interface import SellCheckTuple
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -4,7 +4,6 @@ This module contains class to define a RPC communications
 import logging
 from abc import abstractmethod
 from datetime import date, datetime, timedelta, timezone
-from enum import Enum
 from math import isnan
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -28,24 +27,6 @@ from freqtrade.strategy.interface import SellCheckTuple
 
 
 logger = logging.getLogger(__name__)
-
-
-class RPCMessageType(Enum):
-    STATUS = 'status'
-    WARNING = 'warning'
-    STARTUP = 'startup'
-    BUY = 'buy'
-    BUY_FILL = 'buy_fill'
-    BUY_CANCEL = 'buy_cancel'
-    SELL = 'sell'
-    SELL_FILL = 'sell_fill'
-    SELL_CANCEL = 'sell_cancel'
-
-    def __repr__(self):
-        return self.value
-
-    def __str__(self):
-        return self.value
 
 
 class RPCException(Exception):

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -15,7 +15,7 @@ from pandas import DataFrame
 from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CANCEL_REASON, DATETIME_PRINT_FORMAT
 from freqtrade.data.history import load_data
-from freqtrade.enums import SellType
+from freqtrade.enums import SellType, State
 from freqtrade.exceptions import ExchangeError, PricingError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_msecs
 from freqtrade.loggers import bufferHandler
@@ -24,7 +24,6 @@ from freqtrade.persistence import PairLocks, Trade
 from freqtrade.persistence.models import PairLock
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
-from freqtrade.state import State
 from freqtrade.strategy.interface import SellCheckTuple
 
 

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -4,7 +4,8 @@ This module contains class to manage RPC communications (Telegram, Slack, ...)
 import logging
 from typing import Any, Dict, List
 
-from freqtrade.rpc import RPC, RPCHandler, RPCMessageType
+from freqtrade.enums import RPCMessageType
+from freqtrade.rpc import RPC, RPCHandler
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -22,9 +22,10 @@ from telegram.utils.helpers import escape_markdown
 
 from freqtrade.__init__ import __version__
 from freqtrade.constants import DUST_PER_COIN
+from freqtrade.enums import RPCMessageType
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import chunks, round_coin_value
-from freqtrade.rpc import RPC, RPCException, RPCHandler, RPCMessageType
+from freqtrade.rpc import RPC, RPCException, RPCHandler
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -6,7 +6,8 @@ from typing import Any, Dict
 
 from requests import RequestException, post
 
-from freqtrade.rpc import RPC, RPCHandler, RPCMessageType
+from freqtrade.enums import RPCMessageType
+from freqtrade.rpc import RPC, RPCHandler
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -14,8 +14,8 @@ with suppress(ImportError):
     from skopt.space import Integer, Real, Categorical
     from freqtrade.optimize.space import SKDecimal
 
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -14,11 +14,11 @@ from pandas import DataFrame
 
 from freqtrade.constants import ListPairsWithTimeframes
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.exchange.exchange import timeframe_to_next_date
 from freqtrade.persistence import PairLocks, Trade
-from freqtrade.enums import SellType
 from freqtrade.strategy.hyper import HyperStrategyMixin
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -6,7 +6,6 @@ import logging
 import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 
 import arrow

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -18,6 +18,7 @@ from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.exchange.exchange import timeframe_to_next_date
 from freqtrade.persistence import PairLocks, Trade
+from freqtrade.enums import SellType
 from freqtrade.strategy.hyper import HyperStrategyMixin
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from freqtrade.wallets import Wallets
@@ -33,25 +34,6 @@ class SignalType(Enum):
     """
     BUY = "buy"
     SELL = "sell"
-
-
-class SellType(Enum):
-    """
-    Enum to distinguish between sell reasons
-    """
-    ROI = "roi"
-    STOP_LOSS = "stop_loss"
-    STOPLOSS_ON_EXCHANGE = "stoploss_on_exchange"
-    TRAILING_STOP_LOSS = "trailing_stop_loss"
-    SELL_SIGNAL = "sell_signal"
-    FORCE_SELL = "force_sell"
-    EMERGENCY_SELL = "emergency_sell"
-    CUSTOM_SELL = "custom_sell"
-    NONE = ""
-
-    def __str__(self):
-        # explicitly convert to String to help with exporting data.
-        return self.value
 
 
 class SellCheckTuple(object):

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -14,7 +14,7 @@ from pandas import DataFrame
 
 from freqtrade.constants import ListPairsWithTimeframes
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.enums import SellType
+from freqtrade.enums import SellType, SignalType
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.exchange.exchange import timeframe_to_next_date
@@ -26,14 +26,6 @@ from freqtrade.wallets import Wallets
 
 logger = logging.getLogger(__name__)
 CUSTOM_SELL_MAX_LENGTH = 64
-
-
-class SignalType(Enum):
-    """
-    Enum to distinguish between buy and sell signals
-    """
-    BUY = "buy"
-    SELL = "sell"
 
 
 class SellCheckTuple(object):

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -8,10 +8,10 @@ from typing import Any, Dict, NamedTuple
 import arrow
 
 from freqtrade.constants import UNLIMITED_STAKE_AMOUNT
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import DependencyException
 from freqtrade.exchange import Exchange
 from freqtrade.persistence import LocalTrade, Trade
-from freqtrade.state import RunMode
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -11,9 +11,9 @@ import sdnotify
 
 from freqtrade import __version__, constants
 from freqtrade.configuration import Configuration
+from freqtrade.enums import State
 from freqtrade.exceptions import OperationalException, TemporaryError
 from freqtrade.freqtradebot import FreqtradeBot
-from freqtrade.state import State
 
 
 logger = logging.getLogger(__name__)

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -17,8 +17,8 @@ from freqtrade.commands import (start_convert_data, start_create_userdir, start_
 from freqtrade.commands.deploy_commands import (clean_ui_subdir, download_and_install_ui,
                                                 get_ui_download_url, read_ui_version)
 from freqtrade.configuration import setup_utils_configuration
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
-from freqtrade.state import RunMode
 from tests.conftest import (create_mock_trades, get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 from tests.conftest_trades import MOCK_TRADE_COUNT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,11 @@ from freqtrade import constants
 from freqtrade.commands import Arguments
 from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.edge import Edge, PairInfo
+from freqtrade.enums import RunMode
 from freqtrade.exchange import Exchange
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import LocalTrade, Trade, init_db
 from freqtrade.resolvers import ExchangeResolver
-from freqtrade.state import RunMode
 from freqtrade.worker import Worker
 from tests.conftest_trades import (mock_trade_1, mock_trade_2, mock_trade_3, mock_trade_4,
                                    mock_trade_5, mock_trade_6)

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -5,9 +5,9 @@ import pytest
 from pandas import DataFrame
 
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import ExchangeError, OperationalException
 from freqtrade.plugins.pairlistmanager import PairListManager
-from freqtrade.state import RunMode
 from tests.conftest import get_patched_exchange
 
 

--- a/tests/edge/test_edge.py
+++ b/tests/edge/test_edge.py
@@ -12,8 +12,8 @@ from pandas import DataFrame, to_datetime
 
 from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.edge import Edge, PairInfo
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException
-from freqtrade.strategy.interface import SellType
 from tests.conftest import get_patched_freqtradebot, log_has
 from tests.optimize import (BTContainer, BTrade, _build_backtest_dataframe,
                             _get_frame_time_from_offset)

--- a/tests/optimize/__init__.py
+++ b/tests/optimize/__init__.py
@@ -3,8 +3,8 @@ from typing import Dict, List, NamedTuple, Optional
 import arrow
 from pandas import DataFrame
 
+from freqtrade.enums import SellType
 from freqtrade.exchange import timeframe_to_minutes
-from freqtrade.strategy.interface import SellType
 
 
 tests_start_time = arrow.get(2018, 10, 3)

--- a/tests/optimize/conftest.py
+++ b/tests/optimize/conftest.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from freqtrade.enums import SellType
 from freqtrade.optimize.hyperopt import Hyperopt
 from freqtrade.state import RunMode
-from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
 
 

--- a/tests/optimize/conftest.py
+++ b/tests/optimize/conftest.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType
 from freqtrade.optimize.hyperopt import Hyperopt
-from freqtrade.state import RunMode
 from tests.conftest import patch_exchange
 
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -4,8 +4,8 @@ import logging
 import pytest
 
 from freqtrade.data.history import get_timerange
+from freqtrade.enums import SellType
 from freqtrade.optimize.backtesting import Backtesting
-from freqtrade.strategy.interface import SellType
 from tests.conftest import patch_exchange
 from tests.optimize import (BTContainer, BTrade, _build_backtest_dataframe,
                             _get_frame_time_from_offset, tests_timeframe)

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -16,12 +16,12 @@ from freqtrade.data.btanalysis import BT_DATA_COLUMNS, evaluate_result_multi
 from freqtrade.data.converter import clean_ohlcv_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange
+from freqtrade.enums import SellType
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.persistence import LocalTrade
 from freqtrade.resolvers import StrategyResolver
 from freqtrade.state import RunMode
-from freqtrade.strategy.interface import SellType
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -16,12 +16,11 @@ from freqtrade.data.btanalysis import BT_DATA_COLUMNS, evaluate_result_multi
 from freqtrade.data.converter import clean_ohlcv_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.persistence import LocalTrade
 from freqtrade.resolvers import StrategyResolver
-from freqtrade.state import RunMode
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 

--- a/tests/optimize/test_edge_cli.py
+++ b/tests/optimize/test_edge_cli.py
@@ -4,8 +4,8 @@
 from unittest.mock import MagicMock
 
 from freqtrade.commands.optimize_commands import setup_optimize_configuration, start_edge
+from freqtrade.enums import RunMode
 from freqtrade.optimize.edge_cli import EdgeCli
-from freqtrade.state import RunMode
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -13,6 +13,7 @@ from filelock import Timeout
 
 from freqtrade.commands.optimize_commands import setup_optimize_configuration, start_hyperopt
 from freqtrade.data.history import load_data
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.hyperopt import Hyperopt
 from freqtrade.optimize.hyperopt_auto import HyperOptAuto
@@ -22,7 +23,6 @@ from freqtrade.optimize.space import SKDecimal
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
 from freqtrade.state import RunMode
 from freqtrade.strategy.hyper import IntParameter
-from freqtrade.strategy.interface import SellType
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -13,7 +13,7 @@ from filelock import Timeout
 
 from freqtrade.commands.optimize_commands import setup_optimize_configuration, start_hyperopt
 from freqtrade.data.history import load_data
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType
 from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.hyperopt import Hyperopt
 from freqtrade.optimize.hyperopt_auto import HyperOptAuto
@@ -21,7 +21,6 @@ from freqtrade.optimize.hyperopt_tools import HyperoptTools
 from freqtrade.optimize.optimize_reports import generate_strategy_stats
 from freqtrade.optimize.space import SKDecimal
 from freqtrade.resolvers.hyperopt_resolver import HyperOptResolver
-from freqtrade.state import RunMode
 from freqtrade.strategy.hyper import IntParameter
 from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -12,6 +12,7 @@ from freqtrade.constants import DATETIME_PRINT_FORMAT, LAST_BT_RESULT_FN
 from freqtrade.data import history
 from freqtrade.data.btanalysis import get_latest_backtest_filename, load_backtest_data
 from freqtrade.edge import PairInfo
+from freqtrade.enums import SellType
 from freqtrade.optimize.optimize_reports import (generate_backtest_stats, generate_daily_stats,
                                                  generate_edge_table, generate_pair_metrics,
                                                  generate_sell_reason_stats,
@@ -20,7 +21,6 @@ from freqtrade.optimize.optimize_reports import (generate_backtest_stats, genera
                                                  text_table_bt_results, text_table_sell_reason,
                                                  text_table_strategy)
 from freqtrade.resolvers.strategy_resolver import StrategyResolver
-from freqtrade.strategy.interface import SellType
 from tests.data.test_history import _backup_file, _clean_test_file
 
 

--- a/tests/plugins/test_protections.py
+++ b/tests/plugins/test_protections.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 import pytest
 
 from freqtrade import constants
+from freqtrade.enums import SellType
 from freqtrade.persistence import PairLocks, Trade
 from freqtrade.plugins.protectionmanager import ProtectionManager
-from freqtrade.strategy.interface import SellType
 from tests.conftest import get_patched_freqtradebot, log_has_re
 
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -8,12 +8,12 @@ import pytest
 from numpy import isnan
 
 from freqtrade.edge import PairInfo
+from freqtrade.enums import State
 from freqtrade.exceptions import ExchangeError, InvalidOrderException, TemporaryError
 from freqtrade.persistence import Trade
 from freqtrade.persistence.pairlock_middleware import PairLocks
 from freqtrade.rpc import RPC, RPCException
 from freqtrade.rpc.fiat_convert import CryptoToFiatConverter
-from freqtrade.state import State
 from tests.conftest import create_mock_trades, get_patched_freqtradebot, patch_get_signal
 
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -15,6 +15,7 @@ from numpy import isnan
 from requests.auth import _basic_auth_str
 
 from freqtrade.__init__ import __version__
+from freqtrade.enums import RunMode, State
 from freqtrade.exceptions import ExchangeError
 from freqtrade.loggers import setup_logging, setup_logging_pre
 from freqtrade.persistence import PairLocks, Trade
@@ -22,7 +23,6 @@ from freqtrade.rpc import RPC
 from freqtrade.rpc.api_server import ApiServer
 from freqtrade.rpc.api_server.api_auth import create_token, get_user_from_token
 from freqtrade.rpc.api_server.uvicorn_threaded import UvicornServer
-from freqtrade.state import RunMode, State
 from tests.conftest import (create_mock_trades, get_mock_coro, get_patched_freqtradebot, log_has,
                             log_has_re, patch_get_signal)
 

--- a/tests/rpc/test_rpc_manager.py
+++ b/tests/rpc/test_rpc_manager.py
@@ -3,7 +3,8 @@ import logging
 import time
 from unittest.mock import MagicMock
 
-from freqtrade.rpc import RPCManager, RPCMessageType
+from freqtrade.enums import RPCMessageType
+from freqtrade.rpc import RPCManager
 from tests.conftest import get_patched_freqtradebot, log_has
 
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -17,6 +17,7 @@ from telegram.error import NetworkError
 from freqtrade import __version__
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.edge import PairInfo
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.loggers import setup_logging
@@ -24,7 +25,6 @@ from freqtrade.persistence import PairLocks, Trade
 from freqtrade.rpc import RPC, RPCMessageType
 from freqtrade.rpc.telegram import Telegram, authorized_only
 from freqtrade.state import RunMode, State
-from freqtrade.strategy.interface import SellType
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, log_has, patch_exchange,
                             patch_get_signal, patch_whitelist)
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -17,12 +17,12 @@ from telegram.error import NetworkError
 from freqtrade import __version__
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.edge import PairInfo
-from freqtrade.enums import RunMode, SellType, State
+from freqtrade.enums import RPCMessageType, RunMode, SellType, State
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.loggers import setup_logging
 from freqtrade.persistence import PairLocks, Trade
-from freqtrade.rpc import RPC, RPCMessageType
+from freqtrade.rpc import RPC
 from freqtrade.rpc.telegram import Telegram, authorized_only
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, log_has, patch_exchange,
                             patch_get_signal, patch_whitelist)

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -17,14 +17,13 @@ from telegram.error import NetworkError
 from freqtrade import __version__
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.edge import PairInfo
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType, State
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.loggers import setup_logging
 from freqtrade.persistence import PairLocks, Trade
 from freqtrade.rpc import RPC, RPCMessageType
 from freqtrade.rpc.telegram import Telegram, authorized_only
-from freqtrade.state import RunMode, State
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, log_has, patch_exchange,
                             patch_get_signal, patch_whitelist)
 

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 import pytest
 from requests import RequestException
 
-from freqtrade.enums import SellType
-from freqtrade.rpc import RPC, RPCMessageType
+from freqtrade.enums import RPCMessageType, SellType
+from freqtrade.rpc import RPC
 from freqtrade.rpc.webhook import Webhook
 from tests.conftest import get_patched_freqtradebot, log_has
 

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 from requests import RequestException
 
+from freqtrade.enums import SellType
 from freqtrade.rpc import RPC, RPCMessageType
 from freqtrade.rpc.webhook import Webhook
-from freqtrade.strategy.interface import SellType
 from tests.conftest import get_patched_freqtradebot, log_has
 
 

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -10,12 +10,13 @@ from pandas import DataFrame
 from freqtrade.configuration import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import load_data
+from freqtrade.enums import SellType
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.persistence import PairLocks, Trade
 from freqtrade.resolvers import StrategyResolver
 from freqtrade.strategy.hyper import (BaseParameter, CategoricalParameter, DecimalParameter,
                                       IntParameter, RealParameter)
-from freqtrade.strategy.interface import SellCheckTuple, SellType
+from freqtrade.strategy.interface import SellCheckTuple
 from freqtrade.strategy.strategy_wrapper import strategy_safe_wrapper
 from tests.conftest import log_has, log_has_re
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -20,9 +20,9 @@ from freqtrade.configuration.deprecated_settings import (check_conflicting_setti
                                                          process_temporary_deprecated_settings)
 from freqtrade.configuration.load_config import load_config_file, load_file, log_config_error_range
 from freqtrade.constants import DEFAULT_DB_DRYRUN_URL, DEFAULT_DB_PROD_URL
+from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.loggers import _set_loggers, setup_logging, setup_logging_pre
-from freqtrade.state import RunMode
 from tests.conftest import log_has, log_has_re, patched_configuration_load_config_file
 
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -11,14 +11,13 @@ import arrow
 import pytest
 
 from freqtrade.constants import CANCEL_REASON, MATH_CLOSE_PREC, UNLIMITED_STAKE_AMOUNT
-from freqtrade.enums import RunMode, SellType, State
+from freqtrade.enums import RPCMessageType, RunMode, SellType, State
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, OperationalException, PricingError,
                                   TemporaryError)
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Order, PairLocks, Trade
 from freqtrade.persistence.models import PairLock
-from freqtrade.rpc import RPCMessageType
 from freqtrade.strategy.interface import SellCheckTuple
 from freqtrade.worker import Worker
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, get_patched_worker,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -11,6 +11,7 @@ import arrow
 import pytest
 
 from freqtrade.constants import CANCEL_REASON, MATH_CLOSE_PREC, UNLIMITED_STAKE_AMOUNT
+from freqtrade.enums import SellType
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, OperationalException, PricingError,
                                   TemporaryError)
@@ -19,7 +20,7 @@ from freqtrade.persistence import Order, PairLocks, Trade
 from freqtrade.persistence.models import PairLock
 from freqtrade.rpc import RPCMessageType
 from freqtrade.state import RunMode, State
-from freqtrade.strategy.interface import SellCheckTuple, SellType
+from freqtrade.strategy.interface import SellCheckTuple
 from freqtrade.worker import Worker
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, get_patched_worker,
                             log_has, log_has_re, patch_edge, patch_exchange, patch_get_signal,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -11,7 +11,7 @@ import arrow
 import pytest
 
 from freqtrade.constants import CANCEL_REASON, MATH_CLOSE_PREC, UNLIMITED_STAKE_AMOUNT
-from freqtrade.enums import SellType
+from freqtrade.enums import RunMode, SellType, State
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, OperationalException, PricingError,
                                   TemporaryError)
@@ -19,7 +19,6 @@ from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Order, PairLocks, Trade
 from freqtrade.persistence.models import PairLock
 from freqtrade.rpc import RPCMessageType
-from freqtrade.state import RunMode, State
 from freqtrade.strategy.interface import SellCheckTuple
 from freqtrade.worker import Worker
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, get_patched_worker,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,9 +2,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from freqtrade.enums import SellType
 from freqtrade.persistence import Trade
 from freqtrade.rpc.rpc import RPC
-from freqtrade.strategy.interface import SellCheckTuple, SellType
+from freqtrade.strategy.interface import SellCheckTuple
 from tests.conftest import get_patched_freqtradebot, patch_get_signal
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 
 from freqtrade.commands import Arguments
+from freqtrade.enums import State
 from freqtrade.exceptions import FreqtradeException, OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.main import main
-from freqtrade.state import State
 from freqtrade.worker import Worker
 from tests.conftest import (log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@ import time
 from unittest.mock import MagicMock, PropertyMock
 
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.state import State
+from freqtrade.enums import State
 from freqtrade.worker import Worker
 from tests.conftest import get_patched_worker, log_has, log_has_re
 


### PR DESCRIPTION
## Summary
Move enums to their own package to prevent circular dependencies, and make it clear that these are enums.


Also closes #5101 - (the caused circular import is the reason to move enums to their own package).