### PR TITLE
Update warning message open trades

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -193,21 +193,22 @@ class FreqtradeBot(LoggingMixin):
 
     def check_for_open_trades(self):
         """
-        Notify the user when the bot is stopped
+        Notify the user when the bot is stopped (not reloaded)
         and there are still open trades active.
         """
         open_trades = Trade.get_trades([Trade.is_open.is_(True)]).all()
 
         if len(open_trades) != 0:
-            msg = {
-                'type': RPCMessageType.WARNING,
-                'status': f"{len(open_trades)} open trades active.\n\n"
-                          f"Handle these trades manually on {self.exchange.name}, "
-                          f"or '/start' the bot again and use '/stopbuy' "
-                          f"to handle open trades gracefully. \n"
-                          f"{'Trades are simulated.' if self.config['dry_run'] else ''}",
-            }
-            self.rpc.send_msg(msg)
+            if self.state != State.RELOAD_CONFIG:
+                msg = {
+                    'type': RPCMessageType.WARNING,
+                    'status':  f"{len(open_trades)} open trades active.\n\n"
+                               f"Handle these trades manually on {self.exchange.name}, "
+                               f"or '/start' the bot again and use '/stopbuy' "
+                               f"to handle open trades gracefully. \n"
+                               f"{'Note: Trades are simulated (dry run).' if self.config['dry_run'] else ''}",
+                }
+                self.rpc.send_msg(msg)
 
     def _refresh_active_whitelist(self, trades: List[Trade] = []) -> List[str]:
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -198,17 +198,17 @@ class FreqtradeBot(LoggingMixin):
         """
         open_trades = Trade.get_trades([Trade.is_open.is_(True)]).all()
 
-        if len(open_trades) != 0:
-            if self.state != State.RELOAD_CONFIG:
-                msg = {
-                    'type': RPCMessageType.WARNING,
-                    'status':  f"{len(open_trades)} open trades active.\n\n"
-                               f"Handle these trades manually on {self.exchange.name}, "
-                               f"or '/start' the bot again and use '/stopbuy' "
-                               f"to handle open trades gracefully. \n"
-                               f"{'Note: Trades are simulated (dry run).' if self.config['dry_run'] else ''}",
-                }
-                self.rpc.send_msg(msg)
+        if len(open_trades) != 0 and self.state != State.RELOAD_CONFIG:
+            msg = {
+                'type': RPCMessageType.WARNING,
+                'status':
+                    f"{len(open_trades)} open trades active.\n\n"
+                    f"Handle these trades manually on {self.exchange.name}, "
+                    f"or '/start' the bot again and use '/stopbuy' "
+                    f"to handle open trades gracefully. \n"
+                    f"{'Note: Trades are simulated (dry run).' if self.config['dry_run'] else ''}",
+            }
+            self.rpc.send_msg(msg)
 
     def _refresh_active_whitelist(self, trades: List[Trade] = []) -> List[str]:
         """


### PR DESCRIPTION
## Summary

I saw a user in the Freqtrade discord sending the following screenshot and saying:
![image](https://user-images.githubusercontent.com/24569139/140555854-ede7e88f-fb40-4940-8a5c-efacf0e06433.png)
>Is there no way to have it keep running the trades if I just /start?
>so I have to do the /stopbuy or can I just /start?

I understand that maybe to (especially new) people this message can be confusing if they are only **reloading** their configuration file. The message is not really necessary when you just reload the config, since the bot will be up and running within a few seconds. If you think this change is unnecessary then just feel free to close this request.

## Quick changelog

- Don't send the `left open trades` warning message when the user is just reloading their config.
- Made the message slightly clearer when the bot is in dry run mode.

