### PR TITLE
Added timerange and max open trades info above multiple strategy backtest result summary table

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -660,8 +660,9 @@ def show_backtest_results(config: Dict, backtest_stats: Dict):
         show_backtest_result(strategy, results, stake_currency)
 
     if len(backtest_stats['strategy']) > 1:
-        backtest_timerange = f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_start']} -> " \
-                             f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_end']}"
+        backtest_timerange = \
+            f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_start']} -> " \
+            f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_end']}"
 
         # Print Strategy summary table
 

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -660,14 +660,12 @@ def show_backtest_results(config: Dict, backtest_stats: Dict):
         show_backtest_result(strategy, results, stake_currency)
 
     if len(backtest_stats['strategy']) > 1:
-        backtest_timerange = \
-            f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_start']} -> " \
-            f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_end']}"
-
         # Print Strategy summary table
 
+        first_strat_stats = next(iter(backtest_stats['strategy'].items()))[1]
         table = text_table_strategy(backtest_stats['strategy_comparison'], stake_currency)
-        print(backtest_timerange)
+        print(f"{first_strat_stats['backtest_start']} -> {first_strat_stats['backtest_end']} |"
+              f" Max open trades : {first_strat_stats['max_open_trades']}")
         print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
         print(table)
         print('=' * len(table.splitlines()[0]))

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -662,10 +662,9 @@ def show_backtest_results(config: Dict, backtest_stats: Dict):
     if len(backtest_stats['strategy']) > 1:
         # Print Strategy summary table
 
-        first_strat_stats = next(iter(backtest_stats['strategy'].items()))[1]
         table = text_table_strategy(backtest_stats['strategy_comparison'], stake_currency)
-        print(f"{first_strat_stats['backtest_start']} -> {first_strat_stats['backtest_end']} |"
-              f" Max open trades : {first_strat_stats['max_open_trades']}")
+        print(f"{results['backtest_start']} -> {results['backtest_end']} |"
+              f" Max open trades : {results['max_open_trades']}")
         print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
         print(table)
         print('=' * len(table.splitlines()[0]))

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -660,9 +660,13 @@ def show_backtest_results(config: Dict, backtest_stats: Dict):
         show_backtest_result(strategy, results, stake_currency)
 
     if len(backtest_stats['strategy']) > 1:
+        backtest_timerange = f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_start']} -> " \
+                             f"{next(iter(backtest_stats['strategy'].items()))[1]['backtest_end']}"
+
         # Print Strategy summary table
 
         table = text_table_strategy(backtest_stats['strategy_comparison'], stake_currency)
+        print(backtest_timerange)
         print(' STRATEGY SUMMARY '.center(len(table.splitlines()[0]), '='))
         print(table)
         print('=' * len(table.splitlines()[0]))

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -993,4 +993,5 @@ def test_backtest_start_multi_strat_nomock(default_conf, mocker, caplog, testdat
     assert 'BACKTESTING REPORT' in captured.out
     assert 'SELL REASON STATS' in captured.out
     assert 'LEFT OPEN TRADES REPORT' in captured.out
+    assert '2017-11-14 21:17:00 -> 2017-11-14 22:58:00' in captured.out
     assert 'STRATEGY SUMMARY' in captured.out

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -993,5 +993,5 @@ def test_backtest_start_multi_strat_nomock(default_conf, mocker, caplog, testdat
     assert 'BACKTESTING REPORT' in captured.out
     assert 'SELL REASON STATS' in captured.out
     assert 'LEFT OPEN TRADES REPORT' in captured.out
-    assert '2017-11-14 21:17:00 -> 2017-11-14 22:58:00' in captured.out
+    assert '2017-11-14 21:17:00 -> 2017-11-14 22:58:00 | Max open trades : 1' in captured.out
     assert 'STRATEGY SUMMARY' in captured.out


### PR DESCRIPTION
## Summary
When people are sharing backtest results; only to show the timerange that they backtested, they have to include the detailed table of the last strategy as in the image below. By this addition, people wont have to include the last strategy detailed result only to show the timerange

![image](https://user-images.githubusercontent.com/18678845/123604394-19876980-d7fb-11eb-8e9d-c72efb5f6662.png)

## What's new?
Added timerange above multiple strategy backtest result summary table

![image](https://user-images.githubusercontent.com/18678845/123659651-363f9380-d833-11eb-8e05-c49580806088.png)
