### PR TITLE
Convert contract size to underlying asset size

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -399,22 +399,16 @@ class Exchange:
 
     def _amount_to_contracts(self, pair: str, amount: float):
 
-        contract_size = None
-        if ('contractSize' in self.markets[pair]):
-            contract_size = self.markets[pair]['contractSize']
-
-        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+        contract_size = self._get_contract_size(pair)
+        if contract_size and contract_size != 1:
             return amount / contract_size
         else:
             return amount
 
     def _contracts_to_amount(self, pair: str, num_contracts: float):
 
-        contract_size = None
-        if ('contractSize' in self.markets[pair]):
-            contract_size = self.markets[pair]['contractSize']
-
-        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+        contract_size = self._get_contract_size(pair)
+        if contract_size and contract_size != 1:
             return num_contracts * contract_size
         else:
             return num_contracts

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1765,7 +1765,7 @@ class Exchange:
             self._async_get_trade_history(pair=pair, since=since,
                                           until=until, from_id=from_id))
 
-    @ retrier
+    @retrier
     def _get_funding_fees_from_exchange(self, pair: str, since: Union[datetime, int]) -> float:
         """
         Returns the sum of all funding fees that were exchanged for a pair within a timeframe
@@ -1871,7 +1871,7 @@ class Exchange:
         """
         return open_date.minute > 0 or open_date.second > 0
 
-    @ retrier
+    @retrier
     def set_margin_mode(self, pair: str, collateral: Collateral, params: dict = {}):
         """
         Set's the margin mode on the exchange to cross or isolated for a specific pair

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -649,7 +649,10 @@ class Exchange:
 
         if ('amount' in limits and 'min' in limits['amount']
                 and limits['amount']['min'] is not None):
-            self._contract_size_to_amount(pair, min_stake_amounts.append(limits['amount']['min'] * price))
+            self._contract_size_to_amount(
+                pair,
+                min_stake_amounts.append(limits['amount']['min'] * price)
+            )
 
         if not min_stake_amounts:
             return None
@@ -837,15 +840,15 @@ class Exchange:
 
     def _amount_to_contract_size(self, pair: str, amount: float):
 
-        if ('contractSize' in self.markets[pair]):
-            return amount / self.markets[pair]['contractSize']
+        if ('contractSize' in self._api.markets[pair]):
+            return amount / self._api.markets[pair]['contractSize']
         else:
             return amount
 
     def _contract_size_to_amount(self, pair: str, amount: float):
 
-        if ('contractSize' in self.markets[pair]):
-            return amount * self.markets[pair]['contractSize']
+        if ('contractSize' in self._api.markets[pair]):
+            return amount * self._api.markets[pair]['contractSize']
         else:
             return amount
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -875,15 +875,23 @@ class Exchange:
 
     def _amount_to_contracts(self, pair: str, amount: float):
 
+        contract_size = None
         if ('contractSize' in self.markets[pair]):
-            return amount / self.markets[pair]['contractSize']
+            contract_size = self.markets[pair]['contractSize']
+
+        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+            return amount / contract_size
         else:
             return amount
 
     def _contracts_to_amount(self, pair: str, num_contracts: float):
 
+        contract_size = None
         if ('contractSize' in self.markets[pair]):
-            return num_contracts * self.markets[pair]['contractSize']
+            contract_size = self.markets[pair]['contractSize']
+
+        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+            return num_contracts * contract_size
         else:
             return num_contracts
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -397,6 +397,28 @@ class Exchange:
                         order[prop] = order[prop] * contract_size
         return order
 
+    def _amount_to_contracts(self, pair: str, amount: float):
+
+        contract_size = None
+        if ('contractSize' in self.markets[pair]):
+            contract_size = self.markets[pair]['contractSize']
+
+        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+            return amount / contract_size
+        else:
+            return amount
+
+    def _contracts_to_amount(self, pair: str, num_contracts: float):
+
+        contract_size = None
+        if ('contractSize' in self.markets[pair]):
+            contract_size = self.markets[pair]['contractSize']
+
+        if (contract_size and self.trading_mode == TradingMode.FUTURES):
+            return num_contracts * contract_size
+        else:
+            return num_contracts
+
     def set_sandbox(self, api: ccxt.Exchange, exchange_config: dict, name: str) -> None:
         if exchange_config.get('sandbox'):
             if api.urls.get('test'):
@@ -872,28 +894,6 @@ class Exchange:
             param = self._ft_has.get('time_in_force_parameter', '')
             params.update({param: time_in_force})
         return params
-
-    def _amount_to_contracts(self, pair: str, amount: float):
-
-        contract_size = None
-        if ('contractSize' in self.markets[pair]):
-            contract_size = self.markets[pair]['contractSize']
-
-        if (contract_size and self.trading_mode == TradingMode.FUTURES):
-            return amount / contract_size
-        else:
-            return amount
-
-    def _contracts_to_amount(self, pair: str, num_contracts: float):
-
-        contract_size = None
-        if ('contractSize' in self.markets[pair]):
-            contract_size = self.markets[pair]['contractSize']
-
-        if (contract_size and self.trading_mode == TradingMode.FUTURES):
-            return num_contracts * contract_size
-        else:
-            return num_contracts
 
     def create_order(self, pair: str, ordertype: str, side: str, amount: float,
                      rate: float, leverage: float = 1.0, time_in_force: str = 'gtc') -> Dict:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -381,21 +381,20 @@ class Exchange:
             return 1
 
     def _trades_contracts_to_amount(self, trades: List) -> List:
-        if len(trades) > 0:
+        if len(trades) > 0 and 'symbol' in trades[0]:
             contract_size = self._get_contract_size(trades[0]['symbol'])
             if contract_size != 1:
                 for trade in trades:
                     trade['amount'] = trade['amount'] * contract_size
-            return trades
-        else:
-            return trades
+        return trades
 
     def _order_contracts_to_amount(self, order: Dict) -> Dict:
-        contract_size = self._get_contract_size(order['symbol'])
-        if contract_size != 1:
-            for prop in ['amount', 'cost', 'filled', 'remaining']:
-                if prop in order and order[prop] is not None:
-                    order[prop] = order[prop] * contract_size
+        if 'symbol' in order:
+            contract_size = self._get_contract_size(order['symbol'])
+            if contract_size != 1:
+                for prop in ['amount', 'cost', 'filled', 'remaining']:
+                    if prop in order and order[prop] is not None:
+                        order[prop] = order[prop] * contract_size
         return order
 
     def set_sandbox(self, api: ccxt.Exchange, exchange_config: dict, name: str) -> None:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -631,8 +631,12 @@ class Exchange:
         else:
             return 1 / pow(10, precision)
 
-    def get_min_pair_stake_amount(self, pair: str, price: float, stoploss: float,
-                                  leverage: Optional[float] = 1.0) -> Optional[float]:
+    def get_min_pair_stake_amount(
+        self,
+        pair: str,
+        price: float,
+        stoploss: float
+    ) -> Optional[float]:
         try:
             market = self.markets[pair]
         except KeyError:
@@ -666,22 +670,10 @@ class Exchange:
         # The value returned should satisfy both limits: for amount (base currency) and
         # for cost (quote, stake currency), so max() is used here.
         # See also #2575 at github.
-        return self._get_stake_amount_considering_leverage(
-            self._contract_size_to_amount(
-                pair,
-                max(min_stake_amounts) * amount_reserve_percent
-            ),
-            leverage or 1.0
+        return self._contract_size_to_amount(
+            pair,
+            max(min_stake_amounts) * amount_reserve_percent
         )
-
-    def _get_stake_amount_considering_leverage(self, stake_amount: float, leverage: float):
-        """
-        Takes the minimum stake amount for a pair with no leverage and returns the minimum
-        stake amount when leverage is considered
-        :param stake_amount: The stake amount for a pair before leverage is considered
-        :param leverage: The amount of leverage being used on the current trade
-        """
-        return stake_amount / leverage
 
     # Dry-run methods
 
@@ -840,15 +832,15 @@ class Exchange:
 
     def _amount_to_contract_size(self, pair: str, amount: float):
 
-        if ('contractSize' in self._api.markets[pair]):
-            return amount / self._api.markets[pair]['contractSize']
+        if ('contractSize' in self.markets[pair]):
+            return amount / self.markets[pair]['contractSize']
         else:
             return amount
 
     def _contract_size_to_amount(self, pair: str, amount: float):
 
-        if ('contractSize' in self._api.markets[pair]):
-            return amount * self._api.markets[pair]['contractSize']
+        if ('contractSize' in self.markets[pair]):
+            return amount * self.markets[pair]['contractSize']
         else:
             return amount
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1904,46 +1904,6 @@ class Exchange:
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
 
-    @retrier
-    def _get_mark_price_history(self, pair: str, since: int) -> Dict:
-        """
-        Get's the mark price history for a pair
-        :param pair: The quote/base pair of the trade
-        :param since: The earliest time to start downloading candles, in ms.
-        """
-
-        try:
-            candles = self._api.fetch_ohlcv(
-                pair,
-                timeframe="1h",
-                since=since,
-                params={
-                    'price': self._ft_has["mark_ohlcv_price"]
-                }
-            )
-            history = {}
-            for candle in candles:
-                d = datetime.fromtimestamp(int(candle[0] / 1000), timezone.utc)
-                # Round down to the nearest hour, in case of a delayed timestamp
-                # The millisecond timestamps can be delayed ~20ms
-                time = timeframe_to_prev_date('1h', d).timestamp() * 1000
-                opening_mark_price = candle[1]
-                history[time] = opening_mark_price
-            return history
-        except ccxt.NotSupported as e:
-            raise OperationalException(
-                f'Exchange {self._api.name} does not support fetching historical '
-                f'mark price candle (OHLCV) data. Message: {e}') from e
-        except ccxt.DDoSProtection as e:
-            raise DDosProtection(e) from e
-        except (ccxt.NetworkError, ccxt.ExchangeError) as e:
-            raise TemporaryError(f'Could not fetch historical mark price candle (OHLCV) data '
-                                 f'for pair {pair} due to {e.__class__.__name__}. '
-                                 f'Message: {e}') from e
-        except ccxt.BaseError as e:
-            raise OperationalException(f'Could not fetch historical mark price candle (OHLCV) data '
-                                       f'for pair {pair}. Message: {e}') from e
-
     def _calculate_funding_fees(
         self,
         pair: str,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1288,13 +1288,9 @@ class Exchange:
             # since needs to be int in milliseconds
             _params = params if params else {}
             my_trades = self._api.fetch_my_trades(
-                pair,
-                int((since.replace(tzinfo=timezone.utc).timestamp() - 5) * 1000),
-                params=_params
-            )
-            matched_trades = self._trades_contracts_to_amount(
-                trades=[trade for trade in my_trades if trade['order'] == order_id]
-            )
+                pair, int((since.replace(tzinfo=timezone.utc).timestamp() - 5) * 1000),
+                params=_params)
+            matched_trades = [trade for trade in my_trades if trade['order'] == order_id]
 
             self._log_exchange_response('get_trades_for_order', matched_trades)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -914,6 +914,7 @@ def get_markets():
             'active': True,
             'spot': True,
             'type': 'spot',
+            'contractSize': None,
             'precision': {
                 'amount': 8,
                 'price': 8
@@ -937,7 +938,8 @@ def get_markets():
             'quote': 'USDT',
             'active': True,
             'spot': False,
-            'type': 'SomethingElse',
+            'type': 'swap',
+            'contractSize': 0.01,
             'precision': {
                 'amount': 8,
                 'price': 8
@@ -985,6 +987,59 @@ def get_markets():
             'info': {
             }
         },
+        'ETH/USDT:USDT': {
+            'id': 'ETH_USDT',
+            'symbol': 'ETH/USDT:USDT',
+            'base': 'ETH',
+            'quote': 'USDT',
+            'settle': 'USDT',
+            'baseId': 'ETH',
+            'quoteId': 'USDT',
+            'settleId': 'USDT',
+            'type': 'swap',
+            'spot': False,
+            'margin': False,
+            'swap': True,
+            'futures': False,
+            'option': False,
+            'derivative': True,
+            'contract': True,
+            'linear': True,
+            'inverse': False,
+            'tierBased': False,
+            'percentage': True,
+            'taker': 0.0006,
+            'maker': 0.0002,
+            'contractSize': 10,
+            'active': True,
+            'expiry': None,
+            'expiryDatetime': None,
+            'strike': None,
+            'optionType': None,
+            'limits': {
+                'leverage': {
+                    'min': 1,
+                    'max': 100
+                },
+                'amount': {
+                    'min': 1,
+                    'max': 300000
+                },
+                'price': {
+                    'min': None,
+                    'max': None,
+                },
+                'cost': {
+                    'min': None,
+                    'max': None,
+                }
+            },
+            'precision': {
+                'price': 0.05,
+                'amount': 1
+            },
+            'info': {}
+        }
     }
 
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -398,9 +398,6 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 1, stoploss)
     expected_result = 2 * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 1, stoploss, 3.0)
-    assert isclose(result, expected_result/3)
 
     # min amount is set
     markets["ETH/BTC"]["limits"] = {
@@ -414,9 +411,6 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = 2 * 2 * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 5.0)
-    assert isclose(result, expected_result/5)
 
     # min amount and cost are set (cost is minimal)
     markets["ETH/BTC"]["limits"] = {
@@ -430,9 +424,6 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = max(2, 2 * 2) * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 10)
-    assert isclose(result, expected_result/10)
 
     # min amount and cost are set (amount is minial)
     markets["ETH/BTC"]["limits"] = {
@@ -446,24 +437,15 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = max(8, 2 * 2) * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 7.0)
-    assert isclose(result, expected_result/7.0)
 
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4)
     expected_result = max(8, 2 * 2) * 1.5
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4, 8.0)
-    assert isclose(result, expected_result/8.0)
 
     # Really big stoploss
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1)
     expected_result = max(8, 2 * 2) * 1.5
     assert isclose(result, expected_result)
-    # With Leverage
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1, 12.0)
-    assert isclose(result, expected_result/12)
 
 
 def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
@@ -483,8 +465,6 @@ def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss)
     expected_result = max(0.0001, 0.001 * 0.020405) * (1+0.05) / (1-abs(stoploss))
     assert round(result, 8) == round(expected_result, 8)
-    result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss, 3.0)
-    assert round(result, 8) == round(expected_result/3, 8)
 
 
 def test_set_sandbox(default_conf, mocker):
@@ -3261,25 +3241,6 @@ def test__get_funding_fees_from_exchange(default_conf, mocker, exchange_name):
         pair="XRP/USDT",
         since=unix_time
     )
-
-
-@pytest.mark.parametrize('exchange', ['binance', 'kraken', 'ftx'])
-@pytest.mark.parametrize('stake_amount,leverage,min_stake_with_lev', [
-    (9.0, 3.0, 3.0),
-    (20.0, 5.0, 4.0),
-    (100.0, 100.0, 1.0)
-])
-def test_get_stake_amount_considering_leverage(
-    exchange,
-    stake_amount,
-    leverage,
-    min_stake_with_lev,
-    mocker,
-    default_conf
-):
-    exchange = get_patched_exchange(mocker, default_conf, id=exchange)
-    assert exchange._get_stake_amount_considering_leverage(
-        stake_amount, leverage) == min_stake_with_lev
 
 
 @pytest.mark.parametrize("exchange_name,trading_mode", [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -225,22 +225,31 @@ def test_validate_order_time_in_force(default_conf, mocker, caplog):
     ex.validate_order_time_in_force(tif2)
 
 
-@pytest.mark.parametrize("amount,precision_mode,precision,contract_size,expected", [
-    (2.34559, 2, 4, 1, 2.3455),
-    (2.34559, 2, 5, 1, 2.34559),
-    (2.34559, 2, 3, 1, 2.345),
-    (2.9999, 2, 3, 1, 2.999),
-    (2.9909, 2, 3, 1, 2.990),
+@pytest.mark.parametrize("amount,precision_mode,precision,contract_size,expected,trading_mode", [
+    (2.34559, 2, 4, 1, 2.3455, 'spot'),
+    (2.34559, 2, 5, 1, 2.34559, 'spot'),
+    (2.34559, 2, 3, 1, 2.345, 'spot'),
+    (2.9999, 2, 3, 1, 2.999, 'spot'),
+    (2.9909, 2, 3, 1, 2.990, 'spot'),
     # Tests for Tick-size
-    (2.34559, 4, 0.0001, 1, 2.3455),
-    (2.34559, 4, 0.00001, 1, 2.34559),
-    (2.34559, 4, 0.001, 1, 2.345),
-    (2.9999, 4, 0.001, 1, 2.999),
-    (2.9909, 4, 0.001, 1, 2.990),
-    (2.9909, 4, 0.005, 0.01, 299.09),
-    (2.9999, 4, 0.005, 10, 0.295),
+    (2.34559, 4, 0.0001, 1, 2.3455, 'spot'),
+    (2.34559, 4, 0.00001, 1, 2.34559, 'spot'),
+    (2.34559, 4, 0.001, 1, 2.345, 'spot'),
+    (2.9999, 4, 0.001, 1, 2.999, 'spot'),
+    (2.9909, 4, 0.001, 1, 2.990, 'spot'),
+    (2.9909, 4, 0.005, 0.01, 299.09, 'futures'),
+    (2.9999, 4, 0.005, 10, 0.295, 'futures'),
 ])
-def test_amount_to_precision(default_conf, mocker, amount, precision_mode, precision, contract_size, expected):
+def test_amount_to_precision(
+    default_conf,
+    mocker,
+    amount,
+    precision_mode,
+    precision,
+    contract_size,
+    expected,
+    trading_mode
+):
     """
     Test rounds down
     """
@@ -253,6 +262,9 @@ def test_amount_to_precision(default_conf, mocker, amount, precision_mode, preci
             }
         }
     })
+
+    default_conf['trading_mode'] = trading_mode
+    default_conf['collateral'] = 'isolated'
 
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
     # digits counting mode

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -243,6 +243,7 @@ def test_amount_to_precision(default_conf, mocker, amount, precision_mode, preci
     """
     Test rounds down
     """
+    # TODO-lev: Test for contract sizes of 0.01 and 10
 
     markets = PropertyMock(return_value={'ETH/BTC': {'precision': {'amount': precision}}})
 
@@ -324,6 +325,7 @@ def test_price_get_one_pip(default_conf, mocker, price, precision_mode, precisio
 
 
 def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
+    # TODO-lev: Test for contract sizes of 0.01 and 10
 
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
     stoploss = -0.05
@@ -1004,6 +1006,7 @@ def test_exchange_has(default_conf, mocker):
 ])
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_create_dry_run_order(default_conf, mocker, side, exchange_name):
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     default_conf['dry_run'] = True
     exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
 
@@ -1120,6 +1123,7 @@ def test_create_dry_run_order_market_fill(default_conf, mocker, side, rate, amou
 ])
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_create_order(default_conf, mocker, side, ordertype, rate, marketprice, exchange_name):
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     api_mock = MagicMock()
     order_id = 'test_prod_{}_{}'.format(side, randint(0, 10 ** 6))
     api_mock.options = {} if not marketprice else {"createMarketBuyOrderRequiresPrice": True}
@@ -2243,7 +2247,7 @@ async def test___async_get_candle_history_sort(default_conf, mocker, exchange_na
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 async def test__async_fetch_trades(default_conf, mocker, caplog, exchange_name,
                                    fetch_trades_result):
-
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     caplog.set_level(logging.DEBUG)
     exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
     # Monkey-patch async function
@@ -2513,6 +2517,7 @@ def test_cancel_order_with_result_error(default_conf, mocker, exchange_name, cap
 # Ensure that if not dry_run, we should call API
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_cancel_order(default_conf, mocker, exchange_name):
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     default_conf['dry_run'] = False
     api_mock = MagicMock()
     api_mock.cancel_order = MagicMock(return_value={'id': '123'})
@@ -2591,6 +2596,7 @@ def test_cancel_stoploss_order_with_result(default_conf, mocker, exchange_name):
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_fetch_order(default_conf, mocker, exchange_name, caplog):
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     default_conf['dry_run'] = True
     default_conf['exchange']['log_responses'] = True
     order = MagicMock()
@@ -2702,7 +2708,7 @@ def test_name(default_conf, mocker, exchange_name):
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_get_trades_for_order(default_conf, mocker, exchange_name):
-
+    # TODO-lev: Test for contract sizes of 0.01 and 10
     order_id = 'ABCD-ABCD'
     since = datetime(2018, 5, 5, 0, 0, 0)
     default_conf["dry_run"] = False
@@ -3578,25 +3584,25 @@ def test__calculate_funding_fees_datetime_called(
 
 
 def test__get_contract_size():
-    # TODO
+    # TODO-lev
     return
 
 
 def test__trades_contracts_to_amount():
-    # TODO
+    # TODO-lev
     return
 
 
 def test__order_contracts_to_amount():
-    # TODO
+    # TODO-lev
     return
 
 
 def test__amount_to_contract_size():
-    # TODO
+    # TODO-lev
     return
 
 
 def test__contract_size_to_amount():
-    # TODO
+    # TODO-lev
     return

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -398,6 +398,9 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 1, stoploss)
     expected_result = 2 * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 1, stoploss, 3.0)
+    assert isclose(result, expected_result/3)
 
     # min amount is set
     markets["ETH/BTC"]["limits"] = {
@@ -411,6 +414,9 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = 2 * 2 * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 5.0)
+    assert isclose(result, expected_result/5)
 
     # min amount and cost are set (cost is minimal)
     markets["ETH/BTC"]["limits"] = {
@@ -424,6 +430,9 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = max(2, 2 * 2) * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 10)
+    assert isclose(result, expected_result/10)
 
     # min amount and cost are set (amount is minial)
     markets["ETH/BTC"]["limits"] = {
@@ -437,15 +446,24 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss)
     expected_result = max(8, 2 * 2) * (1+0.05) / (1-abs(stoploss))
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, stoploss, 7.0)
+    assert isclose(result, expected_result/7.0)
 
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4)
     expected_result = max(8, 2 * 2) * 1.5
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -0.4, 8.0)
+    assert isclose(result, expected_result/8.0)
 
     # Really big stoploss
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1)
     expected_result = max(8, 2 * 2) * 1.5
     assert isclose(result, expected_result)
+    # With Leverage
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 2, -1, 12.0)
+    assert isclose(result, expected_result/12)
 
 
 def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
@@ -465,6 +483,8 @@ def test_get_min_pair_stake_amount_real_data(mocker, default_conf) -> None:
     result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss)
     expected_result = max(0.0001, 0.001 * 0.020405) * (1+0.05) / (1-abs(stoploss))
     assert round(result, 8) == round(expected_result, 8)
+    result = exchange.get_min_pair_stake_amount('ETH/BTC', 0.020405, stoploss, 3.0)
+    assert round(result, 8) == round(expected_result/3, 8)
 
 
 def test_set_sandbox(default_conf, mocker):
@@ -3241,6 +3261,25 @@ def test__get_funding_fees_from_exchange(default_conf, mocker, exchange_name):
         pair="XRP/USDT",
         since=unix_time
     )
+
+
+@pytest.mark.parametrize('exchange', ['binance', 'kraken', 'ftx'])
+@pytest.mark.parametrize('stake_amount,leverage,min_stake_with_lev', [
+    (9.0, 3.0, 3.0),
+    (20.0, 5.0, 4.0),
+    (100.0, 100.0, 1.0)
+])
+def test_get_stake_amount_considering_leverage(
+    exchange,
+    stake_amount,
+    leverage,
+    min_stake_with_lev,
+    mocker,
+    default_conf
+):
+    exchange = get_patched_exchange(mocker, default_conf, id=exchange)
+    assert exchange._get_stake_amount_considering_leverage(
+        stake_amount, leverage) == min_stake_with_lev
 
 
 @pytest.mark.parametrize("exchange_name,trading_mode", [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3747,11 +3747,27 @@ def test__calculate_funding_fees_datetime_called(
     ('LTC/ETH', 1, 'futures'),
     ('ETH/USDT:USDT', 10, 'futures')
 ])
-def test__get_contract_size(mocker, default_conf, markets, pair, expected_size, trading_mode):
+def test__get_contract_size(mocker, default_conf, pair, expected_size, trading_mode):
     api_mock = MagicMock()
     default_conf['trading_mode'] = trading_mode
     default_conf['collateral'] = 'isolated'
-    mocker.patch('freqtrade.exchange.Exchange.markets', markets)
+    mocker.patch('freqtrade.exchange.Exchange.markets', {
+        'LTC/USD': {
+            'symbol': 'LTC/USD',
+            'contractSize': None,
+        },
+        'XLTCUSDT': {
+            'symbol': 'XLTCUSDT',
+            'contractSize': 0.01,
+        },
+        'LTC/ETH': {
+            'symbol': 'LTC/ETH',
+        },
+        'ETH/USDT:USDT': {
+            'symbol': 'ETH/USDT:USDT',
+            'contractSize': 10,
+        }
+    })
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
     size = exchange._get_contract_size(pair)
     assert expected_size == size

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -237,8 +237,8 @@ def test_validate_order_time_in_force(default_conf, mocker, caplog):
     (2.34559, 4, 0.001, 1, 2.345),
     (2.9999, 4, 0.001, 1, 2.999),
     (2.9909, 4, 0.001, 1, 2.990),
-    (2.9909, 4, 0.005, 0.01, 0.025),
-    (2.9999, 4, 0.005, 10, 29.995),
+    (2.9909, 4, 0.005, 0.01, 299.09),
+    (2.9999, 4, 0.005, 10, 0.295),
 ])
 def test_amount_to_precision(default_conf, mocker, amount, precision_mode, precision, contract_size, expected):
     """

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -486,6 +486,9 @@ def test_get_min_pair_stake_amount(mocker, default_conf) -> None:
     assert isclose(result, expected_result/12)
 
     markets["ETH/BTC"]["contractSize"] = 0.01
+    default_conf['trading_mode'] = 'futures'
+    default_conf['collateral'] = 'isolated'
+    exchange = get_patched_exchange(mocker, default_conf, id="binance")
     mocker.patch(
         'freqtrade.exchange.Exchange.markets',
         PropertyMock(return_value=markets)

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -20,7 +20,6 @@ from freqtrade.exchange.common import (API_FETCH_ORDER_RETRY_COUNT, API_RETRY_CO
 from freqtrade.exchange.exchange import (market_is_active, timeframe_to_minutes, timeframe_to_msecs,
                                          timeframe_to_next_date, timeframe_to_prev_date,
                                          timeframe_to_seconds)
-from freqtrade.persistence.models import Trade
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import get_mock_coro, get_patched_exchange, log_has, log_has_re, num_log_has_re
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -2797,7 +2797,7 @@ def test_name(default_conf, mocker, exchange_name):
 
 @pytest.mark.parametrize("trading_mode,amount", [
     ('spot', 0.2340606),
-    ('futures', 2.340606),
+    ('futures', 23.40606),
 ])
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_get_trades_for_order(default_conf, mocker, exchange_name, trading_mode, amount):
@@ -2835,7 +2835,7 @@ def test_get_trades_for_order(default_conf, mocker, exchange_name, trading_mode,
     orders = exchange.get_trades_for_order(order_id, 'ETH/USDT:USDT', since)
     assert len(orders) == 1
     assert orders[0]['price'] == 165
-    assert orders[0]['amount'] == amount
+    assert isclose(orders[0]['amount'], amount)
     assert api_mock.fetch_my_trades.call_count == 1
     # since argument should be
     assert isinstance(api_mock.fetch_my_trades.call_args[0][1], int)
@@ -3556,81 +3556,6 @@ def test__get_funding_fee(
             kraken._get_funding_fee(size, funding_rate, mark_price, time_in_ratio)
     else:
         assert kraken._get_funding_fee(size, funding_rate, mark_price, time_in_ratio) == kraken_fee
-
-
-def test__get_mark_price_history(mocker, default_conf, mark_ohlcv):
-    api_mock = MagicMock()
-    api_mock.fetch_ohlcv = MagicMock(return_value=mark_ohlcv)
-    type(api_mock).has = PropertyMock(return_value={'fetchOHLCV': True})
-
-    # mocker.patch('freqtrade.exchange.Exchange.get_funding_fees', lambda pair, since: y)
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
-    mark_prices = exchange._get_mark_price_history("ADA/USDT", 1630454400000)
-    assert mark_prices == {
-        1630454400000: 2.77,
-        1630458000000: 2.73,
-        1630461600000: 2.74,
-        1630465200000: 2.76,
-        1630468800000: 2.76,
-        1630472400000: 2.77,
-        1630476000000: 2.78,
-        1630479600000: 2.78,
-        1630483200000: 2.77,
-        1630486800000: 2.77,
-        1630490400000: 2.84,
-        1630494000000: 2.81,
-        1630497600000: 2.81,
-        1630501200000: 2.82,
-    }
-
-    ccxt_exceptionhandlers(
-        mocker,
-        default_conf,
-        api_mock,
-        "binance",
-        "_get_mark_price_history",
-        "fetch_ohlcv",
-        pair="ADA/USDT",
-        since=1635580800001
-    )
-
-
-def test_get_funding_rate_history(mocker, default_conf, funding_rate_history_hourly):
-    api_mock = MagicMock()
-    api_mock.fetch_funding_rate_history = MagicMock(return_value=funding_rate_history_hourly)
-    type(api_mock).has = PropertyMock(return_value={'fetchFundingRateHistory': True})
-
-    # mocker.patch('freqtrade.exchange.Exchange.get_funding_fees', lambda pair, since: y)
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
-    funding_rates = exchange.get_funding_rate_history('ADA/USDT', 1635580800001)
-
-    assert funding_rates == {
-        1630454400000: -0.000008,
-        1630458000000: -0.000004,
-        1630461600000: 0.000012,
-        1630465200000: -0.000003,
-        1630468800000: -0.000007,
-        1630472400000: 0.000003,
-        1630476000000: 0.000019,
-        1630479600000: 0.000003,
-        1630483200000: -0.000003,
-        1630486800000: 0,
-        1630490400000: 0.000013,
-        1630494000000: 0.000077,
-        1630497600000: 0.000072,
-        1630501200000: 0.000097,
-    }
-
-    ccxt_exceptionhandlers(
-        mocker,
-        default_conf,
-        api_mock,
-        "binance",
-        "get_funding_rate_history",
-        "fetch_funding_rate_history",
-        pair="ADA/USDT",
-        since=1630454400000
-    )
 
 
 @pytest.mark.parametrize('exchange,rate_start,rate_end,d1,d2,amount,expected_fees', [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -2797,7 +2797,7 @@ def test_name(default_conf, mocker, exchange_name):
 
 @pytest.mark.parametrize("trading_mode,amount", [
     ('spot', 0.2340606),
-    ('futures', 23.40606),
+    ('futures', 2.340606),
 ])
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
 def test_get_trades_for_order(default_conf, mocker, exchange_name, trading_mode, amount):

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3549,7 +3549,7 @@ def test__calculate_funding_fees(
     assert pytest.approx(funding_fees) == expected_fees
 
 
-@ pytest.mark.parametrize('exchange,expected_fees', [
+@pytest.mark.parametrize('exchange,expected_fees', [
     ('binance', -0.0009140999999999999),
     ('gateio', -0.0009140999999999999),
 ])
@@ -3575,3 +3575,28 @@ def test__calculate_funding_fees_datetime_called(
     time_machine.move_to("2021-09-01 08:00:00 +00:00")
     funding_fees = exchange._calculate_funding_fees('ADA/USDT', 30.0, d1)
     assert funding_fees == expected_fees
+
+
+def test__get_contract_size():
+    # TODO
+    return
+
+
+def test__trades_contracts_to_amount():
+    # TODO
+    return
+
+
+def test__order_contracts_to_amount():
+    # TODO
+    return
+
+
+def test__amount_to_contract_size():
+    # TODO
+    return
+
+
+def test__contract_size_to_amount():
+    # TODO
+    return

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1200,7 +1200,6 @@ def test_create_order(default_conf, mocker, side, ordertype, rate, marketprice, 
 
     assert exchange._set_leverage.call_count == 1
     assert exchange.set_margin_mode.call_count == 1
-    # assert api_mock.create_order.call_args[0][3] == 100
     assert order['amount'] == 0.01
 
 

--- a/tests/exchange/test_kraken.py
+++ b/tests/exchange/test_kraken.py
@@ -21,6 +21,7 @@ def test_buy_kraken_trading_agreement(default_conf, mocker):
     api_mock.options = {}
     api_mock.create_order = MagicMock(return_value={
         'id': order_id,
+        'symbol': 'ETH/BTC',
         'info': {
             'foo': 'bar'
         }
@@ -53,6 +54,7 @@ def test_sell_kraken_trading_agreement(default_conf, mocker):
     api_mock.options = {}
     api_mock.create_order = MagicMock(return_value={
         'id': order_id,
+        'symbol': 'ETH/BTC',
         'info': {
             'foo': 'bar'
         }


### PR DESCRIPTION
## Summary

Some exchanges express their minimal amount in terms of contract, for example, if you run `node ccxt/examples/js/cli gateio fetchMarkets '{"type": "swap"}` you can see a field called `contractSize`, and for BTC this value is `0.0001`. This means that 1 contract of BTC is worth 0.0001 BTC, and the minimal order is for 1 contract. It makes more sense for us to handle all exchanges as ordering the amount of the underlying asset (this is how binance does it anyway). Also all prices are given in relation to the underlying asset anyway

