### PR TITLE
Offset without sell profit only

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -589,7 +589,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if (self.sell_profit_only and current_profit <= self.sell_profit_offset):
+        if ((self.sell_profit_only and current_profit <= self.sell_profit_offset) 
+            or (current_profit >= 0 and current_profit <= self.sell_profit_offset)):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal
             pass
         elif self.use_sell_signal and not buy:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -590,7 +590,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_profit = trade.calc_profit_ratio(current_rate)
 
         if ((self.sell_profit_only and current_profit <= self.sell_profit_offset)
-            or (current_profit >= 0 and current_profit <= self.sell_profit_offset)):
+                or (current_profit >= 0 and current_profit <= self.sell_profit_offset)):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal
             pass
         elif self.use_sell_signal and not buy:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -589,7 +589,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if ((self.sell_profit_only and current_profit <= self.sell_profit_offset) 
+        if ((self.sell_profit_only and current_profit <= self.sell_profit_offset)
             or (current_profit >= 0 and current_profit <= self.sell_profit_offset)):
             # sell_profit_only and profit doesn't reach the offset - ignore sell signal
             pass


### PR DESCRIPTION
## Summary
Tried to modify a condition in `interface.py` on line `592` to become able to set `sell_profit_offset` without having to point `sell_profit_only` to `True`.
This is one of my very first PRs so, I'd be more than appreciated if you can expose any mistakes made there.

Solve the issue: #___

## Quick changelog
modified:   freqtrade/strategy/interface.py

## What's new?
An if condition expanded. Should also work with the second phrase alone, after `or`.

## Test results
```
freqtrade on  offset-without-sell-profit-only using ☁️  default/ via .env took 12s 
➜ pytest
====================================================================== test session starts ======================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/zx/Downloads/freqtrade
plugins: asyncio-0.15.1, mock-3.6.1, cov-2.12.1, random-order-1.0.4
collected 1696 items / 30 deselected / 1666 selected                                                                                                            

tests/test_arguments.py .........................                                                                                                         [  1%]
tests/test_configuration.py ...............................s...........................................                                                   [  6%]
tests/test_directory_operations.py .......                                                                                                                [  6%]
tests/test_freqtradebot.py .............................................................................................................................. [ 13%]
................................                                                                                                                          [ 15%]
tests/test_indicators.py .                                                                                                                                [ 15%]
tests/test_integration.py ...                                                                                                                             [ 16%]
tests/test_main.py .........                                                                                                                              [ 16%]
tests/test_misc.py ........................                                                                                                               [ 18%]
tests/test_persistence.py .......................................                                                                                         [ 20%]
tests/test_plotting.py .......................                                                                                                            [ 21%]
tests/test_talib.py .                                                                                                                                     [ 21%]
tests/test_timerange.py ...                                                                                                                               [ 22%]
tests/test_wallets.py ..........................                                                                                                          [ 23%]
tests/test_worker.py .......                                                                                                                              [ 24%]
tests/commands/test_build_config.py .........                                                                                                             [ 24%]
tests/commands/test_commands.py ..................................                                                                                        [ 26%]
tests/data/test_btanalysis.py ................                                                                                                            [ 27%]
tests/data/test_converter.py ...........                                                                                                                  [ 28%]
tests/data/test_dataprovider.py ............                                                                                                              [ 28%]
tests/data/test_history.py .......................................................                                                                        [ 32%]
tests/edge/test_edge.py ....................                                                                                                              [ 33%]
tests/exchange/test_binance.py .....                                                                                                                      [ 33%]
tests/exchange/test_exchange.py ......................................................................................................................... [ 41%]
......................................................................................................................................................... [ 50%]
......................................................................................................................................................... [ 59%]
...............................................                                                                                                           [ 62%]
tests/exchange/test_ftx.py .....                                                                                                                          [ 62%]
tests/exchange/test_kraken.py .......                                                                                                                     [ 62%]
tests/optimize/test_backtest_detail.py ..................................                                                                                 [ 65%]
tests/optimize/test_backtesting.py .........................................                                                                              [ 67%]
tests/optimize/test_edge_cli.py ......                                                                                                                    [ 67%]
tests/optimize/test_hyperopt.py ..................................                                                                                        [ 69%]
tests/optimize/test_hyperopt_tools.py ......................                                                                                              [ 71%]
tests/optimize/test_hyperoptloss.py ...........                                                                                                           [ 71%]
tests/optimize/test_optimize_reports.py ..........                                                                                                        [ 72%]
tests/plugins/test_pairlist.py .......................................................................................................................... [ 79%]
............................................................................                                                                              [ 84%]
tests/plugins/test_pairlocks.py ....                                                                                                                      [ 84%]
tests/plugins/test_protections.py .......................                                                                                                 [ 85%]
tests/rpc/test_fiat_convert.py ............                                                                                                               [ 86%]
tests/rpc/test_rpc.py ........................                                                                                                            [ 88%]
tests/rpc/test_rpc_apiserver.py ..........................................                                                                                [ 90%]
tests/rpc/test_rpc_manager.py .............                                                                                                               [ 91%]
tests/rpc/test_rpc_telegram.py ...........F......................................................                                                         [ 95%]
tests/rpc/test_rpc_webhook.py .....                                                                                                                       [ 95%]
tests/strategy/test_default_strategy.py ..                                                                                                                [ 95%]
tests/strategy/test_interface.py ............................................                                                                             [ 98%]
tests/strategy/test_strategy_helpers.py ....                                                                                                              [ 98%]
tests/strategy/test_strategy_loading.py ......................                                                                                            [100%]

=========================================================================== FAILURES ============================================================================
______________________________________________________________________ test_profit_handle _______________________________________________________________________

default_conf = {'amend_last_stake_amount': False, 'ask_strategy': {'order_book_top': 1, 'price_side': 'ask', 'use_order_book': False}...delta': 1, 'enabled': False}, 'order_book_top': 1, 'price_side': 'bid', ...}, 'cancel_open_orders_on_exit': False, ...}
update = <telegram.update.Update object at 0x7fb87b671400>, ticker = <MagicMock id='140430301481808'>, ticker_sell_up = <MagicMock id='140430301489664'>
fee = <MagicMock id='140430301497328'>
limit_buy_order = {'amount': 90.99181073, 'cost': 0.0009999, 'datetime': '2021-08-09T23:56:56.039290+00:00', 'filled': 90.99181073, ...}
limit_sell_order = {'amount': 90.99181073, 'datetime': '2021-08-09T23:56:56.039448+00:00', 'filled': 90.99181073, 'id': 'mocked_limit_sell', ...}
mocker = <pytest_mock.plugin.MockerFixture object at 0x7fb87a4a2070>

    def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
                           limit_buy_order, limit_sell_order, mocker) -> None:
        mocker.patch('freqtrade.rpc.rpc.CryptoToFiatConverter._find_price', return_value=15000.0)
        mocker.patch.multiple(
            'freqtrade.exchange.Exchange',
            fetch_ticker=ticker,
            get_fee=fee,
        )
    
        telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
        patch_get_signal(freqtradebot, (True, False, None))
    
        telegram._profit(update=update, context=MagicMock())
        assert msg_mock.call_count == 1
        assert 'No trades yet.' in msg_mock.call_args_list[0][0][0]
        msg_mock.reset_mock()
    
        # Create some test data
        freqtradebot.enter_positions()
        trade = Trade.query.first()
    
        # Simulate fulfilled LIMIT_BUY order for trade
        trade.update(limit_buy_order)
        context = MagicMock()
        # Test with invalid 2nd argument (should silently pass)
        context.args = ["aaa"]
        telegram._profit(update=update, context=context)
        assert msg_mock.call_count == 1
        assert 'No closed trade' in msg_mock.call_args_list[-1][0][0]
        assert '*ROI:* All trades' in msg_mock.call_args_list[-1][0][0]
        mocker.patch('freqtrade.wallets.Wallets.get_starting_balance', return_value=0.01)
        assert ('∙ `-0.00000500 BTC (-0.50%) (-0.0 \N{GREEK CAPITAL LETTER SIGMA}%)`'
                in msg_mock.call_args_list[-1][0][0])
        msg_mock.reset_mock()
    
        # Update the ticker with a market going up
        mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', ticker_sell_up)
        trade.update(limit_sell_order)
    
        trade.close_date = datetime.utcnow()
        trade.is_open = False
    
        telegram._profit(update=update, context=MagicMock())
        assert msg_mock.call_count == 1
>       assert '*ROI:* Closed trades' in msg_mock.call_args_list[-1][0][0]
E       AssertionError: assert '*ROI:* Closed trades' in 'No trades yet.'

tests/rpc/test_rpc_telegram.py:470: AssertionError
----------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------
DEBUG    freqtrade.persistence.migrations:migrations.py:26 trying trades_bak0
INFO     freqtrade.freqtradebot:freqtradebot.py:52 Starting freqtrade develop-b40bd74c
DEBUG    freqtrade.resolvers.iresolver:iresolver.py:91 Searching for IStrategy DefaultStrategy in '/home/zx/Downloads/freqtrade/tests/strategy/strats'
DEBUG    freqtrade.resolvers.iresolver:iresolver.py:95 Ignoring /home/zx/Downloads/freqtrade/tests/strategy/strats/__pycache__
INFO     freqtrade.resolvers.iresolver:iresolver.py:124 Using resolved strategy DefaultStrategy from '/home/zx/Downloads/freqtrade/tests/strategy/strats/default_strategy.py'...
INFO     freqtrade.strategy.hyper:hyper.py:391 Found no parameter file.
INFO     freqtrade.strategy.hyper:hyper.py:401 No params for buy found, using default values.
INFO     freqtrade.strategy.hyper:hyper.py:401 No params for sell found, using default values.
INFO     freqtrade.strategy.hyper:hyper.py:401 No params for protection found, using default values.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'minimal_roi' with value in config file: {'40': 0.0, '30': 0.01, '20': 0.02, '0': 0.04}.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'timeframe' with value in config file: 5m.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'stoploss' with value in config file: -0.1.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'stake_currency' with value in config file: BTC.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'stake_amount' with value in config file: 0.001.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:125 Override strategy 'unfilledtimeout' with value in config file: {'buy': 10, 'sell': 30}.
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using minimal_roi: {'40': 0.0, '30': 0.01, '20': 0.02, '0': 0.04}
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using timeframe: 5m
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using stoploss: -0.1
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using trailing_stop: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using trailing_stop_positive_offset: 0.0
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using trailing_only_offset_is_reached: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using use_custom_stoploss: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using process_only_new_candles: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using order_types: {'buy': 'limit', 'sell': 'limit', 'stoploss': 'limit', 'stoploss_on_exchange': False}
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using order_time_in_force: {'buy': 'gtc', 'sell': 'gtc'}
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using stake_currency: BTC
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using stake_amount: 0.001
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using protections: []
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using startup_candle_count: 20
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using unfilledtimeout: {'buy': 10, 'sell': 30}
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using use_sell_signal: True
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using sell_profit_only: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using ignore_roi_if_buy_signal: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using sell_profit_offset: 0.0
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using disable_dataframe_checks: False
INFO     freqtrade.resolvers.strategy_resolver:strategy_resolver.py:104 Strategy using ignore_buying_expired_candle_after: 0
INFO     freqtrade.configuration.config_validation:config_validation.py:85 Validating configuration ...
INFO     freqtrade.exchange.exchange:exchange.py:104 Instance is running with dry_run enabled
INFO     freqtrade.exchange.exchange:exchange.py:105 Using CCXT 1.54.62
INFO     freqtrade.exchange.exchange:exchange.py:137 Using Exchange "Binance"
INFO     freqtrade.resolvers.exchange_resolver:exchange_resolver.py:56 Using resolved exchange 'Binance'...
DEBUG    freqtrade.persistence.migrations:migrations.py:26 trying trades_bak0
INFO     freqtrade.wallets:wallets.py:126 Wallets synced.
INFO     freqtrade.plugins.protectionmanager:protectionmanager.py:31 No protection Handlers defined.
DEBUG    freqtrade.resolvers.iresolver:iresolver.py:91 Searching for IPairList StaticPairList in '/home/zx/Downloads/freqtrade/freqtrade/plugins/pairlist'
DEBUG    freqtrade.resolvers.iresolver:iresolver.py:95 Ignoring /home/zx/Downloads/freqtrade/freqtrade/plugins/pairlist/__pycache__
INFO     freqtrade.resolvers.iresolver:iresolver.py:124 Using resolved pairlist StaticPairList from '/home/zx/Downloads/freqtrade/freqtrade/plugins/pairlist/StaticPairList.py'...
DEBUG    freqtrade.rpc.telegram:telegram.py:63 Executing handler: _profit for chat_id: 0
DEBUG    freqtrade.freqtradebot:freqtradebot.py:401 create_trade for pair ETH/BTC
INFO     freqtrade.wallets:wallets.py:126 Wallets synced.
DEBUG    freqtrade.exchange.exchange:exchange.py:1027 Using Last Bid / Last Price
INFO     freqtrade.freqtradebot:freqtradebot.py:502 Buy signal found: about create a new trade for ETH/BTC with stake_amount: 0.001 ...
INFO     freqtrade.freqtradebot:freqtradebot.py:1245 Found open order for Trade(id=None, pair=ETH/BTC, amount=91.07468123, open_rate=0.00001098, open_since=2021-08-09 23:56:56)
INFO     freqtrade.freqtradebot:freqtradebot.py:1323 Fee for Trade Trade(id=None, pair=ETH/BTC, amount=91.07468123, open_rate=0.00001098, open_since=2021-08-09 23:56:56) [buy]: 2.5e-06 BTC - rate: 0.0025
INFO     freqtrade.persistence.models:models.py:419 Updating trade (id=None) ...
INFO     freqtrade.persistence.models:models.py:427 LIMIT_BUY has been fulfilled for Trade(id=None, pair=ETH/BTC, amount=91.07468123, open_rate=0.00001098, open_since=2021-08-09 23:56:56).
INFO     freqtrade.wallets:wallets.py:126 Wallets synced.
DEBUG    freqtrade.freqtradebot:freqtradebot.py:401 create_trade for pair LTC/BTC
DEBUG    freqtrade.freqtradebot:freqtradebot.py:419 Can't open a new trade for LTC/BTC: max number of trades is reached.
DEBUG    freqtrade.freqtradebot:freqtradebot.py:401 create_trade for pair XRP/BTC
DEBUG    freqtrade.freqtradebot:freqtradebot.py:419 Can't open a new trade for XRP/BTC: max number of trades is reached.
DEBUG    freqtrade.freqtradebot:freqtradebot.py:401 create_trade for pair NEO/BTC
DEBUG    freqtrade.freqtradebot:freqtradebot.py:419 Can't open a new trade for NEO/BTC: max number of trades is reached.
INFO     freqtrade.persistence.models:models.py:419 Updating trade (id=1) ...
INFO     freqtrade.persistence.models:models.py:427 LIMIT_BUY has been fulfilled for Trade(id=1, pair=ETH/BTC, amount=90.99181073, open_rate=0.00001099, open_since=2021-08-09 23:56:56).
DEBUG    freqtrade.rpc.telegram:telegram.py:63 Executing handler: _profit for chat_id: 0
DEBUG    freqtrade.exchange.exchange:exchange.py:1027 Using Last Ask / Last Price
INFO     freqtrade.persistence.models:models.py:419 Updating trade (id=1) ...
INFO     freqtrade.persistence.models:models.py:431 LIMIT_SELL has been fulfilled for Trade(id=1, pair=ETH/BTC, amount=90.99181073, open_rate=0.00001099, open_since=2021-08-09 23:56:56).
INFO     freqtrade.persistence.models:models.py:457 Marking Trade(id=1, pair=ETH/BTC, amount=90.99181073, open_rate=0.00001099, open_since=closed) as closed as the trade is fulfilled and found no open orders for it.
DEBUG    freqtrade.rpc.telegram:telegram.py:63 Executing handler: _profit for chat_id: 0
======================================================================= warnings summary ========================================================================
.env/lib/python3.8/site-packages/skopt/space/space.py:253
  /home/zx/Downloads/freqtrade/.env/lib/python3.8/site-packages/skopt/space/space.py:253: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    name=None, dtype=np.float):

tests/data/test_history.py::test_hdf5datahandler_trades_load
tests/data/test_history.py::test_hdf5datahandler_trades_load
  /home/zx/Downloads/freqtrade/.env/lib/python3.8/site-packages/tables/__init__.py:99: DeprecationWarning:
  
  `np.typeDict` is a deprecated alias for `np.sctypeDict`.

tests/data/test_history.py: 62 warnings
  /home/zx/Downloads/freqtrade/.env/lib/python3.8/site-packages/tables/array.py:241: DeprecationWarning:
  
  `np.object` is a deprecated alias for the builtin `object`. To silence this warning, use `object` by itself. Doing this will not modify any behavior and is safe. 
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/optimize/test_hyperopt.py::test_in_strategy_auto_hyperopt
tests/strategy/test_interface.py::test_hyperopt_parameters
  /home/zx/Downloads/freqtrade/.env/lib/python3.8/site-packages/skopt/space/space.py:273: DeprecationWarning:
  
  `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== short test summary info ====================================================================
FAILED tests/rpc/test_rpc_telegram.py::test_profit_handle - AssertionError: assert '*ROI:* Closed trades' in 'No trades yet.'
======================================= 1 failed, 1664 passed, 1 skipped, 30 deselected, 67 warnings in 91.01s (0:01:31) ========================================
```

