### PR TITLE
Honor skip_pair_validation setting when downloading pairs.

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -48,7 +48,8 @@ def start_download_data(args: Dict[str, Any]) -> None:
     # Init exchange
     exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config, validate=False)
     # Manual validations of relevant settings
-    exchange.validate_pairs(config['pairs'])
+    if not config['exchange'].get('skip_pair_validation', False):
+        exchange.validate_pairs(config['pairs'])
     expanded_pairs = expand_pairlist(config['pairs'], list(exchange.markets))
 
     logger.info(f"About to download pairs: {expanded_pairs}, "


### PR DESCRIPTION
I tried downloading dead pairs as suggested on discord and could not. Turns out there was no way to disable pair validation after all. This fixes the issue.