### PR TITLE
⚡ `setup.sh` - Use `build_helpers/install_ta-lib.sh` for TA-Lib insta…

### DIFF
--- a/build_helpers/install_ta-lib.sh
+++ b/build_helpers/install_ta-lib.sh
@@ -12,9 +12,12 @@ if [ ! -f "${INSTALL_LOC}/lib/libta_lib.a" ]; then
   && curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' -o config.sub \
   && ./configure --prefix=${INSTALL_LOC}/ \
   && make -j$(nproc) \
-  && which sudo && sudo make install || make install \
-  && cd .. && rm -rf ./ta-lib/
+  && which sudo && sudo make install || make install
+  if [ -x "$(command -v apt-get)" ]; then
+    echo "Updating library path using ldconfig"
+    sudo ldconfig
+  fi
+  cd .. && rm -rf ./ta-lib/
 else
   echo "TA-lib already installed, skipping installation"
 fi
-#  && sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h \

--- a/build_helpers/install_ta-lib.sh
+++ b/build_helpers/install_ta-lib.sh
@@ -13,7 +13,7 @@ if [ ! -f "${INSTALL_LOC}/lib/libta_lib.a" ]; then
   && ./configure --prefix=${INSTALL_LOC}/ \
   && make -j$(nproc) \
   && which sudo && sudo make install || make install \
-  && cd ..
+  && cd .. && rm -rf ./ta-lib/
 else
   echo "TA-lib already installed, skipping installation"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -95,19 +95,7 @@ function install_talib() {
         return
     fi
 
-    cd build_helpers
-    tar zxvf ta-lib-0.4.0-src.tar.gz
-    cd ta-lib
-    sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h
-    ./configure --prefix=/usr/local
-    make
-    sudo make install
-    if [ -x "$(command -v apt-get)" ]; then
-        echo "Updating library path using ldconfig"
-        sudo ldconfig
-    fi
-    cd .. && rm -rf ./ta-lib/
-    cd ..
+    cd build_helpers && ./install_ta-lib.sh && cd ..
 }
 
 function install_mac_newer_python_dependencies() {    


### PR DESCRIPTION
See PR https://github.com/freqtrade/freqtrade/pull/5523

This PRs goal is the same but without muddying the checksum of the TA-Lib binary.