### PR TITLE
Hardcoded temp fix for Kucoin API issue

### DIFF
--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -81,9 +81,16 @@ def retrier_async(f):
                 count -= 1
                 kwargs.update({'count': count})
                 if isinstance(ex, DDosProtection):
-                    backoff_delay = calculate_backoff(count + 1, API_RETRY_COUNT)
-                    logger.info(f"Applying DDosProtection backoff delay: {backoff_delay}")
-                    await asyncio.sleep(backoff_delay)
+                    if "kucoin" in str(ex) and "429000" in str(ex):
+                        # Temporary fix for 429000 error on kucoin
+                        # see https://github.com/freqtrade/freqtrade/issues/5700 for details.
+                        logger.warning(
+                            f"Kucoin 429 error, avoid triggering DDosProtection backoff delay. "
+                            f"{count} tries left before giving up")
+                    else:
+                        backoff_delay = calculate_backoff(count + 1, API_RETRY_COUNT)
+                        logger.info(f"Applying DDosProtection backoff delay: {backoff_delay}")
+                        await asyncio.sleep(backoff_delay)
                 return await wrapper(*args, **kwargs)
             else:
                 logger.warning('Giving up retrying: %s()', f.__name__)


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Keep the DDosProtection count as normal, to avoid triggering DDosProtection backoff delay, since we know it's an issue on Kucoin side, and their support suggest so

closes #5700 

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?
This PR will make sure the bot doesn't trigger the DDos backoff, so it will keep trying to pull the data from Kucoin API. I'm keeping the old code commented, so once Kucoin fix their issue, we can revert back to the old code
