### PR TITLE
Show a Volume Profile and split in Buy/Sell Volume in Plot

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -211,6 +211,12 @@ Sample configuration with inline comments explaining the process:
             "RSI": {
                 'rsi': {'color': 'red'}
             }
+        },
+        'volume': {
+            'showBuySell': 'true',
+            'showVolumeProfile': 'true',
+            # 'VolumeProfileHistoryBars': 96,  # default: all
+            # 'VolumeProfilePriceRangeSplices': 100  # default: 50
         }
     }
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -432,8 +432,7 @@ def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFra
     fig['layout']['yaxis1'].update(title='Price')
     fig['layout']['yaxis3'].update(title='Volume')
     for i, name in enumerate(plot_config['subplots']):
-        fig['layout'][f'yaxis{5 + i }'].update(title=name)
-        # ToDo: if more then one subplot is used, the title is not shown
+        fig['layout'][f'yaxis{5 + i*2 }'].update(title=name)
     fig['layout']['xaxis']['rangeslider'].update(visible=False)
     fig.update_layout(modebar_add=["v1hovermode", "toggleSpikeLines"])
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -404,12 +404,24 @@ def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFra
     plot_config = create_plotconfig(indicators1, indicators2, plot_config)
     rows = 2 + len(plot_config['subplots'])
     row_widths = [1 for _ in plot_config['subplots']]
+
+    # load  VolumeProfile configurations
+    volume_config = plot_config['volume'] if 'volume' in plot_config else {}
+    showBuySell = volume_config['showBuySell'] if 'showBuySell' in volume_config else 'false'
+    showVolumeProfile = volume_config['showVolumeProfile'] if 'showVolumeProfile' in \
+        volume_config else 'false'
+    VolumeProfileHistoryBars = volume_config['VolumeProfileHistoryBars'] if \
+        'VolumeProfileHistoryBars' in volume_config else -1
+    VolumeProfilePriceRangeSplices = volume_config[
+        'VolumeProfilePriceRangeSplices'] if 'VolumeProfilePriceRangeSplices' in \
+        volume_config else 50
+
     # Define the graph
     fig = make_subplots(
         rows=rows,
         cols=2,  # ToDo: Check if 2 columns (instead of one) cause any issues somewhere else
-                 # ToDo: when showVolumeProfile==false, don't show the second column
-        column_widths=[8, 1],  # set the width of the Volume Profile
+        # set the width of the Volume Profile
+        column_widths=[8, 1 if showVolumeProfile.lower() == 'true' else 0],
         shared_xaxes=True,
         shared_yaxes=True,
         row_width=row_widths + [1, 4],
@@ -488,15 +500,6 @@ def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFra
     fig = plot_trades(fig, trades)
 
     # VolumeProfile
-    volume_config = plot_config['volume'] if 'volume' in plot_config else {}
-    showBuySell = volume_config['showBuySell'] if 'showBuySell' in volume_config else 'false'
-    showVolumeProfile = volume_config['showVolumeProfile'] if 'showVolumeProfile' in \
-        volume_config else 'false'
-    VolumeProfileHistoryBars = volume_config['VolumeProfileHistoryBars'] if \
-        'VolumeProfileHistoryBars' in volume_config else -1
-    VolumeProfilePriceRangeSplices = volume_config[
-        'VolumeProfilePriceRangeSplices'] if 'VolumeProfilePriceRangeSplices' in \
-        volume_config else 50
 
     if showVolumeProfile.lower() == 'true':
         volumeProfileData = createVolumeProfileData(

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -364,11 +364,13 @@ def generateBuySellVolumes(dataframe) -> pd.DataFrame:
 
         candles['volume_buy'].iat[i] = (candles['volume'].iat[i] *
                                         (candles['close'].iat[i]-candles['low'].iat[i]) /
-                                        (candles['high'].iat[i]-candles['low'].iat[i])) if (candles['high'].iat[i]-candles['low'].iat[i]) > 0 else 0
+                                        (candles['high'].iat[i]-candles['low'].iat[i])) \
+            if (candles['high'].iat[i]-candles['low'].iat[i]) > 0 else 0
 
         candles['volume_sell'].iat[i] = (candles['volume'].iat[i] *
                                          (candles['high'].iat[i]-candles['close'].iat[i]) /
-                                         (candles['high'].iat[i]-candles['low'].iat[i])) if (candles['high'].iat[i]-candles['low'].iat[i]) > 0 else 0
+                                         (candles['high'].iat[i]-candles['low'].iat[i])) \
+            if (candles['high'].iat[i]-candles['low'].iat[i]) > 0 else 0
 
     return candles
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -424,6 +424,45 @@ def createVolumeProfileData(data: pd.DataFrame, bar_split: int = 50,
     return df_vol
 
 
+def add_volumeProfile(data: pd.DataFrame, fig, plot_config: Dict[str, Dict]):
+    # load VolumeProfile configurations
+    volume_config = plot_config['volume'] if 'volume' in plot_config else {}
+    showVolumeProfile = volume_config['showVolumeProfile'] if 'showVolumeProfile' in \
+        volume_config else 'false'
+    VolumeProfileHistoryBars = volume_config['VolumeProfileHistoryBars'] if \
+        'VolumeProfileHistoryBars' in volume_config else -1
+    VolumeProfilePriceRangeSplices = volume_config[
+        'VolumeProfilePriceRangeSplices'] if 'VolumeProfilePriceRangeSplices' in \
+        volume_config else 50
+
+    # Show VolumeProfile
+    if showVolumeProfile.lower() == 'true':
+
+        volumeProfileData = createVolumeProfileData(
+            data, VolumeProfilePriceRangeSplices, VolumeProfileHistoryBars)
+
+        volume_buy = go.Bar(
+            x=volumeProfileData['volume_buy'],
+            y=volumeProfileData['price_avg'],
+            name='VolumeProfile Buy',
+            marker_color='rgba(99, 146, 52, 0.6)',
+            marker_line_color='rgba(99, 146, 52, 0.6)',
+            orientation='h',
+        )
+        volume_sell = go.Bar(
+            x=volumeProfileData['volume_sell'],
+            y=volumeProfileData['price_avg'],
+            name='VolumeProfile Sell',
+            marker_color='rgba(208, 41, 41, 0.6)',
+            marker_line_color='rgba(208, 41, 41, 0.6)',
+            orientation='h',
+        )
+
+        fig.add_trace(volume_sell, 1, 2)
+        fig.add_trace(volume_buy, 1, 2)
+        fig.update_layout(barmode='stack')
+
+
 def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFrame = None, *,
                                indicators1: List[str] = [],
                                indicators2: List[str] = [],
@@ -449,11 +488,6 @@ def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFra
     showBuySell = volume_config['showBuySell'] if 'showBuySell' in volume_config else 'false'
     showVolumeProfile = volume_config['showVolumeProfile'] if 'showVolumeProfile' in \
         volume_config else 'false'
-    VolumeProfileHistoryBars = volume_config['VolumeProfileHistoryBars'] if \
-        'VolumeProfileHistoryBars' in volume_config else -1
-    VolumeProfilePriceRangeSplices = volume_config[
-        'VolumeProfilePriceRangeSplices'] if 'VolumeProfilePriceRangeSplices' in \
-        volume_config else 50
 
     # Define the graph
     fig = make_subplots(
@@ -537,33 +571,7 @@ def generate_candlestick_graph(pair: str, data: pd.DataFrame, trades: pd.DataFra
     fig = add_areas(fig, 1, data, plot_config['main_plot'])
     fig = plot_trades(fig, trades)
 
-    # VolumeProfile
-
-    if showVolumeProfile.lower() == 'true':
-
-        volumeProfileData = createVolumeProfileData(
-            data, VolumeProfilePriceRangeSplices, VolumeProfileHistoryBars)
-
-        volume_buy = go.Bar(
-            x=volumeProfileData['volume_buy'],
-            y=volumeProfileData['price_avg'],
-            name='VolumeProfile Buy',
-            marker_color='rgba(99, 146, 52, 0.6)',
-            marker_line_color='rgba(99, 146, 52, 0.6)',
-            orientation='h',
-        )
-        volume_sell = go.Bar(
-            x=volumeProfileData['volume_sell'],
-            y=volumeProfileData['price_avg'],
-            name='VolumeProfile Sell',
-            marker_color='rgba(208, 41, 41, 0.6)',
-            marker_line_color='rgba(208, 41, 41, 0.6)',
-            orientation='h',
-        )
-
-        fig.add_trace(volume_sell, 1, 2)
-        fig.add_trace(volume_buy, 1, 2)
-        fig.update_layout(barmode='stack')
+    add_volumeProfile(data, fig, plot_config)
 
     # standard volume plot
     if showBuySell.lower() == 'true':  # show volume plot split by sell & buy trades

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -13,9 +13,10 @@ from freqtrade.configuration import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import create_cum_profit, load_backtest_data
 from freqtrade.exceptions import OperationalException
-from freqtrade.plot.plotting import (add_areas, add_indicators, add_profit, create_plotconfig, createVolumeProfileData,
-                                     generate_candlestick_graph, generate_plot_filename,
-                                     generate_profit_graph, generateBuySellVolumes, init_plotscript, load_and_plot_trades,
+from freqtrade.plot.plotting import (add_areas, add_indicators, add_profit, create_plotconfig,
+                                     createVolumeProfileData, generate_candlestick_graph,
+                                     generate_plot_filename, generate_profit_graph,
+                                     generateBuySellVolumes, init_plotscript, load_and_plot_trades,
                                      plot_profit, plot_trades, store_plot_file)
 from freqtrade.resolvers import StrategyResolver
 from tests.conftest import get_args, log_has, log_has_re, patch_exchange
@@ -314,12 +315,13 @@ def test_generate_candlestick_graph_withVolumeProfile(default_conf, mocker, test
     data['buy'] = 0
     data['sell'] = 0
 
-    indicators1 = []
-    indicators2 = []
     fig = generate_candlestick_graph(pair=pair, data=data, trades=None,
                                      plot_config={'main_plot': {'sma': {}, 'ema200': {}},
                                                   'subplots': {'Other': {'macdsignal': {}}},
-                                                  'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true', 'VolumeProfileHistoryBars': 96, 'VolumeProfilePriceRangeSplices': 60}})
+                                                  'volume': {'showBuySell': 'true',
+                                                             'showVolumeProfile': 'true',
+                                                             'VolumeProfileHistoryBars': 96,
+                                                             'VolumeProfilePriceRangeSplices': 60}})
     assert isinstance(fig, go.Figure)
     assert fig.layout.title.text == pair
     figure = fig.layout.figure
@@ -568,20 +570,24 @@ def test_plot_profit(default_conf, mocker, testdatadir):
     # No indicators, use plot_conf with just volume profile
     ([], [],
      {
-        'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true', 'VolumeProfileHistoryBars': 96, 'VolumeProfilePriceRangeSplices': 100},
+        'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true',
+                   'VolumeProfileHistoryBars': 96, 'VolumeProfilePriceRangeSplices': 100},
     },
         {'main_plot': {'sma': {}, 'ema3': {}, 'ema5': {}},
          'subplots': {'Other': {'macd': {}, 'macdsignal': {}}},
-         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true', 'VolumeProfileHistoryBars': 96, 'VolumeProfilePriceRangeSplices': 100}},
+         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true',
+                    'VolumeProfileHistoryBars': 96, 'VolumeProfilePriceRangeSplices': 100}},
     ),
     # No indicators, use full plot_conf with volume profile
     ([], [],
         {'main_plot': {'sma': {}, 'ema200': {}},
          'subplots': {'Other': {'macdsignal': {}}},
-         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true', 'VolumeProfileHistoryBars': 9, 'VolumeProfilePriceRangeSplices': 111}},
+         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true',
+                    'VolumeProfileHistoryBars': 9, 'VolumeProfilePriceRangeSplices': 111}},
         {'main_plot': {'sma': {}, 'ema200': {}},
          'subplots': {'Other': {'macdsignal': {}}},
-         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true', 'VolumeProfileHistoryBars': 9, 'VolumeProfilePriceRangeSplices': 111}},
+         'volume': {'showBuySell': 'true', 'showVolumeProfile': 'true',
+                    'VolumeProfileHistoryBars': 9, 'VolumeProfilePriceRangeSplices': 111}},
      )
 
 ])


### PR DESCRIPTION
## Summary

I missed a volume profile in the plot, so I added one

## Quick changelog

- Adding a volume profile on the right side of the main plot
- Allowing to split the volume bars in sell and buy volume
- Make everything configurable in the `plot_config`
- Adding some basic unit tests

## What's new?

### Volume Profile
You can activate a volume profile in the plot. This can be activated by `'showVolumeProfile': 'true'` in `plot_config`
<img width="1401" alt="volume Profile" src="https://user-images.githubusercontent.com/17532472/138754893-30077ceb-f969-476c-b37d-c8d18546e7d7.png">
 
### Split volume by sell and buy volume
 You can also split the 'normal' volume on the bottom of the plot in buy and sell volume. This can be activated by ` 'showBuySell': 'true'` in `plot_config`
<img width="475" alt="volume_bars" src="https://user-images.githubusercontent.com/17532472/138754876-3521cf70-6793-4432-9b78-426ed28f907d.png">


### This are all new possible parameters in the plot_config:
plot_config = {
        'main_plot': { },
        'subplots': { },
        'volume': {
            'showBuySell': 'true', #split the volume graph on the bottom in buy and sell volume; default: false
            'showVolumeProfile': 'true', #show a volume profile on the right of the main plot; default: false 
            'VolumeProfileHistoryBars': 96, #define how many bars should be used for the volume profile; default: all bars in the plot
            'VolumeProfilePriceRangeSplices': 100 # define in how many 'slices' the price is split up; default: 50
        }
    }
By default, all this is disabled.

### Possible improvements
Next step could be to just show the volume profile for the zoomed-in area. Currently, the volume profile is always based on all data in the plot for the last x bars (see `VolumeProfileHistoryBars`). It would be cool to dynamically calculate the vp based on the currently selected are/zoom. 


