### PR TITLE
Added method throw_exception_if_method_not_on_exchange to exchange

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -228,6 +228,16 @@ class Exchange:
         """exchange ccxt precisionMode"""
         return self._api.precisionMode
 
+    def throw_exception_if_method_not_on_exchange(self, method_name: str):
+        """
+            Throws exception if method is implemented by the current exchange on ccxt
+            :param method_name: The method that may/may not exist for this exchange class
+        """
+        # api_method = hasattr(self._api, method_name, None)
+        if not self._api.describe()['has'][method_name]:
+            raise OperationalException(
+                f"{method_name}() has not been implemented on ccxt.{self.name}")
+
     def _log_exchange_response(self, endpoint, response) -> None:
         """ Log exchange responses """
         if self.log_responses:
@@ -361,7 +371,7 @@ class Exchange:
             raise OperationalException(
                 'Could not load markets, therefore cannot start. '
                 'Please investigate the above error for more details.'
-                )
+            )
         quote_currencies = self.get_quote_currencies()
         if stake_currency not in quote_currencies:
             raise OperationalException(


### PR DESCRIPTION
## Summary
Adds a method that checks if a method is implemented on the ccxt exchange class

## Quick changelog
Adds this method to exchange class
- throw_exception_if_method_not_on_exchange(self, method_name: str)

Currently the test for this fail, I think this is because of the way that the exchange object is instantiated in the test

```
exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
```

I don't know how I would write an actual exchange object implementation in order to pass the tests.

-------------------

There is some overlap between this and `funding-fee`. I realized I needed this method in multiple PRs