### PR TITLE
Export HDF5 and CBLOSC paths.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -119,6 +119,7 @@ function install_mac_newer_python_dependencies() {
         echo "-------------------------"
         brew install hdf5
     fi
+    export HDF5_DIR=$(brew --prefix)
 
     if [ ! $(brew --prefix --installed c-blosc 2>/dev/null) ]
     then
@@ -127,6 +128,7 @@ function install_mac_newer_python_dependencies() {
         echo "-------------------------"
         brew install c-blosc
     fi    
+    export CBLOSC_DIR=$(brew --prefix)
 }
 
 # Install bot MacOS


### PR DESCRIPTION
This is needed if homebrew isn't installed in the standard path, say,
/usr/local/.