### PR TITLE
Daily profit plotting / equity curve

### DIFF
--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -130,6 +130,39 @@ trades = load_backtest_data(backtest_dir)
 trades.groupby("pair")["sell_reason"].value_counts()
 ```
 
+## Plotting daily profit / equity line
+
+
+```python
+# Plotting equity line (starting with 0 on day 1 and adding daily profit for each backtested day)
+
+from freqtrade.configuration import Configuration
+from freqtrade.data.btanalysis import load_backtest_data, load_backtest_stats
+import plotly.express as px
+import pandas as pd
+
+# strategy = 'SampleStrategy'
+# config = Configuration.from_files(["user_data/config.json"])
+# backtest_dir = config["user_data_dir"] / "backtest_results"
+
+stats = load_backtest_stats(backtest_dir)
+strategy_stats = stats['strategy'][strategy]
+
+equity = 0
+equity_daily = []
+for dp in strategy_stats['daily_profit']:
+    equity_daily.append(equity)
+    equity += float(dp)
+
+dates = pd.date_range(strategy_stats['backtest_start'], strategy_stats['backtest_end'])
+
+df = pd.DataFrame({'dates': dates,'equity_daily': equity_daily})
+
+fig = px.line(df, x="dates", y="equity_daily")
+fig.show()
+
+```
+
 ### Load live trading results into a pandas dataframe
 
 In case you did already some trading and want to analyze your performance

--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -261,6 +261,7 @@ def generate_daily_stats(results: DataFrame) -> Dict[str, Any]:
             'winning_days': 0,
             'draw_days': 0,
             'losing_days': 0,
+            'daily_profit_list': [],
         }
     daily_profit_rel = results.resample('1d', on='close_date')['profit_ratio'].sum()
     daily_profit = results.resample('1d', on='close_date')['profit_abs'].sum().round(10)
@@ -271,6 +272,7 @@ def generate_daily_stats(results: DataFrame) -> Dict[str, Any]:
     winning_days = sum(daily_profit > 0)
     draw_days = sum(daily_profit == 0)
     losing_days = sum(daily_profit < 0)
+    daily_profit_list = daily_profit.tolist()
 
     return {
         'backtest_best_day': best_rel,
@@ -280,6 +282,7 @@ def generate_daily_stats(results: DataFrame) -> Dict[str, Any]:
         'winning_days': winning_days,
         'draw_days': draw_days,
         'losing_days': losing_days,
+        'daily_profit': daily_profit_list,
     }
 
 

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
     "\n",
     "dates = pd.date_range(strategy_stats['backtest_start'], strategy_stats['backtest_end'])\n",
     "\n",
-    "df = pd.DataFrame({'dates':dates,'equity_daily':equity_daily})\n",
+    "df = pd.DataFrame({'dates': dates,'equity_daily': equity_daily})\n",
     "\n",
     "fig = px.line(df, x=\"dates\", y=\"equity_daily\")\n",
     "fig.show()\n"

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -192,6 +192,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Plotting daily profit / equity line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plotting equity line (starting with 0 on day 1 and adding daily profit for each backtested day)\n",
+    "\n",
+    "from freqtrade.configuration import Configuration\n",
+    "from freqtrade.data.btanalysis import load_backtest_data, load_backtest_stats\n",
+    "import plotly.express as px\n",
+    "import pandas as pd\n",
+    "\n",
+    "# strategy = 'SampleStrategy'\n",
+    "# config = Configuration.from_files([\"user_data/config.json\"])\n",
+    "# backtest_dir = config[\"user_data_dir\"] / \"backtest_results\"\n",
+    "\n",
+    "stats = load_backtest_stats(backtest_dir)\n",
+    "strategy_stats = stats['strategy'][strategy]\n",
+    "\n",
+    "equity = 0\n",
+    "equity_daily = []\n",
+    "for dp in strategy_stats['daily_profit']:\n",
+    "    equity_daily.append(equity)\n",
+    "    equity += float(dp)\n",
+    "\n",
+    "dates = pd.date_range(strategy_stats['backtest_start'], strategy_stats['backtest_end'])\n",
+    "\n",
+    "df = pd.DataFrame({'dates':dates,'equity_daily':equity_daily})\n",
+    "\n",
+    "fig = px.line(df, x=\"dates\", y=\"equity_daily\")\n",
+    "fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Load live trading results into a pandas dataframe\n",
     "\n",
     "In case you did already some trading and want to analyze your performance"
@@ -329,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   },
   "mimetype": "text/x-python",
   "name": "python",


### PR DESCRIPTION
## Summary
Add ability to plot daily profits for backtests.

## Quick changelog

- added extra key **daily_profit** in return of **optimize_reports.generate_daily_stats**

## What's new?

this allows us to analyze and plot a daily profit chart / equity line using snippet below inside jupyter notebook


```
# Plotting equity line (starting with 0 on day 1 and adding daily profit for each backtested day)

from freqtrade.configuration import Configuration
from freqtrade.data.btanalysis import load_backtest_data, load_backtest_stats
import plotly.express as px
import pandas as pd

# strategy = 'Strat'
# config = Configuration.from_files(["user_data/config.json"])
# backtest_dir = config["user_data_dir"] / "backtest_results"

stats = load_backtest_stats(backtest_dir)
strategy_stats = stats['strategy'][strategy]

equity = 0
equity_daily = []
for dp in strategy_stats['daily_profit']:
    equity_daily.append(equity)
    equity += float(dp)

dates = pd.date_range(strategy_stats['backtest_start'], strategy_stats['backtest_end'])

df = pd.DataFrame({'dates':dates,'equity_daily':equity_daily})

fig = px.line(df, x="dates", y="equity_daily")
fig.show()

```

![image](https://user-images.githubusercontent.com/86911628/124385524-5c9f7c00-dcd6-11eb-82c8-8f59edf7864e.png)
