### PR TITLE
Introduce webserver mode subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - stable
       - develop
+      - feat/**
     tags:
   release:
     types: [published]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - master
       - stable
       - develop
-      - feat/**
     tags:
   release:
     types: [published]

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -614,6 +614,48 @@ Show whitelist when using a [dynamic pairlist](plugins.md#pairlists).
 freqtrade test-pairlist --config config.json --quote USDT BTC
 ```
 
+## Webserver mode
+
+!!! Warning "Experimental"
+    Webserver mode is an experimental mode to increase backesting and strategy development productivity.
+    There may still be bugs - so if you happen to stumble across these, please report them as github issues, thanks.
+
+Run freqtrade in webserver mode.
+Freqtrade will start the webserver and allow FreqUI to start and control backtesting processes.
+This has the advantage that data will not be reloaded between backtesting runs (as long as timeframe and timerange remain identical).
+FreqUI will also show the backtesting results.
+
+```
+usage: freqtrade webserver [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
+                           [--userdir PATH] [-s NAME] [--strategy-path PATH]
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+Common arguments:
+  -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
+  --logfile FILE        Log to the file specified. Special values are:
+                        'syslog', 'journald'. See the documentation for more
+                        details.
+  -V, --version         show program's version number and exit
+  -c PATH, --config PATH
+                        Specify configuration file (default:
+                        `userdir/config.json` or `config.json` whichever
+                        exists). Multiple --config options may be used. Can be
+                        set to `-` to read config from stdin.
+  -d PATH, --datadir PATH
+                        Path to directory with historical backtesting data.
+  --userdir PATH, --user-data-dir PATH
+                        Path to userdata directory.
+
+Strategy arguments:
+  -s NAME, --strategy NAME
+                        Specify strategy class name which will be used by the
+                        bot.
+  --strategy-path PATH  Specify additional strategy lookup path.
+
+```
+
 ## List Hyperopt results
 
 You can list the hyperoptimization epochs the Hyperopt module evaluated previously with the `hyperopt-list` sub-command.

--- a/freqtrade/commands/__init__.py
+++ b/freqtrade/commands/__init__.py
@@ -19,4 +19,5 @@ from freqtrade.commands.list_commands import (start_list_exchanges, start_list_h
 from freqtrade.commands.optimize_commands import start_backtesting, start_edge, start_hyperopt
 from freqtrade.commands.pairlist_commands import start_test_pairlist
 from freqtrade.commands.plot_commands import start_plot_dataframe, start_plot_profit
-from freqtrade.commands.trade_commands import start_trading, start_webserver
+from freqtrade.commands.trade_commands import start_trading
+from freqtrade.commands.webserver_commands import start_webserver

--- a/freqtrade/commands/__init__.py
+++ b/freqtrade/commands/__init__.py
@@ -19,4 +19,4 @@ from freqtrade.commands.list_commands import (start_list_exchanges, start_list_h
 from freqtrade.commands.optimize_commands import start_backtesting, start_edge, start_hyperopt
 from freqtrade.commands.pairlist_commands import start_test_pairlist
 from freqtrade.commands.plot_commands import start_plot_dataframe, start_plot_profit
-from freqtrade.commands.trade_commands import start_trading
+from freqtrade.commands.trade_commands import start_trading, start_webserver

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -390,6 +390,6 @@ class Arguments:
 
         # Add webserver subcommand
         webserver_cmd = subparsers.add_parser('webserver', help='Webserver module.',
-                                              parents=[_common_parser, _strategy_parser])
+                                              parents=[_common_parser])
         webserver_cmd.set_defaults(func=start_webserver)
         self._build_args(optionlist=ARGS_WEBSERVER, parser=webserver_cmd)

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -16,6 +16,8 @@ ARGS_STRATEGY = ["strategy", "strategy_path"]
 
 ARGS_TRADE = ["db_url", "sd_notify", "dry_run", "dry_run_wallet", "fee"]
 
+ARGS_WEBSERVER: List[str] = []
+
 ARGS_COMMON_OPTIMIZE = ["timeframe", "timerange", "dataformat_ohlcv",
                         "max_open_trades", "stake_amount", "fee", "pairs"]
 
@@ -176,7 +178,8 @@ class Arguments:
                                         start_list_markets, start_list_strategies,
                                         start_list_timeframes, start_new_config, start_new_hyperopt,
                                         start_new_strategy, start_plot_dataframe, start_plot_profit,
-                                        start_show_trades, start_test_pairlist, start_trading)
+                                        start_show_trades, start_test_pairlist, start_trading,
+                                        start_webserver)
 
         subparsers = self.parser.add_subparsers(dest='command',
                                                 # Use custom message when no subhandler is added
@@ -384,3 +387,9 @@ class Arguments:
         )
         plot_profit_cmd.set_defaults(func=start_plot_profit)
         self._build_args(optionlist=ARGS_PLOT_PROFIT, parser=plot_profit_cmd)
+
+        # Add webserver subcommand
+        webserver_cmd = subparsers.add_parser('webserver', help='Webserver module.',
+                                              parents=[_common_parser, _strategy_parser])
+        webserver_cmd.set_defaults(func=start_webserver)
+        self._build_args(optionlist=ARGS_WEBSERVER, parser=webserver_cmd)

--- a/freqtrade/commands/trade_commands.py
+++ b/freqtrade/commands/trade_commands.py
@@ -27,16 +27,3 @@ def start_trading(args: Dict[str, Any]) -> int:
             logger.info("worker found ... calling exit")
             worker.exit()
     return 0
-
-
-def start_webserver(args: Dict[str, Any]) -> None:
-    """
-    Main entry point for webserver mode
-    """
-    from freqtrade.configuration import Configuration
-    from freqtrade.enums import RunMode
-    from freqtrade.rpc.api_server import ApiServer
-
-    # Initialize configuration
-    config = Configuration(args, RunMode.WEBSERVER).get_config()
-    ApiServer(config, standalone=True)

--- a/freqtrade/commands/trade_commands.py
+++ b/freqtrade/commands/trade_commands.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any, Dict
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -29,9 +28,14 @@ def start_trading(args: Dict[str, Any]) -> int:
     return 0
 
 
-def start_webserver(args: Dict[str, Any]) -> int:
+def start_webserver(args: Dict[str, Any]) -> None:
     """
     Main entry point for webserver mode
     """
+    from freqtrade.rpc.api_server import ApiServer
+    from freqtrade.configuration import Configuration
+    from freqtrade.enums import RunMode
 
-    print(args)
+    # Initialize configuration
+    config = Configuration(args, RunMode.WEBSERVER).get_config()
+    ApiServer(config, standalone=True)

--- a/freqtrade/commands/trade_commands.py
+++ b/freqtrade/commands/trade_commands.py
@@ -27,3 +27,11 @@ def start_trading(args: Dict[str, Any]) -> int:
             logger.info("worker found ... calling exit")
             worker.exit()
     return 0
+
+
+def start_webserver(args: Dict[str, Any]) -> int:
+    """
+    Main entry point for webserver mode
+    """
+
+    print(args)

--- a/freqtrade/commands/trade_commands.py
+++ b/freqtrade/commands/trade_commands.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,9 +33,9 @@ def start_webserver(args: Dict[str, Any]) -> None:
     """
     Main entry point for webserver mode
     """
-    from freqtrade.rpc.api_server import ApiServer
     from freqtrade.configuration import Configuration
     from freqtrade.enums import RunMode
+    from freqtrade.rpc.api_server import ApiServer
 
     # Initialize configuration
     config = Configuration(args, RunMode.WEBSERVER).get_config()

--- a/freqtrade/commands/webserver_commands.py
+++ b/freqtrade/commands/webserver_commands.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+
+from freqtrade.enums import RunMode
+
+
+def start_webserver(args: Dict[str, Any]) -> None:
+    """
+    Main entry point for webserver mode
+    """
+    from freqtrade.configuration import Configuration
+    from freqtrade.rpc.api_server import ApiServer
+
+    # Initialize configuration
+    config = Configuration(args, RunMode.WEBSERVER).get_config()
+    ApiServer(config, standalone=True)

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -71,7 +71,7 @@ class Configuration:
 
             # Merge config options, overwriting old values
             config = deep_merge_dicts(load_config_file(path), config)
-
+        config['config_files'] = files
         # Normalize config
         if 'internals' not in config:
             config['internals'] = {}

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+from freqtrade.enums.backteststate import BacktestState
 from freqtrade.enums.rpcmessagetype import RPCMessageType
 from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODES, RunMode
 from freqtrade.enums.selltype import SellType

--- a/freqtrade/enums/backteststate.py
+++ b/freqtrade/enums/backteststate.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class BacktestState(Enum):
+    """
+    Bot application states
+    """
+    STARTUP = 1
+    DATALOAD = 2
+    ANALYZE = 3
+    BACKTEST = 4
+
+    def __str__(self):
+        return f"{self.name.lower()}"

--- a/freqtrade/enums/backteststate.py
+++ b/freqtrade/enums/backteststate.py
@@ -8,7 +8,8 @@ class BacktestState(Enum):
     STARTUP = 1
     DATALOAD = 2
     ANALYZE = 3
-    BACKTEST = 4
+    CONVERT = 4
+    BACKTEST = 5
 
     def __str__(self):
         return f"{self.name.lower()}"

--- a/freqtrade/enums/runmode.py
+++ b/freqtrade/enums/runmode.py
@@ -14,6 +14,7 @@ class RunMode(Enum):
     UTIL_EXCHANGE = "util_exchange"
     UTIL_NO_EXCHANGE = "util_no_exchange"
     PLOT = "plot"
+    WEBSERVER = "webserver"
     OTHER = "other"
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -57,6 +57,7 @@ class Backtesting:
 
         LoggingMixin.show_output = False
         self.config = config
+        self.results: Optional[Dict[str, Any]] = None
 
         # Reset keys for backtesting
         remove_credentials(self.config)
@@ -537,11 +538,12 @@ class Backtesting:
         for strat in self.strategylist:
             min_date, max_date = self.backtest_one_strategy(strat, data, timerange)
         if len(self.strategylist) > 0:
-            stats = generate_backtest_stats(data, self.all_results,
-                                            min_date=min_date, max_date=max_date)
+
+            self.results = generate_backtest_stats(data, self.all_results,
+                                                   min_date=min_date, max_date=max_date)
 
             if self.config.get('export', 'none') == 'trades':
-                store_backtest_stats(self.config['exportfilename'], stats)
+                store_backtest_stats(self.config['exportfilename'], self.results)
 
             # Show backtest results
-            show_backtest_results(self.config, stats)
+            show_backtest_results(self.config, self.results)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -120,6 +120,7 @@ class Backtesting:
         self.required_startup = max([strat.startup_candle_count for strat in self.strategylist])
 
         self.progress = BTProgress()
+        self.abort = False
 
     def __del__(self):
         LoggingMixin.show_output = True
@@ -202,6 +203,8 @@ class Backtesting:
 
         # Create dict with data
         for pair, pair_data in processed.items():
+            if self.abort:
+                raise DependencyException("Stop requested")
             self.progress.increment()
             if not pair_data.empty:
                 pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
@@ -419,7 +422,8 @@ class Backtesting:
         # Loop timerange and get candle for each pair at that point in time
         while tmp <= end_date:
             open_trade_count_start = open_trade_count
-
+            if self.abort:
+                raise DependencyException("Stop requested")
             for i, pair in enumerate(data):
                 row_index = indexes[pair]
                 try:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -189,6 +189,15 @@ class Backtesting:
         self.rejected_trades = 0
         self.dataprovider.clear_cache()
 
+    def check_abort(self):
+        """
+        Check if abort was requested, raise DependencyException if that's the case
+        Only applies to Interactive backtest mode (webserver mode)
+        """
+        if self.abort:
+            self.abort = False
+            raise DependencyException("Stop requested")
+
     def _get_ohlcv_as_lists(self, processed: Dict[str, DataFrame]) -> Dict[str, Tuple]:
         """
         Helper function to convert a processed dataframes into lists for performance reasons.
@@ -203,8 +212,7 @@ class Backtesting:
 
         # Create dict with data
         for pair, pair_data in processed.items():
-            if self.abort:
-                raise DependencyException("Stop requested")
+            self.check_abort()
             self.progress.increment()
             if not pair_data.empty:
                 pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
@@ -422,8 +430,7 @@ class Backtesting:
         # Loop timerange and get candle for each pair at that point in time
         while tmp <= end_date:
             open_trade_count_start = open_trade_count
-            if self.abort:
-                raise DependencyException("Stop requested")
+            self.check_abort()
             for i, pair in enumerate(data):
                 row_index = indexes[pair]
                 try:

--- a/freqtrade/optimize/bt_progress.py
+++ b/freqtrade/optimize/bt_progress.py
@@ -1,4 +1,3 @@
-
 from freqtrade.enums import BacktestState
 
 

--- a/freqtrade/optimize/bt_progress.py
+++ b/freqtrade/optimize/bt_progress.py
@@ -1,0 +1,34 @@
+
+from freqtrade.enums import BacktestState
+
+
+class BTProgress:
+    _action: BacktestState = BacktestState.STARTUP
+    _progress: float = 0
+    _max_steps: float = 0
+
+    def __init__(self):
+        pass
+
+    def init_step(self, action: BacktestState, max_steps: float):
+        self._action = action
+        self._max_steps = max_steps
+        self._proress = 0
+
+    def set_new_value(self, new_value: float):
+        self._progress = new_value
+
+    def increment(self):
+        self._progress += 1
+
+    @property
+    def progress(self):
+        """
+        Get progress as ratio, capped to be between 0 and 1 (to avoid small calculation errors).
+        """
+        return max(min(round(self._progress / self._max_steps, 5)
+                       if self._max_steps > 0 else 0, 1), 0)
+
+    @property
+    def action(self):
+        return str(self._action)

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -1,0 +1,149 @@
+
+import asyncio
+import logging
+from copy import deepcopy
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+
+from freqtrade.enums import BacktestState
+from freqtrade.rpc.api_server.api_schemas import BacktestRequest, BacktestResponse
+from freqtrade.rpc.api_server.deps import get_config
+from freqtrade.rpc.api_server.webserver import ApiServer
+from freqtrade.rpc.rpc import RPCException
+
+
+logger = logging.getLogger(__name__)
+
+# Private API, protected by authentication
+router = APIRouter()
+
+
+@router.post('/backtest', response_model=BacktestResponse, tags=['webserver', 'backtest'])
+async def api_start_backtest(bt_settings: BacktestRequest, background_tasks: BackgroundTasks,
+                             config=Depends(get_config)):
+    """Start backtesting if not done so already"""
+    if ApiServer._bgtask_running:
+        raise RPCException('Bot Background task already running')
+
+    btconfig = deepcopy(config)
+    settings = dict(bt_settings)
+    # Pydantic models will contain all keys, but non-provided ones are None
+    for setting in settings.keys():
+        if settings[setting] is not None:
+            btconfig[setting] = settings[setting]
+
+    # Start backtesting
+    # Initialize backtesting object
+    def run_backtest():
+        from freqtrade.optimize.optimize_reports import generate_backtest_stats
+        from freqtrade.resolvers import StrategyResolver
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        try:
+            # Reload strategy
+            lastconfig = ApiServer._lastbacktestconfig
+            strat = StrategyResolver.load_strategy(btconfig)
+
+            if (not ApiServer._bt
+                    or lastconfig.get('timeframe') != strat.timeframe
+                    or lastconfig.get('stake_amount') != btconfig.get('stake_amount')
+                    or lastconfig.get('enable_protections') != btconfig.get('enable_protections')
+                    or lastconfig.get('protections') != btconfig.get('protections', [])
+                    or lastconfig.get('dry_run_wallet') != btconfig.get('dry_run_wallet', 0)):
+                # TODO: Investigate if enabling protections can be dynamically ingested from here...
+                from freqtrade.optimize.backtesting import Backtesting
+                ApiServer._bt = Backtesting(btconfig)
+                # Reset data if backtesting is reloaded
+
+            if (not ApiServer._backtestdata or not ApiServer._bt_timerange
+                    or lastconfig.get('timerange') != btconfig['timerange']
+                    or lastconfig.get('timeframe') != strat.timeframe):
+                lastconfig['timerange'] = btconfig['timerange']
+                lastconfig['protections'] = btconfig.get('protections', [])
+                lastconfig['enable_protections'] = btconfig.get('enable_protections')
+                lastconfig['dry_run_wallet'] = btconfig.get('dry_run_wallet')
+                lastconfig['timeframe'] = strat.timeframe
+                ApiServer._backtestdata, ApiServer._bt_timerange = ApiServer._bt.load_bt_data()
+
+            min_date, max_date = ApiServer._bt.backtest_one_strategy(
+                strat, ApiServer._backtestdata,
+                ApiServer._bt_timerange)
+            ApiServer._bt.results = generate_backtest_stats(
+                ApiServer._backtestdata, ApiServer._bt.all_results,
+                min_date=min_date, max_date=max_date)
+            logger.info("Backtesting finished.")
+
+        finally:
+            ApiServer._bgtask_running = False
+
+    background_tasks.add_task(run_backtest)
+    ApiServer._bgtask_running = True
+
+    return {
+        "status": "running",
+        "running": True,
+        "progress": 0,
+        "step": str(BacktestState.STARTUP),
+        "status_msg": "Backtest started",
+    }
+
+
+@router.get('/backtest', response_model=BacktestResponse, tags=['webserver', 'backtest'])
+def api_get_backtest():
+    """
+    Get backtesting result.
+    Returns Result after backtesting has been ran.
+    """
+    from freqtrade.persistence import LocalTrade
+    if ApiServer._bgtask_running:
+        return {
+            "status": "running",
+            "running": True,
+            "step": ApiServer._bt.progress.action if ApiServer._bt else str(BacktestState.STARTUP),
+            "progress": ApiServer._bt.progress.progress if ApiServer._bt else 0,
+            "trade_count": len(LocalTrade.trades),
+            "status_msg": "Backtest running",
+        }
+
+    if not ApiServer._bt:
+        return {
+            "status": "not_started",
+            "running": False,
+            "step": "",
+            "progress": 0,
+            "status_msg": "Backtesting not yet executed"
+        }
+
+    return {
+        "status": "ended",
+        "running": False,
+        "status_msg": "Backtest ended",
+        "step": "finished",
+        "progress": 1,
+        "backtest_result": ApiServer._bt.results,
+    }
+
+
+@router.delete('/backtest', response_model=BacktestResponse, tags=['webserver', 'backtest'])
+def api_delete_backtest():
+    """Reset backtesting"""
+    if ApiServer._bgtask_running:
+        return {
+            "status": "running",
+            "running": True,
+            "step": "",
+            "progress": 0,
+            "status_msg": "Backtest running",
+        }
+    if ApiServer._bt:
+        del ApiServer._bt
+        ApiServer._bt = None
+        del ApiServer._backtestdata
+        ApiServer._backtestdata = None
+        logger.info("Backtesting reset")
+    return {
+        "status": "reset",
+        "running": False,
+        "step": "",
+        "progress": 0,
+        "status_msg": "Backtesting reset",
+    }

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -70,7 +70,7 @@ async def api_start_backtest(bt_settings: BacktestRequest, background_tasks: Bac
             ApiServer._bt.results = generate_backtest_stats(
                 ApiServer._backtestdata, ApiServer._bt.all_results,
                 min_date=min_date, max_date=max_date)
-            logger.info("Backtesting finished.")
+            logger.info("Backtest finished.")
 
         finally:
             ApiServer._bgtask_running = False
@@ -110,7 +110,7 @@ def api_get_backtest():
             "running": False,
             "step": "",
             "progress": 0,
-            "status_msg": "Backtesting not yet executed"
+            "status_msg": "Backtest not yet executed"
         }
 
     return {
@@ -145,5 +145,5 @@ def api_delete_backtest():
         "running": False,
         "step": "",
         "progress": 0,
-        "status_msg": "Backtesting reset",
+        "status_msg": "Backtest reset",
     }

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import logging
 from copy import deepcopy

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -45,17 +45,16 @@ async def api_start_backtest(bt_settings: BacktestRequest, background_tasks: Bac
 
             if (not ApiServer._bt
                     or lastconfig.get('timeframe') != strat.timeframe
-                    or lastconfig.get('stake_amount') != btconfig.get('stake_amount')
-                    or lastconfig.get('enable_protections') != btconfig.get('enable_protections')
-                    or lastconfig.get('protections') != btconfig.get('protections', [])
                     or lastconfig.get('dry_run_wallet') != btconfig.get('dry_run_wallet', 0)):
-                # TODO: Investigate if enabling protections can be dynamically ingested from here...
                 from freqtrade.optimize.backtesting import Backtesting
                 ApiServer._bt = Backtesting(btconfig)
 
             # Only reload data if timeframe or timerange changed.
             if (not ApiServer._backtestdata or not ApiServer._bt_timerange
                     or lastconfig.get('timerange') != btconfig['timerange']
+                    or lastconfig.get('stake_amount') != btconfig.get('stake_amount')
+                    or lastconfig.get('enable_protections') != btconfig.get('enable_protections')
+                    or lastconfig.get('protections') != btconfig.get('protections', [])
                     or lastconfig.get('timeframe') != strat.timeframe):
                 lastconfig['timerange'] = btconfig['timerange']
                 lastconfig['protections'] = btconfig.get('protections', [])

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -52,8 +52,8 @@ async def api_start_backtest(bt_settings: BacktestRequest, background_tasks: Bac
                 # TODO: Investigate if enabling protections can be dynamically ingested from here...
                 from freqtrade.optimize.backtesting import Backtesting
                 ApiServer._bt = Backtesting(btconfig)
-                # Reset data if backtesting is reloaded
 
+            # Only reload data if timeframe or timerange changed.
             if (not ApiServer._backtestdata or not ApiServer._bt_timerange
                     or lastconfig.get('timerange') != btconfig['timerange']
                     or lastconfig.get('timeframe') != strat.timeframe):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -331,5 +331,6 @@ class BacktestResponse(BaseModel):
     status_msg: str
     step: str
     progress: float
+    trade_count: Optional[float]
     # TODO: Properly type backtestresult...
     backtest_result: Optional[Dict[str, Any]]

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -321,6 +321,7 @@ class BacktestRequest(BaseModel):
     timerange: Optional[str]
     max_open_trades: Optional[int]
     stake_amount: Optional[int]
+    enable_protections: bool
 
 
 class BacktestResponse(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -320,8 +320,9 @@ class BacktestRequest(BaseModel):
     timeframe: Optional[str]
     timerange: Optional[str]
     max_open_trades: Optional[int]
-    stake_amount: Optional[int]
+    stake_amount: Optional[Union[float, str]]
     enable_protections: bool
+    dry_run_wallet: Optional[float]
 
 
 class BacktestResponse(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -313,3 +313,19 @@ class PairHistory(BaseModel):
         json_encoders = {
             datetime: lambda v: v.strftime(DATETIME_PRINT_FORMAT),
         }
+
+
+class BacktestRequest(BaseModel):
+    strategy: str
+    timeframe: Optional[str]
+    timerange: Optional[str]
+    max_open_trades: Optional[int]
+    stake_amount: Optional[int]
+
+
+class BacktestResponse(BaseModel):
+    status: str
+    running: bool
+    status_msg: str
+    # TODO: Properly type backtestresult...
+    backtest_result: Optional[Dict[str, Any]]

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -329,5 +329,7 @@ class BacktestResponse(BaseModel):
     status: str
     running: bool
     status_msg: str
+    step: str
+    progress: float
     # TODO: Properly type backtestresult...
     backtest_result: Optional[Dict[str, Any]]

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -118,17 +118,17 @@ class ShowConfig(BaseModel):
     stake_currency_decimals: int
     max_open_trades: int
     minimal_roi: Dict[str, Any]
-    stoploss: float
-    trailing_stop: bool
+    stoploss: Optional[float]
+    trailing_stop: Optional[bool]
     trailing_stop_positive: Optional[float]
     trailing_stop_positive_offset: Optional[float]
     trailing_only_offset_is_reached: Optional[bool]
     use_custom_stoploss: Optional[bool]
-    timeframe: str
+    timeframe: Optional[str]
     timeframe_ms: int
     timeframe_min: int
     exchange: str
-    strategy: str
+    strategy: Optional[str]
     forcebuy_enabled: bool
     ask_strategy: Dict[str, Any]
     bid_strategy: Dict[str, Any]

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -256,3 +256,4 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
         'pair_interval': pair_interval,
     }
     return result
+

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -11,15 +11,14 @@ from freqtrade.constants import USERPATH_STRATEGIES
 from freqtrade.data.history import get_datahandler
 from freqtrade.exceptions import OperationalException
 from freqtrade.rpc import RPC
-from freqtrade.rpc.api_server.api_schemas import (AvailablePairs,
-                                                  Balances, BlacklistPayload, BlacklistResponse,
-                                                  Count, Daily, DeleteLockRequest, DeleteTrade,
-                                                  ForceBuyPayload, ForceBuyResponse,
-                                                  ForceSellPayload, Locks, Logs, OpenTradeSchema,
-                                                  PairHistory, PerformanceEntry, Ping, PlotConfig,
-                                                  Profit, ResultMsg, ShowConfig, Stats, StatusMsg,
-                                                  StrategyListResponse, StrategyResponse, Version,
-                                                  WhitelistResponse)
+from freqtrade.rpc.api_server.api_schemas import (AvailablePairs, Balances, BlacklistPayload,
+                                                  BlacklistResponse, Count, Daily,
+                                                  DeleteLockRequest, DeleteTrade, ForceBuyPayload,
+                                                  ForceBuyResponse, ForceSellPayload, Locks, Logs,
+                                                  OpenTradeSchema, PairHistory, PerformanceEntry,
+                                                  Ping, PlotConfig, Profit, ResultMsg, ShowConfig,
+                                                  Stats, StatusMsg, StrategyListResponse,
+                                                  StrategyResponse, Version, WhitelistResponse)
 from freqtrade.rpc.api_server.deps import get_config, get_rpc, get_rpc_optional
 from freqtrade.rpc.rpc import RPCException
 
@@ -260,4 +259,3 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
         'pair_interval': pair_interval,
     }
     return result
-

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -339,14 +339,14 @@ def api_get_backtest():
     Get backtesting result.
     Returns Result after backtesting has been ran.
     """
-    from freqtrade.persistence import Trade
+    from freqtrade.persistence import LocalTrade
     if ApiServer._bgtask_running:
         return {
             "status": "running",
             "running": True,
             "step": ApiServer._bt.get_action() if ApiServer._bt else str(BacktestState.STARTUP),
             "progress": ApiServer._bt.get_progress() if ApiServer._bt else 0,
-            "trade_count": Trade.get_trades_proxy(is_open=False),
+            "trade_count": len(LocalTrade.trades),
             "status_msg": "Backtest running",
         }
 

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -252,7 +252,7 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
     pair_interval = sorted(pair_interval, key=lambda x: x[0])
 
     pairs = list({x[0] for x in pair_interval})
-
+    pairs.sort()
     result = {
         'length': len(pairs),
         'pairs': pairs,

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -339,12 +339,14 @@ def api_get_backtest():
     Get backtesting result.
     Returns Result after backtesting has been ran.
     """
+    from freqtrade.persistence import Trade
     if ApiServer._bgtask_running:
         return {
             "status": "running",
             "running": True,
             "step": ApiServer._bt.get_action() if ApiServer._bt else str(BacktestState.STARTUP),
             "progress": ApiServer._bt.get_progress() if ApiServer._bt else 0,
+            "trade_count": Trade.get_trades_proxy(is_open=False),
             "status_msg": "Backtest running",
         }
 

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -112,10 +112,14 @@ class ApiServer(RPCHandler):
         from freqtrade.rpc.api_server.api_v1 import router as api_v1
         from freqtrade.rpc.api_server.api_v1 import router_public as api_v1_public
         from freqtrade.rpc.api_server.web_ui import router_ui
+        from freqtrade.rpc.api_server.api_backtest import router as api_backtest
 
         app.include_router(api_v1_public, prefix="/api/v1")
 
         app.include_router(api_v1, prefix="/api/v1",
+                           dependencies=[Depends(http_basic_or_jwt_token)],
+                           )
+        app.include_router(api_backtest, prefix="/api/v1",
                            dependencies=[Depends(http_basic_or_jwt_token)],
                            )
         app.include_router(router_login, prefix="/api/v1", tags=["auth"])

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -33,6 +33,8 @@ class ApiServer(RPCHandler):
     __initialized = False
 
     _rpc: RPC
+    # Backtesting type: Backtesting
+    _backtesting = None
     _has_rpc: bool = False
     _bgtask_running: bool = False
     _config: Dict[str, Any] = {}

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -86,6 +86,14 @@ class ApiServer(RPCHandler):
             logger.info("Stopping API Server")
             self._server.cleanup()
 
+    @classmethod
+    def shutdown(cls):
+        cls.__initialized = False
+        del cls.__instance
+        cls.__instance = None
+        cls._has_rpc = False
+        cls._rpc = None
+
     def send_msg(self, msg: Dict[str, str]) -> None:
         pass
 

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -109,10 +109,10 @@ class ApiServer(RPCHandler):
 
     def configure_app(self, app: FastAPI, config):
         from freqtrade.rpc.api_server.api_auth import http_basic_or_jwt_token, router_login
+        from freqtrade.rpc.api_server.api_backtest import router as api_backtest
         from freqtrade.rpc.api_server.api_v1 import router as api_v1
         from freqtrade.rpc.api_server.api_v1 import router_public as api_v1_public
         from freqtrade.rpc.api_server.web_ui import router_ui
-        from freqtrade.rpc.api_server.api_backtest import router as api_backtest
 
         app.include_router(api_v1_public, prefix="/api/v1")
 

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -34,6 +34,7 @@ class ApiServer(RPCHandler):
 
     _rpc: RPC
     _has_rpc: bool = False
+    _bgtask_running: bool = False
     _config: Dict[str, Any] = {}
 
     def __new__(cls, *args, **kwargs):
@@ -47,13 +48,13 @@ class ApiServer(RPCHandler):
         return ApiServer.__instance
 
     def __init__(self, config: Dict[str, Any], standalone: bool = False) -> None:
+        ApiServer._config = config
         if self.__initialized and (standalone or self._standalone):
             return
         self._standalone: bool = standalone
-        self._config = config
         self._server = None
+        ApiServer.__initialized = True
 
-        ApiServer._config = config
         api_config = self._config['api_server']
 
         self.app = FastAPI(title="Freqtrade API",
@@ -69,7 +70,7 @@ class ApiServer(RPCHandler):
         """
         Attach rpc handler
         """
-        if not self._rpc:
+        if not self._has_rpc:
             self._rpc = rpc
             ApiServer._rpc = rpc
             ApiServer._has_rpc = True

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -34,7 +34,10 @@ class ApiServer(RPCHandler):
 
     _rpc: RPC
     # Backtesting type: Backtesting
-    _backtesting = None
+    _bt = None
+    _backtestdata = None
+    _bt_timerange = None
+    _lastbacktestconfig: Dict[str, Any] = {}
     _has_rpc: bool = False
     _bgtask_running: bool = False
     _config: Dict[str, Any] = {}

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -166,6 +166,9 @@ class ApiServer(RPCHandler):
                                   )
         try:
             self._server = UvicornServer(uvconfig)
-            self._server.run_in_thread()
+            if self._standalone:
+                self._server.run()
+            else:
+                self._server.run_in_thread()
         except Exception:
             logger.exception("Api server failed to start.")

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -35,9 +35,9 @@ class ApiServer(RPCHandler):
     _rpc: RPC
     # Backtesting type: Backtesting
     _bt = None
-    _backtestdata = None
+    _bt_data = None
     _bt_timerange = None
-    _lastbacktestconfig: Dict[str, Any] = {}
+    _bt_last_config: Dict[str, Any] = {}
     _has_rpc: bool = False
     _bgtask_running: bool = False
     _config: Dict[str, Any] = {}

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -76,7 +76,6 @@ class ApiServer(RPCHandler):
         Attach rpc handler
         """
         if not self._has_rpc:
-            self._rpc = rpc
             ApiServer._rpc = rpc
             ApiServer._has_rpc = True
         else:
@@ -85,7 +84,9 @@ class ApiServer(RPCHandler):
 
     def cleanup(self) -> None:
         """ Cleanup pending module resources """
-        if self._server:
+        ApiServer._has_rpc = False
+        del ApiServer._rpc
+        if self._server and not self._standalone:
             logger.info("Stopping API Server")
             self._server.cleanup()
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -118,9 +118,9 @@ class RPC:
             'bot_name': config.get('bot_name', 'freqtrade'),
             'timeframe': config.get('timeframe'),
             'timeframe_ms': timeframe_to_msecs(config['timeframe']
-                                               ) if 'timeframe' in config else '',
+                                               ) if 'timeframe' in config else 0,
             'timeframe_min': timeframe_to_minutes(config['timeframe']
-                                                  ) if 'timeframe' in config else '',
+                                                  ) if 'timeframe' in config else 0,
             'exchange': config['exchange']['name'],
             'strategy': config['strategy'],
             'forcebuy_enabled': config.get('forcebuy_enable', False),

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -36,15 +36,16 @@ class RPCManager:
         if config.get('api_server', {}).get('enabled', False):
             logger.info('Enabling rpc.api_server')
             from freqtrade.rpc.api_server import ApiServer
-
-            self.registered_modules.append(ApiServer(self._rpc, config))
+            apiserver = ApiServer(config)
+            apiserver.add_rpc_handler(self._rpc)
+            self.registered_modules.append(apiserver)
 
     def cleanup(self) -> None:
         """ Stops all enabled rpc modules """
         logger.info('Cleaning up rpc modules ...')
         while self.registered_modules:
             mod = self.registered_modules.pop()
-            logger.debug('Cleaning up rpc.%s ...', mod.name)
+            logger.info('Cleaning up rpc.%s ...', mod.name)
             mod.cleanup()
             del mod
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -13,10 +13,9 @@ from freqtrade.commands import (start_convert_data, start_create_userdir, start_
                                 start_list_data, start_list_exchanges, start_list_hyperopts,
                                 start_list_markets, start_list_strategies, start_list_timeframes,
                                 start_new_hyperopt, start_new_strategy, start_show_trades,
-                                start_test_pairlist, start_trading)
+                                start_test_pairlist, start_trading, start_webserver)
 from freqtrade.commands.deploy_commands import (clean_ui_subdir, download_and_install_ui,
                                                 get_ui_download_url, read_ui_version)
-from freqtrade.commands.trade_commands import start_webserver
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -16,6 +16,7 @@ from freqtrade.commands import (start_convert_data, start_create_userdir, start_
                                 start_test_pairlist, start_trading)
 from freqtrade.commands.deploy_commands import (clean_ui_subdir, download_and_install_ui,
                                                 get_ui_download_url, read_ui_version)
+from freqtrade.commands.trade_commands import start_webserver
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
@@ -56,6 +57,18 @@ def test_start_trading_fail(mocker, caplog):
     start_trading(get_args(args))
     assert exitmock.call_count == 0
     assert log_has('Fatal exception!', caplog)
+
+
+def test_start_webserver(mocker, caplog):
+
+    api_server_mock = mocker.patch("freqtrade.rpc.api_server.ApiServer", )
+
+    args = [
+        'webserver',
+        '-c', 'config_bittrex.json.example'
+    ]
+    start_webserver(get_args(args))
+    assert api_server_mock.call_count == 1
 
 
 def test_list_exchanges(capsys):

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -346,6 +346,20 @@ def test_data_to_dataframe_bt(default_conf, mocker, testdatadir) -> None:
     assert processed['UNITTEST/BTC'].equals(processed2['UNITTEST/BTC'])
 
 
+def test_backtest_abort(default_conf, mocker, testdatadir) -> None:
+    patch_exchange(mocker)
+    backtesting = Backtesting(default_conf)
+    backtesting.check_abort()
+
+    backtesting.abort = True
+
+    with pytest.raises(DependencyException, match="Stop requested"):
+        backtesting.check_abort()
+    # abort flag resets
+    assert backtesting.abort is False
+    assert backtesting.progress.progress == 0
+
+
 def test_backtesting_start(default_conf, mocker, testdatadir, caplog) -> None:
     def get_timerange(input1):
         return Arrow(2017, 11, 14, 21, 17), Arrow(2017, 11, 14, 22, 59)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1252,10 +1252,6 @@ def test_api_backtesting(botclient, mocker, fee):
     assert not result['running']
     assert result['status_msg'] == 'Backtest reset'
 
-    # bt_mock = mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest_one_strategy',
-    #                        return_value=(1, 2))
-    # stats_mock = mocker.patch('freqtrade.optimize.optimize_reports.generate_backtest_stats')
-    # bt_mock.load_bt_data = MagicMock(return_value=(xxx, 'asdfadf'))
     # start backtesting
     data = {
         "strategy": "DefaultStrategy",
@@ -1284,6 +1280,13 @@ def test_api_backtesting(botclient, mocker, fee):
     assert result['status_msg'] == 'Backtest ended'
     assert result['progress'] == 1
     assert result['backtest_result']
+
+    rc = client_get(client, f"{BASE_URI}/backtest/abort")
+    assert_response(rc)
+    result = rc.json()
+    assert result['status'] == 'not_running'
+    assert not result['running']
+    assert result['status_msg'] == 'Backtest ended'
 
     # Delete backtesting to avoid leakage since the backtest-object may stick around.
     rc = client_delete(client, f"{BASE_URI}/backtest")

--- a/tests/rpc/test_rpc_manager.py
+++ b/tests/rpc/test_rpc_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from freqtrade.enums import RPCMessageType
 from freqtrade.rpc import RPCManager
+from freqtrade.rpc.api_server.webserver import ApiServer
 from tests.conftest import get_patched_freqtradebot, log_has
 
 
@@ -190,3 +191,4 @@ def test_init_apiserver_enabled(mocker, default_conf, caplog) -> None:
     assert len(rpc_manager.registered_modules) == 1
     assert 'apiserver' in [mod.name for mod in rpc_manager.registered_modules]
     assert run_mock.call_count == 1
+    ApiServer.shutdown()


### PR DESCRIPTION
## Summary
Add  `freqtrade webserver` as subcommand to freqtrade.
This mode will start only the webserver, which will serve freqUI and will allow backtesting.

in future iterations this mode MAY allow trading, but for now that is not the focus.

## Quick changelog

- Start webserver in standalone mode
- FreqUI will support backtesting in this mode - and will display backtest results
- iterative backtesting (backtesting after small changes to the strategy) will become faster, as data is not reloaded again and again