### PR TITLE
Is future method fix

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -3,7 +3,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import arrow
 import ccxt
@@ -118,10 +118,6 @@ class Binance(Exchange):
                 f'Could not place {side} order due to {e.__class__.__name__}. Message: {e}') from e
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
-
-    def market_is_future(self, market: Dict[str, Any]) -> bool:
-        # TODO-lev: This should be unified in ccxt to "swap"...
-        return market.get('future', False) is True
 
     @retrier
     def fill_leverage_brackets(self):

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -338,7 +338,7 @@ class Exchange:
         return self.markets.get(pair, {}).get('base', '')
 
     def market_is_future(self, market: Dict[str, Any]) -> bool:
-        return market.get('swap', False) is True
+        return market.get(self._ft_has["ccxt_futures_name"], False) is True
 
     def market_is_spot(self, market: Dict[str, Any]) -> bool:
         return market.get('spot', False) is True

--- a/freqtrade/exchange/ftx.py
+++ b/freqtrade/exchange/ftx.py
@@ -20,7 +20,8 @@ class Ftx(Exchange):
     _ft_has: Dict = {
         "stoploss_on_exchange": True,
         "ohlcv_candle_limit": 1500,
-        "mark_ohlcv_price": "index"
+        "mark_ohlcv_price": "index",
+        "ccxt_futures_name": "future"
     }
 
     _supported_trading_mode_collateral_pairs: List[Tuple[TradingMode, Collateral]] = [
@@ -159,7 +160,3 @@ class Ftx(Exchange):
         if order['type'] == 'stop':
             return safe_value_fallback2(order, order, 'id_stop', 'id')
         return order['id']
-
-    def market_is_future(self, market: Dict[str, Any]) -> bool:
-        # TODO-lev: This should be unified in ccxt to "swap"...
-        return market.get('future', False) is True

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3309,7 +3309,7 @@ def test_validate_trading_mode_and_collateral(
     ("bibox", "margin", {"has": {"fetchCurrencies": False}, "options": {"defaultType": "margin"}}),
     ("bibox", "futures", {"has": {"fetchCurrencies": False}, "options": {"defaultType": "swap"}}),
     ("bybit", "futures", {"options": {"defaultType": "linear"}}),
-    ("ftx", "futures", {"options": {"defaultType": "swap"}}),
+    ("ftx", "futures", {"options": {"defaultType": "future"}}),
     ("gateio", "futures", {"options": {"defaultType": "swap"}}),
     ("hitbtc", "futures", {"options": {"defaultType": "swap"}}),
     ("kraken", "futures", {"options": {"defaultType": "swap"}}),


### PR DESCRIPTION
On binance it's `future`, instead of `swap`

I don't think the `market_is_margin` method will work for all exchanges, it will work for binance, gateio and okex, but not ftx, and not kraken either I'm pretty sure. I'll have to think about a better solution for that.