### PR TITLE
Update HyperoptTools.export_csv_file usage

### DIFF
--- a/freqtrade/commands/hyperopt_commands.py
+++ b/freqtrade/commands/hyperopt_commands.py
@@ -53,7 +53,7 @@ def start_hyperopt_list(args: Dict[str, Any]) -> None:
 
     if epochs and export_csv:
         HyperoptTools.export_csv_file(
-            config, epochs, total_epochs, not config.get('hyperopt_list_best', False), export_csv
+            config, epochs, export_csv
         )
 
 

--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -435,8 +435,7 @@ class HyperoptTools():
         return table
 
     @staticmethod
-    def export_csv_file(config: dict, results: list, total_epochs: int, highlight_best: bool,
-                        csv_file: str) -> None:
+    def export_csv_file(config: dict, results: list, csv_file: str) -> None:
         """
         Log result to csv-file
         """


### PR DESCRIPTION
## Summary
Remove unused parameters from HyperoptTools.export_csv_file and update its usage found in hyperopt_commands.py

## Quick changelog

- hyperopt_commands.py 
- hyperopt_tools.py

