### PR TITLE
add weekly and monthly to valid keys

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -112,6 +112,7 @@ class Telegram(RPCHandler):
                                  r'/stats$', r'/count$', r'/locks$', r'/balance$',
                                  r'/stopbuy$', r'/reload_config$', r'/show_config$',
                                  r'/logs$', r'/whitelist$', r'/blacklist$', r'/edge$',
+                                 r'/weekly$', r'/weekly \d+$', r'/monthly$', r'/monthly \d+$',
                                  r'/forcebuy$', r'/help$', r'/version$']
         # Create keys for generation
         valid_keys_print = [k.replace('$', '') for k in valid_keys]


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Add /weekly and /monthly to valid keys because some users would want to add them in the custom keyboard

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

*Explain in details what this PR solve or improve. You can include visuals.* 
