### PR TITLE
Added min_profit param to PerformanceFilter

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -194,17 +194,22 @@ Trade count is used as a tie breaker.
 You can use the `minutes` parameter to only consider performance of the past X minutes (rolling window).
 Not defining this parameter (or setting it to 0) will use all-time performance.
 
+The optional `min_profit` parameter defines the minimum profit a pair must have to be considered.
+Pairs below this level will be filtered out.
+Using this parameter without `minutes` is highly discouraged, as it can lead to an empty pairlist without without a way to recover.
+
 ```json
 "pairlists": [
     // ...
     {
         "method": "PerformanceFilter",
-        "minutes": 1440  // rolling 24h
+        "minutes": 1440,  // rolling 24h
+        "min_profit": 0.01
     }
 ],
 ```
 
-!!! Note
+!!! Warning "Backtesting"
     `PerformanceFilter` does not support backtesting mode.
 
 #### PrecisionFilter

--- a/freqtrade/plugins/pairlist/PerformanceFilter.py
+++ b/freqtrade/plugins/pairlist/PerformanceFilter.py
@@ -21,6 +21,7 @@ class PerformanceFilter(IPairList):
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
         self._minutes = pairlistconfig.get('minutes', 0)
+        self._min_profit = pairlistconfig.get('min_profit', None)
 
     @property
     def needstickers(self) -> bool:
@@ -68,6 +69,8 @@ class PerformanceFilter(IPairList):
         sorted_df = list_df.merge(performance, on='pair', how='left')\
             .fillna(0).sort_values(by=['count', 'pair'], ascending=True)\
             .sort_values(by=['profit'], ascending=False)
+        if self._min_profit is not None:
+            sorted_df = sorted_df[sorted_df['profit'] >= self._min_profit]
         pairlist = sorted_df['pair'].tolist()
 
         return pairlist

--- a/freqtrade/plugins/pairlist/PerformanceFilter.py
+++ b/freqtrade/plugins/pairlist/PerformanceFilter.py
@@ -70,7 +70,13 @@ class PerformanceFilter(IPairList):
             .fillna(0).sort_values(by=['count', 'pair'], ascending=True)\
             .sort_values(by=['profit'], ascending=False)
         if self._min_profit is not None:
+            removed = sorted_df[sorted_df['profit'] < self._min_profit]
+            for _, row in removed.iterrows():
+                self.log_once(
+                    f"Removing pair {row['pair']} since {row['profit']} is "
+                    f"below {self._min_profit}", logger.info)
             sorted_df = sorted_df[sorted_df['profit'] >= self._min_profit]
+
         pairlist = sorted_df['pair'].tolist()
 
         return pairlist


### PR DESCRIPTION
## Summary

As a user, I want to filter out pair by min profit (according to minutes param, it will be minimal profit during some time)

## Quick changelog

Added min_profit param to PerformanceFilter
