### PR TITLE
Remove ordereddict

### DIFF
--- a/freqtrade/commands/list_commands.py
+++ b/freqtrade/commands/list_commands.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 import sys
-from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -154,7 +153,7 @@ def start_list_markets(args: Dict[str, Any], pairs_only: bool = False) -> None:
                                      pairs_only=pairs_only,
                                      active_only=active_only)
         # Sort the pairs/markets by symbol
-        pairs = OrderedDict(sorted(pairs.items()))
+        pairs = dict(sorted(pairs.items()))
     except Exception as e:
         raise OperationalException(f"Cannot get markets. Reason: {e}") from e
 

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -1,7 +1,6 @@
 
 import io
 import logging
-from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -111,16 +110,9 @@ class HyperoptTools():
             if space in ['buy', 'sell']:
                 result_dict.setdefault('params', {}).update(space_params)
             elif space == 'roi':
-                # TODO: get rid of OrderedDict when support for python 3.6 will be
-                # dropped (dicts keep the order as the language feature)
-
                 # Convert keys in min_roi dict to strings because
                 # rapidjson cannot dump dicts with integer keys...
-                # OrderedDict is used to keep the numeric order of the items
-                # in the dict.
-                result_dict['minimal_roi'] = OrderedDict(
-                    (str(k), v) for k, v in space_params.items()
-                )
+                result_dict['minimal_roi'] = {str(k): v for k, v in space_params.items()}
             else:  # 'stoploss', 'trailing'
                 result_dict.update(space_params)
 
@@ -132,13 +124,9 @@ class HyperoptTools():
             if space == 'stoploss':
                 result += f"stoploss = {space_params.get('stoploss')}"
             elif space == 'roi':
-                # TODO: get rid of OrderedDict when support for python 3.6 will be
-                # dropped (dicts keep the order as the language feature)
-                minimal_roi_result = rapidjson.dumps(
-                    OrderedDict(
-                        (str(k), v) for k, v in space_params.items()
-                    ),
-                    default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
+                minimal_roi_result = rapidjson.dumps({
+                        str(k): v for k, v in space_params.items()
+                }, default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
                 result += f"minimal_roi = {minimal_roi_result}"
             elif space == 'trailing':
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -6,7 +6,6 @@ This module load custom strategies
 import logging
 import tempfile
 from base64 import urlsafe_b64decode
-from collections import OrderedDict
 from inspect import getfullargspec
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -139,7 +138,7 @@ class StrategyResolver(IResolver):
 
         # Sort and apply type conversions
         if hasattr(strategy, 'minimal_roi'):
-            strategy.minimal_roi = OrderedDict(sorted(
+            strategy.minimal_roi = dict(sorted(
                 {int(key): value for (key, value) in strategy.minimal_roi.items()}.items(),
                 key=lambda t: t[0]))
         if hasattr(strategy, 'stoploss'):

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -129,13 +129,16 @@ def test_strategy_override_minimal_roi(caplog, default_conf):
     default_conf.update({
         'strategy': 'DefaultStrategy',
         'minimal_roi': {
+            "20": 0.1,
             "0": 0.5
         }
     })
     strategy = StrategyResolver.load_strategy(default_conf)
 
     assert strategy.minimal_roi[0] == 0.5
-    assert log_has("Override strategy 'minimal_roi' with value in config file: {'0': 0.5}.", caplog)
+    assert log_has(
+        "Override strategy 'minimal_roi' with value in config file: {'20': 0.1, '0': 0.5}.",
+        caplog)
 
 
 def test_strategy_override_stoploss(caplog, default_conf):


### PR DESCRIPTION
## Summary
Remove orderedDict - as we're no longer supporting python 3.6, make naming for hyperopt-details displaying clearer