### PR TITLE
Don't build ta-lib in parallel, this causes failures

### DIFF
--- a/build_helpers/install_ta-lib.sh
+++ b/build_helpers/install_ta-lib.sh
@@ -11,8 +11,13 @@ if [ ! -f "${INSTALL_LOC}/lib/libta_lib.a" ]; then
   && curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -o config.guess \
   && curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' -o config.sub \
   && ./configure --prefix=${INSTALL_LOC}/ \
-  && make -j$(nproc) \
-  && which sudo && sudo make install || make install
+  && make
+  if [ $? -ne 0 ]; then
+    echo "Failed building ta-lib."
+    cd .. && rm -rf ./ta-lib/
+    exit 1
+  fi
+  which sudo && sudo make install || make install
   if [ -x "$(command -v apt-get)" ]; then
     echo "Updating library path using ldconfig"
     sudo ldconfig


### PR DESCRIPTION
## Summary
Don't build ta-lib with parallel enabled (-j). This causes failures in the ta-lib build process [source](https://aur.archlinux.org/packages/ta-lib/#comment-582238)

closes #5714
