### PR TITLE
Fix code to get Bittrex US-restricted markets

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -77,8 +77,9 @@ You can get a list of restricted markets by using the following snippet:
 ``` python
 import ccxt
 ct = ccxt.bittrex()
-ct.load_markets()
-res = [f"{x['quoteCurrencySymbol']}/{x['baseCurrencySymbol']}" for x in ct.publicGetMarkets() if 'US' in x['prohibitedIn']]
+lm = ct.load_markets()
+
+res = [p for p, x in lm.items() if 'US' in x['info']['prohibitedIn']]
 print(res)
 ```
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -77,8 +77,8 @@ You can get a list of restricted markets by using the following snippet:
 ``` python
 import ccxt
 ct = ccxt.bittrex()
-_ = ct.load_markets()
-res = [ f"{x['MarketCurrency']}/{x['BaseCurrency']}" for x in ct.publicGetMarkets()['result'] if x['IsRestricted']]
+ct.load_markets()
+res = [f"{x['quoteCurrencySymbol']}/{x['baseCurrencySymbol']}" for x in ct.publicGetMarkets() if 'US' in x['prohibitedIn']]
 print(res)
 ```
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -387,7 +387,7 @@ class Exchange:
                 # its contents depend on the exchange.
                 # It can also be a string or similar ... so we need to verify that first.
             elif (isinstance(self.markets[pair].get('info', None), dict)
-                  and self.markets[pair].get('info', {}).get('IsRestricted', False)):
+                  and self.markets[pair].get('info', {}).get('prohibitedIn', False)):
                 # Warn users about restricted pairs in whitelist.
                 # We cannot determine reliably if Users are affected.
                 logger.warning(f"Pair {pair} is restricted for some users on this exchange."

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -673,7 +673,7 @@ def test_validate_pairs_restricted(default_conf, mocker, caplog):
     api_mock = MagicMock()
     type(api_mock).load_markets = MagicMock(return_value={
         'ETH/BTC': {'quote': 'BTC'}, 'LTC/BTC': {'quote': 'BTC'},
-        'XRP/BTC': {'quote': 'BTC', 'info': {'IsRestricted': True}},
+        'XRP/BTC': {'quote': 'BTC', 'info': {'prohibitedIn': ['US']}},
         'NEO/BTC': {'quote': 'BTC', 'info': 'TestString'},  # info can also be a string ...
     })
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt', MagicMock(return_value=api_mock))


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Old code to grab Bittrex US-restricted markets was no longer working.

Changed
```python
res = [ f"{x['MarketCurrency']}/{x['BaseCurrency']}" for x in ct.publicGetMarkets()['result'] if x['IsRestricted']]
```

to
```python
res = [f"{x['quoteCurrencySymbol']}/{x['baseCurrencySymbol']}" for x in ct.publicGetMarkets() if 'US' in x['prohibitedIn']]
```