### PR TITLE
Clean up file handles

### DIFF
--- a/freqtrade/optimize/hyperopt_tools.py
+++ b/freqtrade/optimize/hyperopt_tools.py
@@ -1,4 +1,3 @@
-
 import io
 import logging
 from copy import deepcopy
@@ -64,10 +63,11 @@ class HyperoptTools():
             'export_time': datetime.now(timezone.utc),
         }
         logger.info(f"Dumping parameters to {filename}")
-        rapidjson.dump(final_params, filename.open('w'), indent=2,
-                       default=hyperopt_serializer,
-                       number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
-                       )
+        with filename.open('w') as f:
+            rapidjson.dump(final_params, f, indent=2,
+                           default=hyperopt_serializer,
+                           number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
+                           )
 
     @staticmethod
     def try_export_params(config: Dict[str, Any], strategy_name: str, params: Dict):

--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -381,7 +381,8 @@ class HyperStrategyMixin(object):
         if filename.is_file():
             logger.info(f"Loading parameters from file {filename}")
             try:
-                params = json_load(filename.open('r'))
+                with filename.open('r') as f:
+                    params = json_load(f)
                 if params.get('strategy_name') != self.__class__.__name__:
                     raise OperationalException('Invalid parameter file provided.')
                 return params

--- a/tests/optimize/test_hyperopt_tools.py
+++ b/tests/optimize/test_hyperopt_tools.py
@@ -209,7 +209,8 @@ def test_export_params(tmpdir):
 
     assert filename.is_file()
 
-    content = rapidjson.load(filename.open('r'))
+    with filename.open('r') as f:
+        content = rapidjson.load(f)
     assert content['strategy_name'] == 'StrategyTestV2'
     assert 'params' in content
     assert "buy" in content["params"]

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -62,8 +62,8 @@ def test_load_strategy(default_conf, result):
 
 
 def test_load_strategy_base64(result, caplog, default_conf):
-    with (Path(__file__).parents[2] / 'freqtrade/templates/sample_strategy.py').open("rb") as file:
-        encoded_string = urlsafe_b64encode(file.read()).decode("utf-8")
+    filepath = Path(__file__).parents[2] / 'freqtrade/templates/sample_strategy.py'
+    encoded_string = urlsafe_b64encode(filepath.read_bytes()).decode("utf-8")
     default_conf.update({'strategy': 'SampleStrategy:{}'.format(encoded_string)})
 
     strategy = StrategyResolver.load_strategy(default_conf)


### PR DESCRIPTION
Clean up unclosed file handles. Close all file handles that are left dangling to avoid warnings such as
```
ResourceWarning: unclosed file <_io.TextIOWrapper
name='...' mode='r' encoding='UTF-8'> params = json_load(filename.open('r'))
```
