### PR TITLE
Add CPU,RAM sysinfo support to the REST API to help with bot system m…

### DIFF
--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -348,6 +348,7 @@ class BacktestResponse(BaseModel):
     # TODO: Properly type backtestresult...
     backtest_result: Optional[Dict[str, Any]]
 
+
 class SysInfo(BaseModel):
     cpu_pct: float
     ram_pct: float

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -347,3 +347,7 @@ class BacktestResponse(BaseModel):
     trade_count: Optional[float]
     # TODO: Properly type backtestresult...
     backtest_result: Optional[Dict[str, Any]]
+
+class SysInfo(BaseModel):
+    cpu_pct: float
+    ram_pct: float

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -350,5 +350,5 @@ class BacktestResponse(BaseModel):
 
 
 class SysInfo(BaseModel):
-    cpu_pct: float
+    cpu_pct: List[float]
     ram_pct: float

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -18,7 +18,8 @@ from freqtrade.rpc.api_server.api_schemas import (AvailablePairs, Balances, Blac
                                                   OpenTradeSchema, PairHistory, PerformanceEntry,
                                                   Ping, PlotConfig, Profit, ResultMsg, ShowConfig,
                                                   Stats, StatusMsg, StrategyListResponse,
-                                                  StrategyResponse, SysInfo, Version, WhitelistResponse)
+                                                  StrategyResponse, SysInfo, Version,
+                                                  WhitelistResponse)
 from freqtrade.rpc.api_server.deps import get_config, get_rpc, get_rpc_optional
 from freqtrade.rpc.rpc import RPCException
 
@@ -259,6 +260,7 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
         'pair_interval': pair_interval,
     }
     return result
+
 
 @router.get('/sysinfo', response_model=SysInfo, tags=['info'])
 def sysinfo():

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -18,7 +18,7 @@ from freqtrade.rpc.api_server.api_schemas import (AvailablePairs, Balances, Blac
                                                   OpenTradeSchema, PairHistory, PerformanceEntry,
                                                   Ping, PlotConfig, Profit, ResultMsg, ShowConfig,
                                                   Stats, StatusMsg, StrategyListResponse,
-                                                  StrategyResponse, Version, WhitelistResponse)
+                                                  StrategyResponse, SysInfo, Version, WhitelistResponse)
 from freqtrade.rpc.api_server.deps import get_config, get_rpc, get_rpc_optional
 from freqtrade.rpc.rpc import RPCException
 
@@ -260,6 +260,6 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
     }
     return result
 
-@router.get('/sysinfo', tags=['info'])
-def sysinfo(rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_sysinfo()
+@router.get('/sysinfo', response_model=SysInfo, tags=['info'])
+def sysinfo():
+    return RPC._rpc_sysinfo()

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -259,3 +259,7 @@ def list_available_pairs(timeframe: Optional[str] = None, stake_currency: Option
         'pair_interval': pair_interval,
     }
     return result
+
+@router.get('/sysinfo', tags=['info'])
+def sysinfo(rpc: RPC = Depends(get_rpc)):
+    return rpc._rpc_sysinfo()

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1,7 +1,7 @@
 """
 This module contains class to define a RPC communications
 """
-import logging
+import logging, psutil
 from abc import abstractmethod
 from datetime import date, datetime, timedelta, timezone
 from math import isnan
@@ -870,3 +870,6 @@ class RPC:
                 'subplots' not in self._freqtrade.strategy.plot_config):
             self._freqtrade.strategy.plot_config['subplots'] = {}
         return self._freqtrade.strategy.plot_config
+
+    def _rpc_sysinfo(self) -> Dict[str, Any]:
+        return {"cpu_pct": psutil.cpu_percent(interval=1, percpu=True), "ram_pct": psutil.virtual_memory().percent}

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1,13 +1,14 @@
 """
 This module contains class to define a RPC communications
 """
-import logging, psutil
+import logging
 from abc import abstractmethod
 from datetime import date, datetime, timedelta, timezone
 from math import isnan
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import arrow
+import psutil
 from numpy import NAN, inf, int64, mean
 from pandas import DataFrame
 
@@ -873,4 +874,7 @@ class RPC:
 
     @staticmethod
     def _rpc_sysinfo() -> Dict[str, Any]:
-        return {"cpu_pct": psutil.cpu_percent(interval=1, percpu=True), "ram_pct": psutil.virtual_memory().percent}
+        return {
+            "cpu_pct": psutil.cpu_percent(interval=1, percpu=True),
+            "ram_pct": psutil.virtual_memory().percent
+        }

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -871,5 +871,6 @@ class RPC:
             self._freqtrade.strategy.plot_config['subplots'] = {}
         return self._freqtrade.strategy.plot_config
 
-    def _rpc_sysinfo(self) -> Dict[str, Any]:
+    @staticmethod
+    def _rpc_sysinfo() -> Dict[str, Any]:
         return {"cpu_pct": psutil.cpu_percent(interval=1, percpu=True), "ram_pct": psutil.virtual_memory().percent}

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ fastapi==0.68.1
 uvicorn==0.15.0
 pyjwt==2.1.0
 aiofiles==0.7.0
+psutil==5.8.0
 
 # Support for colorized terminal output
 colorama==0.4.4

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -341,6 +341,7 @@ class FtRestClient():
         """
         return self._get("sysinfo")
 
+
 def add_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("command",

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -334,6 +334,12 @@ class FtRestClient():
             "timerange": timerange if timerange else '',
         })
 
+    def sysinfo(self):
+        """Provides system information (CPU, RAM usage)
+
+        :return: json object
+        """
+        return self._get("sysinfo")
 
 def add_arguments():
     parser = argparse.ArgumentParser()

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1271,6 +1271,16 @@ def test_list_available_pairs(botclient):
     assert len(rc.json()['pair_interval']) == 1
 
 
+def test_sysinfo(botclient):
+    ftbot, client = botclient
+
+    rc = client_get(client, f"{BASE_URI}/sysinfo")
+    assert_response(rc)
+    result = rc.json()
+    assert 'cpu_pct' in result
+    assert 'ram_pct' in result
+
+
 def test_api_backtesting(botclient, mocker, fee, caplog):
     ftbot, client = botclient
     mocker.patch('freqtrade.exchange.Exchange.get_fee', fee)


### PR DESCRIPTION
…onitoring

## Summary

To add simple CPU and RAM usage support to the REST API.

## Quick changelog

- Add psutil requirement to requirements.txt
- Add psutil import and rpc function call to rpc.py
- Add api_v1 GET endpoint for RPC sysinfo call
- Add REST API client function

## What's new?

A simple addition of a new RPC function to get the underlying bot system's CPU and RAM usage to help with UI development.

e.g. in frogtrade9000

![image](https://user-images.githubusercontent.com/1872302/134775807-04475d97-ed49-4241-ac55-39382b806892.png)

