### PR TITLE
Fix Agefilter cannot appear on startup messages

### DIFF
--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -58,10 +58,10 @@ class AgeFilter(IPairList):
         return (
             f"{self.name} - Filtering pairs with age less than "
             f"{self._min_days_listed} {plural(self._min_days_listed, 'day')}"
-        ) + (
+        ) + ((
             " or more than "
             f"{self._max_days_listed} {plural(self._max_days_listed, 'day')}"
-        ) if self._max_days_listed else ''
+        ) if self._max_days_listed else '')
 
     def filter_pairlist(self, pairlist: List[str], tickers: Dict) -> List[str]:
         """


### PR DESCRIPTION
## Summary
Sorry, this is related to PR #5228
Age filter will be empty string when there is no max_age_listed, fix with this PR
![image](https://user-images.githubusercontent.com/13866266/124970186-cced2b00-e051-11eb-8658-949926a4d5e5.png)

to prevent this, should we test startup messages ?