### PR TITLE
Cache Intermediate Trade Files to Improve the Download Experience

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
     - requests
     - urllib3
     - wrapt
+    - intervaltree
     - jsonschema
     - TA-Lib
     - tabulate

--- a/freqtrade/configuration/directory_operations.py
+++ b/freqtrade/configuration/directory_operations.py
@@ -21,6 +21,11 @@ def create_datadir(config: Dict[str, Any], datadir: Optional[str] = None) -> Pat
     if not folder.is_dir():
         folder.mkdir(parents=True)
         logger.info(f'Created data directory: {datadir}')
+
+    intermediate_dir = folder.joinpath('trades-intermediate-parts')
+    if not intermediate_dir.is_dir():
+        intermediate_dir.mkdir(parents=True)
+        logger.info(f'Created intermediate data directory: {intermediate_dir}')
     return folder
 
 

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -306,6 +306,7 @@ def _download_trades_history(exchange: Exchange,
                                                   since=since,
                                                   until=until,
                                                   from_id=from_id,
+                                                  datadir=data_handler._datadir
                                                   )
         trades.extend(new_trades[1])
         # Remove duplicates to make sure we're not storing data we don't need

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1379,7 +1379,7 @@ class Exchange:
 
     # Directory name for a pair, e.g., given `ETH/BTC` returns `ETH-BTC`.
     def _pair_dir(self, pair: str) -> str:
-        return pair.replace("/","-")
+        return pair.replace("/", "-")
 
     # Returns the directory path that contains the intermediate trade files for a given pair.
     def _intermediate_trades_dir_for_pair(self, datadir: str, pair: str) -> str:
@@ -1414,7 +1414,7 @@ class Exchange:
     async def _get_interval_tree_for_pair(self, datadir: str, pair: str) -> IntervalTree:
         cached_res = self._intermediate_data_cache.get(pair, None)
         if cached_res:
-            return cached_res;
+            return cached_res
 
         logger.debug("Caching intervals for pair %s", pair)
         cache_interval_tree = IntervalTree()
@@ -1433,8 +1433,8 @@ class Exchange:
                                 trades_list_from_id = trades_list[0][1]
                                 trades_list_to_id = trades_list[-1][1]
                                 cache_interval_tree.add(Interval(
-                                    int(trades_list_from_id), #inclusive
-                                    int(trades_list_to_id), #exclusive
+                                    int(trades_list_from_id),  # inclusive
+                                    int(trades_list_to_id),  # exclusive
                                     tmpdata_file))
 
         logger.debug("Cached intervals for pair %s: %s intervals", pair, len(cache_interval_tree))
@@ -1467,15 +1467,16 @@ class Exchange:
             # fetch trades asynchronously
             if params:
                 logger.debug("Fetching trades for pair %s, params: %s ", pair, params)
-                trades = await self._api_async.fetch_trades(pair, params=params, limit=self.batch_size())
+                trades = await self._api_async.fetch_trades(
+                    pair, params=params, limit=self.batch_size())
             else:
                 logger.debug(
                     "Fetching trades for pair %s, since %s %s...",
                     pair,  since,
                     '(' + arrow.get(since // 1000).isoformat() + ') ' if since is not None else ''
                 )
-                trades = await self._api_async.fetch_trades(pair, since=since, limit=self.batch_size())
-
+                trades = await self._api_async.fetch_trades(
+                    pair, since=since, limit=self.batch_size())
 
             trades_list = trades_dict_to_list(trades)
             if trades_list and datadir and len(trades_list) == self.batch_size():
@@ -1517,7 +1518,6 @@ class Exchange:
                                  len(trades_list))
                     return trades_list
 
-
                 # If neither `from_id` nor `to_id` are cached, we cache the trades in an
                 # intermediate trade file.
                 tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
@@ -1552,8 +1552,7 @@ class Exchange:
                                           until: int,
                                           since: Optional[int] = None,
                                           from_id: Optional[str] = None,
-                                          datadir: Optional[str] = None
-                                         ) -> Tuple[str, List[List]]:
+                                          datadir: Optional[str] = None) -> Tuple[str, List[List]]:
         """
         Asyncronously gets trade history using fetch_trades
         use this when exchange uses id-based iteration (check `self._trades_pagination`)
@@ -1617,10 +1616,9 @@ class Exchange:
 
         return (pair, trades)
 
-    async def _async_get_trade_history_time(self, pair: str, until: int,
-                                            since: Optional[int] = None,
-                                            datadir: Optional[str] = None
-                                           ) -> Tuple[str, List[List]]:
+    async def _async_get_trade_history_time(
+        self, pair: str, until: int, since: Optional[int] = None, datadir: Optional[str] = None
+    ) -> Tuple[str, List[List]]:
         """
         Asyncronously gets trade history using fetch_trades,
         when the exchange uses time-based iteration (check `self._trades_pagination`)
@@ -1652,8 +1650,7 @@ class Exchange:
                                        since: Optional[int] = None,
                                        until: Optional[int] = None,
                                        from_id: Optional[str] = None,
-                                       datadir: Optional[str] = None
-                                      ) -> Tuple[str, List[List]]:
+                                       datadir: Optional[str] = None) -> Tuple[str, List[List]]:
         """
         Async wrapper handling downloading trades using either time or id based methods.
         """

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1450,12 +1450,12 @@ class Exchange:
         if cached_res:
             return cached_res
 
-        logger.debug("Caching intervals for pair %s", pair)
+        logger.debug("Reading cached intervals for pair %s", pair)
         cache_interval_tree = IntervalTree()
         tmpdata_dir = self._intermediate_trades_dir_for_pair(datadir, pair)
         await self._async_read_interval_tree_for_pair(tmpdata_dir, pair, cache_interval_tree)
 
-        logger.debug("Cached intervals for pair %s: %s intervals", pair, len(cache_interval_tree))
+        logger.debug("Read cached intervals for pair %s: %s intervals", pair, len(cache_interval_tree))
         self._intermediate_data_cache[pair] = cache_interval_tree
         return cache_interval_tree
 
@@ -1504,7 +1504,7 @@ class Exchange:
 
                 if not from_pg_id:
                     from_pg_id = trades_list[0][0]
-                    to_pg_id = trades_list[-1][0]
+                    to_pg_id = trades_list[-1][0] + 1  # as it's exclusive
                     pagination_method = "by_since"
 
                 pagination_col_index = 1 if pagination_method == "by_id" else 0
@@ -1525,7 +1525,7 @@ class Exchange:
                     if int(from_pg_id) != cached_from_pg_id_interval.begin:
                         trades_list = list(filter(
                             lambda trade: (int(trade[pagination_col_index]) <
-                                           cached_from_pg_id_interval.begin),
+                                           cached_from_pg_id_interval.end),
                             trades_list
                         ))
                         logger.debug("The result was partially cached in the intermediate result " +

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1530,7 +1530,7 @@ class Exchange:
                     logger.debug("Cached the intermediate trades in %s", tmpdata_file)
             else:
                 from_id = trades_list[0][1] if trades_list else 0
-                datadir = datadir or ""
+                datadir = datadir or Path(".")
                 tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
                 logger.debug("DID NOT CACHE the intermediate trades in %s with len=%s",
                              tmpdata_file, len(trades_list))

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1388,10 +1388,12 @@ class Exchange:
         return tmpdata_dir
 
     # Returns the intermediate trade file name for a given pair starting with `from_id` trade ID
-    def _intermediate_trades_file(self, datadir: Path, pair: str, from_id: str) -> str:
+    def _intermediate_trades_file(self, datadir: Path, pair: str, from_id: str,
+                                  mkdir: bool = True) -> str:
         tmpdata_file = self._intermediate_trades_dir_for_pair(datadir, pair)
         tmpdata_file = os.path.join(tmpdata_file, str(int(from_id)//1000000))
-        Path(tmpdata_file).mkdir(parents=True, exist_ok=True)
+        if mkdir:
+            Path(tmpdata_file).mkdir(parents=True, exist_ok=True)
         tmpdata_file = os.path.join(tmpdata_file, self._pair_dir(pair)+"_"+str(from_id)+".json")
         return tmpdata_file
 
@@ -1531,7 +1533,7 @@ class Exchange:
             else:
                 from_id = trades_list[0][1] if trades_list else 0
                 datadir = datadir or Path(".")
-                tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
+                tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id, False)
                 logger.debug("DID NOT CACHE the intermediate trades in %s with len=%s",
                              tmpdata_file, len(trades_list))
             return trades_list

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -5,23 +5,22 @@ Cryptocurrency Exchanges support
 import asyncio
 import http
 import inspect
+import json
 import logging
+import os
 from copy import deepcopy
 from datetime import datetime, timezone
 from math import ceil
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import arrow
 import ccxt
-import json
-import os
-from pathlib import Path
-from intervaltree import Interval, IntervalTree
-
 import ccxt.async_support as ccxt_async
 from cachetools import TTLCache
 from ccxt.base.decimal_to_precision import (ROUND_DOWN, ROUND_UP, TICK_SIZE, TRUNCATE,
                                             decimal_to_precision)
+from intervaltree import Interval, IntervalTree
 from pandas import DataFrame
 
 from freqtrade.constants import (DEFAULT_AMOUNT_RESERVE_PERCENT, NON_OPEN_EXCHANGE_STATES,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -16,6 +16,7 @@ import ccxt
 import json
 import os
 from pathlib import Path
+from intervaltree import Interval, IntervalTree
 
 import ccxt.async_support as ccxt_async
 from cachetools import TTLCache
@@ -77,6 +78,11 @@ class Exchange:
         "l2_limit_range_required": True,  # Allow Empty L2 limit (kucoin)
     }
     _ft_has: Dict = {}
+
+    # For each pair, we cache the intermediate data files stored for trades if they exist
+    # This dictionary maps each pair name (e.g., `ETH-BTC`) to an `IntervalTree`. This interval tree
+    # contains the intervals of trade IDs that are already cached in the intermediate files.
+    _intermediate_data_cache: Dict = {}
 
     def __init__(self, config: Dict[str, Any], validate: bool = True) -> None:
         """
@@ -1372,15 +1378,25 @@ class Exchange:
             raise OperationalException(f'Could not fetch historical candle (OHLCV) data '
                                        f'for pair {pair}. Message: {e}') from e
 
-    # Fetch historic trades
-    def _intermediate_trades_dir(self, datadir: str, pair: str, from_id: int) -> str:
-        tmpdata_file = os.path.join(datadir, "trades-intermediate-parts")
-        tmpdata_file = os.path.join(tmpdata_file, pair.replace("/","-"))
+    # Directory name for a pair, e.g., given `ETH/BTC` returns `ETH-BTC`.
+    def _pair_dir(self, pair: str) -> str:
+        return pair.replace("/","-")
+
+    # Returns the directory path that contains the intermediate trade files for a given pair.
+    def _intermediate_trades_dir_for_pair(self, datadir: str, pair: str) -> str:
+        tmpdata_dir = os.path.join(datadir, "trades-intermediate-parts")
+        tmpdata_dir = os.path.join(tmpdata_dir, self._pair_dir(pair))
+        return tmpdata_dir
+
+    # Returns the intermediate trade file name for a given pair starting with `from_id` trade ID
+    def _intermediate_trades_file(self, datadir: str, pair: str, from_id: int) -> str:
+        tmpdata_file = self._intermediate_trades_dir_for_pair(datadir, pair)
         tmpdata_file = os.path.join(tmpdata_file, str(int(from_id)//1000000))
         Path(tmpdata_file).mkdir(parents=True, exist_ok=True)
-        tmpdata_file = os.path.join(tmpdata_file, pair.replace("/","-")+"_"+from_id+".json")
+        tmpdata_file = os.path.join(tmpdata_file, self._pair_dir(pair)+"_"+from_id+".json")
         return tmpdata_file
 
+    # Fetch historic trades
     @retrier_async
     async def _async_fetch_trades_from_file(self, datafile: str) -> List[List]:
         # Open a file: file
@@ -1393,6 +1409,48 @@ class Exchange:
         file.close()
         trades_list = json.loads(json_string)
         return trades_list
+
+    # Builds the interval tree (from the intermediate trade files) for a given pair
+    @retrier_async
+    async def _get_interval_tree_for_pair(self, datadir: str, pair: str) -> IntervalTree:
+        cached_res = self._intermediate_data_cache.get(pair, None)
+        if cached_res:
+            return cached_res;
+
+        logger.debug("Caching intervals for pair %s", pair)
+        cache_interval_tree = IntervalTree()
+        tmpdata_dir = self._intermediate_trades_dir_for_pair(datadir, pair)
+        if os.path.isdir(tmpdata_dir):
+            tmpdata_subdirs = os.listdir(tmpdata_dir)
+            for tmpdata_subdir in tmpdata_subdirs:
+                if tmpdata_subdir.isnumeric():
+                    tmpdata_subdir = os.path.join(tmpdata_dir, tmpdata_subdir)
+                    tmpdata_files = os.listdir(tmpdata_subdir)
+                    for tmpdata_file in tmpdata_files:
+                        if tmpdata_file.startswith(self._pair_dir(pair)):
+                            tmpdata_file = os.path.join(tmpdata_subdir, tmpdata_file)
+                            if os.path.isfile(tmpdata_file):
+                                trades_list = await self._async_fetch_trades_from_file(tmpdata_file)
+                                trades_list_from_id = trades_list[0][1]
+                                trades_list_to_id = trades_list[-1][1]
+                                cache_interval_tree.addi(
+                                    int(trades_list_from_id),
+                                    int(trades_list_to_id)+1,
+                                    tmpdata_file)
+
+        logger.debug("Cached intervals for pair %s: %s intervals", pair, len(cache_interval_tree))
+        self._intermediate_data_cache[pair] = cache_interval_tree
+        return cache_interval_tree
+
+    # Checks whether the given trade id is cached in the intermediate trade files.
+    # If it exists, returns the `Interval` for the cache file. Otherwise, returns `None`.
+    @retrier_async
+    async def _is_id_cached_in_intermediate_data(
+        self, datadir: str, pair: str, id: int
+    ) -> Optional[Interval]:
+        int_tree = await self._get_interval_tree_for_pair(datadir, pair)
+        intervals = sorted(int_tree[int(id)])
+        return intervals[0] if len(intervals) > 0 else None
 
     @retrier_async
     async def _async_fetch_trades(self, pair: str,
@@ -1421,18 +1479,58 @@ class Exchange:
 
 
             trades_list = trades_dict_to_list(trades)
-            if trades_list and len(trades_list) == self.batch_size() and datadir:
+            if trades_list and datadir and len(trades_list) == self.batch_size():
                 from_id = trades_list[0][1]
-                tmpdata_file = self._intermediate_trades_dir(datadir, pair, from_id)
+                to_id = trades_list[-1][1]
 
+                cached_from_id_interval = await self._is_id_cached_in_intermediate_data(
+                    datadir, pair, from_id)
+                cached_to_id_interval = await self._is_id_cached_in_intermediate_data(
+                    datadir, pair, to_id)
+
+                # If `from_id` exists in a cached interval, we return everything before the
+                # beginning of this cached interval. In the next round, the cached trades (starting
+                # from `from_id`) will be requested and the response will be handled using a
+                # cached intermediate trade file.
+                if cached_from_id_interval:
+                    # If the cached interval starts from `from_id`, then it's already cached and we
+                    # return it. Otherwise, we filter all trades before the beginning of this cached
+                    # interval.
+                    if int(from_id) != cached_from_id_interval.begin:
+                        trades_list = list(filter(
+                            lambda trade: int(trade[1]) < cached_from_id_interval.begin, trades_list
+                        ))
+                        logger.debug("The result was partially cached in the intermediate result " +
+                                     "(using from_id). Returned %s elements without caching them.",
+                                     len(trades_list))
+                    return trades_list
+
+                # If `to_id` exists in a cached interval, we return everything before the
+                # beginning of this cached interval. In the next round, the cached trades (starting
+                # from `to_id`) will be requested and the response will be handled using a
+                # cached intermediate trade file.
+                if cached_to_id_interval:
+                    trades_list = list(filter(
+                        lambda trade: int(trade[1]) < cached_to_id_interval.begin, trades_list
+                    ))
+                    logger.debug("The result was partially cached in the intermediate result " +
+                                 "(using to_id). Returned %s elements without caching them.",
+                                 len(trades_list))
+                    return trades_list
+
+
+                # If neither `from_id` nor `to_id` are cached, we cache the trades in an
+                # intermediate trade file.
+                tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
                 json_string = json.dumps(trades_list)
                 with open(tmpdata_file, "w") as text_file:
                     text_file.write(json_string)
                     logger.debug("Cached the intermediate trades in %s", tmpdata_file)
             else:
                 from_id = trades_list[0][1] if trades_list else 0
-                tmpdata_file = self._intermediate_trades_dir(datadir, pair, from_id)
-                logger.debug("DID NOT CACHE the intermediate trades in %s with len=%s", tmpdata_file, len(trades_list))
+                tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
+                logger.debug("DID NOT CACHE the intermediate trades in %s with len=%s",
+                             tmpdata_file, len(trades_list))
             return trades_list
         except ccxt.NotSupported as e:
             raise OperationalException(
@@ -1477,9 +1575,12 @@ class Exchange:
             # DEFAULT_TRADES_COLUMNS: 0 -> timestamp
             # DEFAULT_TRADES_COLUMNS: 1 -> id
             from_id = t[-1][1]
+            logger.debug(
+                "Did not cache the intermediate trades since %s with len=%s and from_id=%s", since,
+                len(t), from_id)
             trades.extend(t[:-1])
         while True:
-            tmpdata_file = self._intermediate_trades_dir(datadir, pair, from_id)
+            tmpdata_file = self._intermediate_trades_file(datadir, pair, from_id)
 
             t = []
             success_cache_read = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ cachetools==4.2.2
 requests==2.26.0
 urllib3==1.26.6
 wrapt==1.12.1
+intervaltree==3.1.0
 jsonschema==3.2.0
 TA-Lib==0.4.21
 technical==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'requests',
         'urllib3',
         'wrapt',
+        'intervaltree',
         'jsonschema',
         'TA-Lib',
         'technical',

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -2274,6 +2274,12 @@ def test__intermediate_trades_file(default_conf, mocker, caplog, exchange_name,
     expected_file = ("user_data/data/" + exchange_name +
                      "/trades-intermediate-parts/ETH-BTC/254/ETH-BTC_254648140.json")
     assert expected_file == exchange._intermediate_trades_file(datadir, pair, "254648140", False)
+    expected_file = (
+        "user_data/data/" + exchange_name +
+        "/trades-intermediate-parts/ETH-BTC/1/623/216/788/143/ETH-BTC_1623216788143201587.json"
+    )
+    assert expected_file == exchange._intermediate_trades_file(
+        datadir, pair, "1623216788143201587", False)
 
 
 @pytest.mark.asyncio
@@ -2298,7 +2304,7 @@ async def test__async_fetch_trades_from_file(default_conf, mocker, caplog, excha
     expected_trades_list = await exchange._async_fetch_trades_from_file(expected_file)
     assert expected_trades_list == json.loads(trades_list_string)
 
-    expected_interval_tree = await exchange._get_interval_tree_for_pair(datadir, pair)
+    expected_interval_tree = await exchange._async_get_interval_tree_for_pair(datadir, pair)
     expected_interval = Interval(254648140, 254648143, expected_file)
     assert len(expected_interval_tree) == 1
 


### PR DESCRIPTION
## Summary

This PR caches the intermediate trade files taken from the exchange API calls to avoid re-doing them later.

## Quick changelog

- Creates a directory of temporary files under `user_data/data/binance/trades-intermediate-parts`. This folder can be removed after a complete download if you don't plan to have incremental downloads later. If your data download gets interrupted (e.g., due to network connectivity issues or a problem with the exchange), these temporary files avoid re-downloading the trades again.

## What's new?

This PR improves the download experience of users by storing the extracted data from the exchange API calls in temporary files. In addition, it creates an interval tree for each pair and stores the intervals that we have data downloaded for them. This way, the incremental data download experience also improves, as the future overlapping requests will also use the cached trade files if possible.
