### PR TITLE
Funding Fee

### DIFF
--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -1,8 +1,11 @@
 # flake8: noqa: F401
 from freqtrade.enums.backteststate import BacktestState
+from freqtrade.enums.collateral import Collateral
 from freqtrade.enums.interestmode import InterestMode
+from freqtrade.enums.liqformula import LiqFormula
 from freqtrade.enums.rpcmessagetype import RPCMessageType
 from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODES, RunMode
 from freqtrade.enums.selltype import SellType
 from freqtrade.enums.signaltype import SignalTagType, SignalType
 from freqtrade.enums.state import State
+from freqtrade.enums.tradingmode import TradingMode

--- a/freqtrade/enums/collateral.py
+++ b/freqtrade/enums/collateral.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class Collateral(Enum):
+    """
+        Enum to distinguish between
+        cross margin/futures collateral and
+        isolated margin/futures collateral
+    """
+    CROSS = "cross"
+    ISOLATED = "isolated"

--- a/freqtrade/enums/liqformula.py
+++ b/freqtrade/enums/liqformula.py
@@ -1,0 +1,108 @@
+# from decimal import Decimal
+from enum import Enum
+
+from freqtrade.enums.collateral import Collateral
+from freqtrade.enums.tradingmode import TradingMode
+from freqtrade.exceptions import OperationalException
+
+
+# from math import ceil
+
+
+class LiqFormula(Enum):
+    """Equations to calculate liquidation price"""
+
+    BINANCE = "Binance"
+    KRAKEN = "Kraken"
+    FTX = "FTX"
+    NONE = None
+
+    def __call__(self, **k):
+
+        trading_mode: TradingMode = k['trading_mode']
+        if trading_mode == TradingMode.SPOT or self.name == "NONE":
+            return None
+
+        collateral: Collateral = k['collateral']
+
+        if self.name == "BINANCE":
+            return binance(trading_mode, collateral)
+        elif self.name == "KRAKEN":
+            return kraken(trading_mode, collateral)
+        elif self.name == "FTX":
+            return ftx(trading_mode, collateral)
+        else:
+            exception(self.name, trading_mode, collateral)
+
+
+def exception(name: str, trading_mode: TradingMode, collateral: Collateral):
+    """
+        Raises an exception if exchange used doesn't support desired leverage mode
+        :param name: Name of the exchange
+        :param trading_mode: spot, margin, futures
+        :param collateral: cross, isolated
+    """
+    raise OperationalException(
+        f"{name} does not support {collateral.value} {trading_mode.value} trading")
+
+
+def binance(name: str, trading_mode: TradingMode, collateral: Collateral):
+    """
+        Calculates the liquidation price on Binance
+        :param name: Name of the exchange
+        :param trading_mode: spot, margin, futures
+        :param collateral: cross, isolated
+    """
+    # TODO-lev: Additional arguments, fill in formulas
+
+    if trading_mode == TradingMode.MARGIN and collateral == Collateral.CROSS:
+        # TODO-lev: perform a calculation based on this formula
+        # https://www.binance.com/en/support/faq/f6b010588e55413aa58b7d63ee0125ed
+        exception(name, trading_mode, collateral)
+    elif trading_mode == TradingMode.FUTURES and collateral == Collateral.CROSS:
+        # TODO-lev: perform a calculation based on this formula
+        # https://www.binance.com/en/support/faq/b3c689c1f50a44cabb3a84e663b81d93
+        exception(name, trading_mode, collateral)
+    elif trading_mode == TradingMode.FUTURES and collateral == Collateral.ISOLATED:
+        # TODO-lev: perform a calculation based on this formula
+        # https://www.binance.com/en/support/faq/b3c689c1f50a44cabb3a84e663b81d93
+        exception(name, trading_mode, collateral)
+
+    # If nothing was returned
+    exception(name, trading_mode, collateral)
+
+
+def kraken(name: str, trading_mode: TradingMode, collateral: Collateral):
+    """
+        Calculates the liquidation price on Kraken
+        :param name: Name of the exchange
+        :param trading_mode: spot, margin, futures
+        :param collateral: cross, isolated
+    """
+    # TODO-lev: Additional arguments, fill in formulas
+
+    if collateral == Collateral.CROSS:
+        if trading_mode == TradingMode.MARGIN:
+            exception(name, trading_mode, collateral)
+            # TODO-lev: perform a calculation based on this formula
+            # https://support.kraken.com/hc/en-us/articles/203325763-Margin-Call-Level-and-Margin-Liquidation-Level
+        elif trading_mode == TradingMode.FUTURES:
+            exception(name, trading_mode, collateral)
+
+    # If nothing was returned
+    exception(name, trading_mode, collateral)
+
+
+def ftx(name: str, trading_mode: TradingMode, collateral: Collateral):
+    """
+        Calculates the liquidation price on FTX
+        :param name: Name of the exchange
+        :param trading_mode: spot, margin, futures
+        :param collateral: cross, isolated
+    """
+    if collateral == Collateral.CROSS:
+        # TODO-lev: Additional arguments, fill in formulas
+        exception(name, trading_mode, collateral)
+
+    # If nothing was returned
+    exception(name, trading_mode, collateral)

--- a/freqtrade/enums/tradingmode.py
+++ b/freqtrade/enums/tradingmode.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class TradingMode(Enum):
+    """
+        Enum to distinguish between
+        spot, margin, futures or any other trading method
+    """
+    SPOT = "spot"
+    MARGIN = "margin"
+    FUTURES = "futures"

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -16,10 +16,11 @@ from freqtrade.configuration import validate_config_consistency
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
-from freqtrade.enums import RPCMessageType, SellType, State
+from freqtrade.enums import RPCMessageType, SellType, State, TradingMode
 from freqtrade.exceptions import (DependencyException, ExchangeError, InsufficientFundsError,
                                   InvalidOrderException, PricingError)
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_seconds
+from freqtrade.leverage import FundingFee
 from freqtrade.misc import safe_value_fallback, safe_value_fallback2
 from freqtrade.mixins import LoggingMixin
 from freqtrade.persistence import Order, PairLocks, Trade, cleanup_db, init_db
@@ -101,6 +102,11 @@ class FreqtradeBot(LoggingMixin):
         # Protect sell-logic from forcesell and vice versa
         self._sell_lock = Lock()
         LoggingMixin.__init__(self, logger, timeframe_to_seconds(self.strategy.timeframe))
+
+        self.trading_mode = TradingMode.SPOT
+        if self.trading_mode == TradingMode.FUTURES:
+            self.funding_fee = FundingFee()
+            self.funding_fee.start()
 
     def notify_status(self, msg: str) -> None:
         """
@@ -553,6 +559,10 @@ class FreqtradeBot(LoggingMixin):
             amount = safe_value_fallback(order, 'filled', 'amount')
             buy_limit_filled_price = safe_value_fallback(order, 'average', 'price')
 
+        funding_fee = (self.funding_fee.initial_funding_fee(amount)
+                       if self.trading_mode == TradingMode.FUTURES
+                       else None)
+
         # Fee is applied twice because we make a LIMIT_BUY and LIMIT_SELL
         fee = self.exchange.get_fee(symbol=pair, taker_or_maker='maker')
         trade = Trade(
@@ -570,9 +580,14 @@ class FreqtradeBot(LoggingMixin):
             open_order_id=order_id,
             strategy=self.strategy.get_strategy_name(),
             buy_tag=buy_tag,
-            timeframe=timeframe_to_minutes(self.config['timeframe'])
+            timeframe=timeframe_to_minutes(self.config['timeframe']),
+            funding_fee=funding_fee,
+            trading_mode=self.trading_mode
         )
         trade.orders.append(order_obj)
+
+        if self.trading_mode == TradingMode.FUTURES:
+            self.funding_fee.add_new_trade(trade)
 
         # Update fees if order is closed
         if order_status == 'closed':

--- a/freqtrade/leverage/__init__.py
+++ b/freqtrade/leverage/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from freqtrade.leverage.funding_fee import FundingFee

--- a/freqtrade/leverage/funding_fee.py
+++ b/freqtrade/leverage/funding_fee.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+from typing import List
+
+import schedule
+
+from freqtrade.persistence import Trade
+
+
+class FundingFee:
+
+    trades: List[Trade]
+    begin_times = [
+        # TODO-lev: Make these UTC time
+        "23:59:45",
+        "07:59:45",
+        "15:59:45",
+    ]
+
+    def _is_time_between(self, begin_time, end_time):
+        # If check time is not given, default to current UTC time
+        check_time = datetime.utcnow().time()
+        if begin_time < end_time:
+            return check_time >= begin_time and check_time <= end_time
+        else:  # crosses midnight
+            return check_time >= begin_time or check_time <= end_time
+
+    def _apply_funding_fees(self, num_of: int = 1):
+        if num_of == 0:
+            return
+        for trade in self.trades:
+            trade.adjust_funding_fee(self._calculate(trade.amount) * num_of)
+
+    def _calculate(self, amount):
+        # TODO-futures: implement
+        # TODO-futures: Check how other exchages do it and adjust accordingly
+        # https://www.binance.com/en/support/faq/360033525031
+        # mark_price =
+        # contract_size = maybe trade.amount
+        # funding_rate =  # https://www.binance.com/en/futures/funding-history/0
+        # nominal_value = mark_price * contract_size
+        # adjustment = nominal_value * funding_rate
+        # return adjustment
+        return
+
+    def initial_funding_fee(self, amount) -> float:
+        # A funding fee interval is applied immediately if within 30s of an iterval
+        for begin_string in self.begin_times:
+            begin_time = datetime.strptime(begin_string, "%H:%M:%S")
+            end_time = (begin_time + timedelta(seconds=30))
+            if self._is_time_between(begin_time.time(), end_time.time()):
+                return self._calculate(amount)
+        return 0.0
+
+    def start(self):
+        for interval in self.begin_times:
+            schedule.every().day.at(interval).do(self._apply_funding_fees())
+
+        # https://stackoverflow.com/a/30393162/6331353
+        # TODO-futures: Put schedule.run_pending() somewhere in the bot_loop
+
+    def reboot(self):
+        # TODO-futures Find out how many begin_times have passed since last funding_fee added
+        amount_missed = 0
+        self.apply_funding_fees(num_of=amount_missed)
+        self.start()
+
+    def add_new_trade(self, trade):
+        self.trades.append(trade)
+
+    def remove_trade(self, trade):
+        self.trades.remove(trade)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,6 @@ colorama==0.4.4
 # Building config files interactively
 questionary==1.10.0
 prompt-toolkit==3.0.19
+
+#Futures
+schedule==1.1.0

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import isnan
 
 from freqtrade.edge import PairInfo
-from freqtrade.enums import State
+from freqtrade.enums import State, TradingMode
 from freqtrade.exceptions import ExchangeError, InvalidOrderException, TemporaryError
 from freqtrade.persistence import Trade
 from freqtrade.persistence.pairlock_middleware import PairLocks
@@ -108,10 +108,15 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'stoploss_entry_dist_ratio': -0.10448878,
         'open_order': None,
         'exchange': 'binance',
-        'leverage': 1.0,
-        'interest_rate': 0.0,
+        'trading_mode': TradingMode.SPOT,
         'isolated_liq': None,
         'is_short': False,
+        'leverage': 1.0,
+        'liq_formula': None,
+        'interest_mode': None,
+        'interest_rate': 0.0,
+        'funding_fee': None,
+        'last_funding_adjustment': None,
     }
 
     mocker.patch('freqtrade.exchange.Exchange.get_rate',
@@ -179,10 +184,15 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'stoploss_entry_dist_ratio': -0.10448878,
         'open_order': None,
         'exchange': 'binance',
-        'leverage': 1.0,
-        'interest_rate': 0.0,
+        'trading_mode': TradingMode.SPOT,
         'isolated_liq': None,
         'is_short': False,
+        'leverage': 1.0,
+        'liq_formula': None,
+        'interest_mode': None,
+        'interest_rate': 0.0,
+        'funding_fee': None,
+        'last_funding_adjustment': None,
     }
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -11,7 +11,7 @@ import pytest
 from sqlalchemy import create_engine, inspect, text
 
 from freqtrade import constants
-from freqtrade.enums import InterestMode
+from freqtrade.enums import InterestMode, TradingMode
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.persistence import LocalTrade, Order, Trade, clean_dry_run_db, init_db
 from tests.conftest import create_mock_trades, create_mock_trades_with_leverage, log_has, log_has_re
@@ -91,7 +91,7 @@ def test_enter_exit_side(fee):
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test__set_stop_loss_isolated_liq(fee):
+def test_set_stop_loss_isolated_liq(fee):
     trade = Trade(
         id=2,
         pair='ADA/USDT',
@@ -106,7 +106,7 @@ def test__set_stop_loss_isolated_liq(fee):
         is_short=False,
         leverage=2.0
     )
-    trade.set_isolated_liq(0.09)
+    trade.set_isolated_liq(isolated_liq=0.09)
     assert trade.isolated_liq == 0.09
     assert trade.stop_loss == 0.09
     assert trade.initial_stop_loss == 0.09
@@ -116,12 +116,12 @@ def test__set_stop_loss_isolated_liq(fee):
     assert trade.stop_loss == 0.1
     assert trade.initial_stop_loss == 0.09
 
-    trade.set_isolated_liq(0.08)
+    trade.set_isolated_liq(isolated_liq=0.08)
     assert trade.isolated_liq == 0.08
     assert trade.stop_loss == 0.1
     assert trade.initial_stop_loss == 0.09
 
-    trade.set_isolated_liq(0.11)
+    trade.set_isolated_liq(isolated_liq=0.11)
     assert trade.isolated_liq == 0.11
     assert trade.stop_loss == 0.11
     assert trade.initial_stop_loss == 0.09
@@ -145,7 +145,7 @@ def test__set_stop_loss_isolated_liq(fee):
     trade.stop_loss = None
     trade.initial_stop_loss = None
 
-    trade.set_isolated_liq(0.09)
+    trade.set_isolated_liq(isolated_liq=0.09)
     assert trade.isolated_liq == 0.09
     assert trade.stop_loss == 0.09
     assert trade.initial_stop_loss == 0.09
@@ -155,12 +155,12 @@ def test__set_stop_loss_isolated_liq(fee):
     assert trade.stop_loss == 0.08
     assert trade.initial_stop_loss == 0.09
 
-    trade.set_isolated_liq(0.1)
+    trade.set_isolated_liq(isolated_liq=0.1)
     assert trade.isolated_liq == 0.1
     assert trade.stop_loss == 0.08
     assert trade.initial_stop_loss == 0.09
 
-    trade.set_isolated_liq(0.07)
+    trade.set_isolated_liq(isolated_liq=0.07)
     assert trade.isolated_liq == 0.07
     assert trade.stop_loss == 0.07
     assert trade.initial_stop_loss == 0.09
@@ -237,7 +237,8 @@ def test_interest(market_buy_order_usdt, fee):
         exchange='kraken',
         leverage=3.0,
         interest_rate=0.0005,
-        interest_mode=InterestMode.HOURSPERDAY
+        interest_mode=InterestMode.HOURSPERDAY,
+        trading_mode=TradingMode.MARGIN
     )
 
     # 10min, 3x leverage
@@ -506,7 +507,7 @@ def test_update_limit_order(limit_buy_order_usdt, limit_sell_order_usdt, fee, ca
         open_date=arrow.utcnow().datetime,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
-        exchange='binance',
+        exchange='binance'
     )
     assert trade.open_order_id is None
     assert trade.close_profit is None
@@ -550,7 +551,8 @@ def test_update_limit_order(limit_buy_order_usdt, limit_sell_order_usdt, fee, ca
         is_short=True,
         leverage=3.0,
         interest_rate=0.0005,
-        interest_mode=InterestMode.HOURSPERDAY
+        interest_mode=InterestMode.HOURSPERDAY,
+        trading_mode=TradingMode.MARGIN
     )
     trade.open_order_id = 'something'
     trade.update(limit_sell_order_usdt)
@@ -642,7 +644,9 @@ def test_calc_open_close_trade_price(limit_buy_order_usdt, limit_sell_order_usdt
     assert isclose(trade.calc_close_trade_value(), 65.835)
     assert trade.calc_profit() == 5.685
     assert trade.calc_profit_ratio() == round(0.0945137157107232, 8)
+
     # 3x leverage, binance
+    trade.trading_mode = TradingMode.MARGIN
     trade.leverage = 3
     trade.interest_mode = InterestMode.HOURSPERDAY
     assert trade._calc_open_trade_value() == 60.15
@@ -801,12 +805,19 @@ def test_calc_open_trade_value(limit_buy_order_usdt, fee):
 
     # Get the open rate price with the standard fee rate
     assert trade._calc_open_trade_value() == 60.15
+
+    # Margin
+    trade.trading_mode = TradingMode.MARGIN
     trade.is_short = True
     trade.recalc_open_trade_value()
     assert trade._calc_open_trade_value() == 59.85
+
+    # 3x short margin leverage
     trade.leverage = 3
     trade.interest_mode = InterestMode.HOURSPERDAY
     assert trade._calc_open_trade_value() == 59.85
+
+    # 3x long margin leverage
     trade.is_short = False
     trade.recalc_open_trade_value()
     assert trade._calc_open_trade_value() == 60.15
@@ -844,6 +855,7 @@ def test_calc_close_trade_price(limit_buy_order_usdt, limit_sell_order_usdt, fee
     assert trade.calc_close_trade_value(fee=0.005) == 65.67
 
     # 3x leverage binance
+    trade.trading_mode = TradingMode.MARGIN
     trade.leverage = 3.0
     assert round(trade.calc_close_trade_value(rate=2.5), 8) == 74.81166667
     assert round(trade.calc_close_trade_value(rate=2.5, fee=0.003), 8) == 74.77416667
@@ -1044,6 +1056,8 @@ def test_calc_profit(limit_buy_order_usdt, limit_sell_order_usdt, fee):
     trade.open_trade_value = 0.0
     trade.open_trade_value = trade._calc_open_trade_value()
 
+    # Margin
+    trade.trading_mode = TradingMode.MARGIN
     # 3x leverage, long ###################################################
     trade.leverage = 3.0
     # Higher than open rate - 2.1 quote
@@ -1147,6 +1161,8 @@ def test_calc_profit_ratio(limit_buy_order_usdt, limit_sell_order_usdt, fee):
     assert trade.calc_profit_ratio(fee=0.003) == 0.0
     trade.open_trade_value = trade._calc_open_trade_value()
 
+    # Margin
+    trade.trading_mode = TradingMode.MARGIN
     # 3x leverage, long ###################################################
     trade.leverage = 3.0
     # 2.1 quote - Higher than open rate
@@ -1575,11 +1591,11 @@ def test_adjust_stop_loss_short(fee):
     assert trade.initial_stop_loss_pct == 0.05
     #  Initial is true but stop_loss set - so doesn't do anything
     trade.adjust_stop_loss(0.3, -0.1, True)
-    assert round(trade.stop_loss, 8) == 0.66  # TODO-mg: What is this test?
+    assert round(trade.stop_loss, 8) == 0.66
     assert trade.initial_stop_loss == 1.05
     assert trade.initial_stop_loss_pct == 0.05
     assert trade.stop_loss_pct == 0.1
-    trade.set_isolated_liq(0.63)
+    trade.set_isolated_liq(isolated_liq=0.63)
     trade.adjust_stop_loss(0.59, -0.1)
     assert trade.stop_loss == 0.63
     assert trade.isolated_liq == 0.63
@@ -1707,10 +1723,15 @@ def test_to_json(default_conf, fee):
                       'buy_tag': None,
                       'timeframe': None,
                       'exchange': 'binance',
-                      'leverage': None,
-                      'interest_rate': None,
+                      'trading_mode': None,
                       'isolated_liq': None,
                       'is_short': None,
+                      'leverage': None,
+                      'liq_formula': None,
+                      'interest_mode': None,
+                      'interest_rate': None,
+                      'funding_fee': None,
+                      'last_funding_adjustment': None
                       }
 
     # Simulate dry_run entries
@@ -1778,10 +1799,15 @@ def test_to_json(default_conf, fee):
                       'buy_tag': 'buys_signal_001',
                       'timeframe': None,
                       'exchange': 'binance',
-                      'leverage': None,
-                      'interest_rate': None,
+                      'trading_mode': None,
                       'isolated_liq': None,
                       'is_short': None,
+                      'leverage': None,
+                      'liq_formula': None,
+                      'interest_mode': None,
+                      'interest_rate': None,
+                      'funding_fee': None,
+                      'last_funding_adjustment': None
                       }
 
 
@@ -1899,7 +1925,7 @@ def test_stoploss_reinitialization_short(default_conf, fee):
     assert trade_adj.initial_stop_loss == 1.04
     assert trade_adj.initial_stop_loss_pct == 0.04
     # Stoploss can't go above liquidation price
-    trade_adj.set_isolated_liq(1.0)
+    trade_adj.set_isolated_liq(isolated_liq=1.0)
     trade.adjust_stop_loss(0.97, -0.04)
     assert trade_adj.stop_loss == 1.0
     assert trade_adj.stop_loss == 1.0
@@ -2197,6 +2223,7 @@ def test_Trade_object_idem():
         'get_open_trades_without_assigned_fees',
         'get_open_order_trades',
         'get_trades',
+        'last_funding_adjustment'
     )
 
     # Parent (LocalTrade) should have the same attributes


### PR DESCRIPTION
Needed for futures. Funding fees are charged, or rewarded to traders based on the price of the asset, and keep the futures contracts in line with the actual asset. Binance charges them at 00:00, 08:00, and 16:00 UTC every day.

They're explained here
https://www.binance.com/en/blog/421499824684900382/A-Beginners-Guide-To-Funding-Rates

## Summary
Creates a funding fee object which periodically increases the funding fee on all trades by looping through all trades at 00:00, 08:00, and 16:00 UTC and adding a certain amount to each trade. When the bot crashes, FundingFee has a reboot function which checks all trades for when the last funding fee was applied, and applies missed funding fees. When a new trade is created, if the time is within 15s of 00:00, 08:00, or 16:00 UTC, then a funding fee amount is applied immediately

