### PR TITLE
Improve dynamic stake with multiple bots on the same exchange

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,7 @@ You can configure the "untouched" amount by using the `tradable_balance_ratio` s
 For example, if you have 10 ETH available in your wallet on the exchange and `tradable_balance_ratio=0.5` (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers this as available balance. The rest of the wallet is untouched by the trades.
 
 !!! Danger
-    This setting should **not** be used when running multiple bots on the same exchange. Please look at [Available Capital to the bot](#assign-available-capital) instead.
+    This setting should **not** be used when running multiple bots on the same account. Please look at [Available Capital to the bot](#assign-available-capital) instead.
 
 !!! Warning
     The `tradable_balance_ratio` setting applies to the current balance (free balance + tied up in trades). Therefore, assuming the starting balance of 1000, a configuration with `tradable_balance_ratio=0.99` will not guarantee that 10 currency units will always remain available on the exchange. For example, the free amount may reduce to 5 units if the total balance is reduced to 500 (either by a losing streak, or by withdrawing balance).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `stake_currency` | **Required.** Crypto-currency used for trading. <br> **Datatype:** String
 | `stake_amount` | **Required.** Amount of crypto-currency your bot will use for each trade. Set it to `"unlimited"` to allow the bot to use all available balance. [More information below](#configuring-amount-per-trade). <br> **Datatype:** Positive float or `"unlimited"`.
 | `tradable_balance_ratio` | Ratio of the total account balance the bot is allowed to trade. [More information below](#configuring-amount-per-trade). <br>*Defaults to `0.99` 99%).*<br> **Datatype:** Positive float between `0.1` and `1.0`.
+| `available_capital` | Available starting capital for the bot. Useful when running multiple bots on the same exchange account.[More information below](#configuring-amount-per-trade). <br> **Datatype:** Positive float.
 | `amend_last_stake_amount` | Use reduced last stake amount if necessary. [More information below](#configuring-amount-per-trade). <br>*Defaults to `false`.* <br> **Datatype:** Boolean
 | `last_stake_amount_min_ratio` | Defines minimum stake amount that has to be left and executed. Applies only to the last stake amount when it's amended to a reduced value (i.e. if `amend_last_stake_amount` is set to `true`). [More information below](#configuring-amount-per-trade). <br>*Defaults to `0.5`.* <br> **Datatype:** Float (as ratio)
 | `amount_reserve_percent` | Reserve some amount in min pair stake amount. The bot will reserve `amount_reserve_percent` + stoploss value when calculating min pair stake amount in order to avoid possible trade refusals. <br>*Defaults to `0.05` (5%).* <br> **Datatype:** Positive Float as ratio.
@@ -192,8 +193,24 @@ You can configure the "untouched" amount by using the `tradable_balance_ratio` s
 
 For example, if you have 10 ETH available in your wallet on the exchange and `tradable_balance_ratio=0.5` (which is 50%), then the bot will use a maximum amount of 5 ETH for trading and considers this as available balance. The rest of the wallet is untouched by the trades.
 
+!!! Danger
+    This setting should **not** be used when running multiple bots on the same exchange. Please look at [Available Capital to the bot](#assign-available-capital) instead.
+
 !!! Warning
     The `tradable_balance_ratio` setting applies to the current balance (free balance + tied up in trades). Therefore, assuming the starting balance of 1000, a configuration with `tradable_balance_ratio=0.99` will not guarantee that 10 currency units will always remain available on the exchange. For example, the free amount may reduce to 5 units if the total balance is reduced to 500 (either by a losing streak, or by withdrawing balance).
+
+#### Assign available Capital
+
+To fully utilize compounding profits when using multiple bots on the same exchange account, you'll want to limit each bot to a certain starting balance.
+This can be accomplished by setting `available_capital` to the desired starting balance.
+
+Assuming your account has 10.000 USDT and you want to run 2 different strategies on this exchange.
+You'd set `available_capital=5000` - granting each bot an initial capital of 5000 USDT.
+The bot will then split this starting balance equally into `max_open_trades` buckets.
+Profitable trades will result in increased stake-sizes for this bot - without affecting stake-sizes of the other bot.
+
+!!! Warning "Incompatible with `tradable_balance_ratio`"
+    Setting this option will replace any configuration of `tradable_balance_ratio`.
 
 #### Amend last stake amount
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -113,6 +113,10 @@ CONF_SCHEMA = {
             'maximum': 1,
             'default': 0.99
         },
+        'available_capital': {
+            'type': 'number',
+            'minimum': 0,
+        },
         'amend_last_stake_amount': {'type': 'boolean', 'default': False},
         'last_stake_amount_min_ratio': {
             'type': 'number', 'minimum': 0.0, 'maximum': 1.0, 'default': 0.5

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -802,6 +802,19 @@ class Trade(_DECL_BASE, LocalTrade):
                                  ]).all()
 
     @staticmethod
+    def get_total_closed_profit() -> float:
+        """
+        Retrieves total realized profit
+        """
+        if Trade.use_db:
+            total_profit = Trade.query.with_entities(
+                func.sum(Trade.close_profit_abs)).filter(Trade.is_open.is_(False)).scalar()
+        else:
+            total_profit = sum(
+                t.close_profit_abs for t in LocalTrade.get_trades_proxy(is_open=False))
+        return total_profit or 0
+
+    @staticmethod
     def total_open_trades_stakes() -> float:
         """
         Calculates total invested amount in open trades

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -158,7 +158,6 @@ class Wallets:
         (<open_trade stakes> + free amount) * tradable_balance_ratio - <open_trade stakes>
         """
 
-
         free = self.get_free(self._config['stake_currency'])
         return min(self.get_total_stake_amount() - Trade.total_open_trades_stakes(), free)
 

--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -70,9 +70,7 @@ class Wallets:
         # If not backtesting...
         # TODO: potentially remove the ._log workaround to determine backtest mode.
         if self._log:
-            closed_trades = Trade.get_trades_proxy(is_open=False)
-            tot_profit = sum(
-                [trade.close_profit_abs for trade in closed_trades if trade.close_profit_abs])
+            tot_profit = Trade.get_total_closed_profit()
         else:
             tot_profit = LocalTrade.total_profit
         tot_in_trades = sum([trade.stake_amount for trade in open_trades])

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1126,6 +1126,21 @@ def test_total_open_trades_stakes(fee, use_db):
 
 @pytest.mark.usefixtures("init_persistence")
 @pytest.mark.parametrize('use_db', [True, False])
+def test_get_total_closed_profit(fee, use_db):
+
+    Trade.use_db = use_db
+    Trade.reset_trades()
+    res = Trade.get_total_closed_profit()
+    assert res == 0
+    create_mock_trades(fee, use_db)
+    res = Trade.get_total_closed_profit()
+    assert res == 0.000739127
+
+    Trade.use_db = True
+
+
+@pytest.mark.usefixtures("init_persistence")
+@pytest.mark.parametrize('use_db', [True, False])
 def test_get_trades_proxy(fee, use_db):
     Trade.use_db = use_db
     Trade.reset_trades()
@@ -1298,6 +1313,7 @@ def test_Trade_object_idem():
         'open_date',
         'get_best_pair',
         'get_overall_performance',
+        'get_total_closed_profit',
         'total_open_trades_stakes',
         'get_sold_trades_without_assigned_fees',
         'get_open_trades_without_assigned_fees',


### PR DESCRIPTION
## Summary
Improved behaviour when using multiple bots on the same account with dynamic stake amount

Introduces `available_capital` setting - setting the starting capital for the bot (with this, `tradable_balance_ratio` will be ignored!).

## Quick changelog

- Introduce `available_capital` setting
