### PR TITLE
Hyperopt default trailing stop fix

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -766,7 +766,7 @@ As stated in the comment, you can also use it as the values of the corresponding
 
 #### Default Trailing Stop Search Space
 
-If you are optimizing trailing stop values, Freqtrade creates the 'trailing' optimization hyperspace for you. By default, the `trailing_stop` parameter is always set to True in that hyperspace, the value of the `trailing_only_offset_is_reached` vary between True and False, the values of the `trailing_stop_positive` and `trailing_stop_positive_offset` parameters vary in the ranges 0.02...0.35 and 0.01...0.1 correspondingly, which is sufficient in most cases.
+If you are optimizing trailing stop values, Freqtrade creates the 'trailing' optimization hyperspace for you. By default, the `trailing_stop` parameter is always set to True in that hyperspace, the value of the `trailing_only_offset_is_reached` vary between True and False, the values of the `trailing_stop_positive` and `trailing_stop_positive_offset` parameters vary in the ranges 0.001...0.1 and 0.02...0.35 correspondingly, which is sufficient in most cases.
 
 Override the `trailing_space()` method and define the desired range in it if you need values of the trailing stop parameters to vary in other ranges during hyperoptimization. A sample for this method can be found in the [overriding pre-defined spaces section](advanced-hyperopt.md#overriding-pre-defined-spaces).
 

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -180,14 +180,14 @@ class IHyperOpt(ABC):
             # other 'trailing' hyperspace parameters.
             Categorical([True], name='trailing_stop'),
 
-            SKDecimal(0.01, 0.35, decimals=3, name='trailing_stop_positive'),
+            SKDecimal(0.001, 0.1, decimals=3, name='trailing_stop_positive'),
 
             # 'trailing_stop_positive_offset' should be greater than 'trailing_stop_positive',
             # so this intermediate parameter is used as the value of the difference between
             # them. The value of the 'trailing_stop_positive_offset' is constructed in the
             # generate_trailing_params() method.
             # This is similar to the hyperspace dimensions used for constructing the ROI tables.
-            SKDecimal(0.001, 0.1, decimals=3, name='trailing_stop_positive_offset_p1'),
+            SKDecimal(0.02, 0.35, decimals=3, name='trailing_stop_positive_offset_p1'),
 
             Categorical([True, False], name='trailing_only_offset_is_reached'),
         ]


### PR DESCRIPTION
## Summary

Solve the issue: Minor fix on hyperopt default trailing stoploss searching spaces. The old code was wrong that the trailing_stop_positive is greater than trailing_stop_positive_offset. The documentation is also changed to reflect this fix. 


