### PR TITLE
new filter OffsetFilter for offsetting incoming pairlists

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -23,6 +23,7 @@ You may also use something like `.*DOWN/BTC` or `.*UP/BTC` to exclude leveraged 
 * [`StaticPairList`](#static-pair-list) (default, if not configured differently)
 * [`VolumePairList`](#volume-pair-list)
 * [`AgeFilter`](#agefilter)
+* [`OffsetFilter`](#offsetfilter)
 * [`PerformanceFilter`](#performancefilter)
 * [`PrecisionFilter`](#precisionfilter)
 * [`PriceFilter`](#pricefilter)
@@ -88,6 +89,30 @@ in the first few days while the pair goes through its price-discovery period. Bo
 be caught out buying before the pair has finished dropping in price.
 
 This filter allows freqtrade to ignore pairs until they have been listed for at least `min_days_listed` days.
+
+#### OffsetFilter
+
+Offsets an incoming pairlist by a given `offset` value.
+
+As an example it can be used in conjunction with `VolumeFilter` to remove the top X volume pairs. Or to split
+a larger pairlist on two bot instances.
+
+Example to remove the first 10 pairs from the pairlist:
+
+```json
+"pairlists": [{
+        "method": "OffsetFilter",
+        "offset": 10
+}],
+```
+
+!!! Warning
+    When `OffsetFilter` is used to split a larger pairlist among multiple bots in combination with `VolumeFilter` 
+    it can not be guaranteed that pairs won't overlap due to slightly different refresh intervals for the
+    `VolumeFilter`
+
+!!! Note
+    An offset larger then the total length of the incoming pairlist will result in an empty pairlist.
 
 #### PerformanceFilter
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -100,10 +100,12 @@ a larger pairlist on two bot instances.
 Example to remove the first 10 pairs from the pairlist:
 
 ```json
-"pairlists": [{
+"pairlists": [
+    {
         "method": "OffsetFilter",
         "offset": 10
-}],
+    }
+],
 ```
 
 !!! Warning

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -109,7 +109,7 @@ Example to remove the first 10 pairs from the pairlist:
 !!! Warning
     When `OffsetFilter` is used to split a larger pairlist among multiple bots in combination with `VolumeFilter` 
     it can not be guaranteed that pairs won't overlap due to slightly different refresh intervals for the
-    `VolumeFilter`
+    `VolumeFilter`.
 
 !!! Note
     An offset larger then the total length of the incoming pairlist will result in an empty pairlist.

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -26,9 +26,9 @@ HYPEROPT_LOSS_BUILTIN = ['ShortTradeDurHyperOptLoss', 'OnlyProfitHyperOptLoss',
                          'SharpeHyperOptLoss', 'SharpeHyperOptLossDaily',
                          'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
-                       'AgeFilter', 'PerformanceFilter', 'PrecisionFilter',
-                       'PriceFilter', 'RangeStabilityFilter', 'ShuffleFilter',
-                       'SpreadFilter', 'VolatilityFilter']
+                       'AgeFilter', 'OffsetFilter', 'PerformanceFilter',
+                       'PrecisionFilter', 'PriceFilter', 'RangeStabilityFilter',
+                       'ShuffleFilter', 'SpreadFilter', 'VolatilityFilter']
 AVAILABLE_PROTECTIONS = ['CooldownPeriod', 'LowProfitPairs', 'MaxDrawdown', 'StoplossGuard']
 AVAILABLE_DATAHANDLERS = ['json', 'jsongz', 'hdf5']
 DRY_RUN_WALLET = 1000

--- a/freqtrade/plugins/pairlist/OffsetFilter.py
+++ b/freqtrade/plugins/pairlist/OffsetFilter.py
@@ -1,0 +1,54 @@
+"""
+Offset pair list filter
+"""
+import logging
+from typing import Any, Dict, List
+
+from freqtrade.exceptions import OperationalException
+from freqtrade.plugins.pairlist.IPairList import IPairList
+
+
+logger = logging.getLogger(__name__)
+
+
+class OffsetFilter(IPairList):
+
+    def __init__(self, exchange, pairlistmanager,
+                 config: Dict[str, Any], pairlistconfig: Dict[str, Any],
+                 pairlist_pos: int) -> None:
+        super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
+
+        self._offset = pairlistconfig.get('offset', 0)
+
+        if self._offset < 0:
+            raise OperationalException("OffsetFilter requires offset to be >= 0")
+
+    @property
+    def needstickers(self) -> bool:
+        """
+        Boolean property defining if tickers are necessary.
+        If no Pairlist requires tickers, an empty Dict is passed
+        as tickers argument to filter_pairlist
+        """
+        return False
+
+    def short_desc(self) -> str:
+        """
+        Short whitelist method description - used for startup-messages
+        """
+        return f"{self.name} - Offseting pairs by {self._offset}."
+
+    def filter_pairlist(self, pairlist: List[str], tickers: Dict) -> List[str]:
+        """
+        Filters and sorts pairlist and returns the whitelist again.
+        Called on each bot iteration - please use internal caching if necessary
+        :param pairlist: pairlist to filter or sort
+        :param tickers: Tickers (from exchange.get_tickers()). May be cached.
+        :return: new whitelist
+        """
+        if self._offset > len(pairlist):
+            self.log_once(f"Offset of {self._offset} is larger than " +
+                          f"pair count of {len(pairlist)}", logger.warn)
+        pairs = pairlist[self._offset:]
+        self.log_once(f"Searching {len(pairs)} pairs: {pairs}", logger.info)
+        return pairs


### PR DESCRIPTION
## Summary
Introduce a new pairlist filter `OffsetFilter` for ofsetting an incomming pairlist.

closes #5241 

## Quick changelog
- created `OffsetFilter.py`
- enhanced and added tests to `test_pairlist.py`
- updated documentation in`pairlists.md`

## What's new?
Added `OffsetFilter` which can offset the pairlist by specifying `offset` larger than zero. 

Example:
```json
"pairlists": [{
        "method": "OffsetFilter",
        "offset": 10
}],
```
