### PR TITLE
Raise exception when an uncaught error is raised

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -69,6 +69,8 @@ class IResolver:
             logger.warning(f"Could not import {module_path} due to '{err}'")
             if enum_failed:
                 return iter([None])
+        except Exception as e:
+            raise OperationalException(f"Error loading {module_path}: {e}") from e
 
         valid_objects_gen = (
             (obj, inspect.getsource(module)) for

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -70,7 +70,9 @@ class IResolver:
             if enum_failed:
                 return iter([None])
         except Exception as e:
-            raise OperationalException(f"Error loading {module_path}: {e}") from e
+            raise OperationalException(
+                f"Error loading {module_path}: {e.__class__.__name__}{e}"
+            ) from e
 
         valid_objects_gen = (
             (obj, inspect.getsource(module)) for


### PR DESCRIPTION
## Summary
**StrategyResolver.load_strategy** would (practically) silently fail if any error outside of (**ModuleNotFoundError**, **SyntaxError**, **ImportError**, **NameError**) is thrown.

## Quick changelog
Raise an **OperationalException** in **IResolver._get_valid_object** on the`**spec.loader.exec_module(module)** line

## What's new?
The error in my case was a **FileNotFoundError** because I was using **load_strategy** outside of the FT directory and had no idea until I did a step-by-step debug.
Now when that happens it will raise an **OperationalException** with relevant information when that happens.
