### PR TITLE
Added checks for side to for PricingError and checking for use_order_…

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1022,8 +1022,12 @@ class Exchange:
                 return rate
 
         conf_strategy = self._config.get(strat_name, {})
+        use_order_book = (
+            ('use_order_book' in conf_strategy or side == "sell") and
+            conf_strategy.get('use_order_book', False)
+        )
 
-        if conf_strategy.get('use_order_book', False) and ('use_order_book' in conf_strategy):
+        if use_order_book:
 
             order_book_top = conf_strategy.get('order_book_top', 1)
             order_book = self.fetch_l2_order_book(pair, order_book_top)
@@ -1053,8 +1057,8 @@ class Exchange:
                     ticker_rate = ticker_rate - balance * (ticker_rate - ticker['last'])
             rate = ticker_rate
 
-        if rate is None:
-            raise PricingError(f"{name}-Rate for {pair} was empty.")
+        if rate is None and side == "sell":
+            raise PricingError(f"Sell-Rate for {pair} was empty.")
         cache_rate[pair] = rate
 
         return rate


### PR DESCRIPTION
## Summary
Solve the issue: #5334 

## Quick changelog

In `exchange.get_rate`

```
if conf_strategy.get('use_order_book', False) and ('use_order_book' in conf_strategy):
```

was changed to

```
dont_use_order_book = (
        ('use_order_book' in conf_strategy or side == "sell") and
        conf_strategy.get('use_order_book', False)
)

if dont_use_order_book:
```

and

```
if rate is None:
            raise PricingError(f"{name}-Rate for {pair} was empty.")
```

was changed to 

```
if rate is None and side == "sell":
            raise PricingError(f"Sell-Rate for {pair} was empty.")
 ```

## What's new?
In PR #5284 these changes were made when merging the 2 methods

<table style="width:100%">
  <tr>
    <th>get_buy_rate</th>
    <th>get_sell_rate</th> 
    <th>update</th>
  </tr>
  <tr>
    <td>if bid_strategy.get('use_order_book', False) and ('use_order_book' in bid_strategy):</td>
    <td>if ask_strategy.get('use_order_book', False)</td>
    <td>if strategy.get('use_order_book', False) and ('use_order_book' in strategy) is now used for both</td>
  </tr>
  <tr>
     <td>/</td>
     <td>if rate is None: raise PricingError(f"{name}-Rate for {pair} was empty.")</td>
     <td>Both raise this pricing error now</td>
  </tr>
</table>

Both changes are reverted in this PR. I'm guessing that reverting the first change will probably fix the issue  #5334 
I reverted the second change because I assume that the original `get_buy_rate` strategy didn't check for this for a reason given that the other changes have caused problems