### PR TITLE
Liquidation Price

### DIFF
--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 from freqtrade.enums.backteststate import BacktestState
+from freqtrade.enums.maintenancemarginformula import MaintenanceMarginFormula
 from freqtrade.enums.rpcmessagetype import RPCMessageType
 from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODES, RunMode
 from freqtrade.enums.selltype import SellType

--- a/freqtrade/enums/maintenancemarginformula.py
+++ b/freqtrade/enums/maintenancemarginformula.py
@@ -1,0 +1,26 @@
+from enum import Enum
+from freqtrade.exceptions import OperationalException
+
+
+class MaintenanceMarginFormula(Enum):
+    """Equations to calculate maintenance margin"""
+
+    BINANCE = "BINANCE"
+    FTX = "FTX"
+    KRAKEN = "KRAKEN"
+
+    # TODO: Add arguments
+    def __call__(self):
+        if self.name == "BINANCE":
+            raise OperationalException("Cross margin not available on this exchange with freqtrade")
+            # TODO: return This formula
+            # https://www.binance.com/en/support/faq/f6b010588e55413aa58b7d63ee0125ed
+        elif self.name == "FTX":
+            # TODO: Implement
+            raise OperationalException("Cross margin not available on this exchange with freqtrade")
+        elif self.name == "KRAKEN":
+            # TODO: Implement
+            raise OperationalException("Cross margin not available on this exchange with freqtrade")
+            # https://support.kraken.com/hc/en-us/articles/203325763-Margin-Call-Level-and-Margin-Liquidation-Level
+        else:
+            raise OperationalException("Cross margin not available on this exchange with freqtrade")

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict
 
 import ccxt
-
+from freqtrade.enums import MaintenanceMarginFormula
 from freqtrade.exceptions import (DDosProtection, InsufficientFundsError, InvalidOrderException,
                                   OperationalException, TemporaryError)
 from freqtrade.exchange import Exchange
@@ -23,6 +23,8 @@ class Binance(Exchange):
         "trades_pagination_arg": "fromId",
         "l2_limit_range": [5, 10, 20, 50, 100, 500, 1000],
     }
+
+    maintenance_margin_formula = MaintenanceMarginFormula.BINANCE
 
     def stoploss_adjust(self, stop_loss: float, order: Dict) -> bool:
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -21,6 +21,7 @@ from pandas import DataFrame
 
 from freqtrade.constants import DEFAULT_AMOUNT_RESERVE_PERCENT, ListPairsWithTimeframes
 from freqtrade.data.converter import ohlcv_to_dataframe, trades_dict_to_list
+from freqtrade.enums import MaintenanceMarginFormula
 from freqtrade.exceptions import (DDosProtection, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, OperationalException, PricingError,
                                   RetryableOrderError, TemporaryError)
@@ -68,6 +69,7 @@ class Exchange:
         "l2_limit_range_required": True,  # Allow Empty L2 limit (kucoin)
     }
     _ft_has: Dict = {}
+    maintenance_margin_formula: MaintenanceMarginFormula
 
     def __init__(self, config: Dict[str, Any], validate: bool = True) -> None:
         """

--- a/freqtrade/exchange/ftx.py
+++ b/freqtrade/exchange/ftx.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 import ccxt
 
+from freqtrade.enums import MaintenanceMarginFormula
 from freqtrade.exceptions import (DDosProtection, InsufficientFundsError, InvalidOrderException,
                                   OperationalException, TemporaryError)
 from freqtrade.exchange import Exchange
@@ -20,6 +21,8 @@ class Ftx(Exchange):
         "stoploss_on_exchange": True,
         "ohlcv_candle_limit": 1500,
     }
+
+    maintenance_margin_formula = MaintenanceMarginFormula.FTX
 
     def market_is_tradable(self, market: Dict[str, Any]) -> bool:
         """

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 import ccxt
 
+from freqtrade.enums import MaintenanceMarginFormula
 from freqtrade.exceptions import (DDosProtection, InsufficientFundsError, InvalidOrderException,
                                   OperationalException, TemporaryError)
 from freqtrade.exchange import Exchange
@@ -22,6 +23,8 @@ class Kraken(Exchange):
         "trades_pagination": "id",
         "trades_pagination_arg": "since",
     }
+
+    maintenance_margin_formula = MaintenanceMarginFormula.KRAKEN
 
     def market_is_tradable(self, market: Dict[str, Any]) -> bool:
         """

--- a/freqtrade/maintenance_margin.py
+++ b/freqtrade/maintenance_margin.py
@@ -1,0 +1,38 @@
+from freqtrade.enums import MaintenanceMarginFormula
+from freqtrade.persistence import Trade
+
+
+class MaintenanceMargin:
+
+    trades: list[Trade]
+    formula: MaintenanceMarginFormula
+
+    @property
+    def margin_level(self):
+        return self.formula()  # TODO: Add args to formula
+
+    @property
+    def liq_level(self):    # This may be a constant value and may not need a function
+        return
+
+    def __init__(self, formula: MaintenanceMarginFormula):
+        return
+
+    def add_new_trade(self, trade):
+        return
+
+    def remove_trade(self, trade):
+        return
+
+    # ? def update_trade_pric(self):
+
+    def sell_all(self):
+        return
+
+    def run(self):
+        # TODO-mg: implement a thread that constantly updates with every price change,
+        # TODO-mg: must update at least every second
+        # while true:
+        #   if self.margin_level <= self.liq_level:
+        #       self.sell_all()
+        return


### PR DESCRIPTION
## Summary
Implements maintenance margin liquidation, which is used for cross margin 

## Quick changelog

Adds MaintenanceMargin thread class
- thread ran in freqtradebot, started inside __init__
- sells all trades if the maintenance_margin falls below the liquidation level

Adds MaintenanceMarginFormula enum

## What's new?

This mostly just adds skeleton functions that must be written for the maintenance margin to work properly