### PR TITLE
Hyperopt loss function using max drawdown

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -60,7 +60,7 @@ optional arguments:
                         Specify what timerange of data to use.
   --data-format-ohlcv {json,jsongz,hdf5}
                         Storage format for downloaded candle (OHLCV) data.
-                        (default: `None`).
+                        (default: `json`).
   --max-open-trades INT
                         Override the value of the `max_open_trades`
                         configuration setting.
@@ -114,7 +114,8 @@ optional arguments:
                         Hyperopt-loss-functions are:
                         ShortTradeDurHyperOptLoss, OnlyProfitHyperOptLoss,
                         SharpeHyperOptLoss, SharpeHyperOptLossDaily,
-                        SortinoHyperOptLoss, SortinoHyperOptLossDaily
+                        SortinoHyperOptLoss, SortinoHyperOptLossDaily,
+                        MaxDrawDownHyperOptLoss
   --disable-param-export
                         Disable automatic hyperopt parameter export.
 
@@ -512,12 +513,13 @@ This class should be in its own file within the `user_data/hyperopts/` directory
 
 Currently, the following loss functions are builtin:
 
-* `ShortTradeDurHyperOptLoss` (default legacy Freqtrade hyperoptimization loss function) - Mostly for short trade duration and avoiding losses.
-* `OnlyProfitHyperOptLoss` (which takes only amount of profit into consideration)
-* `SharpeHyperOptLoss` (optimizes Sharpe Ratio calculated on trade returns relative to standard deviation)
-* `SharpeHyperOptLossDaily` (optimizes Sharpe Ratio calculated on **daily** trade returns relative to standard deviation)
-* `SortinoHyperOptLoss` (optimizes Sortino Ratio calculated on trade returns relative to **downside** standard deviation)
-* `SortinoHyperOptLossDaily` (optimizes Sortino Ratio calculated on **daily** trade returns relative to **downside** standard deviation)
+* `ShortTradeDurHyperOptLoss` - (default legacy Freqtrade hyperoptimization loss function) - Mostly for short trade duration and avoiding losses.
+* `OnlyProfitHyperOptLoss` - takes only amount of profit into consideration.
+* `SharpeHyperOptLoss` - optimizes Sharpe Ratio calculated on trade returns relative to standard deviation.
+* `SharpeHyperOptLossDaily` - optimizes Sharpe Ratio calculated on **daily** trade returns relative to standard deviation.
+* `SortinoHyperOptLoss` - optimizes Sortino Ratio calculated on trade returns relative to **downside** standard deviation.
+* `SortinoHyperOptLossDaily` - optimizes Sortino Ratio calculated on **daily** trade returns relative to **downside** standard deviation.
+* `MaxDrawDownHyperOptLoss` - Optimizes Maximum drawdown.
 
 Creation of a custom loss function is covered in the [Advanced Hyperopt](advanced-hyperopt.md) part of the documentation.
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -24,7 +24,8 @@ ORDERTYPE_POSSIBILITIES = ['limit', 'market']
 ORDERTIF_POSSIBILITIES = ['gtc', 'fok', 'ioc']
 HYPEROPT_LOSS_BUILTIN = ['ShortTradeDurHyperOptLoss', 'OnlyProfitHyperOptLoss',
                          'SharpeHyperOptLoss', 'SharpeHyperOptLossDaily',
-                         'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily']
+                         'SortinoHyperOptLoss', 'SortinoHyperOptLossDaily',
+                         'MaxDrawDownHyperOptLoss']
 AVAILABLE_PAIRLISTS = ['StaticPairList', 'VolumePairList',
                        'AgeFilter', 'OffsetFilter', 'PerformanceFilter',
                        'PrecisionFilter', 'PriceFilter', 'RangeStabilityFilter',

--- a/freqtrade/optimize/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss_max_drawdown.py
@@ -5,10 +5,11 @@ This module defines the alternative HyperOptLoss class which can be used for
 Hyperoptimization.
 """
 from datetime import datetime
-from freqtrade.data.btanalysis import calculate_max_drawdown
-from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 from pandas import DataFrame
+
+from freqtrade.data.btanalysis import calculate_max_drawdown
+from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
 class MaxDrawDownHyperOptLoss(IHyperOptLoss):
@@ -31,7 +32,7 @@ class MaxDrawDownHyperOptLoss(IHyperOptLoss):
         Uses profit ratio weighted max_drawdown when drawdown is available.
         Otherwise directly optimizes profit ratio.
         """
-        total_profit = results['profit_ratio'].sum()        
+        total_profit = results['profit_ratio'].sum()
         try:
             max_drawdown = calculate_max_drawdown(results)
         except ValueError:

--- a/freqtrade/optimize/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss_max_drawdown.py
@@ -32,9 +32,9 @@ class MaxDrawDownHyperOptLoss(IHyperOptLoss):
         Uses profit ratio weighted max_drawdown when drawdown is available.
         Otherwise directly optimizes profit ratio.
         """
-        total_profit = results['profit_ratio'].sum()
+        total_profit = results['profit_abs'].sum()
         try:
-            max_drawdown = calculate_max_drawdown(results)
+            max_drawdown = calculate_max_drawdown(results, value_col='profit_abs')
         except ValueError:
             # No losing trade, therefore no drawdown.
             return -total_profit

--- a/freqtrade/optimize/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss_max_drawdown.py
@@ -1,0 +1,42 @@
+"""
+MaxDrawDownHyperOptLoss
+
+This module defines the alternative HyperOptLoss class which can be used for
+Hyperoptimization.
+"""
+from datetime import datetime
+from freqtrade.data.btanalysis import calculate_max_drawdown
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+from pandas import DataFrame
+
+
+class MaxDrawDownHyperOptLoss(IHyperOptLoss):
+
+    """
+    Defines the loss function for hyperopt.
+
+    This implementation optimizes for max draw down and profit
+    Less max drawdown more profit -> Lower return value
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               *args, **kwargs) -> float:
+
+        """
+        Objective function.
+
+        Uses profit ratio weighted max_drawdown when drawdown is available.
+        Otherwise directly optimizes profit ratio.
+        """
+        total_profit = results['profit_ratio'].sum()        
+        try:
+            max_drawdown = calculate_max_drawdown(results)
+        except ValueError:
+            # No losing trade, therefore no drawdown.
+            return -total_profit
+        max_drawdown_rev = 1 / max_drawdown[0]
+        ret = max_drawdown_rev * total_profit
+        return -ret

--- a/freqtrade/optimize/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss_max_drawdown.py
@@ -38,6 +38,4 @@ class MaxDrawDownHyperOptLoss(IHyperOptLoss):
         except ValueError:
             # No losing trade, therefore no drawdown.
             return -total_profit
-        max_drawdown_rev = 1 / max_drawdown[0]
-        ret = max_drawdown_rev * total_profit
-        return -ret
+        return -total_profit / max_drawdown[0]

--- a/tests/optimize/test_hyperoptloss.py
+++ b/tests/optimize/test_hyperoptloss.py
@@ -84,13 +84,14 @@ def test_loss_calculation_has_limited_profit(hyperopt_conf, hyperopt_results) ->
     "SortinoHyperOptLossDaily",
     "SharpeHyperOptLoss",
     "SharpeHyperOptLossDaily",
+    "MaxDrawDownHyperOptLoss",
 ])
 def test_loss_functions_better_profits(default_conf, hyperopt_results, lossfunction) -> None:
     results_over = hyperopt_results.copy()
-    results_over['profit_abs'] = hyperopt_results['profit_abs'] * 2
+    results_over['profit_abs'] = hyperopt_results['profit_abs'] * 2 + 0.2
     results_over['profit_ratio'] = hyperopt_results['profit_ratio'] * 2
     results_under = hyperopt_results.copy()
-    results_under['profit_abs'] = hyperopt_results['profit_abs'] / 2
+    results_under['profit_abs'] = hyperopt_results['profit_abs'] / 2 - 0.2
     results_under['profit_ratio'] = hyperopt_results['profit_ratio'] / 2
 
     default_conf.update({'hyperopt_loss': lossfunction})


### PR DESCRIPTION
## Summary

Hyperopt loss function using max drawdown.
As mentioned [here](https://github.com/freqtrade/freqtrade/issues/5514#issuecomment-909055853), the function calculates a multiplier from drawdown, the lower drawdown is, the higher the multiplier.

closes https://github.com/freqtrade/freqtrade/issues/5514
