### PR TITLE
setup.sh mac fix

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,8 @@ function check_installed_python() {
         PYTHON="python3.${v}"
         which $PYTHON
         if [ $? -eq 0 ]; then
+            echo "using ${PYTHON}"
+
             check_installed_pip
             return
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,15 @@ function check_installed_python() {
         exit 2
     fi
 
+    which python3.9
+    if [ $? -eq 0 ]; then
+        echo "using Python 3.9"
+        PYTHON=python3.9
+        check_installed_pip
+        return
+    fi
+
+
     which python3.8
     if [ $? -eq 0 ]; then
         echo "using Python 3.8"
@@ -25,13 +34,6 @@ function check_installed_python() {
         return
     fi
 
-    which python3.9
-    if [ $? -eq 0 ]; then
-        echo "using Python 3.9"
-        PYTHON=python3.9
-        check_installed_pip
-        return
-    fi
 
     which python3.7
     if [ $? -eq 0 ]; then
@@ -122,6 +124,25 @@ function install_talib() {
     cd ..
 }
 
+function install_mac_newer_python_dependencies() {    
+    
+    if [ ! $(brew --prefix --installed hdf5 2>/dev/null) ]
+    then
+        echo "-------------------------"
+        echo "Installing hdf5"
+        echo "-------------------------"
+        brew install hdf5
+    fi
+
+    if [ ! $(brew --prefix --installed c-blosc 2>/dev/null) ]
+    then
+        echo "-------------------------"
+        echo "Installing c-blosc"
+        echo "-------------------------"
+        brew install c-blosc
+    fi    
+}
+
 # Install bot MacOS
 function install_macos() {
     if [ ! -x "$(command -v brew)" ]
@@ -130,6 +151,12 @@ function install_macos() {
         echo "Installing Brew"
         echo "-------------------------"
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+    #Gets number after decimal in python version
+    version=$(egrep -o 3.\[0-9\]+ <<< $PYTHON | sed 's/3.//g' ) 
+    
+    if [[ $version -ge 9 ]]; then               #Checks if python version >= 3.9
+        install_mac_newer_python_dependencies
     fi
     install_talib
     test_and_fix_python_on_mac

--- a/setup.sh
+++ b/setup.sh
@@ -17,37 +17,17 @@ function check_installed_python() {
         exit 2
     fi
 
-    which python3.9
-    if [ $? -eq 0 ]; then
-        echo "using Python 3.9"
-        PYTHON=python3.9
-        check_installed_pip
-        return
-    fi
+    for v in {9..7}; do
+        PYTHON="python3.${v}"
+        which $PYTHON
+        if [ $? -eq 0 ]; then
+            check_installed_pip
+            return
+        fi
+    done 
 
-
-    which python3.8
-    if [ $? -eq 0 ]; then
-        echo "using Python 3.8"
-        PYTHON=python3.8
-        check_installed_pip
-        return
-    fi
-
-
-    which python3.7
-    if [ $? -eq 0 ]; then
-        echo "using Python 3.7"
-        PYTHON=python3.7
-        check_installed_pip
-        return
-    fi
-
-
-   if [ -z ${PYTHON} ]; then
-        echo "No usable python found. Please make sure to have python3.7 or newer installed"
-        exit 1
-   fi
+    echo "No usable python found. Please make sure to have python3.7 or newer installed"
+    exit 1
 }
 
 function updateenv() {

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,8 @@ function check_installed_python() {
         exit 2
     fi
 
-    for v in {9..7}; do
+    for v in 8 9 7
+    do
         PYTHON="python3.${v}"
         which $PYTHON
         if [ $? -eq 0 ]; then
@@ -141,7 +142,6 @@ function install_macos() {
         install_mac_newer_python_dependencies
     fi
     install_talib
-    test_and_fix_python_on_mac
 }
 
 # Install bot Debian_ubuntu
@@ -196,19 +196,6 @@ function reset() {
         exit 1
     fi
     updateenv
-}
-
-function test_and_fix_python_on_mac() {
-
-    if ! [ -x "$(command -v python3.6)" ]
-    then
-        echo "-------------------------"
-        echo "Fixing Python"
-        echo "-------------------------"
-        echo "Python 3.6 is not linked in your system. Fixing it..."
-        brew link --overwrite python
-        echo
-    fi
 }
 
 function config() {


### PR DESCRIPTION
## Summary
The `setup.sh` script installs the needed dependencies on MacOS. 
The `setup.sh` script tries to use python3.9 before trying python3.8

Solve the issue: #4162

## Quick changelog

* installs hdf5 if not installed when using python3.9
* installs c-blosc if not installed when using python3.9
* The `setup.sh` script tries to use python3.9 before trying python3.8
