### PR TITLE
Reduce the spamming the log file with the same messages a few times a second. 

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1038,10 +1038,10 @@ class Exchange:
                 )
                 raise PricingError from e
 
-            logger.info(f"{name} price from orderbook {conf_strategy['price_side'].capitalize()}"
-                        f"side - top {order_book_top} order book {side} rate {rate:.8f}")
+            #logger.info(f"{name} price from orderbook {conf_strategy['price_side'].capitalize()}"
+            #            f"side - top {order_book_top} order book {side} rate {rate:.8f}")
         else:
-            logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
+            #logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
             ticker = self.fetch_ticker(pair)
             ticker_rate = ticker[conf_strategy['price_side']]
             if ticker['last']:


### PR DESCRIPTION
## Summary

Sam Germain on 2021-07-19 introduced changes that post the same message to the log / screen, this PR temporarily removes those messages to reduce the log size.

## Quick changelog

- commented out line 1041, 1042
- commented out line 1044

## What's new?
This does not happen anymore:
```
2021-07-22 15:01:13,223 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:13,720 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:19,265 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:19,450 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:19,946 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:20,446 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
2021-07-22 15:01:20,948 - freqtrade.exchange.exchange - INFO - Using Last Bid / Last Price
``` 
