### PR TITLE
setup.sh - Redhat

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 #encoding=utf8
 
+function echo_block() {
+    echo "----------------------------"
+    echo $1
+    echo "----------------------------"
+}
+
 function check_installed_pip() {
    ${PYTHON} -m pip > /dev/null
    if [ $? -ne 0 ]; then
-        echo "-----------------------------"
-        echo "Installing Pip for ${PYTHON}"
-        echo "-----------------------------"
+        echo_block "Installing Pip for ${PYTHON}"
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         ${PYTHON} get-pip.py
         rm get-pip.py
@@ -37,9 +41,7 @@ function check_installed_python() {
 }
 
 function updateenv() {
-    echo "-------------------------"
-    echo "Updating your virtual env"
-    echo "-------------------------"
+    echo_block "Updating your virtual env"
     if [ ! -f .env/bin/activate ]; then
         echo "Something went wrong, no virtual environment found."
         exit 1
@@ -110,18 +112,14 @@ function install_mac_newer_python_dependencies() {
 
     if [ ! $(brew --prefix --installed hdf5 2>/dev/null) ]
     then
-        echo "-------------------------"
-        echo "Installing hdf5"
-        echo "-------------------------"
+        echo_block "Installing hdf5"
         brew install hdf5
     fi
     export HDF5_DIR=$(brew --prefix)
 
     if [ ! $(brew --prefix --installed c-blosc 2>/dev/null) ]
     then
-        echo "-------------------------"
-        echo "Installing c-blosc"
-        echo "-------------------------"
+        echo_block "Installing c-blosc"
         brew install c-blosc
     fi
     export CBLOSC_DIR=$(brew --prefix)
@@ -131,9 +129,7 @@ function install_mac_newer_python_dependencies() {
 function install_macos() {
     if [ ! -x "$(command -v brew)" ]
     then
-        echo "-------------------------"
-        echo "Installing Brew"
-        echo "-------------------------"
+        echo_block "Installing Brew"
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     fi
     #Gets number after decimal in python version
@@ -160,9 +156,7 @@ function update() {
 
 # Reset Develop or Stable branch
 function reset() {
-    echo "----------------------------"
-    echo "Resetting branch and virtual env"
-    echo "----------------------------"
+    echo_block "Resetting branch and virtual env"
 
     if [ "1" == $(git branch -vv |grep -cE "\* develop|\* stable") ]
     then
@@ -200,16 +194,12 @@ function reset() {
 }
 
 function config() {
-
-    echo "-------------------------"
-    echo "Please use 'freqtrade new-config -c config.json' to generate a new configuration file."
-    echo "-------------------------"
+    echo_block "Please use 'freqtrade new-config -c config.json' to generate a new configuration file."
 }
 
 function install() {
-    echo "-------------------------"
-    echo "Installing mandatory dependencies"
-    echo "-------------------------"
+    
+    echo_block "Installing mandatory dependencies"
 
     if [ "$(uname -s)" == "Darwin" ]
     then
@@ -228,20 +218,14 @@ function install() {
     echo
     reset
     config
-    echo "-------------------------"
-    echo "Run the bot !"
-    echo "-------------------------"
+    echo_block "Run the bot !"
     echo "You can now use the bot by executing 'source .env/bin/activate; freqtrade <subcommand>'."
     echo "You can see the list of available bot sub-commands by executing 'source .env/bin/activate; freqtrade --help'."
     echo "You verify that freqtrade is installed successfully by running 'source .env/bin/activate; freqtrade --version'."
 }
 
 function plot() {
-    echo "
-    -----------------------------------------
-    Installing dependencies for Plotting scripts
-    -----------------------------------------
-    "
+    echo_block "Installing dependencies for Plotting scripts"
     ${PYTHON} -m pip install plotly --upgrade
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -144,7 +144,14 @@ function install_macos() {
 # Install bot Debian_ubuntu
 function install_debian() {
     sudo apt-get update
-    sudo apt-get install -y build-essential autoconf libtool pkg-config make wget git $(echo lib${PYTHON}-dev ${PYTHON}-venv)
+    sudo apt-get install -y gcc build-essential autoconf libtool pkg-config make wget git $(echo lib${PYTHON}-dev ${PYTHON}-venv)
+    install_talib
+}
+
+# Install bot RedHat_CentOS
+function install_redhat() {
+    sudo yum update
+    sudo yum install -y gcc gcc-c++ build-essential autoconf libtool pkg-config make wget git $(echo ${PYTHON}-devel | sed 's/\.//g')
     install_talib
 }
 
@@ -201,17 +208,18 @@ function install() {
     
     echo_block "Installing mandatory dependencies"
 
-    if [ "$(uname -s)" == "Darwin" ]
-    then
+    if [ "$(uname -s)" == "Darwin" ]; then
         echo "macOS detected. Setup for this system in-progress"
         install_macos
-    elif [ -x "$(command -v apt-get)" ]
-    then
+    elif [ -x "$(command -v apt-get)" ]; then
         echo "Debian/Ubuntu detected. Setup for this system in-progress"
         install_debian
+    elif [ -x "$(command -v yum)" ]; then
+        echo "Red Hat/CentOS detected. Setup for this system in-progress"
+        install_redhat
     else
         echo "This script does not support your OS."
-        echo "If you have Python3.6 or Python3.7, pip, virtualenv, ta-lib you can continue."
+        echo "If you have Python version 3.6 - 3.9, pip, virtualenv, ta-lib you can continue."
         echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
         sleep 10
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -151,7 +151,7 @@ function install_debian() {
 # Install bot RedHat_CentOS
 function install_redhat() {
     sudo yum update
-    sudo yum install -y gcc gcc-c++ build-essential autoconf libtool pkg-config make wget git $(echo ${PYTHON}-devel | sed 's/\.//g')
+    sudo yum install -y gcc gcc-c++ make autoconf libtool pkg-config wget git $(echo ${PYTHON}-devel | sed 's/\.//g')
     install_talib
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -219,7 +219,7 @@ function install() {
         install_redhat
     else
         echo "This script does not support your OS."
-        echo "If you have Python version 3.6 - 3.9, pip, virtualenv, ta-lib you can continue."
+        echo "If you have Python version 3.7 - 3.9, pip, virtualenv, ta-lib you can continue."
         echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
         sleep 10
     fi


### PR DESCRIPTION
Updated setup script to work on Redhat (and i believe this includes all CentOS and Rhel operating systems)

Tested on an amazon ec2 t2.medium running Red Hat Enterprise Linux 8 (HVM), SSD Volume Type, 64 bit, with 2 vCPUs and 2GiB memory using Python3.9

The setup script did not work installing Redhat on a t2.micro. If anyone wants to use the setup script on a t2.micro, they should use ubuntu with Python3.9 instead