### PR TITLE
Improve performance of decimalspace.py

### DIFF
--- a/freqtrade/optimize/space/decimalspace.py
+++ b/freqtrade/optimize/space/decimalspace.py
@@ -7,11 +7,15 @@ class SKDecimal(Integer):
     def __init__(self, low, high, decimals=3, prior="uniform", base=10, transform=None,
                  name=None, dtype=np.int64):
         self.decimals = decimals
-        _low = int(low * pow(10, self.decimals))
-        _high = int(high * pow(10, self.decimals))
+
+        self.pow_dot_one = pow(0.1, self.decimals)
+        self.pow_ten = pow(10, self.decimals)
+
+        _low = int(low * self.pow_ten)
+        _high = int(high * self.pow_ten)
         # trunc to precision to avoid points out of space
-        self.low_orig = round(_low * pow(0.1, self.decimals), self.decimals)
-        self.high_orig = round(_high * pow(0.1, self.decimals), self.decimals)
+        self.low_orig = round(_low * self.pow_dot_one, self.decimals)
+        self.high_orig = round(_high * self.pow_dot_one, self.decimals)
 
         super().__init__(_low, _high, prior, base, transform, name, dtype)
 
@@ -25,9 +29,9 @@ class SKDecimal(Integer):
         return self.low_orig <= point <= self.high_orig
 
     def transform(self, Xt):
-        aa = [int(x * pow(10, self.decimals)) for x in Xt]
-        return super().transform(aa)
+        return super().transform([int(v * self.pow_ten) for v in Xt])
 
     def inverse_transform(self, Xt):
         res = super().inverse_transform(Xt)
-        return [round(x * pow(0.1, self.decimals), self.decimals) for x in res]
+        # equivalent to [round(x * pow(0.1, self.decimals), self.decimals) for x in res]
+        return [int(v) / self.pow_ten for v in res]


### PR DESCRIPTION
## Summary

Improve performance for decimalspace.py. Makes it slightly less readable, however, since that code is heavily called in optimization it seems a fair trade-off in my opinion.

## Quick changelog

* Cache `pow(10, decimals)` and `pow(.1, decimals)`
* Minor optimization around (surprisingly slow) `round`

## What's new?

decimalspace.py is heavily used in the hyperoptimization. The following
benchmark code runs an optimization which is taken from optimizing a
real strategy (wtc).
The optimized version takes on my machine approx. 11/12s compared to the
original 32s. Results are equivalent in both cases.

```
import freqtrade.optimize.space
import numpy as np
import skopt
import timeit

def init():
    Decimal = freqtrade.optimize.space.decimalspace.SKDecimal
    dimensions = [Decimal(low=-1.0,
        high=1.0,
        decimals=4,
        prior='uniform',
        transform='identity')] * 20

    return skopt.Optimizer(
        dimensions,
        base_estimator="ET",
        acq_optimizer="auto",
        n_initial_points=5,
        acq_optimizer_kwargs={'n_jobs': 96},
        random_state=0,
        model_queue_size=10,
    )

def test():
    opt = init()
    actual = opt.ask(n_points=2)
    expected = [[
        0.7515, -0.4723, -0.6941, -0.7988, 0.0448, 0.8605, -0.108, 0.5399,
        0.763, -0.2948, 0.8345, -0.7683, 0.7077, -0.2478, -0.333, 0.8575,
        0.6108, 0.4514, 0.5982, 0.3506
    ], [
        0.5563, 0.7386, -0.6407, 0.9073, -0.5211, -0.8167, -0.3771,
        -0.0318, 0.2861, 0.1176, 0.0943, -0.6077, -0.9317, -0.5372,
        -0.4934, -0.3637, -0.8035, -0.8627, -0.5399, 0.6036
    ]]

    absdiff = np.max(np.abs(np.asarray(expected) - np.asarray(actual)))
    assert absdiff < 1e-5

def time():
    opt = init()
    print('dt', timeit.timeit("opt.ask(n_points=20)", globals=locals()))

if __name__ == "__main__":
    test()
    time()
```

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)