### PR TITLE
fixup pairlist filters, change  float_timestamp to int_timestamp

### DIFF
--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -61,10 +61,10 @@ class AgeFilter(IPairList):
         if not needed_pairs:
             return pairlist
 
-        since_ms = int(arrow.utcnow()
-                       .floor('day')
-                       .shift(days=-self._min_days_listed - 1)
-                       .int_timestamp) * 1000
+        since_ms = (arrow.utcnow()
+                         .floor('day')
+                         .shift(days=-self._min_days_listed - 1)
+                         .int_timestamp) * 1000
         candles = self._exchange.refresh_latest_ohlcv(needed_pairs, since_ms=since_ms, cache=False)
         if self._enabled:
             for p in deepcopy(pairlist):

--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -64,7 +64,7 @@ class AgeFilter(IPairList):
         since_ms = int(arrow.utcnow()
                        .floor('day')
                        .shift(days=-self._min_days_listed - 1)
-                       .float_timestamp) * 1000
+                       .int_timestamp) * 1000
         candles = self._exchange.refresh_latest_ohlcv(needed_pairs, since_ms=since_ms, cache=False)
         if self._enabled:
             for p in deepcopy(pairlist):
@@ -89,7 +89,7 @@ class AgeFilter(IPairList):
             if len(daily_candles) >= self._min_days_listed:
                 # We have fetched at least the minimum required number of daily candles
                 # Add to cache, store the time we last checked this symbol
-                self._symbolsChecked[pair] = int(arrow.utcnow().float_timestamp) * 1000
+                self._symbolsChecked[pair] = int(arrow.utcnow().int_timestamp) * 1000
                 return True
             else:
                 self.log_once(f"Removed {pair} from whitelist, because age "

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -72,7 +72,7 @@ class VolatilityFilter(IPairList):
         since_ms = int(arrow.utcnow()
                        .floor('day')
                        .shift(days=-self._days - 1)
-                       .float_timestamp) * 1000
+                       .int_timestamp) * 1000
         # Get all candles
         candles = {}
         if needed_pairs:

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -69,10 +69,10 @@ class VolatilityFilter(IPairList):
         """
         needed_pairs = [(p, '1d') for p in pairlist if p not in self._pair_cache]
 
-        since_ms = int(arrow.utcnow()
-                       .floor('day')
-                       .shift(days=-self._days - 1)
-                       .int_timestamp) * 1000
+        since_ms = (arrow.utcnow()
+                         .floor('day')
+                         .shift(days=-self._days - 1)
+                         .int_timestamp) * 1000
         # Get all candles
         candles = {}
         if needed_pairs:

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -65,7 +65,7 @@ class RangeStabilityFilter(IPairList):
         since_ms = int(arrow.utcnow()
                        .floor('day')
                        .shift(days=-self._days - 1)
-                       .float_timestamp) * 1000
+                       .int_timestamp) * 1000
         # Get all candles
         candles = {}
         if needed_pairs:

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -62,10 +62,10 @@ class RangeStabilityFilter(IPairList):
         """
         needed_pairs = [(p, '1d') for p in pairlist if p not in self._pair_cache]
 
-        since_ms = int(arrow.utcnow()
-                       .floor('day')
-                       .shift(days=-self._days - 1)
-                       .int_timestamp) * 1000
+        since_ms = (arrow.utcnow()
+                         .floor('day')
+                         .shift(days=-self._days - 1)
+                         .int_timestamp) * 1000
         # Get all candles
         candles = {}
         if needed_pairs:


### PR DESCRIPTION

## Summary
changed `float_timestamp` to `int_timestamp` in pairlist filters.

## Quick changelog

- AgeFilter.py
- VolatilityFilter.py
- rangestabilityfilter.py

## What's new?
changed `float_timestamp` to `int_timestamp` to avoid unnecessary conversion.
