### PR TITLE
Log level set to debug on exchange.get_rate

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1037,14 +1037,11 @@ class Exchange:
                     f"determined. Orderbook: {order_book}"
                 )
                 raise PricingError from e
-
-            if side == "buy":
-                price_side = {conf_strategy['price_side'].capitalize()}
-                logger.info(f"{name} price from orderbook {price_side}"
-                            f"side - top {order_book_top} order book {side} rate {rate:.8f}")
+            price_side = {conf_strategy['price_side'].capitalize()}
+            logger.debug(f"{name} price from orderbook {price_side}"
+                         f"side - top {order_book_top} order book {side} rate {rate:.8f}")
         else:
-            if side == "buy":
-                logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
+            logger.debug(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
             ticker = self.fetch_ticker(pair)
             ticker_rate = ticker[conf_strategy['price_side']]
             if ticker['last']:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1038,10 +1038,13 @@ class Exchange:
                 )
                 raise PricingError from e
 
-            logger.info(f"{name} price from orderbook {conf_strategy['price_side'].capitalize()}"
-                        f"side - top {order_book_top} order book {side} rate {rate:.8f}")
+            if side == "buy":
+                price_side = {conf_strategy['price_side'].capitalize()}
+                logger.info(f"{name} price from orderbook {price_side}"
+                            f"side - top {order_book_top} order book {side} rate {rate:.8f}")
         else:
-            logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
+            if side == "buy":
+                logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
             ticker = self.fetch_ticker(pair)
             ticker_rate = ticker[conf_strategy['price_side']]
             if ticker['last']:


### PR DESCRIPTION
## Summary
Fixes spammy/overfilled console log

Solve the issue: #5316

## Quick changelog

- check if the price side is `buy` in `exchange.get_rate` before logging these lines
```
logger.info(f"{name} price from orderbook {price_side}"
                            f"side - top {order_book_top} order book {side} rate {rate:.8f}")
...
logger.info(f"Using Last {conf_strategy['price_side'].capitalize()} / Last Price")
```


