### PR TITLE
Add ability to ignore unparameterized spaces

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -51,6 +51,7 @@ usage: freqtrade hyperopt [-h] [-v] [--logfile FILE] [-V] [-c PATH] [-d PATH]
                           [--print-all] [--no-color] [--print-json] [-j JOBS]
                           [--random-state INT] [--min-trades INT]
                           [--hyperopt-loss NAME] [--disable-param-export]
+                          [--ignore-missing-spaces]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -117,6 +118,9 @@ optional arguments:
                         SortinoHyperOptLoss, SortinoHyperOptLossDaily
   --disable-param-export
                         Disable automatic hyperopt parameter export.
+  --ignore-missing-spaces, --ignore-unparameterized-spaces
+                        Suppress errors for any requested Hyperopt spaces that
+                        do not contain any parameters.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -31,7 +31,8 @@ ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "epochs", "spaces", "print_all",
                                         "print_colorized", "print_json", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
-                                        "hyperopt_loss", "disableparamexport"]
+                                        "hyperopt_loss", "disableparamexport", 
+                                        "hyperopt_ignore_unparam_space"]
 
 ARGS_EDGE = ARGS_COMMON_OPTIMIZE + ["stoploss_range"]
 

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -31,8 +31,8 @@ ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "epochs", "spaces", "print_all",
                                         "print_colorized", "print_json", "hyperopt_jobs",
                                         "hyperopt_random_state", "hyperopt_min_trades",
-                                        "hyperopt_loss", "disableparamexport", 
-                                        "hyperopt_ignore_unparam_space"]
+                                        "hyperopt_loss", "disableparamexport",
+                                        "hyperopt_ignore_missing_space"]
 
 ARGS_EDGE = ARGS_COMMON_OPTIMIZE + ["stoploss_range"]
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -554,7 +554,8 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "hyperopt_ignore_missing_space": Arg(
         "--ignore-missing-spaces", "--ignore-unparameterized-spaces",
-        help="Suppress errors for any requested Hyperopt spaces that do not contain any parameters",
+        help=("Suppress errors for any requested Hyperopt spaces "
+              "that do not contain any parameters."),
         action="store_true",
     ),
 }

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -552,4 +552,9 @@ AVAILABLE_CLI_OPTIONS = {
         help='Do not print epoch details header.',
         action='store_true',
     ),
+    "hyperopt_ignore_unparam_space": Arg(
+        "-u", "--ignore-unparameterized-spaces",
+        help="Suppress errors for any requested Hyperopt spaces that do not contain any parameters",
+        action="store_true",
+    ),
 }

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -552,8 +552,8 @@ AVAILABLE_CLI_OPTIONS = {
         help='Do not print epoch details header.',
         action='store_true',
     ),
-    "hyperopt_ignore_unparam_space": Arg(
-        "-u", "--ignore-unparameterized-spaces",
+    "hyperopt_ignore_missing_space": Arg(
+        "--ignore-missing-spaces", "--ignore-unparameterized-spaces",
         help="Suppress errors for any requested Hyperopt spaces that do not contain any parameters",
         action="store_true",
     ),

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -368,9 +368,9 @@ class Configuration:
 
         self._args_to_config(config, argname='hyperopt_show_no_header',
                              logstring='Parameter --no-header detected: {}')
-        
-        self._args_to_config(config, argname="hyperopt_ignore_unparam_space",
-                             logstring="Paramter --ignore-unparameterized-spaces detected: {}")
+
+        self._args_to_config(config, argname="hyperopt_ignore_missing_space",
+                             logstring="Paramter --ignore-missing-space detected: {}")
 
     def _process_plot_options(self, config: Dict[str, Any]) -> None:
 

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -368,6 +368,9 @@ class Configuration:
 
         self._args_to_config(config, argname='hyperopt_show_no_header',
                              logstring='Parameter --no-header detected: {}')
+        
+        self._args_to_config(config, argname="hyperopt_ignore_unparam_space",
+                             logstring="Paramter --ignore-unparameterized-spaces detected: {}")
 
     def _process_plot_options(self, config: Dict[str, Any]) -> None:
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -237,27 +237,63 @@ class Hyperopt:
             logger.debug("Hyperopt has 'protection' space")
             # Enable Protections if protection space is selected.
             self.config['enable_protections'] = True
-            self.protection_space = self.custom_hyperopt.protection_space()
+            try:
+                self.protection_space = self.custom_hyperopt.protection_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
 
         if HyperoptTools.has_space(self.config, 'buy'):
             logger.debug("Hyperopt has 'buy' space")
-            self.buy_space = self.custom_hyperopt.buy_indicator_space()
+            try:
+                self.buy_space = self.custom_hyperopt.buy_indicator_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
 
         if HyperoptTools.has_space(self.config, 'sell'):
             logger.debug("Hyperopt has 'sell' space")
-            self.sell_space = self.custom_hyperopt.sell_indicator_space()
+            try:
+                self.sell_space = self.custom_hyperopt.sell_indicator_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
 
         if HyperoptTools.has_space(self.config, 'roi'):
             logger.debug("Hyperopt has 'roi' space")
-            self.roi_space = self.custom_hyperopt.roi_space()
+            try:
+                self.roi_space = self.custom_hyperopt.roi_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
 
         if HyperoptTools.has_space(self.config, 'stoploss'):
             logger.debug("Hyperopt has 'stoploss' space")
-            self.stoploss_space = self.custom_hyperopt.stoploss_space()
+            try:
+                self.stoploss_space = self.custom_hyperopt.stoploss_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
 
         if HyperoptTools.has_space(self.config, 'trailing'):
             logger.debug("Hyperopt has 'trailing' space")
-            self.trailing_space = self.custom_hyperopt.trailing_space()
+            try:
+                self.trailing_space = self.custom_hyperopt.trailing_space()
+            except OperationalException as e:
+                if self.config["hyperopt_ignore_unparam_space"]:
+                    logger.warning(e)
+                else:
+                    raise
         self.dimensions = (self.buy_space + self.sell_space + self.protection_space
                            + self.roi_space + self.stoploss_space + self.trailing_space)
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -237,63 +237,28 @@ class Hyperopt:
             logger.debug("Hyperopt has 'protection' space")
             # Enable Protections if protection space is selected.
             self.config['enable_protections'] = True
-            try:
-                self.protection_space = self.custom_hyperopt.protection_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.protection_space = self.custom_hyperopt.protection_space()
 
         if HyperoptTools.has_space(self.config, 'buy'):
             logger.debug("Hyperopt has 'buy' space")
-            try:
-                self.buy_space = self.custom_hyperopt.buy_indicator_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.buy_space = self.custom_hyperopt.buy_indicator_space()
 
         if HyperoptTools.has_space(self.config, 'sell'):
             logger.debug("Hyperopt has 'sell' space")
-            try:
-                self.sell_space = self.custom_hyperopt.sell_indicator_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.sell_space = self.custom_hyperopt.sell_indicator_space()
 
         if HyperoptTools.has_space(self.config, 'roi'):
             logger.debug("Hyperopt has 'roi' space")
-            try:
-                self.roi_space = self.custom_hyperopt.roi_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.roi_space = self.custom_hyperopt.roi_space()
 
         if HyperoptTools.has_space(self.config, 'stoploss'):
             logger.debug("Hyperopt has 'stoploss' space")
-            try:
-                self.stoploss_space = self.custom_hyperopt.stoploss_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.stoploss_space = self.custom_hyperopt.stoploss_space()
 
         if HyperoptTools.has_space(self.config, 'trailing'):
             logger.debug("Hyperopt has 'trailing' space")
-            try:
-                self.trailing_space = self.custom_hyperopt.trailing_space()
-            except OperationalException as e:
-                if self.config["hyperopt_ignore_unparam_space"]:
-                    logger.warning(e)
-                else:
-                    raise
+            self.trailing_space = self.custom_hyperopt.trailing_space()
+
         self.dimensions = (self.buy_space + self.sell_space + self.protection_space
                            + self.roi_space + self.stoploss_space + self.trailing_space)
 

--- a/tests/optimize/test_hyperopt.py
+++ b/tests/optimize/test_hyperopt.py
@@ -702,7 +702,7 @@ def test_simplified_interface_roi_stoploss(mocker, hyperopt_conf, capsys) -> Non
     assert hasattr(hyperopt, "position_stacking")
 
 
-def test_simplified_interface_all_failed(mocker, hyperopt_conf) -> None:
+def test_simplified_interface_all_failed(mocker, hyperopt_conf, caplog) -> None:
     mocker.patch('freqtrade.optimize.hyperopt.dump', MagicMock())
     mocker.patch('freqtrade.optimize.hyperopt.file_dump_json')
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.load_bt_data',
@@ -724,7 +724,13 @@ def test_simplified_interface_all_failed(mocker, hyperopt_conf) -> None:
     hyperopt.custom_hyperopt.generate_roi_table = MagicMock(return_value={})
 
     with pytest.raises(OperationalException, match=r"The 'protection' space is included into *"):
-        hyperopt.start()
+        hyperopt.init_spaces()
+
+    hyperopt.config['hyperopt_ignore_missing_space'] = True
+    caplog.clear()
+    hyperopt.init_spaces()
+    assert log_has_re(r"The 'protection' space is included into *", caplog)
+    assert hyperopt.protection_space == []
 
 
 def test_simplified_interface_buy(mocker, hyperopt_conf, capsys) -> None:


### PR DESCRIPTION
## Summary

Suppress the errors generated by requesting optimization of a space (via the `--spaces` option) for a strategy that doesn't define any parameters for said spaces. Can be useful while developing and tweaking said parameters.

## Quick changelog

- Adding command line parameter `--ignore-unparameterized-spaces` to hyperopt subcommand

## What's new?

Using the `--ignore-unparameterized-spaces` flag for `freqtrade hyperopt` will log any `OperationalErrors` generated by unparameterized spaces as `WARN` as opposed to an `ERROR`.
