### PR TITLE
correctly apply leverage to backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -490,7 +490,7 @@ class Backtesting:
                 open_rate=row[OPEN_IDX],
                 open_date=current_time,
                 stake_amount=stake_amount,
-                amount=round(stake_amount / row[OPEN_IDX], 8),
+                amount=round((stake_amount / row[OPEN_IDX]) * leverage, 8),
                 fee_open=self.fee,
                 fee_close=self.fee,
                 is_open=True,

--- a/tests/optimize/__init__.py
+++ b/tests/optimize/__init__.py
@@ -36,6 +36,7 @@ class BTContainer(NamedTuple):
     trailing_stop_positive_offset: float = 0.0
     use_sell_signal: bool = False
     use_custom_stoploss: bool = False
+    leverage: float = 1.0
 
 
 def _get_frame_time_from_offset(offset):

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -536,6 +536,23 @@ tc33 = BTContainer(data=[
     )]
 )
 
+# Test 34: (copy of test25 with leverage)
+# Sell with signal sell in candle 3 (stoploss also triggers on this candle)
+# Stoploss at 1%.
+# Sell-signal wins over stoploss
+tc34 = BTContainer(data=[
+    # D  O     H     L     C     V    B  S
+    [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
+    [1, 5000, 5025, 4975, 4987, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4987, 5012, 4986, 4986, 6172, 0, 0],
+    [3, 5010, 5010, 4986, 5010, 6172, 0, 1],
+    [4, 5010, 5010, 4855, 4995, 6172, 0, 0],  # Triggers stoploss + sellsignal acted on
+    [5, 4995, 4995, 4950, 4950, 6172, 0, 0]],
+    stop_loss=-0.01, roi={"0": 1}, profit_perc=0.002 * 5.0, use_sell_signal=True,
+    leverage=5.0,
+    trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=4)]
+)
+
 TESTS = [
     tc0,
     tc1,
@@ -571,6 +588,7 @@ TESTS = [
     tc31,
     tc32,
     tc33,
+    tc34,
     # TODO-lev: Add tests for short here
 ]
 
@@ -593,14 +611,19 @@ def test_backtest_results(default_conf, fee, mocker, caplog, data) -> None:
 
     mocker.patch("freqtrade.exchange.Exchange.get_fee", return_value=0.0)
     mocker.patch("freqtrade.exchange.Exchange.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch("freqtrade.exchange.Binance.get_max_leverage", return_value=100)
     patch_exchange(mocker)
     frame = _build_backtest_dataframe(data.data)
     backtesting = Backtesting(default_conf)
     backtesting._set_strategy(backtesting.strategylist[0])
     backtesting.required_startup = 0
+    if data.leverage > 1.0:
+        # TODO-lev: Should we initialize this properly??
+        backtesting._can_short = True
     backtesting.strategy.advise_entry = lambda a, m: frame
     backtesting.strategy.advise_exit = lambda a, m: frame
     backtesting.strategy.use_custom_stoploss = data.use_custom_stoploss
+    backtesting.strategy.leverage = lambda **kwargs: data.leverage
     caplog.set_level(logging.DEBUG)
 
     pair = "UNITTEST/BTC"


### PR DESCRIPTION
Fix "absolute" gains issue in backtesting when using leverage

TODO:
* [x] add at least one test that confirms this