### PR TITLE
Implement strategy-controlled stake sizes

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -523,7 +523,7 @@ class AwesomeStrategy(IStrategy):
 
 ### Stake size management
 
-It is possible to manage your risk by reducing or increasing or reducing stake amount when placing a new trade.
+It is possible to manage your risk by reducing or increasing stake amount when placing a new trade.
 
 ```python
 class AwesomeStrategy(IStrategy):
@@ -546,8 +546,10 @@ class AwesomeStrategy(IStrategy):
         return proposed_stake
 ```
 
+Freqtrade will fall back to the `proposed_stake` value should your code raise an exception. The exception itself will be logged.
+
 !!! Tip
-    You do not _have_ to ensure that `min_stake <= returned_value <= max_stake`. Trades will succeed, as returned value will be clamped to supported range and this acton will be logged.
+    You do not _have_ to ensure that `min_stake <= returned_value <= max_stake`. Trades will succeed as the returned value will be clamped to supported range and this acton will be logged.
 
 !!! Tip
     Returning `0` or `None` will prevent trades from being placed.

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -486,7 +486,7 @@ class FreqtradeBot(LoggingMixin):
         if not self.edge:
             max_stake_amount = self.wallets.get_available_stake_amount()
             stake_amount = strategy_safe_wrapper(self.strategy.custom_stake_amount,
-                                                 default_retval=None)(
+                                                 default_retval=stake_amount)(
                 pair=pair, current_time=datetime.now(timezone.utc),
                 current_rate=buy_limit_requested, proposed_stake=stake_amount,
                 min_stake=min_stake_amount, max_stake=max_stake_amount)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -319,7 +319,7 @@ class Backtesting:
         max_stake_amount = self.wallets.get_available_stake_amount()
 
         stake_amount = strategy_safe_wrapper(self.strategy.custom_stake_amount,
-                                             default_retval=None)(
+                                             default_retval=stake_amount)(
             pair=pair, current_time=row[DATE_IDX].to_pydatetime(), current_rate=row[OPEN_IDX],
             proposed_stake=stake_amount, min_stake=min_stake_amount, max_stake=max_stake_amount)
         stake_amount = self.wallets._validate_stake_amount(pair, stake_amount, min_stake_amount)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -129,6 +129,8 @@ class Backtesting:
         """
         self.strategy: IStrategy = strategy
         strategy.dp = self.dataprovider
+        # Attach Wallets to Strategy baseclass
+        IStrategy.wallets = self.wallets
         # Set stoploss_on_exchange to false for backtesting,
         # since a "perfect" stoploss-sell is assumed anyway
         # And the regular "stoploss" function would not apply to that case
@@ -312,7 +314,18 @@ class Backtesting:
             stake_amount = self.wallets.get_trade_stake_amount(pair, None)
         except DependencyException:
             return None
-        min_stake_amount = self.exchange.get_min_pair_stake_amount(pair, row[OPEN_IDX], -0.05)
+
+        min_stake_amount = self.exchange.get_min_pair_stake_amount(pair, row[OPEN_IDX], -0.05) or 0
+        max_stake_amount = self.wallets.get_available_stake_amount()
+
+        stake_amount = strategy_safe_wrapper(self.strategy.custom_stake_amount,
+                                             default_retval=None)(
+            pair=pair, current_time=row[DATE_IDX].to_pydatetime(), current_rate=row[OPEN_IDX],
+            proposed_stake=stake_amount, min_stake=min_stake_amount, max_stake=max_stake_amount)
+        stake_amount = self.wallets._validate_stake_amount(pair, stake_amount, min_stake_amount)
+
+        if not stake_amount:
+            return None
 
         order_type = self.strategy.order_types['buy']
         time_in_force = self.strategy.order_time_in_force['sell']

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -304,6 +304,23 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return None
 
+    def custom_stake_amount(self, pair: str, current_time: datetime, current_rate: float,
+                            proposed_stake: float, min_stake: float, max_stake: float,
+                            **kwargs) -> float:
+        """
+        Customize stake size for each new trade. This method is not called when edge module is
+        enabled.
+
+        :param pair: Pair that's currently analyzed
+        :param current_time: datetime object, containing the current datetime
+        :param current_rate: Rate, calculated based on pricing settings in ask_strategy.
+        :param proposed_stake: A stake amount proposed by the bot.
+        :param min_stake: Minimal stake size allowed by exchange.
+        :param max_stake: Balance available for trading.
+        :return: A stake size, which is between min_stake and max_stake.
+        """
+        return proposed_stake
+
     def informative_pairs(self) -> ListPairsWithTimeframes:
         """
         Define additional, informative pair/interval combinations to be cached from the exchange.

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -496,6 +496,17 @@ def test_backtest__enter_trade(default_conf, fee, mocker) -> None:
     trade = backtesting._enter_trade(pair, row=row)
     assert trade is not None
 
+    backtesting.strategy.custom_stake_amount = lambda **kwargs: 123.5
+    trade = backtesting._enter_trade(pair, row=row)
+    assert trade
+    assert trade.stake_amount == 123.5
+
+    # In case of error - use proposed stake
+    backtesting.strategy.custom_stake_amount = lambda **kwargs: 20 / 0
+    trade = backtesting._enter_trade(pair, row=row)
+    assert trade
+    assert trade.stake_amount == 495
+
     # Stake-amount too high!
     mocker.patch("freqtrade.exchange.Exchange.get_min_pair_stake_amount", return_value=600.0)
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -886,7 +886,7 @@ def test_rpcforcebuy(mocker, default_conf, ticker, fee, limit_buy_order_open) ->
 
     # Test not buying
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
-    freqtradebot.config['stake_amount'] = 0.0000001
+    freqtradebot.config['stake_amount'] = 0
     patch_get_signal(freqtradebot, (True, False))
     rpc = RPC(freqtradebot)
     pair = 'TKN/BTC'

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -413,6 +413,26 @@ def test_create_trade_too_small_stake_amount(default_conf, ticker, limit_buy_ord
 
     patch_get_signal(freqtrade)
 
+    assert freqtrade.create_trade('ETH/BTC')
+
+
+def test_create_trade_zero_stake_amount(default_conf, ticker, limit_buy_order_open,
+                                        fee, mocker) -> None:
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    buy_mock = MagicMock(return_value=limit_buy_order_open)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        fetch_ticker=ticker,
+        buy=buy_mock,
+        get_fee=fee,
+    )
+
+    freqtrade = FreqtradeBot(default_conf)
+    freqtrade.config['stake_amount'] = 0
+
+    patch_get_signal(freqtrade)
+
     assert not freqtrade.create_trade('ETH/BTC')
 
 


### PR DESCRIPTION
Submitting initial draft of strategy-controlled stake sizes so you can get the feel of it.

What should be max stake size? Should it be `stake_amount` specified in config or entire available balance? Both have their merits i would say.

Otherwise tests pass, but i totally did not test the code so treat it as a rough sketch, a fuel for further discussion.

closes #5076