### PR TITLE
make "/profit N" command output be consistent with "/daily" command

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -339,7 +339,10 @@ class RPC:
             self, stake_currency: str, fiat_display_currency: str,
             start_date: datetime = datetime.fromtimestamp(0)) -> Dict[str, Any]:
         """ Returns cumulative profit statistics """
-        trades = Trade.get_trades([Trade.open_date >= start_date]).order_by(Trade.id).all()
+        trade_filter = \
+            (Trade.is_open.is_(False) & (Trade.close_date >= start_date)) | \
+            Trade.is_open.is_(True)
+        trades = Trade.get_trades(trade_filter).order_by(Trade.id).all()
 
         profit_all_coin = []
         profit_all_ratio = []

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -339,9 +339,8 @@ class RPC:
             self, stake_currency: str, fiat_display_currency: str,
             start_date: datetime = datetime.fromtimestamp(0)) -> Dict[str, Any]:
         """ Returns cumulative profit statistics """
-        trade_filter = \
-            (Trade.is_open.is_(False) & (Trade.close_date >= start_date)) | \
-            Trade.is_open.is_(True)
+        trade_filter = ((Trade.is_open.is_(False) & (Trade.close_date >= start_date)) |
+                        Trade.is_open.is_(True))
         trades = Trade.get_trades(trade_filter).order_by(Trade.id).all()
 
         profit_all_coin = []

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -482,7 +482,7 @@ class Telegram(RPCHandler):
         timescale = None
         try:
             if context.args:
-                timescale = int(context.args[0])
+                timescale = int(context.args[0]) - 1
                 today_start = datetime.combine(date.today(), datetime.min.time())
                 start_date = today_start - timedelta(days=timescale)
         except (TypeError, ValueError, IndexError):


### PR DESCRIPTION
## Summary
Currently "/profit N" command shows statistics for all trades _started_ since N days ago. Other commands like "/daily" show statistics based on trade's close date. Need to change the output of the command to include only trades _closed_ since N days ago plus all open trades