### PR TITLE
Fix errors during ubuntu install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,7 +60,7 @@ OS Specific steps are listed first, the [Common](#common) section below is neces
     sudo apt-get update
 
     # install packages
-    sudo apt install -y python3-pip python3.7-venv python3.7-dev python3-pandas git
+    sudo apt install -y python3-pip python3-venv python3-dev python3-pandas git
     ```
 
 === "RaspberryPi/Raspbian"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,7 +60,7 @@ OS Specific steps are listed first, the [Common](#common) section below is neces
     sudo apt-get update
 
     # install packages
-    sudo apt install -y python3-pip python3-venv python3-pandas git
+    sudo apt install -y python3-pip python3.7-venv python3.7-dev python3-pandas git
     ```
 
 === "RaspberryPi/Raspbian"


### PR DESCRIPTION
Encountering the python header error on a fresh ubuntu install:

```  
utils_find_1st/find_1st.cpp:3:10: fatal error: Python.h: No such file or directory
   #include "Python.h"
            ^~~~~~~~~~
  compilation terminated.
```

solved by installing python3.7-dev. Also need to ensure python3.7-venv for fresh install.

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Avoid python header missing error during debian install.

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 

Avoid errors during install.
