### PR TITLE
Replaced the term margin with leverage when it should say leverage (All comments)

### DIFF
--- a/freqtrade/persistence/migrations.py
+++ b/freqtrade/persistence/migrations.py
@@ -66,7 +66,7 @@ def migrate_trades_table(decl_base, inspector, engine, table_back_name: str, col
     close_profit_abs = get_column_def(
         cols, 'close_profit_abs',
         f"(amount * close_rate * (1 - {fee_close})) - {open_trade_value}")
-    # TODO-mg: update to exit order status
+    # TODO-lev: update to exit order status
     sell_order_status = get_column_def(cols, 'sell_order_status', 'null')
     amount_requested = get_column_def(cols, 'amount_requested', 'amount')
 

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -264,11 +264,13 @@ class LocalTrade():
     buy_tag: Optional[str] = None
     timeframe: Optional[int] = None
 
+    # Leverage trading properties
+    is_short: bool = False
+    isolated_liq: Optional[float] = None
+    leverage: float = 1.0
+
     # Margin trading properties
     interest_rate: float = 0.0
-    isolated_liq: Optional[float] = None
-    is_short: bool = False
-    leverage: float = 1.0
     interest_mode: InterestMode = InterestMode.NONE
 
     @property
@@ -471,12 +473,12 @@ class LocalTrade():
 
         if self.is_short:
             new_loss = float(current_price * (1 + abs(stoploss)))
-            # If trading on margin, don't set the stoploss below the liquidation price
+            # If trading with leverage, don't set the stoploss below the liquidation price
             if self.isolated_liq:
                 new_loss = min(self.isolated_liq, new_loss)
         else:
             new_loss = float(current_price * (1 - abs(stoploss)))
-            # If trading on margin, don't set the stoploss below the liquidation price
+            # If trading with leverage, don't set the stoploss below the liquidation price
             if self.isolated_liq:
                 new_loss = max(self.isolated_liq, new_loss)
 
@@ -497,7 +499,8 @@ class LocalTrade():
             lower_stop = new_loss < self.stop_loss
 
             # stop losses only walk up, never down!,
-            #   ? But adding more to a margin account would create a lower liquidation price,
+            # TODO-lev
+            #   ? But adding more to a leveraged trade would create a lower liquidation price,
             #   ? decreasing the minimum stoploss
             if (higher_stop and not self.is_short) or (lower_stop and self.is_short):
                 logger.debug(f"{self.pair} - Adjusting stoploss...")
@@ -545,10 +548,11 @@ class LocalTrade():
         elif order_type in ('market', 'limit') and self.exit_side == order['side']:
             if self.is_open:
                 payment = "BUY" if self.is_short else "SELL"
-                # TODO-mg: On shorts, you buy a little bit more than the amount (amount + interest)
+                # TODO-lev: On shorts, you buy a little bit more than the amount (amount + interest)
                 # This wll only print the original amount
                 logger.info(f'{order_type.upper()}_{payment} has been fulfilled for {self}.')
-            self.close(safe_value_fallback(order, 'average', 'price'))  # TODO-mg: Double check this
+            # TODO-lev: Double check this
+            self.close(safe_value_fallback(order, 'average', 'price'))
         elif order_type in ('stop_loss_limit', 'stop-loss', 'stop-loss-limit', 'stop'):
             self.stoploss_order_id = None
             self.close_rate_requested = self.stop_loss
@@ -883,19 +887,20 @@ class Trade(_DECL_BASE, LocalTrade):
     max_rate = Column(Float, nullable=True, default=0.0)
     # Lowest price reached
     min_rate = Column(Float, nullable=True)
-    sell_reason = Column(String(100), nullable=True)  # TODO-mg: Change to close_reason
-    sell_order_status = Column(String(100), nullable=True)  # TODO-mg: Change to close_order_status
+    sell_reason = Column(String(100), nullable=True)  # TODO-lev: Change to close_reason
+    sell_order_status = Column(String(100), nullable=True)  # TODO-lev: Change to close_order_status
     strategy = Column(String(100), nullable=True)
     buy_tag = Column(String(100), nullable=True)
     timeframe = Column(Integer, nullable=True)
 
-    # Margin trading properties
+    # Leverage trading properties
     leverage = Column(Float, nullable=True, default=1.0)
-    interest_rate = Column(Float, nullable=False, default=0.0)
-    isolated_liq = Column(Float, nullable=True)
     is_short = Column(Boolean, nullable=False, default=False)
+    isolated_liq = Column(Float, nullable=True)
+
+    # Margin Trading Properties
+    interest_rate = Column(Float, nullable=False, default=0.0)
     interest_mode = Column(Enum(InterestMode), nullable=True)
-    # End of margin trading properties
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tests/conftest_trades.py
+++ b/tests/conftest_trades.py
@@ -380,7 +380,7 @@ def short_trade(fee):
         open_order_id='dry_run_exit_short_12345',
         strategy='DefaultStrategy',
         timeframe=5,
-        sell_reason='sell_signal',  # TODO-mg: Update to exit/close reason
+        sell_reason='sell_signal',  # TODO-lev: Update to exit/close reason
         open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=20),
         # close_date=datetime.now(tz=timezone.utc) - timedelta(minutes=2),
         is_short=True,
@@ -470,7 +470,7 @@ def leverage_trade(fee):
         open_order_id='dry_run_leverage_buy_12368',
         strategy='DefaultStrategy',
         timeframe=5,
-        sell_reason='sell_signal',  # TODO-mg: Update to exit/close reason
+        sell_reason='sell_signal',  # TODO-lev: Update to exit/close reason
         open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=300),
         close_date=datetime.now(tz=timezone.utc),
         interest_rate=0.0005,

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1575,7 +1575,7 @@ def test_adjust_stop_loss_short(fee):
     assert trade.initial_stop_loss_pct == 0.05
     #  Initial is true but stop_loss set - so doesn't do anything
     trade.adjust_stop_loss(0.3, -0.1, True)
-    assert round(trade.stop_loss, 8) == 0.66  # TODO-mg: What is this test?
+    assert round(trade.stop_loss, 8) == 0.66
     assert trade.initial_stop_loss == 1.05
     assert trade.initial_stop_loss_pct == 0.05
     assert trade.stop_loss_pct == 0.1


### PR DESCRIPTION
## Summary
Margin != leverage, even though before this the two terms were used as synonyms

## Quick changelog

- Changes to comments where `mg` change to `lev` and `margin` changed to `leverage`
