### PR TITLE
📝 `mkdocs.yml` - Fixed darktheme toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,8 @@ theme:
       primary: 'blue grey'
       accent: 'tear'
       toggle:
-        icon: material/toggle-switch-off-outline
-        name: Switch to dark mode
+        icon: material/toggle-switch
+        name: Switch to light mode
 extra_css:
   - 'stylesheets/ft.extra.css'
 extra_javascript:


### PR DESCRIPTION
## Summary

Fixes the dark theme toggle on the Read the Docs website.

## Quick changelog

- Changed `toggle`'s `icon` & `name`

## What's new?

Previously the toggle didn't work.