### PR TITLE
Make sure transactions are reset

### DIFF
--- a/freqtrade/rpc/api_server/deps.py
+++ b/freqtrade/rpc/api_server/deps.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 
+from freqtrade.persistence import Trade
 from freqtrade.rpc.rpc import RPC, RPCException
 
 from .webserver import ApiServer
@@ -14,6 +15,7 @@ def get_rpc_optional() -> Optional[RPC]:
 def get_rpc() -> Optional[RPC]:
     _rpc = get_rpc_optional()
     if _rpc:
+        Trade.query.session.rollback()
         return _rpc
     else:
         raise RPCException('Bot is not in the correct state')

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -25,6 +25,7 @@ from freqtrade.constants import DUST_PER_COIN
 from freqtrade.enums import RPCMessageType
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import chunks, plural, round_coin_value
+from freqtrade.persistence import Trade
 from freqtrade.rpc import RPC, RPCException, RPCHandler
 
 
@@ -59,7 +60,8 @@ def authorized_only(command_handler: Callable[..., None]) -> Callable[..., Any]:
                 update.message.chat_id
             )
             return wrapper
-
+        # Rollback session to avoid getting data stored in a transaction.
+        Trade.query.session.rollback()
         logger.debug(
             'Executing handler: %s for chat_id: %s',
             command_handler.__name__,


### PR DESCRIPTION
## Summary
While scopedsession will handle thread-local sessions, we'll need to still commit/rollback in these threads - otherwise the automatic transaction assumes no changes were made to the database.

closes #5719
