### PR TITLE
automatic Hyperopt paramfile

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -533,8 +533,9 @@ class MyAwesomeStrategy(IStrategy):
     }
 ```
 
-!!! Note:
-    Parameter-files will overwrite parameters within the strategy.
+!!! Note
+    Values in the configuration file will overwrite Parameter-file level parameters - and both will overwrite parameters within the strategy.
+    The prevalence is therefore: config > parameter file > strategy
 
 ### Understand Hyperopt ROI results
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -51,7 +51,7 @@ usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                           [--spaces {all,buy,sell,roi,stoploss,trailing,default} [{all,buy,sell,roi,stoploss,trailing,default} ...]]
                           [--print-all] [--no-color] [--print-json] [-j JOBS]
                           [--random-state INT] [--min-trades INT]
-                          [--hyperopt-loss NAME]
+                          [--hyperopt-loss NAME] [--disable-param-export]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -118,6 +118,8 @@ optional arguments:
                         ShortTradeDurHyperOptLoss, OnlyProfitHyperOptLoss,
                         SharpeHyperOptLoss, SharpeHyperOptLossDaily,
                         SortinoHyperOptLoss, SortinoHyperOptLossDaily
+  --disable-param-export
+                        Disable automatic hyperopt parameter export.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
@@ -509,7 +511,13 @@ You should understand this result like:
 * You should not use ADX because `'buy_adx_enabled': False`.
 * You should **consider** using the RSI indicator (`'buy_rsi_enabled': True`) and the best value is `29.0` (`'buy_rsi': 29.0`)
 
-Your strategy class can immediately take advantage of these results. Simply copy hyperopt results block and paste them at class level, replacing old parameters (if any). New parameters will automatically be loaded next time strategy is executed.
+### Automatic parameter application to the strategy
+
+When using Hyperoptable parameters, the result of your hyperopt-run will be written to a json file next to your strategy (so for `MyAwesomeStrategy.py`, the file would be `MyAwesomeStrategy.json`).  
+This file is also updated when using the `hyperopt-show` sub-command, unless `--disable-param-export` is provided to either of the 2 commands.
+
+
+Your strategy class can also contain these results explicitly. Simply copy hyperopt results block and paste them at class level, replacing old parameters (if any). New parameters will automatically be loaded next time strategy is executed.
 
 Transferring your whole hyperopt result to your strategy would then look like:
 
@@ -524,6 +532,9 @@ class MyAwesomeStrategy(IStrategy):
         'buy_trigger': 'bb_lower'
     }
 ```
+
+!!! Note:
+    Parameter-files will overwrite parameters within the strategy.
 
 ### Understand Hyperopt ROI results
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -702,7 +702,8 @@ You can show the details of any hyperoptimization epoch previously evaluated by 
 usage: freqtrade hyperopt-show [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                                [-d PATH] [--userdir PATH] [--best]
                                [--profitable] [-n INT] [--print-json]
-                               [--hyperopt-filename PATH] [--no-header]
+                               [--hyperopt-filename FILENAME] [--no-header]
+                               [--disable-param-export]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -714,6 +715,8 @@ optional arguments:
                         Hyperopt result filename.Example: `--hyperopt-
                         filename=hyperopt_results_2020-09-27_16-20-48.pickle`
   --no-header           Do not print epoch details header.
+  --disable-param-export
+                        Disable automatic hyperopt parameter export.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -29,7 +29,7 @@ ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "epochs", "spaces", "print_all",
                                         "print_colorized", "print_json", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
-                                        "hyperopt_loss"]
+                                        "hyperopt_loss", "disableparamexport"]
 
 ARGS_EDGE = ARGS_COMMON_OPTIMIZE + ["stoploss_range"]
 
@@ -85,7 +85,8 @@ ARGS_HYPEROPT_LIST = ["hyperopt_list_best", "hyperopt_list_profitable",
                       "hyperoptexportfilename", "export_csv"]
 
 ARGS_HYPEROPT_SHOW = ["hyperopt_list_best", "hyperopt_list_profitable", "hyperopt_show_index",
-                      "print_json", "hyperoptexportfilename", "hyperopt_show_no_header"]
+                      "print_json", "hyperoptexportfilename", "hyperopt_show_no_header",
+                      "disableparamexport"]
 
 NO_CONF_REQURIED = ["convert-data", "convert-trade-data", "download-data", "list-timeframes",
                     "list-markets", "list-pairs", "list-strategies", "list-data",

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -178,6 +178,11 @@ AVAILABLE_CLI_OPTIONS = {
         'Example: `--export-filename=user_data/backtest_results/backtest_today.json`',
         metavar='PATH',
     ),
+    "disableparamexport": Arg(
+        '--disable-param-export',
+        help="Disable automatic hyperopt parameter export.",
+        action='store_true',
+    ),
     "fee": Arg(
         '--fee',
         help='Specify fee ratio. Will be applied twice (on trade entry and exit).',

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 from colorama import init as colorama_init
 
 from freqtrade.configuration import setup_utils_configuration
+from freqtrade.constants import FTHYPT_FILEVERSION
 from freqtrade.data.btanalysis import get_latest_hyperopt_file
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
@@ -133,13 +134,14 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
             show_backtest_result(strategy_name, metrics,
                                  metrics['stake_currency'])
 
-            # Export parameters ...
-            # TODO: make this optional? otherwise it'll overwrite previous parameters ...
-            fn = HyperoptTools.get_strategy_filename(config, strategy_name)
-            if fn:
-                HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
-            else:
-                logger.warn("Strategy not found, not exporting parameter file.")
+            if val.get(FTHYPT_FILEVERSION, 1) >= 2:
+                # Export parameters ...
+                # TODO: make this optional? otherwise it'll overwrite previous parameters ...
+                fn = HyperoptTools.get_strategy_filename(config, strategy_name)
+                if fn:
+                    HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
+                else:
+                    logger.warn("Strategy not found, not exporting parameter file.")
 
         HyperoptTools.show_epoch_details(val, total_epochs, print_json, no_header,
                                          header_str="Epoch details")

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -129,8 +129,14 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
 
         metrics = val['results_metrics']
         if 'strategy_name' in metrics:
-            show_backtest_result(metrics['strategy_name'], metrics,
+            strategy_name = metrics['strategy_name']
+            show_backtest_result(strategy_name, metrics,
                                  metrics['stake_currency'])
+
+            # Export parameters ...
+            # TODO: make this optional? otherwise it'll overwrite previous parameters ...
+            fn = HyperoptTools.get_strategy_filename(config, strategy_name)
+            HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
 
         HyperoptTools.show_epoch_details(val, total_epochs, print_json, no_header,
                                          header_str="Epoch details")

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List
 from colorama import init as colorama_init
 
 from freqtrade.configuration import setup_utils_configuration
-from freqtrade.constants import FTHYPT_FILEVERSION
 from freqtrade.data.btanalysis import get_latest_hyperopt_file
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
@@ -134,14 +133,7 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
             show_backtest_result(strategy_name, metrics,
                                  metrics['stake_currency'])
 
-            if val.get(FTHYPT_FILEVERSION, 1) >= 2:
-                # Export parameters ...
-                # TODO: make this optional? otherwise it'll overwrite previous parameters ...
-                fn = HyperoptTools.get_strategy_filename(config, strategy_name)
-                if fn:
-                    HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
-                else:
-                    logger.warn("Strategy not found, not exporting parameter file.")
+            HyperoptTools.try_export_params(config, strategy_name, val)
 
         HyperoptTools.show_epoch_details(val, total_epochs, print_json, no_header,
                                          header_str="Epoch details")

--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -136,7 +136,10 @@ def start_hyperopt_show(args: Dict[str, Any]) -> None:
             # Export parameters ...
             # TODO: make this optional? otherwise it'll overwrite previous parameters ...
             fn = HyperoptTools.get_strategy_filename(config, strategy_name)
-            HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
+            if fn:
+                HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
+            else:
+                logger.warn("Strategy not found, not exporting parameter file.")
 
         HyperoptTools.show_epoch_details(val, total_epochs, print_json, no_header,
                                          header_str="Epoch details")

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -260,6 +260,8 @@ class Configuration:
         self._args_to_config(config, argname='export',
                              logstring='Parameter --export detected: {} ...')
 
+        self._args_to_config(config, argname='disableparamexport',
+                             logstring='Parameter --disableparamexport detected: {} ...')
         # Edge section:
         if 'stoploss_range' in self.args and self.args["stoploss_range"]:
             txt_range = eval(self.args["stoploss_range"])

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -313,6 +313,7 @@ CONF_SCHEMA = {
         },
         'db_url': {'type': 'string'},
         'export': {'type': 'string', 'enum': EXPORT_OPTIONS, 'default': 'trades'},
+        'disableparamexport': {'type': 'boolean'},
         'initial_state': {'type': 'string', 'enum': ['running', 'stopped']},
         'forcebuy_enable': {'type': 'boolean'},
         'disable_dataframe_checks': {'type': 'boolean'},

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -40,6 +40,7 @@ DEFAULT_DATAFRAME_COLUMNS = ['date', 'open', 'high', 'low', 'close', 'volume']
 DEFAULT_TRADES_COLUMNS = ['timestamp', 'id', 'type', 'side', 'price', 'amount', 'cost']
 
 LAST_BT_RESULT_FN = '.last_result.json'
+FTHYPT_FILEVERSION = 'fthypt_fileversion'
 
 USERPATH_HYPEROPTS = 'hyperopts'
 USERPATH_STRATEGIES = 'strategies'

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -29,7 +29,7 @@ from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.optimize.hyperopt_auto import HyperOptAuto
 from freqtrade.optimize.hyperopt_interface import IHyperOpt  # noqa: F401
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F401
-from freqtrade.optimize.hyperopt_tools import HyperoptTools
+from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_parser
 from freqtrade.optimize.optimize_reports import generate_strategy_stats
 from freqtrade.resolvers.hyperopt_resolver import HyperOptLossResolver, HyperOptResolver
 
@@ -163,13 +163,9 @@ class Hyperopt:
         While not a valid json object - this allows appending easily.
         :param epoch: result dictionary for this epoch.
         """
-        def default_parser(x):
-            if isinstance(x, np.integer):
-                return int(x)
-            return str(x)
         epoch[FTHYPT_FILEVERSION] = 2
         with self.results_file.open('a') as f:
-            rapidjson.dump(epoch, f, default=default_parser,
+            rapidjson.dump(epoch, f, default=hyperopt_parser,
                            number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)
             f.write("\n")
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -310,7 +310,7 @@ class Hyperopt:
         results_explanation = HyperoptTools.format_results_explanation_string(
             strat_stats, self.config['stake_currency'])
 
-        not_optimized = self.backtesting.strategy.get_params_dict()
+        not_optimized = self.backtesting.strategy.get_no_optimize_params()
 
         trade_count = strat_stats['total_trades']
         total_profit = strat_stats['profit_total']

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -20,7 +20,7 @@ from colorama import init as colorama_init
 from joblib import Parallel, cpu_count, delayed, dump, load, wrap_non_picklable_objects
 from pandas import DataFrame
 
-from freqtrade.constants import DATETIME_PRINT_FORMAT, LAST_BT_RESULT_FN
+from freqtrade.constants import DATETIME_PRINT_FORMAT, FTHYPT_FILEVERSION, LAST_BT_RESULT_FN
 from freqtrade.data.converter import trim_dataframes
 from freqtrade.data.history import get_timerange
 from freqtrade.misc import deep_merge_dicts, file_dump_json, plural
@@ -167,7 +167,7 @@ class Hyperopt:
             if isinstance(x, np.integer):
                 return int(x)
             return str(x)
-
+        epoch[FTHYPT_FILEVERSION] = 2
         with self.results_file.open('a') as f:
             rapidjson.dump(epoch, f, default=default_parser,
                            number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -77,8 +77,11 @@ class Hyperopt:
 
         if not self.config.get('hyperopt'):
             self.custom_hyperopt = HyperOptAuto(self.config)
+            self.auto_hyperopt = True
         else:
             self.custom_hyperopt = HyperOptResolver.load_hyperopt(self.config)
+            self.auto_hyperopt = False
+
         self.backtesting._set_strategy(self.backtesting.strategylist[0])
         self.custom_hyperopt.strategy = self.backtesting.strategy
 
@@ -484,10 +487,11 @@ class Hyperopt:
                     f"saved to '{self.results_file}'.")
 
         if self.current_best_epoch:
-            HyperoptTools.try_export_params(
-                self.config,
-                self.backtesting.strategy.get_strategy_name(),
-                self.current_best_epoch)
+            if self.auto_hyperopt:
+                HyperoptTools.try_export_params(
+                    self.config,
+                    self.backtesting.strategy.get_strategy_name(),
+                    self.current_best_epoch)
 
             HyperoptTools.show_epoch_details(self.current_best_epoch, self.total_epochs,
                                              self.print_json)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -12,7 +12,6 @@ from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import numpy as np
 import progressbar
 import rapidjson
 from colorama import Fore, Style

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -489,6 +489,11 @@ class Hyperopt:
                     f"saved to '{self.results_file}'.")
 
         if self.current_best_epoch:
+            HyperoptTools.try_export_params(
+                self.config,
+                self.backtesting.strategy.get_strategy_name(),
+                self.current_best_epoch)
+
             HyperoptTools.show_epoch_details(self.current_best_epoch, self.total_epochs,
                                              self.print_json)
         else:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -208,9 +208,9 @@ class Hyperopt:
         result: Dict[str, Any] = {}
         strategy = self.backtesting.strategy
         if not HyperoptTools.has_space(self.config, 'roi'):
-            result['roi'] = strategy.minimal_roi
+            result['roi'] = {str(k): v for k, v in strategy.minimal_roi.items()}
         if not HyperoptTools.has_space(self.config, 'stoploss'):
-            result['stoploss'] = strategy.stoploss
+            result['stoploss'] = {'stoploss': strategy.stoploss}
         if not HyperoptTools.has_space(self.config, 'trailing'):
             result['trailing'] = {
                 'trailing_stop': strategy.trailing_stop,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -28,7 +28,7 @@ from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.optimize.hyperopt_auto import HyperOptAuto
 from freqtrade.optimize.hyperopt_interface import IHyperOpt  # noqa: F401
 from freqtrade.optimize.hyperopt_loss_interface import IHyperOptLoss  # noqa: F401
-from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_parser
+from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_serializer
 from freqtrade.optimize.optimize_reports import generate_strategy_stats
 from freqtrade.resolvers.hyperopt_resolver import HyperOptLossResolver, HyperOptResolver
 
@@ -167,7 +167,7 @@ class Hyperopt:
         """
         epoch[FTHYPT_FILEVERSION] = 2
         with self.results_file.open('a') as f:
-            rapidjson.dump(epoch, f, default=hyperopt_parser,
+            rapidjson.dump(epoch, f, default=hyperopt_serializer,
                            number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN)
             f.write("\n")
 

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -130,9 +130,9 @@ class HyperoptTools():
                                                non_optimized)
             HyperoptTools._params_pretty_print(params, 'sell', "Sell hyperspace params:",
                                                non_optimized)
-            HyperoptTools._params_pretty_print(params, 'roi', "ROI table:")
-            HyperoptTools._params_pretty_print(params, 'stoploss', "Stoploss:")
-            HyperoptTools._params_pretty_print(params, 'trailing', "Trailing stop:")
+            HyperoptTools._params_pretty_print(params, 'roi', "ROI table:", non_optimized)
+            HyperoptTools._params_pretty_print(params, 'stoploss', "Stoploss:", non_optimized)
+            HyperoptTools._params_pretty_print(params, 'trailing', "Trailing stop:", non_optimized)
 
     @staticmethod
     def _params_update_for_json(result_dict, params, non_optimized, space: str) -> None:
@@ -159,19 +159,31 @@ class HyperoptTools():
         if space in params or space in non_optimized:
             space_params = HyperoptTools._space_params(params, space, 5)
             result = f"\n# {header}\n"
-            if space == 'stoploss':
-                result += f"stoploss = {space_params.get('stoploss')}"
-            elif space == 'roi':
+            if space == "stoploss":
+                opt = True
+                if not space_params:
+                    space_params = HyperoptTools._space_params(params, space, 5)
+                    opt = False
+                result += (f"stoploss = {space_params.get('stoploss')}"
+                           f"{'  # value loaded from strategy' if not opt else ''}")
+
+            elif space == "roi":
                 minimal_roi_result = rapidjson.dumps({
                         str(k): v for k, v in space_params.items()
                 }, default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
                 result += f"minimal_roi = {minimal_roi_result}"
-            elif space == 'trailing':
+            elif space == "trailing":
+                opt = True
+                if not space_params:
+                    # Not optimized ...
+                    space_params = HyperoptTools._space_params(non_optimized, space, 5)
+                    opt = False
 
                 for k, v in space_params.items():
-                    result += f'{k} = {v}\n'
+                    result += f"{k} = {v}{'  # value loaded from strategy' if not opt else ''}\n"
 
             else:
+                # Buy / sell parameters
                 no_params = HyperoptTools._space_params(non_optimized, space, 5)
 
                 result += f"{space}_params = {HyperoptTools._pprint(space_params, no_params)}"

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 NON_OPT_PARAM_APPENDIX = "  # value loaded from strategy"
 
 
-def hyperopt_parser(x):
+def hyperopt_serializer(x):
     if isinstance(x, np.integer):
         return int(x)
     return str(x)
@@ -60,7 +60,8 @@ class HyperoptTools():
         }
         logger.info(f"Dumping parameters to {filename}")
         rapidjson.dump(final_params, filename.open('w'), indent=2,
-                       default=hyperopt_parser, number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
+                       default=hyperopt_serializer,
+                       number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
                        )
 
     @staticmethod

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -10,7 +10,7 @@ import tabulate
 from colorama import Fore, Style
 from pandas import isna, json_normalize
 
-from freqtrade.constants import USERPATH_STRATEGIES
+from freqtrade.constants import FTHYPT_FILEVERSION, USERPATH_STRATEGIES
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import deep_merge_dicts, round_coin_value, round_dict, safe_value_fallback2
 
@@ -51,6 +51,16 @@ class HyperoptTools():
         }
         logger.info(f"Dumping parameters to {filename}")
         rapidjson.dump(final_params, filename.open('w'), indent=2)
+
+    @staticmethod
+    def try_export_params(config: Dict[str, Any], strategy_name: str, val: Dict):
+        if val.get(FTHYPT_FILEVERSION, 1) >= 2 and not config.get('disableparamexport', False):
+            # Export parameters ...
+            fn = HyperoptTools.get_strategy_filename(config, strategy_name)
+            if fn:
+                HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
+            else:
+                logger.warn("Strategy not found, not exporting parameter file.")
 
     @staticmethod
     def has_space(config: Dict[str, Any], space: str) -> bool:

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -3,7 +3,7 @@ import io
 import logging
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import rapidjson
 import tabulate
@@ -21,18 +21,19 @@ logger = logging.getLogger(__name__)
 class HyperoptTools():
 
     @staticmethod
-    def get_strategy_filename(config: Dict, strategy_name: str) -> Path:
+    def get_strategy_filename(config: Dict, strategy_name: str) -> Optional[Path]:
         """
         Get Strategy-location (filename) from strategy_name
         """
         from freqtrade.resolvers.strategy_resolver import StrategyResolver
         directory = Path(config.get('strategy_path', config['user_data_dir'] / USERPATH_STRATEGIES))
         strategy_objs = StrategyResolver.search_all_objects(directory, False)
-        strategy = [s for s in strategy_objs if s['name'] == strategy_name]
-        if strategy:
-            strategy = strategy[0]
+        strategies = [s for s in strategy_objs if s['name'] == strategy_name]
+        if strategies:
+            strategy = strategies[0]
 
             return Path(strategy['location'])
+        return None
 
     @staticmethod
     def export_params(params, strategy_name: str, filename: Path):

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -64,12 +64,12 @@ class HyperoptTools():
                        )
 
     @staticmethod
-    def try_export_params(config: Dict[str, Any], strategy_name: str, val: Dict):
-        if val.get(FTHYPT_FILEVERSION, 1) >= 2 and not config.get('disableparamexport', False):
+    def try_export_params(config: Dict[str, Any], strategy_name: str, params: Dict):
+        if params.get(FTHYPT_FILEVERSION, 1) >= 2 and not config.get('disableparamexport', False):
             # Export parameters ...
             fn = HyperoptTools.get_strategy_filename(config, strategy_name)
             if fn:
-                HyperoptTools.export_params(val, strategy_name, fn.with_suffix('.json'))
+                HyperoptTools.export_params(params, strategy_name, fn.with_suffix('.json'))
             else:
                 logger.warn("Strategy not found, not exporting parameter file.")
 

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -2,9 +2,11 @@
 import io
 import logging
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 import rapidjson
 import tabulate
 from colorama import Fore, Style
@@ -18,6 +20,12 @@ from freqtrade.misc import deep_merge_dicts, round_coin_value, round_dict, safe_
 logger = logging.getLogger(__name__)
 
 NON_OPT_PARAM_APPENDIX = "  # value loaded from strategy"
+
+
+def hyperopt_parser(x):
+    if isinstance(x, np.integer):
+        return int(x)
+    return str(x)
 
 
 class HyperoptTools():
@@ -48,9 +56,12 @@ class HyperoptTools():
             'strategy_name': strategy_name,
             'params': final_params,
             'ft_stratparam_v': 1,
+            'export_time': datetime.now(timezone.utc),
         }
         logger.info(f"Dumping parameters to {filename}")
-        rapidjson.dump(final_params, filename.open('w'), indent=2)
+        rapidjson.dump(final_params, filename.open('w'), indent=2,
+                       default=hyperopt_parser, number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
+                       )
 
     @staticmethod
     def try_export_params(config: Dict[str, Any], strategy_name: str, val: Dict):

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -162,32 +162,33 @@ class HyperoptTools():
         if space in params or space in non_optimized:
             space_params = HyperoptTools._space_params(params, space, 5)
             no_params = HyperoptTools._space_params(non_optimized, space, 5)
+            appendix = ''
             if not space_params and not no_params:
                 # No parameters - don't print
                 return
             if not space_params:
                 # Not optimized parameters - append string
-                non_optimized = NON_OPT_PARAM_APPENDIX
+                appendix = NON_OPT_PARAM_APPENDIX
 
             result = f"\n# {header}\n"
             if space == "stoploss":
                 stoploss = safe_value_fallback2(space_params, no_params, space, space)
-                result += (f"stoploss = {stoploss}{non_optimized}")
+                result += (f"stoploss = {stoploss}{appendix}")
 
             elif space == "roi":
-                result = result[:-1] + f'{non_optimized}\n'
+                result = result[:-1] + f'{appendix}\n'
                 minimal_roi_result = rapidjson.dumps({
                         str(k): v for k, v in (space_params or no_params).items()
                 }, default=str, indent=4, number_mode=rapidjson.NM_NATIVE)
                 result += f"minimal_roi = {minimal_roi_result}"
             elif space == "trailing":
                 for k, v in (space_params or no_params).items():
-                    result += f"{k} = {v}{non_optimized}\n"
+                    result += f"{k} = {v}{appendix}\n"
 
             else:
                 # Buy / sell parameters
 
-                result += f"{space}_params = {HyperoptTools.__pprint_dict(space_params, no_params)}"
+                result += f"{space}_params = {HyperoptTools._pprint_dict(space_params, no_params)}"
 
             result = result.replace("\n", "\n    ")
             print(result)
@@ -201,7 +202,7 @@ class HyperoptTools():
         return {}
 
     @staticmethod
-    def __pprint_dict(params, non_optimized, indent: int = 4):
+    def _pprint_dict(params, non_optimized, indent: int = 4):
         """
         Pretty-print hyperopt results (based on 2 dicts - with add. comment)
         """

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -186,7 +186,7 @@ class HyperoptTools():
                 # Buy / sell parameters
                 no_params = HyperoptTools._space_params(non_optimized, space, 5)
 
-                result += f"{space}_params = {HyperoptTools._pprint(space_params, no_params)}"
+                result += f"{space}_params = {HyperoptTools.__pprint_dict(space_params, no_params)}"
 
             result = result.replace("\n", "\n    ")
             print(result)
@@ -200,7 +200,7 @@ class HyperoptTools():
         return {}
 
     @staticmethod
-    def _pprint(params, non_optimized, indent: int = 4):
+    def __pprint_dict(params, non_optimized, indent: int = 4):
         """
         Pretty-print hyperopt results (based on 2 dicts - with add. comment)
         """

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -25,6 +25,9 @@ NON_OPT_PARAM_APPENDIX = "  # value loaded from strategy"
 def hyperopt_serializer(x):
     if isinstance(x, np.integer):
         return int(x)
+    if isinstance(x, np.bool_):
+        return bool(x)
+
     return str(x)
 
 

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -46,7 +46,8 @@ class HyperoptTools():
         final_params = deep_merge_dicts(params['params_details'], final_params)
         final_params = {
             'strategy_name': strategy_name,
-            'params': final_params
+            'params': final_params,
+            'ft_stratparam_v': 1,
         }
         logger.info(f"Dumping parameters to {filename}")
         rapidjson.dump(final_params, filename.open('w'), indent=2)

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -53,6 +53,21 @@ class StrategyResolver(IResolver):
                     )
                 strategy.timeframe = strategy.ticker_interval
 
+        if strategy._ft_params_from_file:
+            # Set parameters from Hyperopt results file
+            params = strategy._ft_params_from_file
+            strategy.minimal_roi = params.get('roi', strategy.minimal_roi)
+
+            strategy.stoploss = params.get('stoploss', {}).get('stoploss', strategy.stoploss)
+            trailing = params.get('trailing', {})
+            strategy.trailing_stop = trailing.get('trailing_stop', strategy.trailing_stop)
+            strategy.trailing_stop_positive = trailing.get('trailing_stop_positive',
+                                                           strategy.trailing_stop_positive)
+            strategy.trailing_stop_positive_offset = trailing.get(
+                'trailing_stop_positive_offset', strategy.trailing_stop_positive_offset)
+            strategy.trailing_only_offset_is_reached = trailing.get(
+                'trailing_only_offset_is_reached', strategy.trailing_only_offset_is_reached)
+
         # Set attributes
         # Check if we need to override configuration
         #             (Attribute name,                    default,     subkey)

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -324,10 +324,14 @@ class HyperStrategyMixin(object):
 
         if filename.is_file():
             logger.info(f"Loading parameters from file {filename}")
-            params = json_load(filename.open('r'))
-            if params.get('strategy_name') != self.__class__.__name__:
-                raise OperationalException('Invalid parameter file provided')
-            return params
+            try:
+                params = json_load(filename.open('r'))
+                if params.get('strategy_name') != self.__class__.__name__:
+                    raise OperationalException('Invalid parameter file provided')
+                return params
+            except ValueError:
+                logger.warning("Invalid parameter file.")
+                return {}
         logger.info("Found no parameter file.")
 
         return {}

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -358,7 +358,7 @@ class HyperStrategyMixin(object):
             else:
                 logger.info(f'Strategy Parameter(default): {attr_name} = {attr.value}')
 
-    def get_params_dict(self):
+    def get_no_optimize_params(self):
         """
         Returns list of Parameters that are not part of the current optimize job
         """

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -309,6 +309,7 @@ class HyperStrategyMixin(object):
         """
         params = self.load_params_from_file()
         params = params.get('params', {})
+        self._ft_params_from_file = params
         buy_params = deep_merge_dicts(params.get('buy', {}), getattr(self, 'buy_params', None))
         sell_params = deep_merge_dicts(params.get('sell', {}), getattr(self, 'sell_params', None))
 
@@ -324,7 +325,7 @@ class HyperStrategyMixin(object):
         if filename.is_file():
             logger.info(f"Loading parameters from file {filename}")
             params = json_load(filename.open('r'))
-            if params.get('strategy_name') != self.get_strategy_name():
+            if params.get('strategy_name') != self.__class__.__name__:
                 raise OperationalException('Invalid parameter file provided')
             return params
         logger.info("Found no parameter file.")

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -327,10 +327,10 @@ class HyperStrategyMixin(object):
             try:
                 params = json_load(filename.open('r'))
                 if params.get('strategy_name') != self.__class__.__name__:
-                    raise OperationalException('Invalid parameter file provided')
+                    raise OperationalException('Invalid parameter file provided.')
                 return params
             except ValueError:
-                logger.warning("Invalid parameter file.")
+                logger.warning("Invalid parameter file format.")
                 return {}
         logger.info("Found no parameter file.")
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -62,6 +62,7 @@ class IStrategy(ABC, HyperStrategyMixin):
     _populate_fun_len: int = 0
     _buy_fun_len: int = 0
     _sell_fun_len: int = 0
+    _ft_params_from_file: Dict = {}
     # associated minimal roi
     minimal_roi: Dict
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1168,6 +1168,7 @@ def test_hyperopt_show(mocker, capsys, saved_hyperopt_results):
         'freqtrade.optimize.hyperopt_tools.HyperoptTools.load_previous_results',
         MagicMock(return_value=saved_hyperopt_results)
     )
+    mocker.patch('freqtrade.commands.hyperopt_commands.show_backtest_result')
 
     args = [
         "hyperopt-show",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,6 +324,7 @@ def get_default_conf(testdatadir):
         "verbosity": 3,
         "strategy_path": str(Path(__file__).parent / "strategy" / "strats"),
         "strategy": "DefaultStrategy",
+        "disableparamexport": True,
         "internals": {},
         "export": "none",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1954,12 +1954,13 @@ def saved_hyperopt_results():
             'params_dict': {
                 'mfi-value': 15, 'fastd-value': 20, 'adx-value': 25, 'rsi-value': 28, 'mfi-enabled': False, 'fastd-enabled': True, 'adx-enabled': True, 'rsi-enabled': True, 'trigger': 'macd_cross_signal', 'sell-mfi-value': 88, 'sell-fastd-value': 97, 'sell-adx-value': 51, 'sell-rsi-value': 67, 'sell-mfi-enabled': False, 'sell-fastd-enabled': False, 'sell-adx-enabled': True, 'sell-rsi-enabled': True, 'sell-trigger': 'sell-bb_upper', 'roi_t1': 1190, 'roi_t2': 541, 'roi_t3': 408, 'roi_p1': 0.026035863879169705, 'roi_p2': 0.12508730043628782, 'roi_p3': 0.27766427921605896, 'stoploss': -0.2562930402099556},  # noqa: E501
             'params_details': {'buy': {'mfi-value': 15, 'fastd-value': 20, 'adx-value': 25, 'rsi-value': 28, 'mfi-enabled': False, 'fastd-enabled': True, 'adx-enabled': True, 'rsi-enabled': True, 'trigger': 'macd_cross_signal'}, 'sell': {'sell-mfi-value': 88, 'sell-fastd-value': 97, 'sell-adx-value': 51, 'sell-rsi-value': 67, 'sell-mfi-enabled': False, 'sell-fastd-enabled': False, 'sell-adx-enabled': True, 'sell-rsi-enabled': True, 'sell-trigger': 'sell-bb_upper'}, 'roi': {0: 0.4287874435315165, 408: 0.15112316431545753, 949: 0.026035863879169705, 2139: 0}, 'stoploss': {'stoploss': -0.2562930402099556}},  # noqa: E501
-            'results_metrics': {'total_trades': 2, 'wins': 0, 'draws': 0, 'losses': 2, 'profit_mean': -0.01254995, 'profit_median': -0.012222, 'profit_total': -0.00125625, 'profit_total_abs': -2.50999, 'holding_avg': timedelta(minutes=3930.0)},  # noqa: E501
+            'results_metrics': {'total_trades': 2, 'wins': 0, 'draws': 0, 'losses': 2, 'profit_mean': -0.01254995, 'profit_median': -0.012222, 'profit_total': -0.00125625, 'profit_total_abs': -2.50999, 'holding_avg': timedelta(minutes=3930.0), 'stake_currency': 'BTC', 'strategy_name': 'SampleStrategy'},  # noqa: E501
             'results_explanation': '     2 trades. Avg profit  -1.25%. Total profit -0.00125625 BTC (  -2.51Σ%). Avg duration 3930.0 min.',  # noqa: E501
             'total_profit': -0.00125625,
             'current_epoch': 1,
             'is_initial_point': True,
-            'is_best': True
+            'is_best': True,
+
         }, {
             'loss': 20.0,
             'params_dict': {

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -686,6 +686,8 @@ def test_generate_optimizer(mocker, hyperopt_conf) -> None:
 def test_clean_hyperopt(mocker, hyperopt_conf, caplog):
     patch_exchange(mocker)
 
+    mocker.patch("freqtrade.strategy.hyper.HyperStrategyMixin.load_params_from_file",
+                 MagicMock(return_value={}))
     mocker.patch("freqtrade.optimize.hyperopt.Path.is_file", MagicMock(return_value=True))
     unlinkmock = mocker.patch("freqtrade.optimize.hyperopt.Path.unlink", MagicMock())
     h = Hyperopt(hyperopt_conf)

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -1020,5 +1020,3 @@ def test_SKDecimal():
     assert space.transform([2.0]) == [200]
     assert space.transform([1.0]) == [100]
     assert space.transform([1.5, 1.6]) == [150, 160]
-
-

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -1,9 +1,6 @@
 # pragma pylint: disable=missing-docstring,W0212,C0103
-import logging
-import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
 from unittest.mock import ANY, MagicMock
 
 import pandas as pd
@@ -26,12 +23,6 @@ from tests.conftest import (get_args, log_has, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 
 from .hyperopts.default_hyperopt import DefaultHyperOpt
-
-
-# Functions for recurrent object patching
-def create_results() -> List[Dict]:
-
-    return [{'loss': 1, 'result': 'foo', 'params': {}, 'is_best': True}]
 
 
 def test_setup_hyperopt_configuration_without_arguments(mocker, default_conf, caplog) -> None:
@@ -303,52 +294,6 @@ def test_no_log_if_loss_does_not_improve(hyperopt, caplog) -> None:
     assert caplog.record_tuples == []
 
 
-def test_save_results_saves_epochs(mocker, hyperopt, tmpdir, caplog) -> None:
-    # Test writing to temp dir and reading again
-    epochs = create_results()
-    hyperopt.results_file = Path(tmpdir / 'ut_results.fthypt')
-
-    caplog.set_level(logging.DEBUG)
-
-    for epoch in epochs:
-        hyperopt._save_result(epoch)
-    assert log_has(f"1 epoch saved to '{hyperopt.results_file}'.", caplog)
-
-    hyperopt._save_result(epochs[0])
-    assert log_has(f"2 epochs saved to '{hyperopt.results_file}'.", caplog)
-
-    hyperopt_epochs = HyperoptTools.load_previous_results(hyperopt.results_file)
-    assert len(hyperopt_epochs) == 2
-
-
-def test_load_previous_results(testdatadir, caplog) -> None:
-
-    results_file = testdatadir / 'hyperopt_results_SampleStrategy.pickle'
-
-    hyperopt_epochs = HyperoptTools.load_previous_results(results_file)
-
-    assert len(hyperopt_epochs) == 5
-    assert log_has_re(r"Reading pickled epochs from .*", caplog)
-
-    caplog.clear()
-
-    # Modern version
-    results_file = testdatadir / 'strategy_SampleStrategy.fthypt'
-
-    hyperopt_epochs = HyperoptTools.load_previous_results(results_file)
-
-    assert len(hyperopt_epochs) == 5
-    assert log_has_re(r"Reading epochs from .*", caplog)
-
-
-def test_load_previous_results2(mocker, testdatadir, caplog) -> None:
-    mocker.patch('freqtrade.optimize.hyperopt_tools.HyperoptTools._read_results_pickle',
-                 return_value=[{'asdf': '222'}])
-    results_file = testdatadir / 'hyperopt_results_SampleStrategy.pickle'
-    with pytest.raises(OperationalException, match=r"The file .* incompatible.*"):
-        HyperoptTools.load_previous_results(results_file)
-
-
 def test_roi_table_generation(hyperopt) -> None:
     params = {
         'roi_t1': 5,
@@ -465,40 +410,6 @@ def test_hyperopt_format_results(hyperopt):
     assert ' 0.71%' in result
     assert 'Total profit  0.00003100 BTC' in result
     assert '0:50:00 min' in result
-
-
-@pytest.mark.parametrize("spaces, expected_results", [
-    (['buy'],
-     {'buy': True, 'sell': False, 'roi': False, 'stoploss': False, 'trailing': False}),
-    (['sell'],
-     {'buy': False, 'sell': True, 'roi': False, 'stoploss': False, 'trailing': False}),
-    (['roi'],
-     {'buy': False, 'sell': False, 'roi': True, 'stoploss': False, 'trailing': False}),
-    (['stoploss'],
-     {'buy': False, 'sell': False, 'roi': False, 'stoploss': True, 'trailing': False}),
-    (['trailing'],
-     {'buy': False, 'sell': False, 'roi': False, 'stoploss': False, 'trailing': True}),
-    (['buy', 'sell', 'roi', 'stoploss'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
-    (['buy', 'sell', 'roi', 'stoploss', 'trailing'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
-    (['buy', 'roi'],
-     {'buy': True, 'sell': False, 'roi': True, 'stoploss': False, 'trailing': False}),
-    (['all'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
-    (['default'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
-    (['default', 'trailing'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
-    (['all', 'buy'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
-    (['default', 'buy'],
-     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
-])
-def test_has_space(hyperopt_conf, spaces, expected_results):
-    for s in ['buy', 'sell', 'roi', 'stoploss', 'trailing']:
-        hyperopt_conf.update({'spaces': spaces})
-        assert HyperoptTools.has_space(hyperopt_conf, s) == expected_results[s]
 
 
 def test_populate_indicators(hyperopt, testdatadir) -> None:
@@ -1070,42 +981,6 @@ def test_simplified_interface_failed(mocker, hyperopt_conf, method, space) -> No
         hyperopt.start()
 
 
-def test_show_epoch_details(capsys):
-    test_result = {
-        'params_details': {
-            'trailing': {
-                'trailing_stop': True,
-                'trailing_stop_positive': 0.02,
-                'trailing_stop_positive_offset': 0.04,
-                'trailing_only_offset_is_reached': True
-            },
-            'roi': {
-                0: 0.18,
-                90: 0.14,
-                225: 0.05,
-                430: 0},
-        },
-        'results_explanation': 'foo result',
-        'is_initial_point': False,
-        'total_profit': 0,
-        'current_epoch': 2,  # This starts from 1 (in a human-friendly manner)
-        'is_best': True
-    }
-
-    HyperoptTools.show_epoch_details(test_result, 5, False, no_header=True)
-    captured = capsys.readouterr()
-    assert '# Trailing stop:' in captured.out
-    # re.match(r"Pairs for .*", captured.out)
-    assert re.search(r'^\s+trailing_stop = True$', captured.out, re.MULTILINE)
-    assert re.search(r'^\s+trailing_stop_positive = 0.02$', captured.out, re.MULTILINE)
-    assert re.search(r'^\s+trailing_stop_positive_offset = 0.04$', captured.out, re.MULTILINE)
-    assert re.search(r'^\s+trailing_only_offset_is_reached = True$', captured.out, re.MULTILINE)
-
-    assert '# ROI table:' in captured.out
-    assert re.search(r'^\s+minimal_roi = \{$', captured.out, re.MULTILINE)
-    assert re.search(r'^\s+\"90\"\:\s0.14,\s*$', captured.out, re.MULTILINE)
-
-
 def test_in_strategy_auto_hyperopt(mocker, hyperopt_conf, tmpdir, fee) -> None:
     patch_exchange(mocker)
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)
@@ -1147,15 +1022,3 @@ def test_SKDecimal():
     assert space.transform([1.5, 1.6]) == [150, 160]
 
 
-def test___pprint():
-    params = {'buy_std': 1.2, 'buy_rsi': 31, 'buy_enable': True, 'buy_what': 'asdf'}
-    non_params = {'buy_notoptimied': 55}
-
-    x = HyperoptTools._pprint(params, non_params)
-    assert x == """{
-    "buy_std": 1.2,
-    "buy_rsi": 31,
-    "buy_enable": True,
-    "buy_what": "asdf",
-    "buy_notoptimied": 55,  # value loaded from strategy
-}"""

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -307,6 +307,18 @@ def test_roi_table_generation(hyperopt) -> None:
     assert hyperopt.custom_hyperopt.generate_roi_table(params) == {0: 6, 15: 3, 25: 1, 30: 0}
 
 
+def test_params_no_optimize_details(hyperopt) -> None:
+    hyperopt.config['spaces'] = ['buy']
+    res = hyperopt._get_no_optimize_details()
+    assert isinstance(res, dict)
+    assert "trailing" in res
+    assert res["trailing"]['trailing_stop'] is False
+    assert "roi" in res
+    assert res['roi']['0'] == 0.04
+    assert "stoploss" in res
+    assert res['stoploss']['stoploss'] == -0.1
+
+
 def test_start_calls_optimizer(mocker, hyperopt_conf, capsys) -> None:
     dumper = mocker.patch('freqtrade.optimize.hyperopt.dump')
     dumper2 = mocker.patch('freqtrade.optimize.hyperopt.Hyperopt._save_result')

--- a/tests/optimize/test_hyperopt_tools.py
+++ b/tests/optimize/test_hyperopt_tools.py
@@ -2,8 +2,8 @@ import logging
 import re
 from pathlib import Path
 from typing import Dict, List
-import numpy as np
 
+import numpy as np
 import pytest
 import rapidjson
 

--- a/tests/optimize/test_hyperopt_tools.py
+++ b/tests/optimize/test_hyperopt_tools.py
@@ -2,13 +2,14 @@ import logging
 import re
 from pathlib import Path
 from typing import Dict, List
+import numpy as np
 
 import pytest
 import rapidjson
 
 from freqtrade.constants import FTHYPT_FILEVERSION
 from freqtrade.exceptions import OperationalException
-from freqtrade.optimize.hyperopt_tools import HyperoptTools
+from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_serializer
 from tests.conftest import log_has, log_has_re
 
 
@@ -307,3 +308,10 @@ def test_params_print(capsys):
     assert re.search('trailing_stop_positive = 0.05  # value loaded.*\n', captured.out)
     assert re.search('trailing_stop_positive_offset = 0.1  # value loaded.*\n', captured.out)
     assert re.search('trailing_only_offset_is_reached = True  # value loaded.*\n', captured.out)
+
+
+def test_hyperopt_serializer():
+
+    assert isinstance(hyperopt_serializer(np.int_(5)), int)
+    assert isinstance(hyperopt_serializer(np.bool_(True)), bool)
+    assert isinstance(hyperopt_serializer(np.bool_(False)), bool)

--- a/tests/optimize/test_hyperopttools.py
+++ b/tests/optimize/test_hyperopttools.py
@@ -133,11 +133,11 @@ def test_show_epoch_details(capsys):
     assert re.search(r'^\s+\"90\"\:\s0.14,\s*$', captured.out, re.MULTILINE)
 
 
-def test___pprint():
+def test___pprint_dict():
     params = {'buy_std': 1.2, 'buy_rsi': 31, 'buy_enable': True, 'buy_what': 'asdf'}
     non_params = {'buy_notoptimied': 55}
 
-    x = HyperoptTools._pprint(params, non_params)
+    x = HyperoptTools.__pprint_dict(params, non_params)
     assert x == """{
     "buy_std": 1.2,
     "buy_rsi": 31,
@@ -171,7 +171,7 @@ def test_export_params(tmpdir):
             },
             "roi": {
                 "0": 0.528,
-                "346": 0.08499999999999999,
+                "346": 0.08499,
                 "507": 0.049,
                 "1595": 0
             }

--- a/tests/optimize/test_hyperopttools.py
+++ b/tests/optimize/test_hyperopttools.py
@@ -1,0 +1,146 @@
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from freqtrade.exceptions import OperationalException
+from freqtrade.optimize.hyperopt_tools import HyperoptTools
+from tests.conftest import log_has, log_has_re
+
+
+# Functions for recurrent object patching
+def create_results() -> List[Dict]:
+
+    return [{'loss': 1, 'result': 'foo', 'params': {}, 'is_best': True}]
+
+
+def test_save_results_saves_epochs(hyperopt, tmpdir, caplog) -> None:
+    # Test writing to temp dir and reading again
+    epochs = create_results()
+    hyperopt.results_file = Path(tmpdir / 'ut_results.fthypt')
+
+    caplog.set_level(logging.DEBUG)
+
+    for epoch in epochs:
+        hyperopt._save_result(epoch)
+    assert log_has(f"1 epoch saved to '{hyperopt.results_file}'.", caplog)
+
+    hyperopt._save_result(epochs[0])
+    assert log_has(f"2 epochs saved to '{hyperopt.results_file}'.", caplog)
+
+    hyperopt_epochs = HyperoptTools.load_previous_results(hyperopt.results_file)
+    assert len(hyperopt_epochs) == 2
+
+
+def test_load_previous_results(testdatadir, caplog) -> None:
+
+    results_file = testdatadir / 'hyperopt_results_SampleStrategy.pickle'
+
+    hyperopt_epochs = HyperoptTools.load_previous_results(results_file)
+
+    assert len(hyperopt_epochs) == 5
+    assert log_has_re(r"Reading pickled epochs from .*", caplog)
+
+    caplog.clear()
+
+    # Modern version
+    results_file = testdatadir / 'strategy_SampleStrategy.fthypt'
+
+    hyperopt_epochs = HyperoptTools.load_previous_results(results_file)
+
+    assert len(hyperopt_epochs) == 5
+    assert log_has_re(r"Reading epochs from .*", caplog)
+
+
+def test_load_previous_results2(mocker, testdatadir, caplog) -> None:
+    mocker.patch('freqtrade.optimize.hyperopt_tools.HyperoptTools._read_results_pickle',
+                 return_value=[{'asdf': '222'}])
+    results_file = testdatadir / 'hyperopt_results_SampleStrategy.pickle'
+    with pytest.raises(OperationalException, match=r"The file .* incompatible.*"):
+        HyperoptTools.load_previous_results(results_file)
+
+
+@pytest.mark.parametrize("spaces, expected_results", [
+    (['buy'],
+     {'buy': True, 'sell': False, 'roi': False, 'stoploss': False, 'trailing': False}),
+    (['sell'],
+     {'buy': False, 'sell': True, 'roi': False, 'stoploss': False, 'trailing': False}),
+    (['roi'],
+     {'buy': False, 'sell': False, 'roi': True, 'stoploss': False, 'trailing': False}),
+    (['stoploss'],
+     {'buy': False, 'sell': False, 'roi': False, 'stoploss': True, 'trailing': False}),
+    (['trailing'],
+     {'buy': False, 'sell': False, 'roi': False, 'stoploss': False, 'trailing': True}),
+    (['buy', 'sell', 'roi', 'stoploss'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
+    (['buy', 'sell', 'roi', 'stoploss', 'trailing'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
+    (['buy', 'roi'],
+     {'buy': True, 'sell': False, 'roi': True, 'stoploss': False, 'trailing': False}),
+    (['all'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
+    (['default'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
+    (['default', 'trailing'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
+    (['all', 'buy'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': True}),
+    (['default', 'buy'],
+     {'buy': True, 'sell': True, 'roi': True, 'stoploss': True, 'trailing': False}),
+])
+def test_has_space(hyperopt_conf, spaces, expected_results):
+    for s in ['buy', 'sell', 'roi', 'stoploss', 'trailing']:
+        hyperopt_conf.update({'spaces': spaces})
+        assert HyperoptTools.has_space(hyperopt_conf, s) == expected_results[s]
+
+
+def test_show_epoch_details(capsys):
+    test_result = {
+        'params_details': {
+            'trailing': {
+                'trailing_stop': True,
+                'trailing_stop_positive': 0.02,
+                'trailing_stop_positive_offset': 0.04,
+                'trailing_only_offset_is_reached': True
+            },
+            'roi': {
+                0: 0.18,
+                90: 0.14,
+                225: 0.05,
+                430: 0},
+        },
+        'results_explanation': 'foo result',
+        'is_initial_point': False,
+        'total_profit': 0,
+        'current_epoch': 2,  # This starts from 1 (in a human-friendly manner)
+        'is_best': True
+    }
+
+    HyperoptTools.show_epoch_details(test_result, 5, False, no_header=True)
+    captured = capsys.readouterr()
+    assert '# Trailing stop:' in captured.out
+    # re.match(r"Pairs for .*", captured.out)
+    assert re.search(r'^\s+trailing_stop = True$', captured.out, re.MULTILINE)
+    assert re.search(r'^\s+trailing_stop_positive = 0.02$', captured.out, re.MULTILINE)
+    assert re.search(r'^\s+trailing_stop_positive_offset = 0.04$', captured.out, re.MULTILINE)
+    assert re.search(r'^\s+trailing_only_offset_is_reached = True$', captured.out, re.MULTILINE)
+
+    assert '# ROI table:' in captured.out
+    assert re.search(r'^\s+minimal_roi = \{$', captured.out, re.MULTILINE)
+    assert re.search(r'^\s+\"90\"\:\s0.14,\s*$', captured.out, re.MULTILINE)
+
+
+def test___pprint():
+    params = {'buy_std': 1.2, 'buy_rsi': 31, 'buy_enable': True, 'buy_what': 'asdf'}
+    non_params = {'buy_notoptimied': 55}
+
+    x = HyperoptTools._pprint(params, non_params)
+    assert x == """{
+    "buy_std": 1.2,
+    "buy_rsi": 31,
+    "buy_enable": True,
+    "buy_what": "asdf",
+    "buy_notoptimied": 55,  # value loaded from strategy
+}"""

--- a/tests/optimize/test_hyperopttools.py
+++ b/tests/optimize/test_hyperopttools.py
@@ -199,3 +199,64 @@ def test_export_params(tmpdir):
     assert "roi" in content["params"]
     assert "stoploss" in content["params"]
     assert "trailing" in content["params"]
+
+
+def test_params_print(capsys):
+
+    params = {
+        "buy": {
+            "buy_rsi": 30
+        },
+        "sell": {
+            "sell_rsi": 70
+        },
+    }
+    non_optimized = {
+        "buy": {
+            "buy_adx": 44
+        },
+        "sell": {
+            "sell_adx": 65
+        },
+        "stoploss": {
+            "stoploss": -0.05,
+        },
+        "roi": {
+            "0": 0.05,
+            "20": 0.01,
+        },
+        "trailing": {
+            "trailing_stop": False,
+            "trailing_stop_positive": 0.05,
+            "trailing_stop_positive_offset": 0.1,
+            "trailing_only_offset_is_reached": True
+        },
+
+    }
+    HyperoptTools._params_pretty_print(params, 'buy', 'No header', non_optimized)
+
+    captured = capsys.readouterr()
+    assert re.search("# No header", captured.out)
+    assert re.search('"buy_rsi": 30,\n', captured.out)
+    assert re.search('"buy_adx": 44,  # value loaded.*\n', captured.out)
+    assert not re.search("sell", captured.out)
+
+    HyperoptTools._params_pretty_print(params, 'sell', 'Sell Header', non_optimized)
+    captured = capsys.readouterr()
+    assert re.search("# Sell Header", captured.out)
+    assert re.search('"sell_rsi": 70,\n', captured.out)
+    assert re.search('"sell_adx": 65,  # value loaded.*\n', captured.out)
+
+    HyperoptTools._params_pretty_print(params, 'roi', 'ROI Table:', non_optimized)
+    captured = capsys.readouterr()
+    assert re.search("# ROI Table:  # value loaded.*\n", captured.out)
+    assert re.search('minimal_roi = {\n', captured.out)
+    assert re.search('"20": 0.01\n', captured.out)
+
+    HyperoptTools._params_pretty_print(params, 'trailing', 'Trailing stop:', non_optimized)
+    captured = capsys.readouterr()
+    assert re.search("# Trailing stop:", captured.out)
+    assert re.search('trailing_stop = False  # value loaded.*\n', captured.out)
+    assert re.search('trailing_stop_positive = 0.05  # value loaded.*\n', captured.out)
+    assert re.search('trailing_stop_positive_offset = 0.1  # value loaded.*\n', captured.out)
+    assert re.search('trailing_only_offset_is_reached = True  # value loaded.*\n', captured.out)

--- a/tests/optimize/test_hyperopttools.py
+++ b/tests/optimize/test_hyperopttools.py
@@ -133,11 +133,11 @@ def test_show_epoch_details(capsys):
     assert re.search(r'^\s+\"90\"\:\s0.14,\s*$', captured.out, re.MULTILINE)
 
 
-def test___pprint_dict():
+def test__pprint_dict():
     params = {'buy_std': 1.2, 'buy_rsi': 31, 'buy_enable': True, 'buy_what': 'asdf'}
     non_params = {'buy_notoptimied': 55}
 
-    x = HyperoptTools.__pprint_dict(params, non_params)
+    x = HyperoptTools._pprint_dict(params, non_params)
     assert x == """{
     "buy_std": 1.2,
     "buy_rsi": 31,

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -1,6 +1,7 @@
 # pragma pylint: disable=missing-docstring, C0103
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import arrow
@@ -692,3 +693,50 @@ def test_auto_hyperopt_interface(default_conf):
 
     with pytest.raises(OperationalException, match=r"Inconclusive parameter.*"):
         [x for x in strategy.detect_parameters('sell')]
+
+
+def test_auto_hyperopt_interface_loadparams(default_conf, mocker, caplog):
+    default_conf.update({'strategy': 'HyperoptableStrategy'})
+    del default_conf['stoploss']
+    del default_conf['minimal_roi']
+    mocker.patch.object(Path, 'is_file', MagicMock(return_value=True))
+    mocker.patch.object(Path, 'open')
+    expected_result = {
+        "strategy_name": "HyperoptableStrategy",
+        "params": {
+            "stoploss": {
+                "stoploss": -0.05,
+            },
+            "roi": {
+                "0": 0.2,
+                "1200": 0.01
+            }
+        }
+    }
+    mocker.patch('freqtrade.strategy.hyper.json_load', return_value=expected_result)
+    PairLocks.timeframe = default_conf['timeframe']
+    strategy = StrategyResolver.load_strategy(default_conf)
+    assert strategy.stoploss == -0.05
+    assert strategy.minimal_roi == {0: 0.2, 1200: 0.01}
+
+    expected_result = {
+        "strategy_name": "HyperoptableStrategy_No",
+        "params": {
+            "stoploss": {
+                "stoploss": -0.05,
+            },
+            "roi": {
+                "0": 0.2,
+                "1200": 0.01
+            }
+        }
+    }
+
+    mocker.patch('freqtrade.strategy.hyper.json_load', return_value=expected_result)
+    with pytest.raises(OperationalException, match="Invalid parameter file provided."):
+        StrategyResolver.load_strategy(default_conf)
+
+    mocker.patch('freqtrade.strategy.hyper.json_load', MagicMock(side_effect=ValueError()))
+
+    StrategyResolver.load_strategy(default_conf)
+    assert log_has("Invalid parameter file format.", caplog)


### PR DESCRIPTION
## Summary
Hyperopt will automatically write the best parameters to a file - which will be loaded and used by subsequent strategy loading.

## Quick changelog

- Automatically write Parameter file (placed alongside the strategy - but with `.json` extension)
- Automatically load parameters from file
- applies to ALL hyperoptable parameters (buy, sell, roi, stoploss, trailing stop)
- automatically write parameter file when using `hyperopt-show`
- Option to disable automatic export


### design considerations:

Current implementation will prevalence as config -> parameter file -> strategy parameters -> parameter defaults 