### PR TITLE
Fix pair_candles to point to correct API call

### DIFF
--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -312,7 +312,7 @@ class FtRestClient():
         :param limit: Limit result to the last n candles.
         :return: json object
         """
-        return self._get("available_pairs", params={
+        return self._get("pair_candles", params={
             "pair": pair,
             "timeframe": timeframe,
             "limit": limit,


### PR DESCRIPTION
## Summary

pair_candles pointed to available_pairs RPC call instead of pair_candles
