### PR TITLE
Agefilter cache

### DIFF
--- a/freqtrade/configuration/PeriodicCache.py
+++ b/freqtrade/configuration/PeriodicCache.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from cachetools.ttl import TTLCache
+
+
+class PeriodicCache(TTLCache):
+    """
+    Special cache that expires at "straight" times
+    A timer with ttl of 3600 (1h) will expire at every full hour (:00).
+    """
+
+    def __init__(self, maxsize, ttl, getsizeof=None):
+        def local_timer():
+            ts = datetime.now(timezone.utc).timestamp()
+            offset = (ts % ttl)
+            return ts - offset
+
+        # Init with smlight offset
+        super().__init__(maxsize=maxsize, ttl=ttl-1e-5, timer=local_timer, getsizeof=getsizeof)

--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 
+from freqtrade.configuration.PeriodicCache import PeriodicCache
 from freqtrade.configuration.check_exchange import check_exchange, remove_credentials
 from freqtrade.configuration.config_setup import setup_utils_configuration
 from freqtrade.configuration.config_validation import validate_config_consistency

--- a/freqtrade/configuration/__init__.py
+++ b/freqtrade/configuration/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa: F401
 
-from freqtrade.configuration.PeriodicCache import PeriodicCache
 from freqtrade.configuration.check_exchange import check_exchange, remove_credentials
 from freqtrade.configuration.config_setup import setup_utils_configuration
 from freqtrade.configuration.config_validation import validate_config_consistency
 from freqtrade.configuration.configuration import Configuration
+from freqtrade.configuration.PeriodicCache import PeriodicCache
 from freqtrade.configuration.timerange import TimeRange

--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 
 class AgeFilter(IPairList):
 
-    # Checked symbols cache (dictionary of ticker symbol => timestamp)
-    _symbolsChecked: Dict[str, int] = {}
-
     def __init__(self, exchange, pairlistmanager,
                  config: Dict[str, Any], pairlistconfig: Dict[str, Any],
                  pairlist_pos: int) -> None:
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
+
+        # Checked symbols cache (dictionary of ticker symbol => timestamp)
+        self._symbolsChecked: Dict[str, int] = {}
 
         self._min_days_listed = pairlistconfig.get('min_days_listed', 10)
         self._max_days_listed = pairlistconfig.get('max_days_listed', None)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,8 @@ pytest-cov==2.12.1
 pytest-mock==3.6.1
 pytest-random-order==1.0.4
 isort==5.9.3
+# For datetime mocking
+time-machine==2.4.0
 
 # Convert jupyter notebooks to markdown documents
 nbconvert==6.1.0

--- a/tests/test_periodiccache.py
+++ b/tests/test_periodiccache.py
@@ -1,5 +1,6 @@
-from freqtrade.configuration import PeriodicCache
 import time_machine
+
+from freqtrade.configuration import PeriodicCache
 
 
 def test_ttl_cache():

--- a/tests/test_periodiccache.py
+++ b/tests/test_periodiccache.py
@@ -1,0 +1,31 @@
+from freqtrade.configuration import PeriodicCache
+import time_machine
+
+
+def test_ttl_cache():
+
+    with time_machine.travel("2021-09-01 05:00:00 +00:00") as t:
+
+        cache = PeriodicCache(5, ttl=60)
+        cache1h = PeriodicCache(5, ttl=3600)
+
+        assert cache.timer() == 1630472400.0
+        cache['a'] = 1235
+        cache1h['a'] = 555123
+        assert 'a' in cache
+        assert 'a' in cache1h
+
+        t.move_to("2021-09-01 05:00:59 +00:00")
+        assert 'a' in cache
+        assert 'a' in cache1h
+
+        # Cache expired
+        t.move_to("2021-09-01 05:01:00 +00:00")
+        assert 'a' not in cache
+        assert 'a' in cache1h
+
+        t.move_to("2021-09-01 05:59:59 +00:00")
+        assert 'a' in cache1h
+
+        t.move_to("2021-09-01 06:00:00 +00:00")
+        assert 'a' not in cache1h


### PR DESCRIPTION
## Summary
Introduce PeriodicCache to cache until the next period is over (like, until midnight).
Fix AgeFilter querying "too young" pairs too often

Closes #5552 

## Quick changelog

- PeriodicCache filter
- introduce time_machine for proper testing of this
- Fix AgeFilter querying pairs on every iteration