### PR TITLE
Update ARMHF image to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-slim-buster as base
+FROM python:3.9.9-slim-bullseye as base
 
 # Setup env
 ENV LANG C.UTF-8

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM python:3.7.10-slim-buster as base
+FROM python:3.9.9-slim-bullseye as base
 
 # Setup env
 ENV LANG C.UTF-8


### PR DESCRIPTION
## Summary
Update armhf docker image to 3.9 - as piwheels now provides wheels for this.