### PR TITLE
New pair download improvement

### DIFF
--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -197,7 +197,8 @@ def _download_pair_history(pair: str, *,
                                                timeframe=timeframe,
                                                since_ms=since_ms if since_ms else
                                                arrow.utcnow().shift(
-                                                   days=-new_pairs_days).int_timestamp * 1000
+                                                   days=-new_pairs_days).int_timestamp * 1000,
+                                               is_new_pair=data.empty
                                                )
         # TODO: Maybe move parsing to exchange class (?)
         new_dataframe = ohlcv_to_dataframe(new_data, timeframe, pair,

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -104,7 +104,7 @@ class Binance(Exchange):
             if x and x[2] and x[2][0] and x[2][0][0] > since_ms:
                 # Set starting date to first available candle.
                 since_ms = x[2][0][0]
-                logger.info(f"Candle-data available starting with "
+                logger.info(f"Candle-data for {pair} available starting with "
                             f"{arrow.get(since_ms // 1000).isoformat()}.")
         return await super()._async_get_historic_ohlcv(
             pair=pair, timeframe=timeframe, since_ms=since_ms, is_new_pair=is_new_pair)

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -20,6 +20,7 @@ class Binance(Exchange):
         "order_time_in_force": ['gtc', 'fok', 'ioc'],
         "time_in_force_parameter": "timeInForce",
         "ohlcv_candle_limit": 1000,
+        "ohlcv_initial_call": True,
         "trades_pagination": "id",
         "trades_pagination_arg": "fromId",
         "l2_limit_range": [5, 10, 20, 50, 100, 500, 1000],

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1226,6 +1226,7 @@ class Exchange:
                                         ) -> List:
         """
         Download historic ohlcv
+        :param is_new_pair: used by binance subclass to allow "fast" new pair downloading
         """
 
         one_call = timeframe_to_msecs(timeframe) * self.ohlcv_candle_limit(timeframe)
@@ -1234,13 +1235,6 @@ class Exchange:
             one_call,
             arrow.utcnow().shift(seconds=one_call // 1000).humanize(only_distance=True)
         )
-        if self._ft_has.get('ohlcv_initial_call', False) and is_new_pair:
-            x = await self._async_get_candle_history(pair, timeframe, 0)
-            if x and x[2] and x[2][0] and x[2][0][0] > since_ms:
-                # Set starting date to first available candle.
-                since_ms = x[2][0][0]
-                logger.info(f"Candle-data available starting with {since_ms}.")
-
         input_coroutines = [self._async_get_candle_history(
             pair, timeframe, since) for since in
             range(since_ms, arrow.utcnow().int_timestamp * 1000, one_call)]

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from random import randint
 from unittest.mock import MagicMock
 
@@ -5,7 +6,7 @@ import ccxt
 import pytest
 
 from freqtrade.exceptions import DependencyException, InvalidOrderException, OperationalException
-from tests.conftest import get_patched_exchange
+from tests.conftest import get_mock_coro, get_patched_exchange, log_has_re
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
 
 
@@ -105,3 +106,35 @@ def test_stoploss_adjust_binance(mocker, default_conf):
     # Test with invalid order case
     order['type'] = 'stop_loss'
     assert not exchange.stoploss_adjust(1501, order)
+
+
+@pytest.mark.asyncio
+async def test__async_get_historic_ohlcv_binance(default_conf, mocker, caplog):
+    ohlcv = [
+        [
+            int((datetime.now(timezone.utc).timestamp() - 1000) * 1000),
+            1,  # open
+            2,  # high
+            3,  # low
+            4,  # close
+            5,  # volume (in quote currency)
+        ]
+    ]
+
+    exchange = get_patched_exchange(mocker, default_conf, id='binance')
+    # Monkey-patch async function
+    exchange._api_async.fetch_ohlcv = get_mock_coro(ohlcv)
+
+    pair = 'ETH/BTC'
+    res = await exchange._async_get_historic_ohlcv(pair, "5m",
+                                                   1500000000000, is_new_pair=False)
+    # Call with very old timestamp - causes tons of requests
+    assert exchange._api_async.fetch_ohlcv.call_count > 400
+    # assert res == ohlcv
+    exchange._api_async.fetch_ohlcv.reset_mock()
+    res = await exchange._async_get_historic_ohlcv(pair, "5m", 1500000000000, is_new_pair=True)
+
+    # Called twice - one "init" call - and one to get the actual data.
+    assert exchange._api_async.fetch_ohlcv.call_count == 2
+    assert res == ohlcv
+    assert log_has_re(r"Candle-data for ETH/BTC available starting with .*", caplog)


### PR DESCRIPTION
## Summary
Improve logic for downloading of new pairs (or new timeframes) on binance.
By doing 1 additional call to detect the earliest date, we can save 100ds of calls if a pair started a long time after the provided starting-date.

## Quick changelog

* Detect starting-date and adjust since_ms if necessary