### PR TITLE
Cache dataframe before cutting the first candle

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -246,10 +246,10 @@ class Backtesting:
             if has_buy_tag:
                 df_analyzed.loc[:, 'buy_tag'] = df_analyzed.loc[:, 'buy_tag'].shift(1)
 
-            df_analyzed.drop(df_analyzed.head(1).index, inplace=True)
-
             # Update dataprovider cache
             self.dataprovider._set_cached_df(pair, self.timeframe, df_analyzed)
+
+            df_analyzed = df_analyzed.drop(df_analyzed.head(1).index)
 
             # Convert from Pandas to list for performance reasons
             # (Looping Pandas is slow.)
@@ -478,9 +478,9 @@ class Backtesting:
                 if row[DATE_IDX] > tmp:
                     continue
 
-                self.dataprovider._set_dataframe_max_index(row_index)
                 row_index += 1
                 indexes[pair] = row_index
+                self.dataprovider._set_dataframe_max_index(row_index)
 
                 # without positionstacking, we can only have one open trade per pair.
                 # max_open_trades must be respected

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -742,9 +742,9 @@ def test_backtest_alternate_buy_sell(default_conf, fee, mocker, testdatadir):
     # 100 buys signals
     results = result['results']
     assert len(results) == 100
-    # Cached data should be 199 (missing 1 candle at the start)
+    # Cached data should be 200
     analyzed_df = backtesting.dataprovider.get_analyzed_dataframe('UNITTEST/BTC', '1m')[0]
-    assert len(analyzed_df) == 199
+    assert len(analyzed_df) == 200
     # Expect last candle to be 1 below end date (as the last candle is assumed as "incomplete"
     # during backtesting)
     expected_last_candle_date = backtest_conf['end_date'] - timedelta(minutes=1)
@@ -807,11 +807,11 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
     assert len(evaluate_result_multi(results['results'], '5m', 3)) == 0
 
     # Cached data correctly removed amounts
-    offset = 2 if tres == 0 else 1
+    offset = 1 if tres == 0 else 0
     removed_candles = len(data[pair]) - offset - backtesting.strategy.startup_candle_count
     assert len(backtesting.dataprovider.get_analyzed_dataframe(pair, '5m')[0]) == removed_candles
     assert len(backtesting.dataprovider.get_analyzed_dataframe(
-        'NXT/BTC', '5m')[0]) == len(data['NXT/BTC']) - 2 - backtesting.strategy.startup_candle_count
+        'NXT/BTC', '5m')[0]) == len(data['NXT/BTC']) - 1 - backtesting.strategy.startup_candle_count
 
     backtest_conf = {
         'processed': processed,


### PR DESCRIPTION

## Summary
Cache dataframe before cutting the first candle

This allows providing the "current closed" candle in all cases.

## Quick changelog

- Provide last finished candle via `dp.get_analyzed_df().iloc[-1]` reliably