### PR TITLE
allow force options with ordertype

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -467,7 +467,7 @@ class FreqtradeBot(LoggingMixin):
             return False
 
     def execute_entry(self, pair: str, stake_amount: float, price: Optional[float] = None, *,
-                      order_type: Optional[str] = None, buy_tag: Optional[str] = None) -> bool:
+                      ordertype: Optional[str] = None, buy_tag: Optional[str] = None) -> bool:
         """
         Executes a limit buy for the given pair
         :param pair: pair for which we want to create a LIMIT_BUY
@@ -510,8 +510,7 @@ class FreqtradeBot(LoggingMixin):
                     f"{stake_amount} ...")
 
         amount = stake_amount / enter_limit_requested
-        if not order_type:
-            order_type = self.strategy.order_types['buy']
+        order_type = ordertype or self.strategy.order_types['buy']
 
         if not strategy_safe_wrapper(self.strategy.confirm_trade_entry, default_retval=True)(
                 pair=pair, order_type=order_type, amount=amount, rate=enter_limit_requested,
@@ -866,7 +865,7 @@ class FreqtradeBot(LoggingMixin):
             logger.info(
                 f'Executing Sell for {trade.pair}. Reason: {should_sell.sell_type}. '
                 f'Tag: {exit_tag if exit_tag is not None else "None"}')
-            self.execute_trade_exit(trade, exit_rate, should_sell, exit_tag)
+            self.execute_trade_exit(trade, exit_rate, should_sell, exit_tag=exit_tag)
             return True
         return False
 
@@ -1079,7 +1078,10 @@ class FreqtradeBot(LoggingMixin):
             trade: Trade,
             limit: float,
             sell_reason: SellCheckTuple,
-            exit_tag: Optional[str] = None) -> bool:
+            *,
+            exit_tag: Optional[str] = None,
+            ordertype: Optional[str] = None,
+            ) -> bool:
         """
         Executes a trade exit for the given trade and limit
         :param trade: Trade instance
@@ -1117,14 +1119,10 @@ class FreqtradeBot(LoggingMixin):
             except InvalidOrderException:
                 logger.exception(f"Could not cancel stoploss order {trade.stoploss_order_id}")
 
-        order_type = self.strategy.order_types[sell_type]
+        order_type = ordertype or self.strategy.order_types[sell_type]
         if sell_reason.sell_type == SellType.EMERGENCY_SELL:
             # Emergency sells (default to market!)
             order_type = self.strategy.order_types.get("emergencysell", "market")
-        if sell_reason.sell_type == SellType.FORCE_SELL:
-            # Force sells (default to the sell_type defined in the strategy,
-            # but we allow this value to be changed)
-            order_type = self.strategy.order_types.get("forcesell", order_type)
 
         amount = self._safe_exit_amount(trade.pair, trade.amount)
         time_in_force = self.strategy.order_time_in_force['sell']

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -466,8 +466,8 @@ class FreqtradeBot(LoggingMixin):
             logger.info(f"Bids to asks delta for {pair} does not satisfy condition.")
             return False
 
-    def execute_entry(self, pair: str, stake_amount: float, price: Optional[float] = None,
-                      forcebuy: bool = False, buy_tag: Optional[str] = None) -> bool:
+    def execute_entry(self, pair: str, stake_amount: float, price: Optional[float] = None, *,
+                      order_type: Optional[str] = None, buy_tag: Optional[str] = None) -> bool:
         """
         Executes a limit buy for the given pair
         :param pair: pair for which we want to create a LIMIT_BUY
@@ -510,10 +510,8 @@ class FreqtradeBot(LoggingMixin):
                     f"{stake_amount} ...")
 
         amount = stake_amount / enter_limit_requested
-        order_type = self.strategy.order_types['buy']
-        if forcebuy:
-            # Forcebuy can define a different ordertype
-            order_type = self.strategy.order_types.get('forcebuy', order_type)
+        if not order_type:
+            order_type = self.strategy.order_types['buy']
 
         if not strategy_safe_wrapper(self.strategy.confirm_trade_entry, default_retval=True)(
                 pair=pair, order_type=order_type, amount=amount, rate=enter_limit_requested,

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -288,6 +288,7 @@ class ForceBuyPayload(BaseModel):
 
 class ForceSellPayload(BaseModel):
     tradeid: str
+    ordertype: Optional[OrderTypeValues]
 
 
 class BlacklistPayload(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
@@ -131,13 +132,21 @@ class UnfilledTimeout(BaseModel):
     exit_timeout_count: Optional[int]
 
 
+class OrderTypeValues(Enum):
+    limit = 'limit'
+    market = 'market'
+
+    class Config:
+        use_enum_values = True
+
+
 class OrderTypes(BaseModel):
-    buy: str
-    sell: str
-    emergencysell: Optional[str]
-    forcesell: Optional[str]
-    forcebuy: Optional[str]
-    stoploss: str
+    buy: OrderTypeValues
+    sell: OrderTypeValues
+    emergencysell: Optional[OrderTypeValues]
+    forcesell: Optional[OrderTypeValues]
+    forcebuy: Optional[OrderTypeValues]
+    stoploss: OrderTypeValues
     stoploss_on_exchange: bool
     stoploss_on_exchange_interval: Optional[int]
 
@@ -274,6 +283,7 @@ class Logs(BaseModel):
 class ForceBuyPayload(BaseModel):
     pair: str
     price: Optional[float]
+    ordertype: Optional[OrderTypeValues]
 
 
 class ForceSellPayload(BaseModel):

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -29,7 +29,8 @@ logger = logging.getLogger(__name__)
 # API version
 # Pre-1.1, no version was provided
 # Version increments should happen in "small" steps (1.1, 1.12, ...) unless big changes happen.
-API_VERSION = 1.1
+# 1.11: forcebuy accepts new option with ordertype
+API_VERSION = 1.11
 
 # Public API, requires no auth.
 router_public = APIRouter()
@@ -129,7 +130,7 @@ def show_config(rpc: Optional[RPC] = Depends(get_rpc_optional), config=Depends(g
 
 @router.post('/forcebuy', response_model=ForceBuyResponse, tags=['trading'])
 def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
-    trade = rpc._rpc_forcebuy(payload.pair, payload.price)
+    trade = rpc._rpc_forcebuy(payload.pair, payload.price, payload.ordertype)
 
     if trade:
         return ForceBuyResponse.parse_obj(trade.to_json())

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -130,7 +130,8 @@ def show_config(rpc: Optional[RPC] = Depends(get_rpc_optional), config=Depends(g
 
 @router.post('/forcebuy', response_model=ForceBuyResponse, tags=['trading'])
 def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
-    trade = rpc._rpc_forcebuy(payload.pair, payload.price, payload.ordertype.value)
+    ordertype = payload.ordertype.value if payload.ordertype else None
+    trade = rpc._rpc_forcebuy(payload.pair, payload.price, ordertype)
 
     if trade:
         return ForceBuyResponse.parse_obj(trade.to_json())
@@ -140,7 +141,8 @@ def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
 
 @router.post('/forcesell', response_model=ResultMsg, tags=['trading'])
 def forcesell(payload: ForceSellPayload, rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_forcesell(payload.tradeid, payload.ordertype.value)
+    ordertype = payload.ordertype.value if payload.ordertype else None
+    return rpc._rpc_forcesell(payload.tradeid, ordertype)
 
 
 @router.get('/blacklist', response_model=BlacklistResponse, tags=['info', 'pairlist'])

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # API version
 # Pre-1.1, no version was provided
 # Version increments should happen in "small" steps (1.1, 1.12, ...) unless big changes happen.
-# 1.11: forcebuy accepts new option with ordertype
+# 1.11: forcebuy and forcesell accept ordertype
 API_VERSION = 1.11
 
 # Public API, requires no auth.
@@ -130,7 +130,7 @@ def show_config(rpc: Optional[RPC] = Depends(get_rpc_optional), config=Depends(g
 
 @router.post('/forcebuy', response_model=ForceBuyResponse, tags=['trading'])
 def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
-    trade = rpc._rpc_forcebuy(payload.pair, payload.price, payload.ordertype)
+    trade = rpc._rpc_forcebuy(payload.pair, payload.price, payload.ordertype.value)
 
     if trade:
         return ForceBuyResponse.parse_obj(trade.to_json())
@@ -140,7 +140,7 @@ def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
 
 @router.post('/forcesell', response_model=ResultMsg, tags=['trading'])
 def forcesell(payload: ForceSellPayload, rpc: RPC = Depends(get_rpc)):
-    return rpc._rpc_forcesell(payload.tradeid)
+    return rpc._rpc_forcesell(payload.tradeid, payload.ordertype.value)
 
 
 @router.get('/blacklist', response_model=BlacklistResponse, tags=['info', 'pairlist'])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -692,7 +692,8 @@ class RPC:
             self._freqtrade.wallets.update()
             return {'result': f'Created sell order for trade {trade_id}.'}
 
-    def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:
+    def _rpc_forcebuy(self, pair: str, price: Optional[float],
+                      order_type: Optional[str] = None) -> Optional[Trade]:
         """
         Handler for forcebuy <asset> <price>
         Buys a pair trade at the given or current price
@@ -720,7 +721,10 @@ class RPC:
         stakeamount = self._freqtrade.wallets.get_trade_stake_amount(pair)
 
         # execute buy
-        if self._freqtrade.execute_entry(pair, stakeamount, price, forcebuy=True):
+        if not order_type:
+            order_type = self._freqtrade.strategy.order_types.get(
+                'forcebuy', self._freqtrade.strategy.order_types['buy'])
+        if self._freqtrade.execute_entry(pair, stakeamount, price, order_type=order_type):
             Trade.commit()
             trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
             return trade

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -1093,7 +1093,7 @@ def test_rpcforcebuy(mocker, default_conf, ticker, fee, limit_buy_order_open) ->
     with pytest.raises(RPCException, match=r'position for ETH/BTC already open - id: 1'):
         rpc._rpc_forcebuy(pair, 0.0001)
     pair = 'XRP/BTC'
-    trade = rpc._rpc_forcebuy(pair, 0.0001)
+    trade = rpc._rpc_forcebuy(pair, 0.0001, order_type='limit')
     assert isinstance(trade, Trade)
     assert trade.pair == pair
     assert trade.open_rate == 0.0001


### PR DESCRIPTION

## Summary

Allow forcebuy / forcesell to specify the order type to be used.
Currently only available through the API, not via Telegram.

## Quick changelog

* Add ordertype to forcebuy
* add ordertype to forcesell