### PR TITLE
Added raw config and retry config to webhook

### DIFF
--- a/docs/webhook-config.md
+++ b/docs/webhook-config.md
@@ -50,7 +50,7 @@ Sample configuration (tested using IFTTT).
 
 The url in `webhook.url` should point to the correct url for your webhook. If you're using [IFTTT](https://ifttt.com) (as shown in the sample above) please insert your event and key to the url.
 
-You can set the POST body format to Form-Encoded (default) or JSON-Encoded. Use `"format": "form"` or `"format": "json"` respectively. Example configuration for Mattermost Cloud integration:
+You can set the POST body format to Form-Encoded (default), JSON-Encoded, or raw data. Use `"format": "form"`, `"format": "json"`, or `"format": "raw"` respectively. Example configuration for Mattermost Cloud integration:
 
 ```json
   "webhook": {
@@ -63,7 +63,36 @@ You can set the POST body format to Form-Encoded (default) or JSON-Encoded. Use 
     },
 ```
 
-The result would be POST request with e.g. `{"text":"Status: running"}` body and `Content-Type: application/json` header which results `Status: running` message in the Mattermost channel.
+The result would be a POST request with e.g. `{"text":"Status: running"}` body and `Content-Type: application/json` header which results `Status: running` message in the Mattermost channel.
+
+When using the Form-Encoded or JSON-Encoded configuration you can configure any number of payload values, and both the key and value will be ouput in the POST request. However, when using the raw data format you can only configure one value and it **must** be named `"data"`. In this instance the data key will not be output in the POST request, only the value. For example:
+
+```json
+  "webhook": {
+        "enabled": true,
+        "url": "https://<YOURHOOKURL>",
+        "format": "raw",
+        "webhookstatus": {
+            "data": "Status: {status}"
+        }
+    },
+```
+
+The result would be a POST request with e.g. `Status: running` body and `Content-Type: text/plain` header.
+
+Optional parameters are available to enable automatic retries for webhook messages. The `webhook.retries` parameter can be set for the maximum number of retries the webhook request should attempt if it is unsuccessful (i.e. HTTP response status is not 200). By default this is set to `0` which is disabled. An additional `webhook.retry_delay` parameter can be set to specify the time in seconds between retry attempts. By default this is set to `0.1` (i.e. 100ms). Note that increasing the number of retries or retry delay may slow down the trader if there are connectivity issues with the webhook. Example configuration for retries:
+
+```json
+  "webhook": {
+        "enabled": true,
+        "url": "https://<YOURHOOKURL>",
+        "retries": 3,
+        "retry_delay": 0.2,
+        "webhookstatus": {
+            "status": "Status: {status}"
+        }
+    },
+```
 
 Different payloads can be configured for different events. Not all fields are necessary, but you should configure at least one of the dicts, otherwise the webhook will never be called.
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -312,6 +312,8 @@ CONF_SCHEMA = {
             'type': 'object',
             'properties': {
                 'enabled': {'type': 'boolean'},
+                'retries': {'type': 'integer', 'minimum': 0},
+                'retry_delay': {'type': 'number', 'minimum': 0},
                 'webhookbuy': {'type': 'object'},
                 'webhookbuycancel': {'type': 'object'},
                 'webhooksell': {'type': 'object'},

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -50,6 +50,8 @@ USERPATH_STRATEGIES = 'strategies'
 USERPATH_NOTEBOOKS = 'notebooks'
 
 TELEGRAM_SETTING_OPTIONS = ['on', 'off', 'silent']
+WEBHOOK_FORMAT_OPTIONS = ['form', 'json', 'raw']
+
 ENV_VAR_PREFIX = 'FREQTRADE__'
 
 NON_OPEN_EXCHANGE_STATES = ('cancelled', 'canceled', 'closed', 'expired')
@@ -312,12 +314,16 @@ CONF_SCHEMA = {
             'type': 'object',
             'properties': {
                 'enabled': {'type': 'boolean'},
+                'url': {'type': 'string'},
+                'format': {'type': 'string', 'enum': WEBHOOK_FORMAT_OPTIONS, 'default': 'form'},
                 'retries': {'type': 'integer', 'minimum': 0},
                 'retry_delay': {'type': 'number', 'minimum': 0},
                 'webhookbuy': {'type': 'object'},
                 'webhookbuycancel': {'type': 'object'},
+                'webhookbuyfill': {'type': 'object'},
                 'webhooksell': {'type': 'object'},
                 'webhooksellcancel': {'type': 'object'},
+                'webhooksellfill': {'type': 'object'},
                 'webhookstatus': {'type': 'object'},
             },
         },

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -33,10 +33,6 @@ class Webhook(RPCHandler):
         self._retries = self._config['webhook'].get('retries', 0)
         self._retry_delay = self._config['webhook'].get('retry_delay', 0.1)
 
-        if not (self._format in ['form', 'json', 'raw']):
-            raise NotImplementedError('Unknown webhook format `{}`, possible values are '
-                                      '`form` (default), `json`, and `raw`'.format(self._format))
-
     def cleanup(self) -> None:
         """
         Cleanup pending module resources.

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -79,7 +79,8 @@ class Webhook(RPCHandler):
         attempts = 0
         while not success and attempts <= self._retries:
             if attempts:
-                if self._retry_delay: time.sleep(self._retry_delay)
+                if self._retry_delay:
+                    time.sleep(self._retry_delay)
                 logger.info("Retrying webhook...")
 
             attempts += 1
@@ -90,10 +91,11 @@ class Webhook(RPCHandler):
                 elif self._format == 'json':
                     response = post(self._url, json=payload)
                 elif self._format == 'raw':
-                    response = post(self._url, data=payload['data'], headers={'Content-Type': 'text/plain'})
+                    response = post(self._url, data=payload['data'],
+                                    headers={'Content-Type': 'text/plain'})
                 else:
                     raise NotImplementedError('Unknown format: {}'.format(self._format))
-            
+
                 # Throw a RequestException if the post was not successful
                 response.raise_for_status()
                 success = True

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -33,9 +33,6 @@ class Webhook(RPCHandler):
         self._retries = self._config['webhook'].get('retries', 0)
         self._retry_delay = self._config['webhook'].get('retry_delay', 0.1)
 
-        if self._retries < 0: self._retries = 0
-        if self._retry_delay < 0: self._retry_delay = 0
-
         if not (self._format in ['form', 'json', 'raw']):
             raise NotImplementedError('Unknown webhook format `{}`, possible values are '
                                       '`form` (default), `json`, and `raw`'.format(self._format))

--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -101,7 +101,7 @@ class Webhook(RPCHandler):
                 else:
                     raise NotImplementedError('Unknown format: {}'.format(self._format))
             
-                """throw a RequestException if the post was not successful"""
+                # Throw a RequestException if the post was not successful
                 response.raise_for_status()
                 success = True
 

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -292,3 +292,14 @@ def test__send_msg_with_json_format(default_conf, mocker, caplog):
     webhook._send_msg(msg)
 
     assert post.call_args[1] == {'json': msg}
+
+def test__send_msg_with_raw_format(default_conf, mocker, caplog):
+    default_conf["webhook"] = get_webhook_dict()
+    default_conf["webhook"]["format"] = "raw"
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
+    msg = {'data': 'Hello'}
+    post = MagicMock()
+    mocker.patch("freqtrade.rpc.webhook.post", post)
+    webhook._send_msg(msg)
+
+    assert post.call_args[1] == {'data': msg['data'], 'headers': {'Content-Type': 'text/plain'}}

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -293,6 +293,7 @@ def test__send_msg_with_json_format(default_conf, mocker, caplog):
 
     assert post.call_args[1] == {'json': msg}
 
+
 def test__send_msg_with_raw_format(default_conf, mocker, caplog):
     default_conf["webhook"] = get_webhook_dict()
     default_conf["webhook"]["format"] = "raw"


### PR DESCRIPTION
## Summary

Needed webhook to talk with a pipe delimited protocol (not form and not json).

## Quick changelog

- Added 'raw' format option to webhook
- Added 'retries' option to webhook
- Added retry_delay option to webhook
- Added 'raw' format to webhook unit test
- Updated webhook docs for raw and retry configs
- Added missing webhook config params for validation

## What's new?

Added a 'raw' option to the webhook config for absolute control over payload formatting. This was needed for an external service that used a specific pipe delimited format for the message payload, and could not include parameter names.

Webhook sometimes has intermittent connection errors, added optional retry configuration. By default retries are disabled, but the user can configure as many retries at they want. There is also a retry delay setting that will execute a sleep between retries. This is default to 100ms.