### PR TITLE
Test freqtradebot usdt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ from freqtrade.resolvers import ExchangeResolver
 from freqtrade.worker import Worker
 from tests.conftest_trades import (mock_trade_1, mock_trade_2, mock_trade_3, mock_trade_4,
                                    mock_trade_5, mock_trade_6)
+from tests.conftest_trades_usdt import (mock_trade_usdt_1, mock_trade_usdt_2, mock_trade_usdt_3,
+                                        mock_trade_usdt_4, mock_trade_usdt_5, mock_trade_usdt_6)
 
 
 logging.getLogger('').setLevel(logging.INFO)
@@ -227,6 +229,39 @@ def create_mock_trades(fee, use_db: bool = True):
         Trade.query.session.flush()
 
 
+def create_mock_trades_usdt(fee, use_db: bool = True):
+    """
+    Create some fake trades ...
+    """
+    def add_trade(trade):
+        if use_db:
+            Trade.query.session.add(trade)
+        else:
+            LocalTrade.add_bt_trade(trade)
+
+    # Simulate dry_run entries
+    trade = mock_trade_usdt_1(fee)
+    add_trade(trade)
+
+    trade = mock_trade_usdt_2(fee)
+    add_trade(trade)
+
+    trade = mock_trade_usdt_3(fee)
+    add_trade(trade)
+
+    trade = mock_trade_usdt_4(fee)
+    add_trade(trade)
+
+    trade = mock_trade_usdt_5(fee)
+    add_trade(trade)
+
+    trade = mock_trade_usdt_6(fee)
+    add_trade(trade)
+
+    if use_db:
+        Trade.query.session.flush()
+
+
 @pytest.fixture(autouse=True)
 def patch_coingekko(mocker) -> None:
     """
@@ -303,7 +338,8 @@ def get_default_conf(testdatadir):
                 "ETH/BTC",
                 "LTC/BTC",
                 "XRP/BTC",
-                "NEO/BTC"
+                "NEO/BTC",
+                "ADA/USDT"
             ],
             "pair_blacklist": [
                 "DOGE/BTC",
@@ -373,6 +409,33 @@ def ticker_sell_down():
 
 
 @pytest.fixture
+def ticker_usdt():
+    return MagicMock(return_value={
+        'bid': 1.99,
+        'ask': 2.0,
+        'last': 1.99,
+    })
+
+
+@pytest.fixture
+def ticker_usdt_sell_up():
+    return MagicMock(return_value={
+        'bid': 2.19,
+        'ask': 2.2,
+        'last': 2.19,
+    })
+
+
+@pytest.fixture
+def ticker_usdt_sell_down():
+    return MagicMock(return_value={
+        'bid': 2.01,
+        'ask': 2.0,
+        'last': 2.01,
+    })
+
+
+@pytest.fixture
 def markets():
     return get_markets()
 
@@ -386,6 +449,31 @@ def get_markets():
             'symbol': 'ETH/BTC',
             'base': 'ETH',
             'quote': 'BTC',
+            'active': True,
+            'precision': {
+                'price': 8,
+                'amount': 8,
+                'cost': 8,
+            },
+            'lot': 0.00000001,
+            'limits': {
+                'amount': {
+                    'min': 0.01,
+                    'max': 1000,
+                },
+                'price': 500000,
+                'cost': {
+                    'min': 0.0001,
+                    'max': 500000,
+                },
+            },
+            'info': {},
+        },
+        'ADA/USDT': {
+            'id': 'ethbtc',
+            'symbol': 'ADA/USDT',
+            'base': 'USDT',
+            'quote': 'ADA',
             'active': True,
             'precision': {
                 'price': 8,
@@ -1816,6 +1904,22 @@ def open_trade():
         fee_open=0.0,
         fee_close=0.0,
         stake_amount=1,
+        open_date=arrow.utcnow().shift(minutes=-601).datetime,
+        is_open=True
+    )
+
+
+@pytest.fixture(scope="function")
+def open_trade_usdt():
+    return Trade(
+        pair='ADA/USDT',
+        open_rate=2.0,
+        exchange='binance',
+        open_order_id='123456789',
+        amount=30.0,
+        fee_open=0.0,
+        fee_close=0.0,
+        stake_amount=60.0,
         open_date=arrow.utcnow().shift(minutes=-601).datetime,
         is_open=True
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,9 +289,19 @@ def init_persistence(default_conf):
     init_db(default_conf['db_url'], default_conf['dry_run'])
 
 
+@pytest.fixture(scope='function')
+def init_persistence_usdt(default_conf_usdt):
+    init_db(default_conf_usdt['db_url'], default_conf_usdt['dry_run'])
+
+
 @pytest.fixture(scope="function")
 def default_conf(testdatadir):
     return get_default_conf(testdatadir)
+
+
+@pytest.fixture(scope="function")
+def default_conf_usdt(testdatadir):
+    return get_default_conf_usdt(testdatadir)
 
 
 def get_default_conf(testdatadir):
@@ -365,6 +375,15 @@ def get_default_conf(testdatadir):
         "internals": {},
         "export": "none",
     }
+    return configuration
+
+
+def get_default_conf_usdt(testdatadir):
+    configuration = get_default_conf(testdatadir)
+    configuration.update({
+        "stake_amount": 60.0,
+        "stake_currency": "USDT",
+    })
     return configuration
 
 
@@ -1602,7 +1621,7 @@ def trades_for_order():
         'info': {
             'id': 34567,
             'orderId': 123456,
-            'price': '0.24544100',
+            'price': '2.0',
             'qty': '8.00000000',
             'commission': '0.00800000',
             'commissionAsset': 'LTC',
@@ -1809,6 +1828,14 @@ def edge_conf(default_conf):
     }
 
     return conf
+
+
+@pytest.fixture(scope="function")
+def edge_conf_usdt(edge_conf):
+    edge_conf.update({
+        "stake_currency": "USDT",
+    })
+    return edge_conf
 
 
 @pytest.fixture
@@ -2049,7 +2076,7 @@ def saved_hyperopt_results():
 @pytest.fixture(scope='function')
 def limit_buy_order_usdt_open():
     return {
-        'id': 'mocked_limit_buy',
+        'id': 'mocked_limit_buy_usdt',
         'type': 'limit',
         'side': 'buy',
         'symbol': 'mocked',
@@ -2076,7 +2103,7 @@ def limit_buy_order_usdt(limit_buy_order_usdt_open):
 @pytest.fixture
 def limit_sell_order_usdt_open():
     return {
-        'id': 'mocked_limit_sell',
+        'id': 'mocked_limit_sell_usdt',
         'type': 'limit',
         'side': 'sell',
         'pair': 'mocked',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1598,27 +1598,34 @@ def result(testdatadir):
 
 @pytest.fixture(scope="function")
 def trades_for_order():
-    return [{'info': {'id': 34567,
-                      'orderId': 123456,
-                      'price': '0.24544100',
-                      'qty': '8.00000000',
-                      'commission': '0.00800000',
-                      'commissionAsset': 'LTC',
-                      'time': 1521663363189,
-                      'isBuyer': True,
-                      'isMaker': False,
-                      'isBestMatch': True},
-             'timestamp': 1521663363189,
-             'datetime': '2018-03-21T20:16:03.189Z',
-             'symbol': 'LTC/ETH',
-             'id': '34567',
-             'order': '123456',
-             'type': None,
-             'side': 'buy',
-             'price': 0.245441,
-             'cost': 1.963528,
-             'amount': 8.0,
-             'fee': {'cost': 0.008, 'currency': 'LTC'}}]
+    return [{
+        'info': {
+            'id': 34567,
+            'orderId': 123456,
+            'price': '0.24544100',
+            'qty': '8.00000000',
+            'commission': '0.00800000',
+            'commissionAsset': 'LTC',
+            'time': 1521663363189,
+            'isBuyer': True,
+            'isMaker': False,
+            'isBestMatch': True
+        },
+        'timestamp': 1521663363189,
+        'datetime': '2018-03-21T20:16:03.189Z',
+        'symbol': 'LTC/USDT',
+        'id': '34567',
+        'order': '123456',
+        'type': None,
+        'side': 'buy',
+        'price': 2.0,
+        'cost': 16.0,
+        'amount': 8.0,
+        'fee': {
+            'cost': 0.008,
+            'currency': 'LTC'
+        }
+    }]
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,7 +441,7 @@ def ticker_sell_down():
 def ticker_usdt():
     return MagicMock(return_value={
         'bid': 2.0,
-        'ask': 2.01,
+        'ask': 2.1,
         'last': 2.0,
     })
 
@@ -449,9 +449,9 @@ def ticker_usdt():
 @pytest.fixture
 def ticker_usdt_sell_up():
     return MagicMock(return_value={
-        'bid': 2.19,
-        'ask': 2.2,
-        'last': 2.19,
+        'bid': 2.2,
+        'ask': 2.3,
+        'last': 2.2,
     })
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,7 +376,7 @@ def get_default_conf(testdatadir):
 def get_default_conf_usdt(testdatadir):
     configuration = get_default_conf(testdatadir)
     configuration.update({
-        "stake_amount": 10.0,
+        "stake_amount": 60.0,
         "stake_currency": "USDT",
         "exchange": {
             "name": "binance",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,8 +338,7 @@ def get_default_conf(testdatadir):
                 "ETH/BTC",
                 "LTC/BTC",
                 "XRP/BTC",
-                "NEO/BTC",
-                "ADA/USDT"
+                "NEO/BTC"
             ],
             "pair_blacklist": [
                 "DOGE/BTC",
@@ -449,31 +448,6 @@ def get_markets():
             'symbol': 'ETH/BTC',
             'base': 'ETH',
             'quote': 'BTC',
-            'active': True,
-            'precision': {
-                'price': 8,
-                'amount': 8,
-                'cost': 8,
-            },
-            'lot': 0.00000001,
-            'limits': {
-                'amount': {
-                    'min': 0.01,
-                    'max': 1000,
-                },
-                'price': 500000,
-                'cost': {
-                    'min': 0.0001,
-                    'max': 500000,
-                },
-            },
-            'info': {},
-        },
-        'ADA/USDT': {
-            'id': 'ethbtc',
-            'symbol': 'ADA/USDT',
-            'base': 'USDT',
-            'quote': 'ADA',
             'active': True,
             'precision': {
                 'price': 8,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,6 +378,22 @@ def get_default_conf_usdt(testdatadir):
     configuration.update({
         "stake_amount": 10.0,
         "stake_currency": "USDT",
+        "exchange": {
+            "name": "binance",
+            "enabled": True,
+            "key": "key",
+            "secret": "secret",
+            "pair_whitelist": [
+                "ETH/USDT",
+                "LTC/USDT",
+                "XRP/USDT",
+                "NEO/USDT"
+            ],
+            "pair_blacklist": [
+                "DOGE/USDT",
+                "HOT/USDT",
+            ]
+        },
     })
     return configuration
 
@@ -424,9 +440,9 @@ def ticker_sell_down():
 @pytest.fixture
 def ticker_usdt():
     return MagicMock(return_value={
-        'bid': 1.99,
-        'ask': 2.0,
-        'last': 1.99,
+        'bid': 2.0,
+        'ask': 2.01,
+        'last': 2.0,
     })
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,7 +387,8 @@ def get_default_conf_usdt(testdatadir):
                 "ETH/USDT",
                 "LTC/USDT",
                 "XRP/USDT",
-                "NEO/USDT"
+                "NEO/USDT",
+                "TKN/USDT",
             ],
             "pair_blacklist": [
                 "DOGE/USDT",
@@ -693,6 +694,81 @@ def get_markets():
                     'min': 1e-08,
                     'max': None
                 }
+            },
+            'info': {},
+        },
+        'XRP/USDT': {
+            'id': 'xrpusdt',
+            'symbol': 'XRP/USDT',
+            'base': 'XRP',
+            'quote': 'USDT',
+            'active': True,
+            'precision': {
+                'price': 8,
+                'amount': 8,
+                'cost': 8,
+            },
+            'lot': 0.00000001,
+            'limits': {
+                'amount': {
+                    'min': 0.01,
+                    'max': 1000,
+                },
+                'price': 500000,
+                'cost': {
+                    'min': 0.0001,
+                    'max': 500000,
+                },
+            },
+            'info': {},
+        },
+        'NEO/USDT': {
+            'id': 'neousdt',
+            'symbol': 'NEO/USDT',
+            'base': 'NEO',
+            'quote': 'USDT',
+            'active': True,
+            'precision': {
+                'price': 8,
+                'amount': 8,
+                'cost': 8,
+            },
+            'lot': 0.00000001,
+            'limits': {
+                'amount': {
+                    'min': 0.01,
+                    'max': 1000,
+                },
+                'price': 500000,
+                'cost': {
+                    'min': 0.0001,
+                    'max': 500000,
+                },
+            },
+            'info': {},
+        },
+        'TKN/USDT': {
+            'id': 'tknusdt',
+            'symbol': 'TKN/USDT',
+            'base': 'TKN',
+            'quote': 'USDT',
+            'active': True,
+            'precision': {
+                'price': 8,
+                'amount': 8,
+                'cost': 8,
+            },
+            'lot': 0.00000001,
+            'limits': {
+                'amount': {
+                    'min': 0.01,
+                    'max': 1000,
+                },
+                'price': 500000,
+                'cost': {
+                    'min': 0.0001,
+                    'max': 500000,
+                },
             },
             'info': {},
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,11 +289,6 @@ def init_persistence(default_conf):
     init_db(default_conf['db_url'], default_conf['dry_run'])
 
 
-@pytest.fixture(scope='function')
-def init_persistence_usdt(default_conf_usdt):
-    init_db(default_conf_usdt['db_url'], default_conf_usdt['dry_run'])
-
-
 @pytest.fixture(scope="function")
 def default_conf(testdatadir):
     return get_default_conf(testdatadir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,7 +381,7 @@ def get_default_conf(testdatadir):
 def get_default_conf_usdt(testdatadir):
     configuration = get_default_conf(testdatadir)
     configuration.update({
-        "stake_amount": 60.0,
+        "stake_amount": 10.0,
         "stake_currency": "USDT",
     })
     return configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1825,14 +1825,6 @@ def edge_conf(default_conf):
     return conf
 
 
-@pytest.fixture(scope="function")
-def edge_conf_usdt(edge_conf):
-    edge_conf.update({
-        "stake_currency": "USDT",
-    })
-    return edge_conf
-
-
 @pytest.fixture
 def rpc_balance():
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -442,7 +442,7 @@ def ticker_sell_down():
 def ticker_usdt():
     return MagicMock(return_value={
         'bid': 2.0,
-        'ask': 2.1,
+        'ask': 2.02,
         'last': 2.0,
     })
 

--- a/tests/conftest_trades_usdt.py
+++ b/tests/conftest_trades_usdt.py
@@ -1,0 +1,305 @@
+from datetime import datetime, timedelta, timezone
+
+from freqtrade.persistence.models import Order, Trade
+
+
+MOCK_TRADE_COUNT = 6
+
+
+def mock_order_usdt_1():
+    return {
+        'id': '1234',
+        'symbol': 'ADA/USDT',
+        'status': 'closed',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 2.0,
+        'amount': 10.0,
+        'filled': 10.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_trade_usdt_1(fee):
+    trade = Trade(
+        pair='ADA/USDT',
+        stake_amount=20.0,
+        amount=10.0,
+        amount_requested=10.0,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        is_open=True,
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=17),
+        open_rate=2.0,
+        exchange='binance',
+        open_order_id='dry_run_buy_12345',
+        strategy='StrategyTestV2',
+        timeframe=5,
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_1(), 'ADA/USDT', 'buy')
+    trade.orders.append(o)
+    return trade
+
+
+def mock_order_usdt_2():
+    return {
+        'id': '1235',
+        'symbol': 'ETC/USDT',
+        'status': 'closed',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 2.0,
+        'amount': 100.0,
+        'filled': 100.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_order_usdt_2_sell():
+    return {
+        'id': '12366',
+        'symbol': 'ETC/USDT',
+        'status': 'closed',
+        'side': 'sell',
+        'type': 'limit',
+        'price': 2.05,
+        'amount': 100.0,
+        'filled': 100.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_trade_usdt_2(fee):
+    """
+    Closed trade...
+    """
+    trade = Trade(
+        pair='ETC/USDT',
+        stake_amount=200.0,
+        amount=100.0,
+        amount_requested=100.0,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        open_rate=2.0,
+        close_rate=2.05,
+        close_profit=5.0,
+        close_profit_abs=3.9875,
+        exchange='binance',
+        is_open=False,
+        open_order_id='dry_run_sell_12345',
+        strategy='StrategyTestV2',
+        timeframe=5,
+        sell_reason='sell_signal',
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=20),
+        close_date=datetime.now(tz=timezone.utc) - timedelta(minutes=2),
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_2(), 'ETC/USDT', 'buy')
+    trade.orders.append(o)
+    o = Order.parse_from_ccxt_object(mock_order_usdt_2_sell(), 'ETC/USDT', 'sell')
+    trade.orders.append(o)
+    return trade
+
+
+def mock_order_usdt_3():
+    return {
+        'id': '41231a12a',
+        'symbol': 'XRP/USDT',
+        'status': 'closed',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 1.0,
+        'amount': 30.0,
+        'filled': 30.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_order_usdt_3_sell():
+    return {
+        'id': '41231a666a',
+        'symbol': 'XRP/USDT',
+        'status': 'closed',
+        'side': 'sell',
+        'type': 'stop_loss_limit',
+        'price': 1.1,
+        'average': 1.1,
+        'amount': 30.0,
+        'filled': 30.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_trade_usdt_3(fee):
+    """
+    Closed trade
+    """
+    trade = Trade(
+        pair='XRP/USDT',
+        stake_amount=30.0,
+        amount=30.0,
+        amount_requested=30.0,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        open_rate=1.0,
+        close_rate=1.1,
+        close_profit=10.0,
+        close_profit_abs=9.8425,
+        exchange='binance',
+        is_open=False,
+        strategy='StrategyTestV2',
+        timeframe=5,
+        sell_reason='roi',
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=20),
+        close_date=datetime.now(tz=timezone.utc),
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_3(), 'XRP/USDT', 'buy')
+    trade.orders.append(o)
+    o = Order.parse_from_ccxt_object(mock_order_usdt_3_sell(), 'XRP/USDT', 'sell')
+    trade.orders.append(o)
+    return trade
+
+
+def mock_order_usdt_4():
+    return {
+        'id': 'prod_buy_12345',
+        'symbol': 'ETC/USDT',
+        'status': 'open',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 2.0,
+        'amount': 10.0,
+        'filled': 0.0,
+        'remaining': 30.0,
+    }
+
+
+def mock_trade_usdt_4(fee):
+    """
+    Simulate prod entry
+    """
+    trade = Trade(
+        pair='ETC/USDT',
+        stake_amount=20.0,
+        amount=10.0,
+        amount_requested=10.01,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=14),
+        is_open=True,
+        open_rate=2.0,
+        exchange='binance',
+        open_order_id='prod_buy_12345',
+        strategy='StrategyTestV2',
+        timeframe=5,
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_4(), 'ETC/USDT', 'buy')
+    trade.orders.append(o)
+    return trade
+
+
+def mock_order_usdt_5():
+    return {
+        'id': 'prod_buy_3455',
+        'symbol': 'XRP/USDT',
+        'status': 'closed',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 2.0,
+        'amount': 10.0,
+        'filled': 10.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_order_usdt_5_stoploss():
+    return {
+        'id': 'prod_stoploss_3455',
+        'symbol': 'XRP/USDT',
+        'status': 'open',
+        'side': 'sell',
+        'type': 'stop_loss_limit',
+        'price': 2.0,
+        'amount': 10.0,
+        'filled': 0.0,
+        'remaining': 30.0,
+    }
+
+
+def mock_trade_usdt_5(fee):
+    """
+    Simulate prod entry with stoploss
+    """
+    trade = Trade(
+        pair='XRP/USDT',
+        stake_amount=20.0,
+        amount=10.0,
+        amount_requested=10.01,
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=12),
+        is_open=True,
+        open_rate=2.0,
+        exchange='binance',
+        strategy='SampleStrategy',
+        stoploss_order_id='prod_stoploss_3455',
+        timeframe=5,
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_5(), 'XRP/USDT', 'buy')
+    trade.orders.append(o)
+    o = Order.parse_from_ccxt_object(mock_order_usdt_5_stoploss(), 'XRP/USDT', 'stoploss')
+    trade.orders.append(o)
+    return trade
+
+
+def mock_order_usdt_6():
+    return {
+        'id': 'prod_buy_6',
+        'symbol': 'LTC/USDT',
+        'status': 'closed',
+        'side': 'buy',
+        'type': 'limit',
+        'price': 10.0,
+        'amount': 2.0,
+        'filled': 2.0,
+        'remaining': 0.0,
+    }
+
+
+def mock_order_usdt_6_sell():
+    return {
+        'id': 'prod_sell_6',
+        'symbol': 'LTC/USDT',
+        'status': 'open',
+        'side': 'sell',
+        'type': 'limit',
+        'price': 12.0,
+        'amount': 2.0,
+        'filled': 0.0,
+        'remaining': 2.0,
+    }
+
+
+def mock_trade_usdt_6(fee):
+    """
+    Simulate prod entry with open sell order
+    """
+    trade = Trade(
+        pair='LTC/USDT',
+        stake_amount=20.0,
+        amount=2.0,
+        amount_requested=2.0,
+        open_date=datetime.now(tz=timezone.utc) - timedelta(minutes=5),
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        is_open=True,
+        open_rate=10.0,
+        exchange='binance',
+        strategy='SampleStrategy',
+        open_order_id="prod_sell_6",
+        timeframe=5,
+    )
+    o = Order.parse_from_ccxt_object(mock_order_usdt_6(), 'LTC/USDT', 'buy')
+    trade.orders.append(o)
+    o = Order.parse_from_ccxt_object(mock_order_usdt_6_sell(), 'LTC/USDT', 'sell')
+    trade.orders.append(o)
+    return trade

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -1003,7 +1003,7 @@ def test_rpc_blacklist(mocker, default_conf) -> None:
     assert len(ret['blacklist']) == 4
     assert ret['blacklist'] == default_conf['exchange']['pair_blacklist']
     assert ret['blacklist'] == ['DOGE/BTC', 'HOT/BTC', 'ETH/BTC', 'XRP/.*']
-    assert ret['blacklist_expanded'] == ['ETH/BTC', 'XRP/BTC']
+    assert ret['blacklist_expanded'] == ['ETH/BTC', 'XRP/BTC', 'XRP/USDT']
     assert 'errors' in ret
     assert isinstance(ret['errors'], dict)
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -937,7 +937,7 @@ def test_api_blacklist(botclient, mocker):
                      data='{"blacklist": ["XRP/.*"]}')
     assert_response(rc)
     assert rc.json() == {"blacklist": ["DOGE/BTC", "HOT/BTC", "ETH/BTC", "XRP/.*"],
-                         "blacklist_expanded": ["ETH/BTC", "XRP/BTC"],
+                         "blacklist_expanded": ["ETH/BTC", "XRP/BTC", "XRP/USDT"],
                          "length": 4,
                          "method": ["StaticPairList"],
                          "errors": {},

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -4043,9 +4043,9 @@ def test_update_closed_trades_without_assigned_fees(mocker, default_conf, fee):
             assert trade.fee_close_currency is not None
 
 
-@pytest.mark.usefixtures("init_persistence")
-def test_reupdate_enter_order_fees(mocker, default_conf, fee, caplog):
-    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+@pytest.mark.usefixtures("init_persistence_usdt")
+def test_reupdate_enter_order_fees(mocker, default_conf_usdt, fee, caplog):
+    freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
     mock_uts = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.update_trade_state')
 
     create_mock_trades(fee)
@@ -4063,13 +4063,13 @@ def test_reupdate_enter_order_fees(mocker, default_conf, fee, caplog):
     # Test with trade without orders
     trade = Trade(
         pair='XRP/ETH',
-        stake_amount=0.001,
+        stake_amount=60.0,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         open_date=arrow.utcnow().datetime,
         is_open=True,
-        amount=20,
-        open_rate=0.01,
+        amount=30,
+        open_rate=2.0,
         exchange='binance',
     )
     Trade.query.session.add(trade)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -126,14 +126,14 @@ def test_get_trade_stake_amount(default_conf_usdt, mocker) -> None:
 
 
 @pytest.mark.parametrize("amend_last,wallet,max_open,lsamr,expected", [
-                        (False, 20, 2, 0.5, [10, None]),
-                        (True, 20, 2, 0.5, [10, 9.8]),
-                        (False, 30, 3, 0.5, [10, 10, None]),
-                        (True, 30, 3, 0.5, [10, 10, 9.7]),
-                        (False, 22, 3, 0.5, [10, 10, None]),
-                        (True, 22, 3, 0.5, [10, 10, 0.0]),
-                        (True, 27, 3, 0.5, [10, 10, 6.73]),
-                        (True, 22, 3, 1, [10, 10, 0.0]),
+                        (False, 120, 2, 0.5, [60, None]),
+                        (True, 120, 2, 0.5, [60, 58.8]),
+                        (False, 180, 3, 0.5, [60, 60, None]),
+                        (True, 180, 3, 0.5, [60, 60, 58.2]),
+                        (False, 122, 3, 0.5, [60, 60, None]),
+                        (True, 122, 3, 0.5, [60, 60, 0.0]),
+                        (True, 167, 3, 0.5, [60, 60, 45.33]),
+                        (True, 122, 3, 1, [60, 60, 0.0]),
 ])
 def test_check_available_stake_amount(
     default_conf_usdt, ticker_usdt, mocker, fee, limit_buy_order_usdt_open,
@@ -256,7 +256,7 @@ def test_total_open_trades_stakes(mocker, default_conf_usdt, ticker_usdt, fee) -
     trade = Trade.query.first()
 
     assert trade is not None
-    assert trade.stake_amount == 10.0
+    assert trade.stake_amount == 60.0
     assert trade.is_open
     assert trade.open_date is not None
 
@@ -264,11 +264,11 @@ def test_total_open_trades_stakes(mocker, default_conf_usdt, ticker_usdt, fee) -
     trade = Trade.query.order_by(Trade.id.desc()).first()
 
     assert trade is not None
-    assert trade.stake_amount == 10.0
+    assert trade.stake_amount == 60.0
     assert trade.is_open
     assert trade.open_date is not None
 
-    assert Trade.total_open_trades_stakes() == 20.0
+    assert Trade.total_open_trades_stakes() == 120.0
 
 
 def test_create_trade(default_conf_usdt, ticker_usdt, limit_buy_order_usdt, fee, mocker) -> None:
@@ -289,7 +289,7 @@ def test_create_trade(default_conf_usdt, ticker_usdt, limit_buy_order_usdt, fee,
 
     trade = Trade.query.first()
     assert trade is not None
-    assert trade.stake_amount == 10.0
+    assert trade.stake_amount == 60.0
     assert trade.is_open
     assert trade.open_date is not None
     assert trade.exchange == 'binance'
@@ -467,7 +467,7 @@ def test_create_trades_multiple_trades(
     patch_exchange(mocker)
     default_conf_usdt['max_open_trades'] = max_open
     default_conf_usdt['tradable_balance_ratio'] = tradable_balance_ratio
-    default_conf_usdt['dry_run_wallet'] = 10.0 * max_open
+    default_conf_usdt['dry_run_wallet'] = 60.0 * max_open
 
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -544,10 +544,10 @@ def test_process_trade_creation(default_conf_usdt, ticker_usdt, limit_buy_order_
     assert trade.open_date is not None
     assert trade.exchange == 'binance'
     assert trade.open_rate == 2.0
-    assert trade.amount == 5.0
+    assert trade.amount == 30.0
 
     assert log_has(
-        'Buy signal found: about create a new trade for ETH/USDT with stake_amount: 10.0 ...',
+        'Buy signal found: about create a new trade for ETH/USDT with stake_amount: 60.0 ...',
         caplog
     )
 
@@ -1265,7 +1265,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf_usdt, fee,
 
     cancel_order_mock.assert_called_once_with(100, 'ETH/USDT')
     stoploss_order_mock.assert_called_once_with(
-        amount=4.56621004,
+        amount=27.39726027,
         pair='ETH/USDT',
         order_types=freqtrade.strategy.order_types,
         stop_price=4.4 * 0.95
@@ -1457,7 +1457,7 @@ def test_handle_stoploss_on_exchange_custom_stop(
 
     cancel_order_mock.assert_called_once_with(100, 'ETH/USDT')
     stoploss_order_mock.assert_called_once_with(
-        amount=5.26315789,
+        amount=31.57894736,
         pair='ETH/USDT',
         order_types=freqtrade.strategy.order_types,
         stop_price=4.4 * 0.96
@@ -2577,11 +2577,11 @@ def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_
         'pair': 'ETH/USDT',
         'gain': 'profit',
         'limit': 2.2,
-        'amount': 5.0,
+        'amount': 30.0,
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.3,
-        'profit_amount': 0.9475,
+        'profit_amount': 5.685,
         'profit_ratio': 0.09451372,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
@@ -2630,11 +2630,11 @@ def test_execute_trade_exit_down(default_conf_usdt, ticker_usdt, fee, ticker_usd
         'pair': 'ETH/USDT',
         'gain': 'loss',
         'limit': 2.01,
-        'amount': 5.0,
+        'amount': 30.0,
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.0,
-        'profit_amount': -0.000125,
+        'profit_amount': -0.00075,
         'profit_ratio': -1.247e-05,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
@@ -2697,11 +2697,11 @@ def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fe
         'pair': 'ETH/USDT',
         'gain': 'profit',
         'limit': 2.25,
-        'amount': 5.0,
+        'amount': 30.0,
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.3,
-        'profit_amount': 1.196875,
+        'profit_amount': 7.18125,
         'profit_ratio': 0.11938903,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
@@ -2756,11 +2756,11 @@ def test_execute_trade_exit_down_stoploss_on_exchange_dry_run(
         'pair': 'ETH/USDT',
         'gain': 'loss',
         'limit': 1.98,
-        'amount': 5.0,
+        'amount': 30.0,
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.0,
-        'profit_amount': -0.14975,
+        'profit_amount': -0.8985,
         'profit_ratio': -0.01493766,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
@@ -2973,11 +2973,11 @@ def test_execute_trade_exit_market_order(default_conf_usdt, ticker_usdt, fee,
         'pair': 'ETH/USDT',
         'gain': 'profit',
         'limit': 2.2,
-        'amount': 5.0,
+        'amount': 30.0,
         'order_type': 'market',
         'open_rate': 2.0,
         'current_rate': 2.3,
-        'profit_amount': 0.9475,
+        'profit_amount': 5.685,
         'profit_ratio': 0.09451372,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
@@ -3742,7 +3742,7 @@ def test_order_book_depth_of_market(
         assert trade is None
     else:
         assert trade is not None
-        assert trade.stake_amount == 10.0
+        assert trade.stake_amount == 60.0
         assert trade.is_open
         assert trade.open_date is not None
         assert trade.exchange == 'binance'
@@ -3891,7 +3891,7 @@ def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_
                              caplog):
     default_conf_usdt['dry_run'] = True
     # Initialize to 2 times stake amount
-    default_conf_usdt['dry_run_wallet'] = 20.0
+    default_conf_usdt['dry_run_wallet'] = 120.0
     default_conf_usdt['max_open_trades'] = 2
     default_conf_usdt['tradable_balance_ratio'] = 1.0
     patch_exchange(mocker)
@@ -3904,7 +3904,7 @@ def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_
 
     bot = get_patched_freqtradebot(mocker, default_conf_usdt)
     patch_get_signal(bot)
-    assert bot.wallets.get_free('USDT') == 20.0
+    assert bot.wallets.get_free('USDT') == 120.0
 
     n = bot.enter_positions()
     assert n == 2
@@ -3915,7 +3915,7 @@ def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_
     n = bot.enter_positions()
     assert n == 0
     assert log_has_re(r"Unable to create trade for XRP/USDT: "
-                      r"Available balance \(0.0 USDT\) is lower than stake amount \(10.0 USDT\)",
+                      r"Available balance \(0.0 USDT\) is lower than stake amount \(60.0 USDT\)",
                       caplog)
 
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3026,12 +3026,12 @@ def test_execute_trade_exit_insufficient_funds_error(default_conf_usdt, ticker_u
     # Enable profit
     (True, 1.9, 2.2, False, True, SellType.SELL_SIGNAL.value),
     # Disable profit
-    (False, 0.00002172, 0.00002173, True,  False, SellType.SELL_SIGNAL.value),
+    (False, 2.9, 3.2, True,  False, SellType.SELL_SIGNAL.value),
     # Enable loss
     # * Shouldn't this be SellType.STOP_LOSS.value
-    (True, 0.00000172, 0.00000173, False, False, None),
+    (True, 0.19, 0.22, False, False, None),
     # Disable loss
-    (False, 0.00000172, 0.00000173, True, False, SellType.SELL_SIGNAL.value),
+    (False, 0.10, 0.22, True, False, SellType.SELL_SIGNAL.value),
 ])
 def test_sell_profit_only(
         default_conf_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -773,10 +773,10 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_buy_order_usdt,
     # In case of rejected or expired order and partially filled
     limit_buy_order_usdt['status'] = 'expired'
     limit_buy_order_usdt['amount'] = 30.0
-    limit_buy_order_usdt['filled'] = 80.99181073
+    limit_buy_order_usdt['filled'] = 20.0
     limit_buy_order_usdt['remaining'] = 10.00
     limit_buy_order_usdt['price'] = 0.5
-    limit_buy_order_usdt['cost'] = 40.495905365
+    limit_buy_order_usdt['cost'] = 15.0
     limit_buy_order_usdt['id'] = '555'
     mocker.patch('freqtrade.exchange.Exchange.create_order',
                  MagicMock(return_value=limit_buy_order_usdt))
@@ -785,7 +785,7 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_buy_order_usdt,
     assert trade
     assert trade.open_order_id == '555'
     assert trade.open_rate == 0.5
-    assert trade.stake_amount == 40.495905365
+    assert trade.stake_amount == 15.0
 
     # Test with custom stake
     limit_buy_order_usdt['status'] = 'open'

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -115,7 +115,7 @@ def test_order_dict(default_conf_usdt, mocker, runmode, caplog) -> None:
     assert not log_has_re(".*stoploss_on_exchange .* dry-run", caplog)
 
 
-def test_get_trade_stake_amount(default_conf_usdt, ticker_usdt, mocker) -> None:
+def test_get_trade_stake_amount(default_conf_usdt, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
 
@@ -243,7 +243,6 @@ def test_edge_overrides_stoploss(limit_buy_order_usdt, fee, caplog, mocker,
 def test_total_open_trades_stakes(mocker, default_conf_usdt, ticker_usdt, fee) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
-    default_conf_usdt['stake_amount'] = 10.0
     default_conf_usdt['max_open_trades'] = 2
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -304,8 +303,7 @@ def test_create_trade(default_conf_usdt, ticker_usdt, limit_buy_order_usdt, fee,
     assert whitelist == default_conf_usdt['exchange']['pair_whitelist']
 
 
-def test_create_trade_no_stake_amount(default_conf_usdt, ticker_usdt, limit_buy_order_usdt,
-                                      fee, mocker) -> None:
+def test_create_trade_no_stake_amount(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     patch_wallet(mocker, free=default_conf_usdt['stake_amount'] * 0.5)
@@ -1477,7 +1475,7 @@ def test_handle_stoploss_on_exchange_custom_stop(
     assert freqtrade.handle_trade(trade) is True
 
 
-def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
+def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee,
                                               limit_buy_order_usdt, limit_sell_order_usdt) -> None:
 
     # When trailing stoploss is set
@@ -2125,7 +2123,7 @@ def test_check_handle_cancelled_buy(default_conf_usdt, ticker_usdt, limit_buy_or
     assert log_has_re("Buy order cancelled on exchange for Trade.*", caplog)
 
 
-def test_check_handle_timedout_buy_exception(default_conf_usdt, ticker_usdt, limit_buy_order_old,
+def test_check_handle_timedout_buy_exception(default_conf_usdt, ticker_usdt,
                                              open_trade, fee, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock()
@@ -3253,7 +3251,7 @@ def test_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usdt,
     assert trade.sell_reason == SellType.ROI.value
 
 
-def test_trailing_stop_loss(default_conf_usdt, limit_buy_order_usdt_open, limit_buy_order_usdt,
+def test_trailing_stop_loss(default_conf_usdt, limit_buy_order_usdt_open,
                             fee, caplog, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
@@ -3724,7 +3722,7 @@ def test_get_real_amount_open_trade(default_conf_usdt, fee, mocker):
     (8.0, 0.1, 8.0, 8.0),
     (8.0, 0.1, 7.9, 7.9),
 ])
-def test_apply_fee_conditional(default_conf_usdt, fee, caplog, mocker,
+def test_apply_fee_conditional(default_conf_usdt, fee, mocker,
                                amount, fee_abs, wallet, amount_exp):
     walletmock = mocker.patch('freqtrade.wallets.Wallets.update')
     mocker.patch('freqtrade.wallets.Wallets.get_free', return_value=wallet)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1483,9 +1483,9 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
         fetch_ticker=MagicMock(return_value={
-            'bid': 1.9,
+            'bid': 2.19,
             'ask': 2.2,
-            'last': 1.9
+            'last': 2.19
         }),
         create_order=MagicMock(side_effect=[
             {'id': limit_buy_order_usdt['id']},
@@ -1540,7 +1540,7 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     # stoploss initially at 20% as edge dictated it.
     assert freqtrade.handle_trade(trade) is False
     assert freqtrade.handle_stoploss_on_exchange(trade) is False
-    assert trade.stop_loss == 2.178
+    assert isclose(trade.stop_loss, 1.76)
 
     cancel_order_mock = MagicMock()
     stoploss_order_mock = MagicMock()
@@ -1549,15 +1549,15 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
 
     # price goes down 5%
     mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', MagicMock(return_value={
-        'bid': 1.9 * 0.95,
+        'bid': 2.19 * 0.95,
         'ask': 2.2 * 0.95,
-        'last': 1.9 * 0.95
+        'last': 2.19 * 0.95
     }))
     assert freqtrade.handle_trade(trade) is False
     assert freqtrade.handle_stoploss_on_exchange(trade) is False
 
     # stoploss should remain the same
-    assert trade.stop_loss == 2.178
+    assert isclose(trade.stop_loss, 1.76)
 
     # stoploss on exchange should not be canceled
     cancel_order_mock.assert_not_called()
@@ -1575,10 +1575,12 @@ def test_tsl_on_exchange_compatible_with_edge(mocker, edge_conf, fee, caplog,
     # stoploss should be set to 1% as trailing is on
     assert trade.stop_loss == 4.4 * 0.99
     cancel_order_mock.assert_called_once_with(100, 'NEO/BTC')
-    stoploss_order_mock.assert_called_once_with(amount=2132892.49146757,
-                                                pair='NEO/BTC',
-                                                order_types=freqtrade.strategy.order_types,
-                                                stop_price=4.4 * 0.99)
+    stoploss_order_mock.assert_called_once_with(
+        amount=11.41438356,
+        pair='NEO/BTC',
+        order_types=freqtrade.strategy.order_types,
+        stop_price=4.4 * 0.99
+    )
 
 
 @pytest.mark.parametrize('return_value,side_effect,log_message', [

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -126,16 +126,16 @@ def test_get_trade_stake_amount(default_conf, ticker, mocker) -> None:
 
 
 @pytest.mark.parametrize("amend_last,wallet,max_open,lsamr,expected", [
-                        (False, 0.002, 2, 0.5, [0.001, None]),
-                        (True, 0.002, 2, 0.5, [0.001, 0.00098]),
-                        (False, 0.003, 3, 0.5, [0.001, 0.001, None]),
-                        (True, 0.003, 3, 0.5, [0.001, 0.001, 0.00097]),
-                        (False, 0.0022, 3, 0.5, [0.001, 0.001, None]),
-                        (True, 0.0022, 3, 0.5, [0.001, 0.001, 0.0]),
-                        (True, 0.0027, 3, 0.5, [0.001, 0.001, 0.000673]),
-                        (True, 0.0022, 3, 1, [0.001, 0.001, 0.0]),
+                        (False, 20, 2, 0.5, [10, None]),
+                        (True, 20, 2, 0.5, [10, 9.8]),
+                        (False, 30, 3, 0.5, [10, 10, None]),
+                        (True, 30, 3, 0.5, [10, 10, 9.7]),
+                        (False, 22, 3, 0.5, [10, 10, None]),
+                        (True, 22, 3, 0.5, [10, 10, 0.0]),
+                        (True, 27, 3, 0.5, [10, 10, 6.73]),
+                        (True, 22, 3, 1, [10, 10, 0.0]),
 ])
-def test_check_available_stake_amount(default_conf, ticker, mocker, fee, limit_buy_order_usdt_open,
+def test_check_available_stake_amount(default_conf_usdt, ticker, mocker, fee, limit_buy_order_usdt_open,
                                       amend_last, wallet, max_open, lsamr, expected) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
@@ -145,12 +145,12 @@ def test_check_available_stake_amount(default_conf, ticker, mocker, fee, limit_b
         create_order=MagicMock(return_value=limit_buy_order_usdt_open),
         get_fee=fee
     )
-    default_conf['dry_run_wallet'] = wallet
+    default_conf_usdt['dry_run_wallet'] = wallet
 
-    default_conf['amend_last_stake_amount'] = amend_last
-    default_conf['last_stake_amount_min_ratio'] = lsamr
+    default_conf_usdt['amend_last_stake_amount'] = amend_last
+    default_conf_usdt['last_stake_amount_min_ratio'] = lsamr
 
-    freqtrade = FreqtradeBot(default_conf)
+    freqtrade = FreqtradeBot(default_conf_usdt)
 
     for i in range(0, max_open):
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1162,7 +1162,7 @@ def test_create_stoploss_order_insufficient_funds(mocker, default_conf, caplog, 
     assert mock_insuf.call_count == 1
 
 
-@pytest.mark.usefixtures("init_persistence_usdt")
+@pytest.mark.usefixtures("init_persistence")
 def test_handle_stoploss_on_exchange_trailing(mocker, default_conf_usdt, fee,
                                               limit_buy_order_usdt, limit_sell_order_usdt) -> None:
     # When trailing stoploss is set
@@ -1353,7 +1353,7 @@ def test_handle_stoploss_on_exchange_trailing_error(mocker, default_conf, fee, c
     assert log_has_re(r"Could not create trailing stoploss order for pair ETH/BTC\..*", caplog)
 
 
-@pytest.mark.usefixtures("init_persistence_usdt")
+@pytest.mark.usefixtures("init_persistence")
 def test_handle_stoploss_on_exchange_custom_stop(
         mocker, default_conf_usdt, fee, limit_buy_order_usdt, limit_sell_order_usdt) -> None:
     # When trailing stoploss is set
@@ -4043,7 +4043,7 @@ def test_update_closed_trades_without_assigned_fees(mocker, default_conf, fee):
             assert trade.fee_close_currency is not None
 
 
-@pytest.mark.usefixtures("init_persistence_usdt")
+@pytest.mark.usefixtures("init_persistence")
 def test_reupdate_enter_order_fees(mocker, default_conf_usdt, fee, caplog):
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
     mock_uts = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.update_trade_state')

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1612,32 +1612,6 @@ def test_enter_positions(mocker, default_conf_usdt, return_value, side_effect,
     assert mock_ct.call_count == len(default_conf_usdt['exchange']['pair_whitelist'])
 
 
-def test_exit_positions(mocker, default_conf_usdt, limit_buy_order_usdt, caplog) -> None:
-    freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
-
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.handle_trade', MagicMock(return_value=True))
-    mocker.patch('freqtrade.exchange.Exchange.fetch_order', return_value=limit_buy_order_usdt)
-    mocker.patch('freqtrade.exchange.Exchange.get_trades_for_order', return_value=[])
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.get_real_amount',
-                 return_value=limit_buy_order_usdt['amount'])
-
-    trade = MagicMock()
-    trade.open_order_id = '123'
-    trade.open_fee = 0.001
-    trades = [trade]
-    n = freqtrade.exit_positions(trades)
-    assert n == 0
-    # Test amount not modified by fee-logic
-    assert not log_has(
-        'Applying fee to amount for Trade {} from 30.0 to 90.81'.format(trade), caplog
-    )
-
-    mocker.patch('freqtrade.freqtradebot.FreqtradeBot.get_real_amount', return_value=90.81)
-    # test amount modified by fee-logic
-    n = freqtrade.exit_positions(trades)
-    assert n == 0
-
-
 def test_exit_positions_exception(mocker, default_conf_usdt, limit_buy_order_usdt, caplog) -> None:
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
     mocker.patch('freqtrade.exchange.Exchange.fetch_order', return_value=limit_buy_order_usdt)

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2672,8 +2672,10 @@ def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fe
         get_fee=fee,
         _is_dry_limit_order_filled=MagicMock(return_value=False),
     )
-    patch_whitelist(mocker, default_conf_usdt)
-    freqtrade = FreqtradeBot(default_conf_usdt)
+    config = deepcopy(default_conf_usdt)
+    config['custom_price_max_distance_ratio'] = 0.1
+    patch_whitelist(mocker, config)
+    freqtrade = FreqtradeBot(config)
     patch_get_signal(freqtrade)
     freqtrade.strategy.confirm_trade_exit = MagicMock(return_value=False)
 
@@ -2716,8 +2718,8 @@ def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fe
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.3,
-        'profit_amount': 6.041e-05,
-        'profit_ratio': 0.07262344,
+        'profit_amount': 1.196875,
+        'profit_ratio': 0.11938903,
         'stake_currency': 'USDT',
         'fiat_currency': 'USD',
         'sell_reason': SellType.SELL_SIGNAL.value,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1207,6 +1207,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf, fee,
     patch_get_signal(freqtrade)
 
     freqtrade.enter_positions()
+    # TODO-lev: Get this trade switched to the usdt trades
     trade = Trade.query.first()
     trade.is_open = True
     trade.open_order_id = None
@@ -1709,17 +1710,20 @@ def test_update_trade_state_withorderdict(default_conf, trades_for_order, limit_
     patch_exchange(mocker)
     amount = sum(x['amount'] for x in trades_for_order)
     freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    caplog.clear()
     trade = Trade(
-        pair='LTC/ETH',
+        pair='LTC/USDT',
         amount=amount,
         exchange='binance',
-        open_rate=0.245441,
+        open_rate=2.0,
         open_date=arrow.utcnow().datetime,
         fee_open=fee.return_value,
         fee_close=fee.return_value,
         open_order_id="123456",
         is_open=True,
     )
+    # TODO-lev: caplog.text has Amount 60.00000000000001 does not match amount 60.00000000000001
+    # TODO-lev: but they are the exact same
     freqtrade.update_trade_state(trade, '123456', limit_buy_order_usdt)
     assert trade.amount != amount
     assert trade.amount == limit_buy_order_usdt['amount']

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -270,7 +270,7 @@ def test_total_open_trades_stakes(mocker, default_conf, ticker, fee) -> None:
     assert Trade.total_open_trades_stakes() == 1.97502e-03
 
 
-def test_create_trade(default_conf, ticker, limit_buy_order_usdt, fee, mocker) -> None:
+def test_create_trade(default_conf_usdt, ticker, limit_buy_order_usdt, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -281,14 +281,14 @@ def test_create_trade(default_conf, ticker, limit_buy_order_usdt, fee, mocker) -
     )
 
     # Save state of current whitelist
-    whitelist = deepcopy(default_conf['exchange']['pair_whitelist'])
-    freqtrade = FreqtradeBot(default_conf)
+    whitelist = deepcopy(default_conf_usdt['exchange']['pair_whitelist'])
+    freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
     freqtrade.create_trade('ETH/BTC')
 
     trade = Trade.query.first()
     assert trade is not None
-    assert trade.stake_amount == 0.001
+    assert trade.stake_amount == 10.0
     assert trade.is_open
     assert trade.open_date is not None
     assert trade.exchange == 'binance'
@@ -299,7 +299,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order_usdt, fee, mocker) -
     assert trade.open_rate == 2.0
     assert trade.amount == 30.0
 
-    assert whitelist == default_conf['exchange']['pair_whitelist']
+    assert whitelist == default_conf_usdt['exchange']['pair_whitelist']
 
 
 def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order_usdt,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1260,7 +1260,7 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf_usdt, fee,
 
     cancel_order_mock.assert_called_once_with(100, 'ETH/BTC')
     stoploss_order_mock.assert_called_once_with(
-        amount=27.39726027,
+        amount=4.56621004,
         pair='ETH/BTC',
         order_types=freqtrade.strategy.order_types,
         stop_price=4.4 * 0.95
@@ -1451,7 +1451,7 @@ def test_handle_stoploss_on_exchange_custom_stop(
 
     cancel_order_mock.assert_called_once_with(100, 'ETH/BTC')
     stoploss_order_mock.assert_called_once_with(
-        amount=31.57894736,
+        amount=5.26315789,
         pair='ETH/BTC',
         order_types=freqtrade.strategy.order_types,
         stop_price=4.4 * 0.96

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2581,7 +2581,6 @@ def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_
         'order_type': 'limit',
         'open_rate': 2.0,
         'current_rate': 2.3,
-        # TODO: Double check that profit_amount and profit_ratio are correct
         'profit_amount': 0.9475,
         'profit_ratio': 0.09451372,
         'stake_currency': 'USDT',
@@ -2624,7 +2623,6 @@ def test_execute_trade_exit_down(default_conf_usdt, ticker_usdt, fee, ticker_usd
 
     assert rpc_mock.call_count == 2
     last_msg = rpc_mock.call_args_list[-1][0][0]
-    # TODO: Should be a loss, but comes out as a gain
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,
@@ -2751,7 +2749,6 @@ def test_execute_trade_exit_down_stoploss_on_exchange_dry_run(
     assert rpc_mock.call_count == 2
     last_msg = rpc_mock.call_args_list[-1][0][0]
 
-    # TODO: Are these values correct?
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,
@@ -3274,7 +3271,6 @@ def test_trailing_stop_loss(default_conf_usdt, limit_buy_order_usdt_open,
     caplog.set_level(logging.DEBUG)
     # Sell as trailing-stop is reached
     assert freqtrade.handle_trade(trade) is True
-    # TODO: Does this make sense? How is stoploss 2.7?
     assert log_has("ETH/USDT - HIT STOP: current price at 2.200000, stoploss is 2.700000, "
                    "initial stoploss was at 1.800000, trade opened at 2.000000", caplog)
     assert trade.sell_reason == SellType.TRAILING_STOP_LOSS.value

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -23,9 +23,9 @@ from freqtrade.worker import Worker
 from tests.conftest import (create_mock_trades, get_patched_freqtradebot, get_patched_worker,
                             log_has, log_has_re, patch_edge, patch_exchange, patch_get_signal,
                             patch_wallet, patch_whitelist)
-from tests.conftest_trades import (
-    MOCK_TRADE_COUNT, mock_order_1, mock_order_2, mock_order_2_sell, mock_order_3,
-    mock_order_3_sell, mock_order_4, mock_order_5_stoploss, mock_order_6_sell)
+from tests.conftest_trades import (MOCK_TRADE_COUNT, mock_order_1, mock_order_2, mock_order_2_sell,
+                                   mock_order_3, mock_order_3_sell, mock_order_4,
+                                   mock_order_5_stoploss, mock_order_6_sell)
 
 
 def patch_RPCManager(mocker) -> MagicMock:
@@ -135,8 +135,10 @@ def test_get_trade_stake_amount(default_conf_usdt, ticker_usdt, mocker) -> None:
                         (True, 27, 3, 0.5, [10, 10, 6.73]),
                         (True, 22, 3, 1, [10, 10, 0.0]),
 ])
-def test_check_available_stake_amount(default_conf_usdt, ticker_usdt, mocker, fee, limit_buy_order_usdt_open,
-                                      amend_last, wallet, max_open, lsamr, expected) -> None:
+def test_check_available_stake_amount(
+    default_conf_usdt, ticker_usdt, mocker, fee, limit_buy_order_usdt_open,
+    amend_last, wallet, max_open, lsamr, expected
+) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -363,8 +365,8 @@ def test_create_trade_minimal_amount(
     (["ETH/USDT"], 1),  # No pairs left
     ([], 0),  # No pairs in whitelist
 ])
-def test_enter_positions_no_pairs_left(default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open, fee,
-                                       whitelist, positions, mocker, caplog) -> None:
+def test_enter_positions_no_pairs_left(default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open,
+                                       fee, whitelist, positions, mocker, caplog) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -459,8 +461,10 @@ def test_create_trade_no_signal(default_conf_usdt, fee, mocker) -> None:
 
 @pytest.mark.parametrize("max_open", range(0, 5))
 @pytest.mark.parametrize("tradable_balance_ratio,modifier", [(1.0, 1), (0.99, 0.8), (0.5, 0.5)])
-def test_create_trades_multiple_trades(default_conf_usdt, ticker_usdt, fee, mocker, limit_buy_order_usdt_open,
-                                       max_open, tradable_balance_ratio, modifier) -> None:
+def test_create_trades_multiple_trades(
+    default_conf_usdt, ticker_usdt, fee, mocker, limit_buy_order_usdt_open,
+    max_open, tradable_balance_ratio, modifier
+) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     default_conf_usdt['max_open_trades'] = max_open
@@ -484,7 +488,8 @@ def test_create_trades_multiple_trades(default_conf_usdt, ticker_usdt, fee, mock
     assert len(trades) == max(int(max_open * modifier), 0)
 
 
-def test_create_trades_preopen(default_conf_usdt, ticker_usdt, fee, mocker, limit_buy_order_usdt_open) -> None:
+def test_create_trades_preopen(default_conf_usdt, ticker_usdt, fee, mocker,
+                               limit_buy_order_usdt_open) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     default_conf_usdt['max_open_trades'] = 4
@@ -513,8 +518,8 @@ def test_create_trades_preopen(default_conf_usdt, ticker_usdt, fee, mocker, limi
     assert len(trades) == 4
 
 
-def test_process_trade_creation(default_conf_usdt, ticker_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,
-                                fee, mocker, caplog) -> None:
+def test_process_trade_creation(default_conf_usdt, ticker_usdt, limit_buy_order_usdt,
+                                limit_buy_order_usdt_open, fee, mocker, caplog) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -584,7 +589,8 @@ def test_process_operational_exception(default_conf_usdt, ticker_usdt, mocker) -
     assert 'OperationalException' in msg_mock.call_args_list[-1][0][0]['status']
 
 
-def test_process_trade_handling(default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open, fee, mocker) -> None:
+def test_process_trade_handling(default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open, fee,
+                                mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -690,7 +696,8 @@ def test_process_informative_pairs_added(default_conf_usdt, ticker_usdt, mocker)
     assert ("ETH/USDT", default_conf_usdt["timeframe"]) in refresh_mock.call_args[0][0]
 
 
-def test_execute_entry(mocker, default_conf_usdt, fee, limit_buy_order_usdt, limit_buy_order_usdt_open) -> None:
+def test_execute_entry(mocker, default_conf_usdt, fee, limit_buy_order_usdt,
+                       limit_buy_order_usdt_open) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     freqtrade = FreqtradeBot(default_conf_usdt)
@@ -1278,8 +1285,9 @@ def test_handle_stoploss_on_exchange_trailing(mocker, default_conf_usdt, fee,
     assert freqtrade.handle_trade(trade) is True
 
 
-def test_handle_stoploss_on_exchange_trailing_error(mocker, default_conf_usdt, fee, caplog,
-                                                    limit_buy_order_usdt, limit_sell_order_usdt) -> None:
+def test_handle_stoploss_on_exchange_trailing_error(
+        mocker, default_conf_usdt, fee, caplog, limit_buy_order_usdt, limit_sell_order_usdt
+) -> None:
     # When trailing stoploss is set
     stoploss = MagicMock(return_value={'id': 13434334})
     patch_exchange(mocker)
@@ -1701,8 +1709,8 @@ def test_update_trade_state(mocker, default_conf_usdt, limit_buy_order_usdt, cap
     (30.0 + 1e-14, True),
     (8.0, False)
 ])
-def test_update_trade_state_withorderdict(default_conf_usdt, trades_for_order, limit_buy_order_usdt, fee,
-                                          mocker, initial_amount, has_rounding_fee, caplog):
+def test_update_trade_state_withorderdict(default_conf_usdt, trades_for_order, limit_buy_order_usdt,
+                                          fee, mocker, initial_amount, has_rounding_fee, caplog):
     trades_for_order[0]['amount'] = initial_amount
     mocker.patch('freqtrade.exchange.Exchange.get_trades_for_order', return_value=trades_for_order)
     # fetch_order should not be called!!
@@ -1798,8 +1806,8 @@ def test_update_trade_state_sell(default_conf_usdt, trades_for_order, limit_sell
     assert order.status == 'closed'
 
 
-def test_handle_trade(default_conf_usdt, limit_buy_order_usdt, limit_sell_order_usdt_open, limit_sell_order_usdt,
-                      fee, mocker) -> None:
+def test_handle_trade(default_conf_usdt, limit_buy_order_usdt, limit_sell_order_usdt_open,
+                      limit_sell_order_usdt, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -1963,8 +1971,8 @@ def test_handle_trade_use_sell_signal(default_conf_usdt, ticker_usdt, limit_buy_
                    caplog)
 
 
-def test_close_trade(default_conf_usdt, ticker_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open, limit_sell_order_usdt,
-                     fee, mocker) -> None:
+def test_close_trade(default_conf_usdt, ticker_usdt, limit_buy_order_usdt,
+                     limit_buy_order_usdt_open, limit_sell_order_usdt, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2003,8 +2011,8 @@ def test_bot_loop_start_called_once(mocker, default_conf_usdt, caplog):
     assert ftbot.strategy.analyze.call_count == 1
 
 
-def test_check_handle_timedout_buy_usercustom(default_conf_usdt, ticker_usdt, limit_buy_order_old, open_trade,
-                                              fee, mocker) -> None:
+def test_check_handle_timedout_buy_usercustom(default_conf_usdt, ticker_usdt, limit_buy_order_old,
+                                              open_trade, fee, mocker) -> None:
     default_conf_usdt["unfilledtimeout"] = {"buy": 1400, "sell": 30}
 
     rpc_mock = patch_RPCManager(mocker)
@@ -2117,8 +2125,8 @@ def test_check_handle_cancelled_buy(default_conf_usdt, ticker_usdt, limit_buy_or
     assert log_has_re("Buy order cancelled on exchange for Trade.*", caplog)
 
 
-def test_check_handle_timedout_buy_exception(default_conf_usdt, ticker_usdt, limit_buy_order_old, open_trade,
-                                             fee, mocker) -> None:
+def test_check_handle_timedout_buy_exception(default_conf_usdt, ticker_usdt, limit_buy_order_old,
+                                             open_trade, fee, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock()
     patch_exchange(mocker)
@@ -2143,8 +2151,8 @@ def test_check_handle_timedout_buy_exception(default_conf_usdt, ticker_usdt, lim
     assert nb_trades == 1
 
 
-def test_check_handle_timedout_sell_usercustom(default_conf_usdt, ticker_usdt, limit_sell_order_old, mocker,
-                                               open_trade) -> None:
+def test_check_handle_timedout_sell_usercustom(default_conf_usdt, ticker_usdt, limit_sell_order_old,
+                                               mocker, open_trade) -> None:
     default_conf_usdt["unfilledtimeout"] = {"buy": 1440, "sell": 1440}
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock()
@@ -2222,8 +2230,8 @@ def test_check_handle_timedout_sell(default_conf_usdt, ticker_usdt, limit_sell_o
     assert freqtrade.strategy.check_sell_timeout.call_count == 0
 
 
-def test_check_handle_cancelled_sell(default_conf_usdt, ticker_usdt, limit_sell_order_old, open_trade,
-                                     mocker, caplog) -> None:
+def test_check_handle_cancelled_sell(default_conf_usdt, ticker_usdt, limit_sell_order_old,
+                                     open_trade, mocker, caplog) -> None:
     """ Handle sell order cancelled on exchange"""
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock()
@@ -2319,8 +2327,8 @@ def test_check_handle_timedout_partial_fee(default_conf_usdt, ticker_usdt, open_
     assert pytest.approx(trades[0].fee_open) == 0.001
 
 
-def test_check_handle_timedout_partial_except(default_conf_usdt, ticker_usdt, open_trade, caplog, fee,
-                                              limit_buy_order_old_partial, trades_for_order,
+def test_check_handle_timedout_partial_except(default_conf_usdt, ticker_usdt, open_trade, caplog,
+                                              fee, limit_buy_order_old_partial, trades_for_order,
                                               limit_buy_order_old_partial_canceled, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     cancel_order_mock = MagicMock(return_value=limit_buy_order_old_partial_canceled)
@@ -2359,7 +2367,8 @@ def test_check_handle_timedout_partial_except(default_conf_usdt, ticker_usdt, op
     assert trades[0].fee_open == fee()
 
 
-def test_check_handle_timedout_exception(default_conf_usdt, ticker_usdt, open_trade_usdt, mocker, caplog) -> None:
+def test_check_handle_timedout_exception(default_conf_usdt, ticker_usdt, open_trade_usdt, mocker,
+                                         caplog) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     cancel_order_mock = MagicMock()
@@ -2546,7 +2555,8 @@ def test_handle_cancel_exit_cancel_exception(mocker, default_conf_usdt) -> None:
     assert freqtrade.handle_cancel_exit(trade, order, reason) == 'error cancelling order'
 
 
-def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_up, mocker) -> None:
+def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_up, mocker
+                               ) -> None:
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2611,7 +2621,8 @@ def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_
     } == last_msg
 
 
-def test_execute_trade_exit_down(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down, mocker) -> None:
+def test_execute_trade_exit_down(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down,
+                                 mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2664,8 +2675,8 @@ def test_execute_trade_exit_down(default_conf_usdt, ticker_usdt, fee, ticker_usd
     } == last_msg
 
 
-def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_up,
-                                              mocker) -> None:
+def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fee,
+                                              ticker_usdt_sell_up, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2731,8 +2742,8 @@ def test_execute_trade_exit_custom_exit_price(default_conf_usdt, ticker_usdt, fe
     } == last_msg
 
 
-def test_execute_trade_exit_down_stoploss_on_exchange_dry_run(default_conf_usdt, ticker_usdt, fee,
-                                                              ticker_usdt_sell_down, mocker) -> None:
+def test_execute_trade_exit_down_stoploss_on_exchange_dry_run(
+        default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down, mocker) -> None:
     rpc_mock = patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -2825,8 +2836,8 @@ def test_execute_trade_exit_sloe_cancel_exception(
     assert log_has('Could not cancel stoploss order abcd', caplog)
 
 
-def test_execute_trade_exit_with_stoploss_on_exchange(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_up,
-                                                      mocker) -> None:
+def test_execute_trade_exit_with_stoploss_on_exchange(default_conf_usdt, ticker_usdt, fee,
+                                                      ticker_usdt_sell_up, mocker) -> None:
 
     default_conf_usdt['exchange']['name'] = 'binance'
     rpc_mock = patch_RPCManager(mocker)
@@ -3169,7 +3180,8 @@ def test__safe_exit_amount(default_conf_usdt, fee, caplog, mocker, amount_wallet
         assert wallet_update.call_count == 1
 
 
-def test_locked_pairs(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down, mocker, caplog) -> None:
+def test_locked_pairs(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down, mocker,
+                      caplog) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -3204,8 +3216,8 @@ def test_locked_pairs(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_down
     assert log_has_re(f"Pair {trade.pair} is still locked.*", caplog)
 
 
-def test_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,
-                                  fee, mocker) -> None:
+def test_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usdt,
+                                  limit_buy_order_usdt_open, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -3301,8 +3313,10 @@ def test_trailing_stop_loss(default_conf_usdt, limit_buy_order_usdt_open, limit_
     (0.011, False, 2.0394),
     (0.055, True, 1.8),
 ])
-def test_trailing_stop_loss_positive(default_conf_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,
-                                     offset, fee, caplog, mocker, trail_if_reached, second_sl) -> None:
+def test_trailing_stop_loss_positive(
+    default_conf_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,
+    offset, fee, caplog, mocker, trail_if_reached, second_sl
+) -> None:
     buy_price = limit_buy_order_usdt['price']
     patch_RPCManager(mocker)
     patch_exchange(mocker)
@@ -3391,8 +3405,8 @@ def test_trailing_stop_loss_positive(default_conf_usdt, limit_buy_order_usdt, li
     assert trade.sell_reason == SellType.TRAILING_STOP_LOSS.value
 
 
-def test_disable_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usdt, limit_buy_order_usdt_open,
-                                          fee, mocker) -> None:
+def test_disable_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usdt,
+                                          limit_buy_order_usdt_open, fee, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)
     mocker.patch.multiple(
@@ -3431,7 +3445,8 @@ def test_disable_ignore_roi_if_buy_signal(default_conf_usdt, limit_buy_order_usd
     assert trade.sell_reason == SellType.SELL_SIGNAL.value
 
 
-def test_get_real_amount_quote(default_conf_usdt, trades_for_order, buy_order_fee, fee, caplog, mocker):
+def test_get_real_amount_quote(default_conf_usdt, trades_for_order, buy_order_fee, fee, caplog,
+                               mocker):
     mocker.patch('freqtrade.exchange.Exchange.get_trades_for_order', return_value=trades_for_order)
     amount = sum(x['amount'] for x in trades_for_order)
     trade = Trade(
@@ -3608,7 +3623,8 @@ def test_get_real_amount_multi(
     assert trade.fee_close_currency is None
 
 
-def test_get_real_amount_invalid_order(default_conf_usdt, trades_for_order, buy_order_fee, fee, mocker):
+def test_get_real_amount_invalid_order(default_conf_usdt, trades_for_order, buy_order_fee, fee,
+                                       mocker):
     limit_buy_order_usdt = deepcopy(buy_order_fee)
     limit_buy_order_usdt['fee'] = {'cost': 0.004}
 
@@ -3629,7 +3645,8 @@ def test_get_real_amount_invalid_order(default_conf_usdt, trades_for_order, buy_
     assert freqtrade.get_real_amount(trade, limit_buy_order_usdt) == amount
 
 
-def test_get_real_amount_wrong_amount(default_conf_usdt, trades_for_order, buy_order_fee, fee, mocker):
+def test_get_real_amount_wrong_amount(default_conf_usdt, trades_for_order, buy_order_fee, fee,
+                                      mocker):
     limit_buy_order_usdt = deepcopy(buy_order_fee)
     limit_buy_order_usdt['amount'] = limit_buy_order_usdt['amount'] - 0.001
 
@@ -3651,8 +3668,8 @@ def test_get_real_amount_wrong_amount(default_conf_usdt, trades_for_order, buy_o
         freqtrade.get_real_amount(trade, limit_buy_order_usdt)
 
 
-def test_get_real_amount_wrong_amount_rounding(default_conf_usdt, trades_for_order, buy_order_fee, fee,
-                                               mocker):
+def test_get_real_amount_wrong_amount_rounding(default_conf_usdt, trades_for_order, buy_order_fee,
+                                               fee, mocker):
     # Floats should not be compared directly.
     limit_buy_order_usdt = deepcopy(buy_order_fee)
     trades_for_order[0]['amount'] = trades_for_order[0]['amount'] + 1e-15
@@ -3671,8 +3688,11 @@ def test_get_real_amount_wrong_amount_rounding(default_conf_usdt, trades_for_ord
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
 
     # Amount changes by fee amount.
-    assert isclose(freqtrade.get_real_amount(trade, limit_buy_order_usdt), amount - (amount * 0.001),
-                   abs_tol=MATH_CLOSE_PREC,)
+    assert isclose(
+        freqtrade.get_real_amount(trade, limit_buy_order_usdt),
+        amount - (amount * 0.001),
+        abs_tol=MATH_CLOSE_PREC,
+    )
 
 
 def test_get_real_amount_open_trade(default_conf_usdt, fee, mocker):
@@ -3729,8 +3749,10 @@ def test_apply_fee_conditional(default_conf_usdt, fee, caplog, mocker,
     (0.1, False),
     (100, True),
 ])
-def test_order_book_depth_of_market(default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open, limit_buy_order_usdt,
-                                    fee, mocker, order_book_l2, delta, is_high_delta):
+def test_order_book_depth_of_market(
+    default_conf_usdt, ticker_usdt, limit_buy_order_usdt_open, limit_buy_order_usdt,
+    fee, mocker, order_book_l2, delta, is_high_delta
+):
     default_conf_usdt['bid_strategy']['check_depth_of_market']['enabled'] = True
     default_conf_usdt['bid_strategy']['check_depth_of_market']['bids_to_ask_delta'] = delta
     patch_RPCManager(mocker)
@@ -3821,8 +3843,9 @@ def test_check_depth_of_market_buy(default_conf_usdt, mocker, order_book_l2) -> 
     assert freqtrade._check_depth_of_market_buy('ETH/USDT', conf) is False
 
 
-def test_order_book_ask_strategy(default_conf_usdt, limit_buy_order_usdt_open, limit_buy_order_usdt, fee,
-                                 limit_sell_order_usdt_open, mocker, order_book_l2, caplog) -> None:
+def test_order_book_ask_strategy(
+        default_conf_usdt, limit_buy_order_usdt_open, limit_buy_order_usdt, fee,
+        limit_sell_order_usdt_open, mocker, order_book_l2, caplog) -> None:
     """
     test order book ask strategy
     """
@@ -3898,7 +3921,8 @@ def test_startup_trade_reinit(default_conf_usdt, edge_conf, mocker):
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_buy_order_usdt_open, caplog):
+def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_buy_order_usdt_open,
+                             caplog):
     default_conf_usdt['dry_run'] = True
     # Initialize to 2 times stake amount
     default_conf_usdt['dry_run_wallet'] = 20.0
@@ -3930,11 +3954,16 @@ def test_sync_wallet_dry_run(mocker, default_conf_usdt, ticker_usdt, fee, limit_
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test_cancel_all_open_orders(mocker, default_conf_usdt, fee, limit_buy_order_usdt, limit_sell_order_usdt):
+def test_cancel_all_open_orders(mocker, default_conf_usdt, fee, limit_buy_order_usdt,
+                                limit_sell_order_usdt):
     default_conf_usdt['cancel_open_orders_on_exit'] = True
     mocker.patch('freqtrade.exchange.Exchange.fetch_order',
                  side_effect=[
-                     ExchangeError(), limit_sell_order_usdt, limit_buy_order_usdt, limit_sell_order_usdt])
+                     ExchangeError(),
+                     limit_sell_order_usdt,
+                     limit_buy_order_usdt,
+                     limit_sell_order_usdt
+                 ])
     buy_mock = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.handle_cancel_enter')
     sell_mock = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.handle_cancel_exit')
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2962,11 +2962,10 @@ def test_execute_trade_exit_market_order(default_conf_usdt, ticker_usdt, fee,
                                  sell_reason=SellCheckTuple(sell_type=SellType.ROI))
 
     assert not trade.is_open
-    assert trade.close_profit == 0.09451372  # TODO: Check this is correct
+    assert trade.close_profit == 0.09451372
 
     assert rpc_mock.call_count == 3
     last_msg = rpc_mock.call_args_list[-1][0][0]
-    # TODO: Is this correct?
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,
@@ -3330,7 +3329,6 @@ def test_trailing_stop_loss_positive(
     )
     # stop-loss not reached, adjusted stoploss
     assert freqtrade.handle_trade(trade) is False
-    # TODO: is 0.0249% correct? Shouldn't it be higher?
     caplog_text = f"ETH/USDT - Using positive stoploss: 0.01 offset: {offset} profit: 0.0249%"
     if trail_if_reached:
         assert not log_has(caplog_text, caplog)


### PR DESCRIPTION
replaces limit_buy_order and limit_sell_order with limit_buy_order_usdt and limit_sell_order_usdt

Parametrizes some tests

I would double check these. I didn't completely understand every test, but I tried to swap with numbers that differed by equivalent percentages to the buy/sell price, and I felt that if the tests were working correctly before, then the new values produced by them should be the correct values

