### PR TITLE
Update optimize_reports

### DIFF
--- a/freqtrade/optimize/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports.py
@@ -797,7 +797,7 @@ def show_backtest_result(strategy: str, results: Dict[str, Any], stake_currency:
         print(' BACKTESTING REPORT '.center(len(table.splitlines()[0]), '='))
     print(table)
 
-    if(results['results_per_buy_tag'] is not None):
+    if results.get('results_per_buy_tag') is not None:
         table = text_table_tags(
             "buy_tag",
             results['results_per_buy_tag'],


### PR DESCRIPTION
## Summary
Update show_backtest_reults() to preserve backwards compatibility by fixing KeyError: 'results_per_buy_tag' for older hyperopt result files.

## Quick changelog

Line 800: `if(results['results_per_buy_tag'] is not None)` > `if results.get('results_per_buy_tag') is not None:`

## What's new?
The new buy_tag changes in the backtest results will work with older hyperopt result files.
