### PR TITLE
Double notifications

### DIFF
--- a/docs/webhook-config.md
+++ b/docs/webhook-config.md
@@ -104,7 +104,8 @@ Possible parameters are:
 * `trade_id`
 * `exchange`
 * `pair`
-* `limit`
+* ~~`limit` # Deprecated - should no longer be used.~~
+* `open_rate`
 * `amount`
 * `open_date`
 * `stake_amount`
@@ -146,6 +147,8 @@ Possible parameters are:
 * `stake_amount`
 * `stake_currency`
 * `fiat_currency`
+* `order_type`
+* `current_rate`
 * `buy_tag`
 
 ### Webhooksell

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -278,7 +278,8 @@ class FreqtradeBot(LoggingMixin):
                 if order:
                     logger.info(f"Updating sell-fee on trade {trade} for order {order.order_id}.")
                     self.update_trade_state(trade, order.order_id,
-                                            stoploss_order=order.ft_order_side == 'stoploss')
+                                            stoploss_order=order.ft_order_side == 'stoploss',
+                                            send_msg=False)
 
         trades: List[Trade] = Trade.get_open_trades_without_assigned_fees()
         for trade in trades:
@@ -286,7 +287,7 @@ class FreqtradeBot(LoggingMixin):
                 order = trade.select_order('buy', False)
                 if order:
                     logger.info(f"Updating buy-fee on trade {trade} for order {order.order_id}.")
-                    self.update_trade_state(trade, order.order_id)
+                    self.update_trade_state(trade, order.order_id, send_msg=False)
 
     def handle_insufficient_funds(self, trade: Trade):
         """
@@ -308,7 +309,7 @@ class FreqtradeBot(LoggingMixin):
         order = trade.select_order('buy', False)
         if order:
             logger.info(f"Updating buy-fee on trade {trade} for order {order.order_id}.")
-            self.update_trade_state(trade, order.order_id)
+            self.update_trade_state(trade, order.order_id, send_msg=False)
 
     def refind_lost_order(self, trade):
         """
@@ -578,10 +579,6 @@ class FreqtradeBot(LoggingMixin):
         )
         trade.orders.append(order_obj)
 
-        # Update fees if order is closed
-        if order_status == 'closed':
-            self.update_trade_state(trade, order_id, order)
-
         Trade.query.session.add(trade)
         Trade.commit()
 
@@ -589,6 +586,10 @@ class FreqtradeBot(LoggingMixin):
         self.wallets.update()
 
         self._notify_enter(trade, order_type)
+
+        # Update fees if order is closed
+        if order_status == 'closed':
+            self.update_trade_state(trade, order_id, order)
 
         return True
 
@@ -1140,16 +1141,16 @@ class FreqtradeBot(LoggingMixin):
         trade.sell_order_status = ''
         trade.close_rate_requested = limit
         trade.sell_reason = exit_tag or sell_reason.sell_reason
-        # In case of market sell orders the order can be closed immediately
-        if order.get('status', 'unknown') in ('closed', 'expired'):
-            self.update_trade_state(trade, trade.open_order_id, order)
-        Trade.commit()
 
         # Lock pair for one candle to prevent immediate re-buys
         self.strategy.lock_pair(trade.pair, datetime.now(timezone.utc),
                                 reason='Auto lock')
 
         self._notify_exit(trade, order_type)
+        # In case of market sell orders the order can be closed immediately
+        if order.get('status', 'unknown') in ('closed', 'expired'):
+            self.update_trade_state(trade, trade.open_order_id, order)
+        Trade.commit()
 
         return True
 
@@ -1246,13 +1247,14 @@ class FreqtradeBot(LoggingMixin):
 #
 
     def update_trade_state(self, trade: Trade, order_id: str, action_order: Dict[str, Any] = None,
-                           stoploss_order: bool = False) -> bool:
+                           stoploss_order: bool = False, send_msg: bool = True) -> bool:
         """
         Checks trades with open orders and updates the amount if necessary
         Handles closing both buy and sell orders.
         :param trade: Trade object of the trade we're analyzing
         :param order_id: Order-id of the order we're analyzing
         :param action_order: Already acquired order object
+        :param send_msg: Send notification - should always be True except in "recovery" methods
         :return: True if order has been cancelled without being filled partially, False otherwise
         """
         if not order_id:
@@ -1292,11 +1294,11 @@ class FreqtradeBot(LoggingMixin):
 
         # Updating wallets when order is closed
         if not trade.is_open:
-            if not stoploss_order and not trade.open_order_id:
+            if send_msg and not stoploss_order and not trade.open_order_id:
                 self._notify_exit(trade, '', True)
             self.handle_protections(trade.pair)
             self.wallets.update()
-        elif not trade.open_order_id:
+        elif send_msg and not trade.open_order_id:
             # Buy fill
             self._notify_enter(trade, fill=True)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,4 +86,5 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
+  - pymdownx.tilde
   - mdx_truly_sane_lists

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -937,7 +937,7 @@ def test_telegram_forcesell_handle(default_conf, update, ticker, fee,
     telegram._forcesell(update=update, context=context)
 
     assert msg_mock.call_count == 4
-    last_msg = msg_mock.call_args_list[-1][0][0]
+    last_msg = msg_mock.call_args_list[-2][0][0]
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,
@@ -1001,7 +1001,7 @@ def test_telegram_forcesell_down_handle(default_conf, update, ticker, fee,
 
     assert msg_mock.call_count == 4
 
-    last_msg = msg_mock.call_args_list[-1][0][0]
+    last_msg = msg_mock.call_args_list[-2][0][0]
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,
@@ -1055,7 +1055,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, fee, mocker) -> None
 
     # Called for each trade 2 times
     assert msg_mock.call_count == 8
-    msg = msg_mock.call_args_list[1][0][0]
+    msg = msg_mock.call_args_list[0][0][0]
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -2979,7 +2979,7 @@ def test_execute_trade_exit_market_order(default_conf_usdt, ticker_usdt, fee,
     assert trade.close_profit == 0.09451372
 
     assert rpc_mock.call_count == 3
-    last_msg = rpc_mock.call_args_list[-1][0][0]
+    last_msg = rpc_mock.call_args_list[-2][0][0]
     assert {
         'type': RPCMessageType.SELL,
         'trade_id': 1,


### PR DESCRIPTION
## Summary
Avoid double notifications

Closes #5989

## Quick changelog

- We should not send a notification twice when filling orders
- fix wrong notification order ("fill" before "buy"  or "sell") which happened in some instances.
- combine buy and buy_fill methods into one (they actually do almost the same).