### PR TITLE
[docs] Update RateLimit value [small]

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -41,12 +41,12 @@ In case of problems related to rate-limits (usually DDOS Exceptions in your logs
     "ccxt_config": {"enableRateLimit": true},
     "ccxt_async_config": {
         "enableRateLimit": true,
-        "rateLimit": 3100
+        "rateLimit": 200
     },
 ```
 
 This configuration enables kraken, as well as rate-limiting to avoid bans from the exchange.
-`"rateLimit": 3100` defines a wait-event of 0.2s between each call. This can also be completely disabled by setting `"enableRateLimit"` to false.
+`"rateLimit": 200` defines a wait-event of 0.2s between each call. This can also be completely disabled by setting `"enableRateLimit"` to false.
 
 !!! Note
     Optimal settings for rate-limiting depend on the exchange and the size of the whitelist, so an ideal parameter will vary on many other settings.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -41,12 +41,12 @@ In case of problems related to rate-limits (usually DDOS Exceptions in your logs
     "ccxt_config": {"enableRateLimit": true},
     "ccxt_async_config": {
         "enableRateLimit": true,
-        "rateLimit": 200
+        "rateLimit": 3100
     },
 ```
 
 This configuration enables kraken, as well as rate-limiting to avoid bans from the exchange.
-`"rateLimit": 200` defines a wait-event of 0.2s between each call. This can also be completely disabled by setting `"enableRateLimit"` to false.
+`"rateLimit": 3100` defines a wait-event of 3.1s between each call. This can also be completely disabled by setting `"enableRateLimit"` to false.
 
 !!! Note
     Optimal settings for rate-limiting depend on the exchange and the size of the whitelist, so an ideal parameter will vary on many other settings.


### PR DESCRIPTION
## Summary
Fix very small mistake in docs [link to the specific part](https://www.freqtrade.io/en/latest/exchanges/#setting-rate-limits), that might confuse people. Let me know if this is the correct value now, there is still another `3100` in there at the Kraken section, which I think makes sense there and is correct.

## Quick changelog
Changed the `rateLimit` 3100 value to 200, to match the 200ms delay and thus 0.2s delay. The 3100 is a mistake, but I'm not 100% sure, just let me know if this is correct or if I should change it to something else.
