### PR TITLE
Add /weekly and /monthly to Telegram (#5527)

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -312,7 +312,6 @@ Return the balance of all crypto-currency your have on the exchange.
 Per default `/daily` will return the 7 last days. The example below if for `/daily 3`:
 
 > **Daily Profit over the last 3 days:**
-
 ```
 Day         Profit BTC      Profit USD
 ----------  --------------  ------------
@@ -327,7 +326,6 @@ Per default `/weekly` will return the 8 last weeks, including the current week. 
 from Monday. The example below if for `/weekly 3`:
 
 > **Weekly Profit over the last 3 weeks (starting from Monday):**
-
 ```
 Monday         Profit BTC      Profit USD
 ----------  --------------  ------------
@@ -342,7 +340,6 @@ Per default `/monthly` will return the 6 last months, including the current mont
 if for `/monthly 3`:
 
 > **Monthly Profit over the last 3 months:**
-
 ```
 Month         Profit BTC      Profit USD
 ----------  --------------  ------------

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -175,6 +175,8 @@ official commands. You can ask at any moment for help with `/help`.
 | `/performance` | Show performance of each finished trade grouped by pair
 | `/balance` | Show account balance per currency
 | `/daily <n>` | Shows profit or loss per day, over the last n days (n defaults to 7)
+| `/weekly <n>` | Shows profit or loss per week, over the last n weeks (n defaults to 8)
+| `/monthly <n>` | Shows profit or loss per month, over the last n months (n defaults to 6)
 | `/stats` | Shows Wins / losses by Sell reason as well as Avg. holding durations for buys and sells
 | `/whitelist` | Show the current whitelist
 | `/blacklist [pair]` | Show the current blacklist, or adds a pair to the blacklist.
@@ -307,16 +309,46 @@ Return the balance of all crypto-currency your have on the exchange.
 
 ### /daily <n>
 
-Per default `/daily` will return the 7 last days.
-The example below if for `/daily 3`:
+Per default `/daily` will return the 7 last days. The example below if for `/daily 3`:
 
 > **Daily Profit over the last 3 days:**
+
 ```
 Day         Profit BTC      Profit USD
 ----------  --------------  ------------
 2018-01-03  0.00224175 BTC  29,142 USD
 2018-01-02  0.00033131 BTC   4,307 USD
 2018-01-01  0.00269130 BTC  34.986 USD
+```
+
+### /weekly <n>
+
+Per default `/weekly` will return the 8 last weeks, including the current week. Each week starts
+from Monday. The example below if for `/weekly 3`:
+
+> **Weekly Profit over the last 3 weeks (starting from Monday):**
+
+```
+Monday         Profit BTC      Profit USD
+----------  --------------  ------------
+2018-01-03  0.00224175 BTC  29,142 USD
+2017-12-27  0.00033131 BTC   4,307 USD
+2017-12-20  0.00269130 BTC  34.986 USD
+```
+
+### /monthly <n>
+
+Per default `/monthly` will return the 6 last months, including the current month. The example below
+if for `/monthly 3`:
+
+> **Monthly Profit over the last 3 months:**
+
+```
+Month         Profit BTC      Profit USD
+----------  --------------  ------------
+2018-01     0.00224175 BTC  29,142 USD
+2017-12     0.00033131 BTC   4,307 USD
+2017-11     0.00269130 BTC  34.986 USD
 ```
 
 ### /whitelist

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -251,7 +251,7 @@ class RPC:
     def _rpc_daily_profit(
             self, timescale: int,
             stake_currency: str, fiat_display_currency: str) -> Dict[str, Any]:
-        today = datetime.utcnow().date()
+        today = datetime.now(timezone.utc).date()
         profit_days: Dict[date, Dict] = {}
 
         if not (isinstance(timescale, int) and timescale > 0):

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -358,7 +358,7 @@ class RPC:
 
         data = [
             {
-                'date': f"{key.year}-{key.month}",
+                'date': f"{key.year}-{key.month:02d}",
                 'abs_profit': value["amount"],
                 'fiat_value': self._fiat_converter.convert_amount(
                     value['amount'],

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -293,7 +293,7 @@ class RPC:
     def _rpc_weekly_profit(
             self, timescale: int,
             stake_currency: str, fiat_display_currency: str) -> Dict[str, Any]:
-        today = datetime.utcnow().date()
+        today = datetime.now(timezone.utc).date()
         first_iso_day_of_week = today - timedelta(days=today.weekday())  # Monday
         profit_weeks: Dict[date, Dict] = {}
 
@@ -336,7 +336,7 @@ class RPC:
     def _rpc_monthly_profit(
             self, timescale: int,
             stake_currency: str, fiat_display_currency: str) -> Dict[str, Any]:
-        first_day_of_month = datetime.utcnow().date().replace(day=1)
+        first_day_of_month = datetime.now(timezone.utc).date().replace(day=1)
         profit_months: Dict[date, Dict] = {}
 
         if not (isinstance(timescale, int) and timescale > 0):

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -492,7 +492,7 @@ class Telegram(RPCHandler):
                   f"{day['fiat_value']:.3f} {stats['fiat_display_currency']}",
                   f"{day['trade_count']} trades"] for day in stats['data']],
                 headers=[
-                    'Month',
+                    'Day',
                     f'Profit {stake_cur}',
                     f'Profit {fiat_disp_cur}',
                     'Trades',
@@ -531,13 +531,14 @@ class Telegram(RPCHandler):
                   f"{week['fiat_value']:.3f} {stats['fiat_display_currency']}",
                   f"{week['trade_count']} trades"] for week in stats['data']],
                 headers=[
-                    'Week',
+                    'Monday',
                     f'Profit {stake_cur}',
                     f'Profit {fiat_disp_cur}',
                     'Trades',
                 ],
                 tablefmt='simple')
-            message = f'<b>Weekly Profit over the last {timescale} weeks</b>:\n<pre>{stats_tab}</pre>'
+            message = f'<b>Weekly Profit over the last {timescale} weeks ' \
+                      f'(starting from Monday)</b>:\n<pre>{stats_tab}</pre> '
             self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
                            callback_path="update_weekly", query=update.callback_query)
         except RPCException as e:
@@ -576,7 +577,8 @@ class Telegram(RPCHandler):
                     'Trades',
                 ],
                 tablefmt='simple')
-            message = f'<b>Monthly Profit over the last {timescale} months</b>:\n<pre>{stats_tab}</pre>'
+            message = f'<b>Monthly Profit over the last {timescale} months' \
+                      f'</b>:\n<pre>{stats_tab}</pre> '
             self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
                            callback_path="update_monthly", query=update.callback_query)
         except RPCException as e:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -177,6 +177,7 @@ class Telegram(RPCHandler):
         callbacks = [
             CallbackQueryHandler(self._status_table, pattern='update_status_table'),
             CallbackQueryHandler(self._daily, pattern='update_daily'),
+            CallbackQueryHandler(self._weekly, pattern='update_weekly'),
             CallbackQueryHandler(self._monthly, pattern='update_monthly'),
             CallbackQueryHandler(self._profit, pattern='update_profit'),
             CallbackQueryHandler(self._balance, pattern='update_balance'),

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -154,6 +154,8 @@ class Telegram(RPCHandler):
             CommandHandler('performance', self._performance),
             CommandHandler('stats', self._stats),
             CommandHandler('daily', self._daily),
+            CommandHandler('weekly', self._weekly),
+            CommandHandler('monthly', self._monthly),
             CommandHandler('count', self._count),
             CommandHandler('locks', self._locks),
             CommandHandler(['unlock', 'delete_locks'], self._delete_locks),
@@ -170,6 +172,7 @@ class Telegram(RPCHandler):
         callbacks = [
             CallbackQueryHandler(self._status_table, pattern='update_status_table'),
             CallbackQueryHandler(self._daily, pattern='update_daily'),
+            CallbackQueryHandler(self._monthly, pattern='update_monthly'),
             CallbackQueryHandler(self._profit, pattern='update_profit'),
             CallbackQueryHandler(self._balance, pattern='update_balance'),
             CallbackQueryHandler(self._performance, pattern='update_performance'),
@@ -478,7 +481,7 @@ class Telegram(RPCHandler):
                   f"{day['fiat_value']:.3f} {stats['fiat_display_currency']}",
                   f"{day['trade_count']} trades"] for day in stats['data']],
                 headers=[
-                    'Day',
+                    'Month',
                     f'Profit {stake_cur}',
                     f'Profit {fiat_disp_cur}',
                     'Trades',
@@ -487,6 +490,84 @@ class Telegram(RPCHandler):
             message = f'<b>Daily Profit over the last {timescale} days</b>:\n<pre>{stats_tab}</pre>'
             self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
                            callback_path="update_daily", query=update.callback_query)
+        except RPCException as e:
+            self._send_msg(str(e))
+
+    @authorized_only
+    def _weekly(self, update: Update, context: CallbackContext) -> None:
+        """
+        Handler for /weekly <n>
+        Returns a weekly profit (in BTC) over the last n weeks.
+        :param bot: telegram bot
+        :param update: message update
+        :return: None
+        """
+        stake_cur = self._config['stake_currency']
+        fiat_disp_cur = self._config.get('fiat_display_currency', '')
+        try:
+            timescale = int(context.args[0]) if context.args else 8
+        except (TypeError, ValueError, IndexError):
+            timescale = 8
+        try:
+            stats = self._rpc._rpc_weekly_profit(
+                timescale,
+                stake_cur,
+                fiat_disp_cur
+            )
+            stats_tab = tabulate(
+                [[week['date'],
+                  f"{round_coin_value(week['abs_profit'], stats['stake_currency'])}",
+                  f"{week['fiat_value']:.3f} {stats['fiat_display_currency']}",
+                  f"{week['trade_count']} trades"] for week in stats['data']],
+                headers=[
+                    'Week',
+                    f'Profit {stake_cur}',
+                    f'Profit {fiat_disp_cur}',
+                    'Trades',
+                ],
+                tablefmt='simple')
+            message = f'<b>Weekly Profit over the last {timescale} weeks</b>:\n<pre>{stats_tab}</pre>'
+            self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
+                           callback_path="update_weekly", query=update.callback_query)
+        except RPCException as e:
+            self._send_msg(str(e))
+
+    @authorized_only
+    def _monthly(self, update: Update, context: CallbackContext) -> None:
+        """
+        Handler for /monthly <n>
+        Returns a monthly profit (in BTC) over the last n months.
+        :param bot: telegram bot
+        :param update: message update
+        :return: None
+        """
+        stake_cur = self._config['stake_currency']
+        fiat_disp_cur = self._config.get('fiat_display_currency', '')
+        try:
+            timescale = int(context.args[0]) if context.args else 6
+        except (TypeError, ValueError, IndexError):
+            timescale = 6
+        try:
+            stats = self._rpc._rpc_monthly_profit(
+                timescale,
+                stake_cur,
+                fiat_disp_cur
+            )
+            stats_tab = tabulate(
+                [[month['date'],
+                  f"{round_coin_value(month['abs_profit'], stats['stake_currency'])}",
+                  f"{month['fiat_value']:.3f} {stats['fiat_display_currency']}",
+                  f"{month['trade_count']} trades"] for month in stats['data']],
+                headers=[
+                    'Month',
+                    f'Profit {stake_cur}',
+                    f'Profit {fiat_disp_cur}',
+                    'Trades',
+                ],
+                tablefmt='simple')
+            message = f'<b>Monthly Profit over the last {timescale} months</b>:\n<pre>{stats_tab}</pre>'
+            self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
+                           callback_path="update_monthly", query=update.callback_query)
         except RPCException as e:
             self._send_msg(str(e))
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -481,7 +481,7 @@ class Telegram(RPCHandler):
                   f"{day['fiat_value']:.3f} {stats['fiat_display_currency']}",
                   f"{day['trade_count']} trades"] for day in stats['data']],
                 headers=[
-                    'Month',
+                    'Day',
                     f'Profit {stake_cur}',
                     f'Profit {fiat_disp_cur}',
                     'Trades',
@@ -520,13 +520,14 @@ class Telegram(RPCHandler):
                   f"{week['fiat_value']:.3f} {stats['fiat_display_currency']}",
                   f"{week['trade_count']} trades"] for week in stats['data']],
                 headers=[
-                    'Week',
+                    'Monday',
                     f'Profit {stake_cur}',
                     f'Profit {fiat_disp_cur}',
                     'Trades',
                 ],
                 tablefmt='simple')
-            message = f'<b>Weekly Profit over the last {timescale} weeks</b>:\n<pre>{stats_tab}</pre>'
+            message = f'<b>Weekly Profit over the last {timescale} weeks ' \
+                      f'(starting from Monday)</b>:\n<pre>{stats_tab}</pre> '
             self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
                            callback_path="update_weekly", query=update.callback_query)
         except RPCException as e:
@@ -565,7 +566,8 @@ class Telegram(RPCHandler):
                     'Trades',
                 ],
                 tablefmt='simple')
-            message = f'<b>Monthly Profit over the last {timescale} months</b>:\n<pre>{stats_tab}</pre>'
+            message = f'<b>Monthly Profit over the last {timescale} months' \
+                      f'</b>:\n<pre>{stats_tab}</pre> '
             self._send_msg(message, parse_mode=ParseMode.HTML, reload_able=True,
                            callback_path="update_monthly", query=update.callback_query)
         except RPCException as e:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,6 @@ types-cachetools==4.2.4
 types-filelock==3.2.1
 types-requests==2.25.11
 types-tabulate==0.8.3
+
+# Extensions to datetime library
+types-python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,6 @@ colorama==0.4.4
 questionary==1.10.0
 prompt-toolkit==3.0.21
 
+# Extensions to datetime library
+types-python-dateutil==2.8.2
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,6 @@ colorama==0.4.4
 questionary==1.10.0
 prompt-toolkit==3.0.20
 
+# Extensions to datetime library
+types-python-dateutil==2.8.2
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,5 +43,4 @@ colorama==0.4.4
 questionary==1.10.0
 prompt-toolkit==3.0.21
 # Extensions to datetime library
-types-python-dateutil==2.8.2
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,5 @@ colorama==0.4.4
 # Building config files interactively
 questionary==1.10.0
 prompt-toolkit==3.0.20
+
+python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ colorama==0.4.4
 # Building config files interactively
 questionary==1.10.0
 prompt-toolkit==3.0.21
-
 # Extensions to datetime library
 types-python-dateutil==2.8.2
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,5 @@ colorama==0.4.4
 # Building config files interactively
 questionary==1.10.0
 prompt-toolkit==3.0.21
+
+python-dateutil==2.8.2

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -5,7 +5,6 @@
 import logging
 import re
 from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
 from functools import reduce
 from random import choice, randint
 from string import ascii_uppercase
@@ -13,6 +12,7 @@ from unittest.mock import ANY, MagicMock
 
 import arrow
 import pytest
+from dateutil.relativedelta import relativedelta
 from telegram import Chat, Message, ReplyKeyboardMarkup, Update
 from telegram.error import BadRequest, NetworkError, TelegramError
 
@@ -354,7 +354,8 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = ["2"]
     telegram._daily(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert 'Daily' in msg_mock.call_args_list[0][0][0]
+    assert "Daily Profit over the last 2 days</b>:" in msg_mock.call_args_list[0][0][0]
+    assert 'Day ' in msg_mock.call_args_list[0][0][0]
     assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
@@ -366,7 +367,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = []
     telegram._daily(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert 'Daily' in msg_mock.call_args_list[0][0][0]
+    assert "Daily Profit over the last 7 days</b>:" in msg_mock.call_args_list[0][0][0]
     assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
@@ -422,7 +423,7 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
     context = MagicMock()
     context.args = ["today"]
     telegram._daily(update=update, context=context)
-    assert str('Daily Profit over the last 7 days') in msg_mock.call_args_list[0][0][0]
+    assert str('Daily Profit over the last 7 days</b>:') in msg_mock.call_args_list[0][0][0]
 
 
 def test_weekly_handle(default_conf, update, ticker, limit_buy_order, fee,
@@ -462,8 +463,12 @@ def test_weekly_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = ["2"]
     telegram._weekly(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert 'Weekly' in msg_mock.call_args_list[0][0][0]
-    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert "Weekly Profit over the last 2 weeks (starting from Monday)</b>:" \
+           in msg_mock.call_args_list[0][0][0]
+    assert 'Monday ' in msg_mock.call_args_list[0][0][0]
+    today = datetime.utcnow().date()
+    first_iso_day_of_current_week = today - timedelta(days=today.weekday())
+    assert str(first_iso_day_of_current_week) in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
     assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
@@ -474,8 +479,9 @@ def test_weekly_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = []
     telegram._weekly(update=update, context=context)
     assert msg_mock.call_count == 1
+    assert "Weekly Profit over the last 8 weeks (starting from Monday)</b>:" \
+           in msg_mock.call_args_list[0][0][0]
     assert 'Weekly' in msg_mock.call_args_list[0][0][0]
-    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
     assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
@@ -519,8 +525,8 @@ def test_weekly_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = ["10"]
     telegram._weekly(update=update, context=context)
     assert msg_mock.call_count == 1
-
-    a = msg_mock.call_args_list[0][0][0]
+    assert "Weekly Profit over the last 10 weeks (starting from Monday)</b>:" \
+           in msg_mock.call_args_list[0][0][0]
     # Now, the time-shifted trade should be included
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
@@ -549,11 +555,12 @@ def test_weekly_wrong_input(default_conf, update, ticker, mocker) -> None:
     # Try invalid data
     msg_mock.reset_mock()
     freqtradebot.state = State.RUNNING
-    # /daily today
+    # /weekly this week
     context = MagicMock()
     context.args = ["this week"]
     telegram._weekly(update=update, context=context)
-    assert str('Weekly Profit over the last 8 weeks') in msg_mock.call_args_list[0][0][0]
+    assert str('Weekly Profit over the last 8 weeks (starting from Monday)</b>:') \
+           in msg_mock.call_args_list[0][0][0]
 
 
 def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
@@ -593,8 +600,11 @@ def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = ["2"]
     telegram._monthly(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert 'Monthly' in msg_mock.call_args_list[0][0][0]
-    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert 'Monthly Profit over the last 2 months</b>:' in msg_mock.call_args_list[0][0][0]
+    assert 'Month ' in msg_mock.call_args_list[0][0][0]
+    today = datetime.utcnow().date()
+    current_month = f"{today.year}-{today.month} "
+    assert current_month in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
     assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
@@ -605,8 +615,9 @@ def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
     context.args = []
     telegram._monthly(update=update, context=context)
     assert msg_mock.call_count == 1
-    assert 'Monthly' in msg_mock.call_args_list[0][0][0]
-    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert 'Monthly Profit over the last 6 months</b>:' in msg_mock.call_args_list[0][0][0]
+    assert 'Month ' in msg_mock.call_args_list[0][0][0]
+    assert current_month in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
     assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
@@ -630,7 +641,7 @@ def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
     trades[0].open_date = datetime.utcnow() - relativedelta(months=6, days=5)
     trades[0].close_date = datetime.utcnow() - relativedelta(months=6, days=3)
 
-    # /weekly
+    # /monthly
     # By default, the 6 previous months are shown
     # So the previous modified trade should be excluded from the stats
     context = MagicMock()
@@ -651,11 +662,39 @@ def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
     telegram._monthly(update=update, context=context)
     assert msg_mock.call_count == 1
 
-    a = msg_mock.call_args_list[0][0][0]
     # Now, the time-shifted trade should be included
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
     assert str('  1 trades') in msg_mock.call_args_list[0][0][0]
+
+
+def test_monthly_wrong_input(default_conf, update, ticker, mocker) -> None:
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        fetch_ticker=ticker
+    )
+
+    telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
+    patch_get_signal(freqtradebot)
+
+    # Try invalid data
+    msg_mock.reset_mock()
+    freqtradebot.state = State.RUNNING
+    # /daily -2
+    context = MagicMock()
+    context.args = ["-3"]
+    telegram._monthly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'must be an integer greater than 0' in msg_mock.call_args_list[0][0][0]
+
+    # Try invalid data
+    msg_mock.reset_mock()
+    freqtradebot.state = State.RUNNING
+    # /monthly february
+    context = MagicMock()
+    context.args = ["february"]
+    telegram._monthly(update=update, context=context)
+    assert str('Monthly Profit over the last 6 months</b>:') in msg_mock.call_args_list[0][0][0]
 
 
 def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -4,7 +4,8 @@
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 from functools import reduce
 from random import choice, randint
 from string import ascii_uppercase
@@ -92,10 +93,11 @@ def test_telegram_init(default_conf, mocker, caplog) -> None:
 
     message_str = ("rpc.telegram is listening for following commands: [['status'], ['profit'], "
                    "['balance'], ['start'], ['stop'], ['forcesell'], ['forcebuy'], ['trades'], "
-                   "['delete'], ['performance'], ['stats'], ['daily'], ['count'], ['locks'], "
-                   "['unlock', 'delete_locks'], ['reload_config', 'reload_conf'], "
-                   "['show_config', 'show_conf'], ['stopbuy'], "
-                   "['whitelist'], ['blacklist'], ['logs'], ['edge'], ['help'], ['version']"
+                   "['delete'], ['performance'], ['stats'], ['daily'], ['weekly'], ['monthly'], "
+                   "['count'], ['locks'], ['unlock', 'delete_locks'], "
+                   "['reload_config', 'reload_conf'], ['show_config', 'show_conf'], "
+                   "['stopbuy'], ['whitelist'], ['blacklist'], "
+                   "['logs'], ['edge'], ['help'], ['version']"
                    "]")
 
     assert log_has(message_str, caplog)
@@ -421,6 +423,239 @@ def test_daily_wrong_input(default_conf, update, ticker, mocker) -> None:
     context.args = ["today"]
     telegram._daily(update=update, context=context)
     assert str('Daily Profit over the last 7 days') in msg_mock.call_args_list[0][0][0]
+
+
+def test_weekly_handle(default_conf, update, ticker, limit_buy_order, fee,
+                       limit_sell_order, mocker) -> None:
+    default_conf['max_open_trades'] = 1
+    mocker.patch(
+        'freqtrade.rpc.rpc.CryptoToFiatConverter._find_price',
+        return_value=15000.0
+    )
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        fetch_ticker=ticker,
+        get_fee=fee,
+    )
+
+    telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
+
+    patch_get_signal(freqtradebot)
+
+    # Create some test data
+    freqtradebot.enter_positions()
+    trade = Trade.query.first()
+    assert trade
+
+    # Simulate fulfilled LIMIT_BUY order for trade
+    trade.update(limit_buy_order)
+
+    # Simulate fulfilled LIMIT_SELL order for trade
+    trade.update(limit_sell_order)
+
+    trade.close_date = datetime.utcnow()
+    trade.is_open = False
+
+    # Try valid data
+    # /weekly 2
+    context = MagicMock()
+    context.args = ["2"]
+    telegram._weekly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'Weekly' in msg_mock.call_args_list[0][0][0]
+    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
+    assert str('  0 trade') in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    context.args = []
+    telegram._weekly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'Weekly' in msg_mock.call_args_list[0][0][0]
+    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
+    assert str('  0 trade') in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    freqtradebot.config['max_open_trades'] = 2
+    # Add two other trades
+    n = freqtradebot.enter_positions()
+    assert n == 2
+
+    trades = Trade.query.all()
+    for trade in trades:
+        trade.update(limit_buy_order)
+        trade.update(limit_sell_order)
+        trade.close_date = datetime.utcnow()
+        trade.is_open = False
+
+    # Make like the first trade was open and closed more than 8 weeks ago
+    trades[0].open_date = datetime.utcnow() - timedelta(weeks=8, days=2)
+    trades[0].close_date = datetime.utcnow() - timedelta(weeks=8, days=1)
+
+    # /weekly
+    # By default, the 8 previous weeks are shown
+    # So the previous modified trade should be excluded from the stats
+    context = MagicMock()
+    context.args = []
+    telegram._weekly(update=update, context=context)
+    # assert str('  0.00012434 BTC') in msg_mock.call_args_list[0][0][0]
+    # assert str('  1.865 USD') in msg_mock.call_args_list[0][0][0]
+    # assert str('  2 trades') in msg_mock.call_args_list[0][0][0]
+
+    # The time-shifted trade should not appear
+    assert str('  0.00006217 BTC') not in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') not in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trades') not in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    context.args = ["10"]
+    telegram._weekly(update=update, context=context)
+    assert msg_mock.call_count == 1
+
+    a = msg_mock.call_args_list[0][0][0]
+    # Now, the time-shifted trade should be included
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trades') in msg_mock.call_args_list[0][0][0]
+
+
+def test_weekly_wrong_input(default_conf, update, ticker, mocker) -> None:
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        fetch_ticker=ticker
+    )
+
+    telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
+    patch_get_signal(freqtradebot)
+
+    # Try invalid data
+    msg_mock.reset_mock()
+    freqtradebot.state = State.RUNNING
+    # /daily -2
+    context = MagicMock()
+    context.args = ["-3"]
+    telegram._weekly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'must be an integer greater than 0' in msg_mock.call_args_list[0][0][0]
+
+    # Try invalid data
+    msg_mock.reset_mock()
+    freqtradebot.state = State.RUNNING
+    # /daily today
+    context = MagicMock()
+    context.args = ["this week"]
+    telegram._weekly(update=update, context=context)
+    assert str('Weekly Profit over the last 8 weeks') in msg_mock.call_args_list[0][0][0]
+
+
+def test_monthly_handle(default_conf, update, ticker, limit_buy_order, fee,
+                        limit_sell_order, mocker) -> None:
+    default_conf['max_open_trades'] = 1
+    mocker.patch(
+        'freqtrade.rpc.rpc.CryptoToFiatConverter._find_price',
+        return_value=15000.0
+    )
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        fetch_ticker=ticker,
+        get_fee=fee,
+    )
+
+    telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
+
+    patch_get_signal(freqtradebot)
+
+    # Create some test data
+    freqtradebot.enter_positions()
+    trade = Trade.query.first()
+    assert trade
+
+    # Simulate fulfilled LIMIT_BUY order for trade
+    trade.update(limit_buy_order)
+
+    # Simulate fulfilled LIMIT_SELL order for trade
+    trade.update(limit_sell_order)
+
+    trade.close_date = datetime.utcnow()
+    trade.is_open = False
+
+    # Try valid data
+    # /monthly 2
+    context = MagicMock()
+    context.args = ["2"]
+    telegram._monthly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'Monthly' in msg_mock.call_args_list[0][0][0]
+    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
+    assert str('  0 trade') in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    context.args = []
+    telegram._monthly(update=update, context=context)
+    assert msg_mock.call_count == 1
+    assert 'Monthly' in msg_mock.call_args_list[0][0][0]
+    assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
+    assert str('  0 trade') in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    freqtradebot.config['max_open_trades'] = 2
+    # Add two other trades
+    n = freqtradebot.enter_positions()
+    assert n == 2
+
+    trades = Trade.query.all()
+    for trade in trades:
+        trade.update(limit_buy_order)
+        trade.update(limit_sell_order)
+        trade.close_date = datetime.utcnow()
+        trade.is_open = False
+
+    # Make like the first trade was open and closed more than 6 months ago
+    trades[0].open_date = datetime.utcnow() - relativedelta(months=6, days=5)
+    trades[0].close_date = datetime.utcnow() - relativedelta(months=6, days=3)
+
+    # /weekly
+    # By default, the 6 previous months are shown
+    # So the previous modified trade should be excluded from the stats
+    context = MagicMock()
+    context.args = []
+    telegram._monthly(update=update, context=context)
+    # assert str('  0.00012434 BTC') in msg_mock.call_args_list[0][0][0]
+    # assert str('  1.865 USD') in msg_mock.call_args_list[0][0][0]
+    # assert str('  2 trades') in msg_mock.call_args_list[0][0][0]
+
+    # The time-shifted trade should not appear
+    assert str('  0.00006217 BTC') not in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') not in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trades') not in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    context.args = ["8"]
+    telegram._monthly(update=update, context=context)
+    assert msg_mock.call_count == 1
+
+    a = msg_mock.call_args_list[0][0][0]
+    # Now, the time-shifted trade should be included
+    assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trades') in msg_mock.call_args_list[0][0][0]
 
 
 def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,


### PR DESCRIPTION
## Summary

Add /weekly and /monthly commands to Telegram RPC

Closes #5527 show average profit in overwiew (more or less)

## Quick changelog

- /weekly <n> shows profit & loss the last n ISO weeks (starting from Monday)
- /monthly <n> shows profit & loss the last n months

## What's new?

```
/weekly

Weekly Profit over the last 8 weeks (starting from Monday):
Monday      Profit BUSD    Profit EUR    Trades
----------  -------------  ------------  --------
2021-11-01  0.000 BUSD     0.000 EUR     0 trades
2021-10-25  0.000 BUSD     0.000 EUR     0 trades
2021-10-18  0.000 BUSD     0.000 EUR     0 trades
2021-10-11  0.000 BUSD     0.000 EUR     0 trades
2021-10-04  0.000 BUSD     0.000 EUR     0 trades
2021-09-27  0.000 BUSD     0.000 EUR     0 trades
2021-09-20  0.000 BUSD     0.000 EUR     0 trades
2021-09-13  0.000 BUSD     0.000 EUR     0 trades


/monthly

Monthly Profit over the last 6 months:
Month    Profit BUSD    Profit EUR    Trades
-------  -------------  ------------  --------
2021-11  0.000 BUSD     0.000 EUR     0 trades
2021-10  0.000 BUSD     0.000 EUR     0 trades
2021-09  0.000 BUSD     0.000 EUR     0 trades
2021-08  26.109 BUSD    22.621 EUR    1 trades
2021-07  -0.591 BUSD    -0.512 EUR    1 trades
2021-06  0.000 BUSD     0.000 EUR     0 trades
```
