### PR TITLE
Include Raspberry Pi armv6 (0, 0W,...)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ function updateenv() {
     then
         REQUIREMENTS_PLOT="-r requirements-plot.txt"
     fi
-    if [ "${SYS_ARCH}" == "armv7l" ]; then
+    if [ "${SYS_ARCH}" == "armv7l" ] || [ "${SYS_ARCH}" == "armv6l" ]; then
         echo "Detected Raspberry, installing cython, skipping hyperopt installation."
         ${PYTHON} -m pip install --upgrade cython
     else


### PR DESCRIPTION
## Summary

Enable oldest Raspberry arch to setup Freqtrade

## Quick changelog

- Added detection of armv6l arch. It allow oldest Raspberry Pi to setup correctly

## Testing

- It has been tested correctly on Raspberry Pi Zero W
