### PR TITLE
Ignore broken symlinks while resolving strategies.

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -91,6 +91,9 @@ class IResolver:
             if not str(entry).endswith('.py'):
                 logger.debug('Ignoring %s', entry)
                 continue
+            if entry.is_symlink() and not entry.is_file():
+                logger.debug('Ignoring broken symlink %s', entry)
+                continue
             module_path = entry.resolve()
 
             obj = next(cls._get_valid_object(module_path, object_name), None)


### PR DESCRIPTION
## Summary
Ignore broken symlinks while resolving strategies.

Without this fix the resolver tries to read from the broken symlink,
resulting in an exception that leads to the the rather confusing
error message

freqtrade.resolvers.iresolver - WARNING - Path "...../user_data/strategies" does not exist.

as a result of a symlink matching .py not being readable.

## Quick changelog

- Ignore broken symlinks while resolving strategies.
