### PR TITLE
Implement most pessimistic handling of trailing stoploss.

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -446,6 +446,7 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Stoploss is evaluated before ROI within one candle. So you can often see more trades with the `stoploss` sell reason comparing to the results obtained with the same strategy in the Dry Run/Live Trade modes
 - Low happens before high for stoploss, protecting capital first
 - Trailing stoploss
+  - Trailing Stoploss is only adjusted if it's below the candle's low (otherwise it would be triggered)
   - High happens first - adjusting stoploss
   - Low uses the adjusted stoploss (so sells with large high-low difference are backtested correctly)
   - ROI applies before trailing-stop, ensuring profits are "top-capped" at ROI if both ROI and trailing stop applies

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -228,13 +228,13 @@ class Backtesting:
             # Special case: trailing triggers within same candle as trade opened. Assume most
             # pessimistic price movement, which is moving just enough to arm stoploss and
             # immediately going down to stop price.
-            if sell.sell_type == SellType.TRAILING_STOP_LOSS and trade_dur == 0 and \
-               self.strategy.trailing_stop_positive:
+            if (sell.sell_type == SellType.TRAILING_STOP_LOSS and trade_dur == 0
+                    and self.strategy.trailing_stop_positive):
                 if self.strategy.trailing_only_offset_is_reached:
                     # Worst case: price reaches stop_positive_offset and dives down.
-                    stop_rate = sell_row[OPEN_IDX] * \
-                                (1 + abs(self.strategy.trailing_stop_positive_offset) -
-                                 abs(self.strategy.trailing_stop_positive))
+                    stop_rate = (sell_row[OPEN_IDX] *
+                                 (1 + abs(self.strategy.trailing_stop_positive_offset) -
+                                 abs(self.strategy.trailing_stop_positive)))
                 else:
                     # Worst case: price ticks tiny bit above open and dives down.
                     stop_rate = sell_row[OPEN_IDX] * (1 - abs(self.strategy.trailing_stop_positive))

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -225,6 +225,22 @@ class Backtesting:
                 # sell at open price.
                 return sell_row[OPEN_IDX]
 
+            # Special case: trailing triggers within same candle as trade opened. Assume most
+            # pessimistic price movement, which is moving just enough to arm stoploss and
+            # immediately going down to stop price.
+            if sell.sell_type == SellType.TRAILING_STOP_LOSS and trade_dur == 0 and \
+               self.strategy.trailing_stop_positive:
+                if self.strategy.trailing_only_offset_is_reached:
+                    # Worst case: price reaches stop_positive_offset and dives down.
+                    stop_rate = sell_row[OPEN_IDX] * \
+                                (1 + abs(self.strategy.trailing_stop_positive_offset) -
+                                 abs(self.strategy.trailing_stop_positive))
+                else:
+                    # Worst case: price ticks tiny bit above open and dives down.
+                    stop_rate = sell_row[OPEN_IDX] * (1 - abs(self.strategy.trailing_stop_positive))
+                    assert stop_rate < sell_row[HIGH_IDX]
+                return stop_rate
+
             # Set close_rate to stoploss
             return trade.stop_loss
         elif sell.sell_type == (SellType.ROI):

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -524,15 +524,14 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param force_stoploss: Externally provided stoploss
         :return: True if trade should be sold, False otherwise
         """
-        # Set current rate to low for backtesting sell
-        current_rate = low or rate
+        current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
         trade.adjust_min_max_rates(high or current_rate)
 
         stoplossflag = self.stop_loss_reached(current_rate=current_rate, trade=trade,
                                               current_time=date, current_profit=current_profit,
-                                              force_stoploss=force_stoploss, high=high)
+                                              force_stoploss=force_stoploss, low=low, high=high)
 
         # Set current rate to high for backtesting sell
         current_rate = high or rate
@@ -599,18 +598,21 @@ class IStrategy(ABC, HyperStrategyMixin):
 
     def stop_loss_reached(self, current_rate: float, trade: Trade,
                           current_time: datetime, current_profit: float,
-                          force_stoploss: float, high: float = None) -> SellCheckTuple:
+                          force_stoploss: float, low: float = None,
+                          high: float = None) -> SellCheckTuple:
         """
         Based on current profit of the trade and configured (trailing) stoploss,
         decides to sell or not
         :param current_profit: current profit as ratio
+        :param low: Low value of this candle, only set in backtesting
+        :param high: High value of this candle, only set in backtesting
         """
         stop_loss_value = force_stoploss if force_stoploss else self.stoploss
 
         # Initiate stoploss with open_rate. Does nothing if stoploss is already set.
         trade.adjust_stop_loss(trade.open_rate, stop_loss_value, initial=True)
 
-        if self.use_custom_stoploss and trade.stop_loss < current_rate:
+        if self.use_custom_stoploss and trade.stop_loss < (low or current_rate):
             stop_loss_value = strategy_safe_wrapper(self.custom_stoploss, default_retval=None
                                                     )(pair=trade.pair, trade=trade,
                                                       current_time=current_time,
@@ -623,7 +625,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             else:
                 logger.warning("CustomStoploss function did not return valid stoploss")
 
-        if self.trailing_stop and trade.stop_loss < current_rate:
+        if self.trailing_stop and trade.stop_loss < (low or current_rate):
             # trailing stoploss handling
             sl_offset = self.trailing_stop_positive_offset
 
@@ -643,7 +645,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         # evaluate if the stoploss was hit if stoploss is not on exchange
         # in Dry-Run, this handles stoploss logic as well, as the logic will not be different to
         # regular stoploss handling.
-        if ((trade.stop_loss >= current_rate) and
+        if ((trade.stop_loss >= (low or current_rate)) and
                 (not self.order_types.get('stoploss_on_exchange') or self.config['dry_run'])):
 
             sell_type = SellType.STOP_LOSS
@@ -652,7 +654,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             if trade.initial_stop_loss != trade.stop_loss:
                 sell_type = SellType.TRAILING_STOP_LOSS
                 logger.debug(
-                    f"{trade.pair} - HIT STOP: current price at {current_rate:.6f}, "
+                    f"{trade.pair} - HIT STOP: current price at {(low or current_rate):.6f}, "
                     f"stoploss is {trade.stop_loss:.6f}, "
                     f"initial stoploss was at {trade.initial_stop_loss:.6f}, "
                     f"trade opened at {trade.open_rate:.6f}")

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -610,7 +610,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         # Initiate stoploss with open_rate. Does nothing if stoploss is already set.
         trade.adjust_stop_loss(trade.open_rate, stop_loss_value, initial=True)
 
-        if self.use_custom_stoploss:
+        if self.use_custom_stoploss and trade.stop_loss < current_rate:
             stop_loss_value = strategy_safe_wrapper(self.custom_stoploss, default_retval=None
                                                     )(pair=trade.pair, trade=trade,
                                                       current_time=current_time,
@@ -623,7 +623,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             else:
                 logger.warning("CustomStoploss function did not return valid stoploss")
 
-        if self.trailing_stop:
+        if self.trailing_stop and trade.stop_loss < current_rate:
             # trailing stoploss handling
             sl_offset = self.trailing_stop_positive_offset
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -457,6 +457,50 @@ tc28 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=3)]
 )
 
+# Test 29: trailing_stop should be triggered by low of next candle, without adjusting stoploss using
+# high of stoploss candle.
+# stop-loss: 10%, ROI: 10% (should not apply)
+tc29 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5050, 5000, 4900, 6172, 0, 0],    # enter trade (signal on last candle)
+    [2, 4900, 5250, 4500, 5100, 6172, 0, 0],    # Triggers trailing-stoploss
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10}, profit_perc=-0.02, trailing_stop=True,
+    trailing_stop_positive=0.03,
+    trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=2)]
+)
+
+# Test 30: trailing_stop should be triggered immediately on trade open candle.
+# stop-loss: 10%, ROI: 10% (should not apply)
+tc30 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5500, 5000, 4900, 6172, 0, 0],    # enter trade (signal on last candle) and stop
+    [2, 4900, 5250, 4500, 5100, 6172, 0, 0],
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10}, profit_perc=-0.01, trailing_stop=True,
+    trailing_stop_positive=0.01,
+    trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=1)]
+)
+
+# Test 31: trailing_stop should be triggered immediately on trade open candle.
+# stop-loss: 10%, ROI: 10% (should not apply)
+tc31 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5500, 5000, 4900, 6172, 0, 0],    # enter trade (signal on last candle) and stop
+    [2, 4900, 5250, 4500, 5100, 6172, 0, 0],
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.10}, profit_perc=0.01, trailing_stop=True,
+    trailing_only_offset_is_reached=True, trailing_stop_positive_offset=0.02,
+    trailing_stop_positive=0.01,
+    trades=[BTrade(sell_reason=SellType.TRAILING_STOP_LOSS, open_tick=1, close_tick=1)]
+)
+
 TESTS = [
     tc0,
     tc1,
@@ -487,6 +531,9 @@ TESTS = [
     tc26,
     tc27,
     tc28,
+    tc29,
+    tc30,
+    tc31,
 ]
 
 


### PR DESCRIPTION
This is a crude sketch attempting to solve https://brookmiles.github.io/freqtrade-stuff/2021/04/12/backtesting-traps/. I am opening PR so we have a spot to discuss proposed changes.

#5032 is another attempt to mitigate this. While improving situation, solution does not produce most pessimistic outcome. It may be a good thing or a bad thing. After all, we are not guaranteed that price will move in a worst possible way, so this solution (or variation of it) may be a good middle ground. We should brainstorm more.

## The idea

Trailing stoploss should produce most pessimistic result possible in backtesting. If we are expecting worst case - the only direction is to go up in live runs. Proposed changes implement these cases:
* With `trailing_only_offset_is_reached == True`, price goes up from `open` to `trailing_stop_positive_offset`, arms trailing stoploss and goes down by `trailing_stop_positive`. As a result, sell is recorded at `open + trailing_stop_positive_offset - trailing_stop_positive` price.
* With `trailing_only_offset_is_reached == False`, price goes up from `open` to `trailing_stop_positive` and goes back to `open`. As a result, sell is recorded at `open` price.

To implement this i used `open` price for stoploss calculations in backtesting. Idea is that stoploss would shift only if we go from `open` upwards, while leaving stoploss at the same level when going from `open` downwards.

Pinging people that may be interested in this discussion: @brookmiles @JoeSchr @cyberd3vil @werkkrew @rextea @j-nixx @zx @froggleston 

## The result

`Magic_Trailing_Stoploss` strategy without this patch:
```
=============== SUMMARY METRICS ===============
| Metric                | Value               |
|-----------------------+---------------------|
| Backtesting from      | 2021-05-01 00:00:00 |
| Backtesting to        | 2021-05-04 23:00:00 |
| Max open trades       | 5                   |
|                       |                     |
| Total trades          | 436                 |
| Starting balance      | 5000.000 USDT       |
| Final balance         | 6267.386 USDT       |
| Absolute profit       | 1267.386 USDT       |
| Total profit %        | 25.35%              |
| Trades per day        | 145.33              |
| Avg. stake amount     | 1000.000 USDT       |
| Total trade volume    | 436000.000 USDT     |
|                       |                     |
| Best Pair             | SUSHI/USDT 41.22%   |
| Worst Pair            | EOS/USDT 0.0%       |
| Best trade            | THETA/USDT 1.0%     |
| Worst trade           | LTC/USDT -1.2%      |
| Best day              | 541.905 USDT        |
| Worst day             | 188.638 USDT        |
| Days win/draw/lose    | 4 / 0 / 0           |
| Avg. Duration Winners | 0:02:00             |
| Avg. Duration Loser   | 0:13:00             |
| Zero Duration Trades  | 67.66% (295)        |
| Rejected Buy signals  | 2256                |
|                       |                     |
| Min balance           | 4994.841 USDT       |
| Max balance           | 6284.321 USDT       |
| Drawdown              | 6.56%               |
| Drawdown              | 65.693 USDT         |
| Drawdown high         | 765.078 USDT        |
| Drawdown low          | 699.385 USDT        |
| Drawdown Start        | 2021-05-03 18:00:00 |
| Drawdown End          | 2021-05-03 20:00:00 |
| Market change         | 1.18%               |
===============================================
```

`Magic_Trailing_Stoploss` strategy with this patch:
```
=============== SUMMARY METRICS ===============
| Metric                | Value               |
|-----------------------+---------------------|
| Backtesting from      | 2021-05-01 00:00:00 |
| Backtesting to        | 2021-05-04 23:00:00 |
| Max open trades       | 5                   |
|                       |                     |
| Total trades          | 425                 |
| Starting balance      | 5000.000 USDT       |
| Final balance         | 4993.297 USDT       |
| Absolute profit       | -6.703 USDT         |
| Total profit %        | -0.13%              |
| Trades per day        | 141.67              |
| Avg. stake amount     | 1000.000 USDT       |
| Total trade volume    | 425000.000 USDT     |
|                       |                     |
| Best Pair             | SUSHI/USDT 10.92%   |
| Worst Pair            | LUNA/USDT -14.15%   |
| Best trade            | THETA/USDT 1.0%     |
| Worst trade           | XLM/USDT -1.2%      |
| Best day              | 214.689 USDT        |
| Worst day             | -156.182 USDT       |
| Days win/draw/lose    | 1 / 0 / 3           |
| Avg. Duration Winners | 0:04:00             |
| Avg. Duration Loser   | 0:07:00             |
| Zero Duration Trades  | 56.24% (239)        |
| Rejected Buy signals  | 2256                |
|                       |                     |
| Min balance           | 4748.529 USDT       |
| Max balance           | 5031.284 USDT       |
| Drawdown              | 27.51%              |
| Drawdown              | 275.337 USDT        |
| Drawdown high         | 13.866 USDT         |
| Drawdown low          | -261.471 USDT       |
| Drawdown Start        | 2021-05-01 03:00:00 |
| Drawdown End          | 2021-05-03 13:00:00 |
| Market change         | 1.18%               |
===============================================
```