### PR TITLE
Funding fees

### DIFF
--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -283,17 +283,20 @@ def refresh_backtest_ohlcv_data(exchange: Exchange, pairs: List[str], timeframes
             # Predefined candletype (and timeframe) depending on exchange
             # Downloads what is necessary to backtest based on futures data.
             timeframe = exchange._ft_has['mark_ohlcv_timeframe']
-            candle_type = CandleType.from_string(exchange._ft_has['mark_ohlcv_price'])
-
-            # TODO: this could be in most parts to the above.
-            if erase:
-                if data_handler.ohlcv_purge(pair, timeframe, candle_type=candle_type):
-                    logger.info(f'Deleting existing data for pair {pair}, interval {timeframe}.')
-            _download_pair_history(pair=pair, process=process,
-                                   datadir=datadir, exchange=exchange,
-                                   timerange=timerange, data_handler=data_handler,
-                                   timeframe=str(timeframe), new_pairs_days=new_pairs_days,
-                                   candle_type=candle_type)
+            fr_candle_type = CandleType.from_string(exchange._ft_has['mark_ohlcv_price'])
+            # All exchanges need FundingRate for futures trading.
+            # The timeframe is aligned to the mark-price timeframe.
+            for candle_type in (CandleType.FUNDING_RATE, fr_candle_type):
+                # TODO: this could be in most parts to the above.
+                if erase:
+                    if data_handler.ohlcv_purge(pair, timeframe, candle_type=candle_type):
+                        logger.info(
+                            f'Deleting existing data for pair {pair}, interval {timeframe}.')
+                _download_pair_history(pair=pair, process=process,
+                                       datadir=datadir, exchange=exchange,
+                                       timerange=timerange, data_handler=data_handler,
+                                       timeframe=str(timeframe), new_pairs_days=new_pairs_days,
+                                       candle_type=candle_type)
 
     return pairs_not_available
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1841,6 +1841,8 @@ class Exchange:
         if self.funding_fee_cutoff(open_date):
             open_date += timedelta(hours=1)
         timeframe = self._ft_has['mark_ohlcv_timeframe']
+        timeframe_ff = self._ft_has.get('funding_fee_timeframe',
+                                        self._ft_has['mark_ohlcv_timeframe'])
         open_date = timeframe_to_prev_date(timeframe, open_date)
 
         fees: float = 0
@@ -1852,7 +1854,7 @@ class Exchange:
         mark_comb: PairWithTimeframe = (
             pair, timeframe, CandleType.from_string(self._ft_has["mark_ohlcv_price"]))
 
-        funding_comb: PairWithTimeframe = (pair, timeframe, CandleType.FUNDING_RATE)
+        funding_comb: PairWithTimeframe = (pair, timeframe_ff, CandleType.FUNDING_RATE)
         candle_histories = self.refresh_latest_ohlcv(
             [mark_comb, funding_comb],
             since_ms=open_timestamp,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1851,7 +1851,9 @@ class Exchange:
 
         mark_comb: PairWithTimeframe = (
             pair, '1h', CandleType.from_string(self._ft_has["mark_ohlcv_price"]))
-        # TODO-lev: funding_rate downloading this way is not yet possible.
+
+        # TODO-lev: 1h seems arbitrary and generates a lot of "empty" lines
+        # TODO-lev: probably a exchange-adjusted parameter would make more sense
         funding_comb: PairWithTimeframe = (pair, '1h', CandleType.FUNDING_RATE)
         candle_histories = self.refresh_latest_ohlcv(
             [mark_comb, funding_comb],
@@ -1863,7 +1865,7 @@ class Exchange:
         mark_rates = candle_histories[mark_comb]
 
         df = funding_rates.merge(mark_rates, on='date', how="inner", suffixes=["_fund", "_mark"])
-        # TODO-lev: filter for relevant timeperiod?
+        df = df[(df['date'] >= open_date) & (df['date'] <= close_date)]
         fees = sum(df['open_fund'] * df['open_mark'] * amount)
 
         return fees

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1840,8 +1840,8 @@ class Exchange:
 
         if self.funding_fee_cutoff(open_date):
             open_date += timedelta(hours=1)
-
-        open_date = timeframe_to_prev_date('1h', open_date)
+        timeframe = self._ft_has['mark_ohlcv_timeframe']
+        open_date = timeframe_to_prev_date(timeframe, open_date)
 
         fees: float = 0
         if not close_date:
@@ -1850,11 +1850,9 @@ class Exchange:
         # close_timestamp = int(close_date.timestamp()) * 1000
 
         mark_comb: PairWithTimeframe = (
-            pair, '1h', CandleType.from_string(self._ft_has["mark_ohlcv_price"]))
+            pair, timeframe, CandleType.from_string(self._ft_has["mark_ohlcv_price"]))
 
-        # TODO-lev: 1h seems arbitrary and generates a lot of "empty" lines
-        # TODO-lev: probably a exchange-adjusted parameter would make more sense
-        funding_comb: PairWithTimeframe = (pair, '1h', CandleType.FUNDING_RATE)
+        funding_comb: PairWithTimeframe = (pair, timeframe, CandleType.FUNDING_RATE)
         candle_histories = self.refresh_latest_ohlcv(
             [mark_comb, funding_comb],
             since_ms=open_timestamp,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1925,42 +1925,6 @@ class Exchange:
         else:
             return 0.0
 
-    @retrier
-    def get_funding_rate_history(self, pair: str, since: int) -> Dict:
-        """
-        :param pair: quote/base currency pair
-        :param since: timestamp in ms of the beginning time
-        :param end: timestamp in ms of the end time
-        """
-        if not self.exchange_has("fetchFundingRateHistory"):
-            raise ExchangeError(
-                f"fetch_funding_rate_history is not available using {self.name}"
-            )
-
-        # TODO-lev: Gateio has a max limit into the past of 333 days, okex has a limit of 3 months
-        try:
-            funding_history: Dict = {}
-            response = self._api.fetch_funding_rate_history(
-                pair,
-                limit=1000,
-                since=since
-            )
-            for fund in response:
-                d = datetime.fromtimestamp(int(fund['timestamp'] / 1000), timezone.utc)
-                # Round down to the nearest hour, in case of a delayed timestamp
-                # The millisecond timestamps can be delayed ~20ms
-                time = int(timeframe_to_prev_date('1h', d).timestamp() * 1000)
-
-                funding_history[time] = fund['fundingRate']
-            return funding_history
-        except ccxt.DDoSProtection as e:
-            raise DDosProtection(e) from e
-        except (ccxt.NetworkError, ccxt.ExchangeError) as e:
-            raise TemporaryError(
-                f'Could not set margin mode due to {e.__class__.__name__}. Message: {e}') from e
-        except ccxt.BaseError as e:
-            raise OperationalException(e) from e
-
 
 def is_exchange_known_ccxt(exchange_name: str, ccxt_module: CcxtModuleType = None) -> bool:
     return exchange_name in ccxt_exchanges(ccxt_module)

--- a/freqtrade/exchange/okex.py
+++ b/freqtrade/exchange/okex.py
@@ -16,6 +16,8 @@ class Okex(Exchange):
 
     _ft_has: Dict = {
         "ohlcv_candle_limit": 100,
+        "mark_ohlcv_timeframe": "4h",
+        "funding_fee_timeframe": "8h",
     }
 
     _supported_trading_mode_collateral_pairs: List[Tuple[TradingMode, Collateral]] = [

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -490,7 +490,7 @@ def test_validate_backtest_data(default_conf, mocker, caplog, testdatadir) -> No
 @pytest.mark.parametrize('trademode,callcount', [
     ('spot', 4),
     ('margin', 4),
-    ('futures', 6),
+    ('futures', 8),  # Called 8 times - 4 normal, 2 funding and 2 mark/index calls
 ])
 def test_refresh_backtest_ohlcv_data(
         mocker, default_conf, markets, caplog, testdatadir, trademode, callcount):

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -91,7 +91,7 @@ def exchange_futures(request, exchange_conf, class_mocker):
         exchange_conf['exchange']['name'] = request.param
         exchange_conf['trading_mode'] = 'futures'
         exchange_conf['collateral'] = 'cross'
-        # TODO-lev This mock should no longer be necessary once futures are enabled.
+        # TODO-lev: This mock should no longer be necessary once futures are enabled.
         class_mocker.patch(
             'freqtrade.exchange.exchange.Exchange.validate_trading_mode_and_collateral')
         class_mocker.patch(

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -202,7 +202,9 @@ class TestCCXTExchange():
 
         pair = EXCHANGES[exchangename].get('futures_pair', EXCHANGES[exchangename]['pair'])
         since = int((datetime.now(timezone.utc) - timedelta(days=5)).timestamp() * 1000)
-        pair_tf = (pair, '1h', CandleType.FUNDING_RATE)
+        timeframe_ff = exchange._ft_has.get('funding_fee_timeframe',
+                                            exchange._ft_has['mark_ohlcv_timeframe'])
+        pair_tf = (pair, timeframe_ff, CandleType.FUNDING_RATE)
 
         funding_ohlcv = exchange.refresh_latest_ohlcv(
             [pair_tf],
@@ -212,9 +214,8 @@ class TestCCXTExchange():
         assert isinstance(funding_ohlcv, dict)
         rate = funding_ohlcv[pair_tf]
 
-        expected_tf = exchange._ft_has['mark_ohlcv_timeframe']
-        this_hour = timeframe_to_prev_date(expected_tf)
-        prev_hour = timeframe_to_prev_date(expected_tf, this_hour - timedelta(minutes=1))
+        this_hour = timeframe_to_prev_date(timeframe_ff)
+        prev_hour = timeframe_to_prev_date(timeframe_ff, this_hour - timedelta(minutes=1))
         assert rate[rate['date'] == this_hour].iloc[0]['open'] != 0.0
         assert rate[rate['date'] == prev_hour].iloc[0]['open'] != 0.0
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3408,43 +3408,6 @@ def test__get_funding_fee(
         assert kraken._get_funding_fee(size, funding_rate, mark_price, time_in_ratio) == kraken_fee
 
 
-def test__get_mark_price_history(mocker, default_conf, mark_ohlcv):
-    api_mock = MagicMock()
-    api_mock.fetch_ohlcv = MagicMock(return_value=mark_ohlcv)
-    type(api_mock).has = PropertyMock(return_value={'fetchOHLCV': True})
-
-    # mocker.patch('freqtrade.exchange.Exchange.get_funding_fees', lambda pair, since: y)
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
-    mark_prices = exchange._get_mark_price_history("ADA/USDT", 1630454400000)
-    assert mark_prices == {
-        1630454400000: 2.77,
-        1630458000000: 2.73,
-        1630461600000: 2.74,
-        1630465200000: 2.76,
-        1630468800000: 2.76,
-        1630472400000: 2.77,
-        1630476000000: 2.78,
-        1630479600000: 2.78,
-        1630483200000: 2.77,
-        1630486800000: 2.77,
-        1630490400000: 2.84,
-        1630494000000: 2.81,
-        1630497600000: 2.81,
-        1630501200000: 2.82,
-    }
-
-    ccxt_exceptionhandlers(
-        mocker,
-        default_conf,
-        api_mock,
-        "binance",
-        "_get_mark_price_history",
-        "fetch_ohlcv",
-        pair="ADA/USDT",
-        since=1635580800001
-    )
-
-
 @pytest.mark.parametrize('exchange,rate_start,rate_end,d1,d2,amount,expected_fees', [
     ('binance', 0, 2, "2021-09-01 00:00:00", "2021-09-01 08:00:00",  30.0, -0.0009140999999999999),
     ('binance', 0, 2, "2021-09-01 00:00:15", "2021-09-01 08:00:00",  30.0, -0.0009140999999999999),
@@ -3553,7 +3516,8 @@ def test__calculate_funding_fees_datetime_called(
 ):
     api_mock = MagicMock()
     api_mock.fetch_ohlcv = get_mock_coro(return_value=mark_ohlcv)
-    api_mock.fetch_funding_rate_history = get_mock_coro(return_value=funding_rate_history_octohourly)
+    api_mock.fetch_funding_rate_history = get_mock_coro(
+        return_value=funding_rate_history_octohourly)
     type(api_mock).has = PropertyMock(return_value={'fetchOHLCV': True})
     type(api_mock).has = PropertyMock(return_value={'fetchFundingRateHistory': True})
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3445,44 +3445,6 @@ def test__get_mark_price_history(mocker, default_conf, mark_ohlcv):
     )
 
 
-def test_get_funding_rate_history(mocker, default_conf, funding_rate_history_hourly):
-    api_mock = MagicMock()
-    api_mock.fetch_funding_rate_history = MagicMock(return_value=funding_rate_history_hourly)
-    type(api_mock).has = PropertyMock(return_value={'fetchFundingRateHistory': True})
-
-    # mocker.patch('freqtrade.exchange.Exchange.get_funding_fees', lambda pair, since: y)
-    exchange = get_patched_exchange(mocker, default_conf, api_mock)
-    funding_rates = exchange.get_funding_rate_history('ADA/USDT', 1635580800001)
-
-    assert funding_rates == {
-        1630454400000: -0.000008,
-        1630458000000: -0.000004,
-        1630461600000: 0.000012,
-        1630465200000: -0.000003,
-        1630468800000: -0.000007,
-        1630472400000: 0.000003,
-        1630476000000: 0.000019,
-        1630479600000: 0.000003,
-        1630483200000: -0.000003,
-        1630486800000: 0,
-        1630490400000: 0.000013,
-        1630494000000: 0.000077,
-        1630497600000: 0.000072,
-        1630501200000: 0.000097,
-    }
-
-    ccxt_exceptionhandlers(
-        mocker,
-        default_conf,
-        api_mock,
-        "binance",
-        "get_funding_rate_history",
-        "fetch_funding_rate_history",
-        pair="ADA/USDT",
-        since=1630454400000
-    )
-
-
 @pytest.mark.parametrize('exchange,rate_start,rate_end,d1,d2,amount,expected_fees', [
     ('binance', 0, 2, "2021-09-01 00:00:00", "2021-09-01 08:00:00",  30.0, -0.0009140999999999999),
     ('binance', 0, 2, "2021-09-01 00:00:15", "2021-09-01 08:00:00",  30.0, -0.0009140999999999999),

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3498,7 +3498,7 @@ def test__calculate_funding_fees(
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange)
     funding_fees = exchange._calculate_funding_fees('ADA/USDT', amount, d1, d2)
-    assert pytest.approx(funding_fees, expected_fees)
+    assert pytest.approx(funding_fees) == expected_fees
 
 
 @ pytest.mark.parametrize('exchange,expected_fees', [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3566,14 +3566,14 @@ def test__calculate_funding_fees(
         'gateio': funding_rate_history_octohourly,
     }[exchange][rate_start:rate_end]
     api_mock = MagicMock()
-    api_mock.fetch_funding_rate_history = MagicMock(return_value=funding_rate_history)
-    api_mock.fetch_ohlcv = MagicMock(return_value=mark_ohlcv)
+    api_mock.fetch_funding_rate_history = get_mock_coro(return_value=funding_rate_history)
+    api_mock.fetch_ohlcv = get_mock_coro(return_value=mark_ohlcv)
     type(api_mock).has = PropertyMock(return_value={'fetchOHLCV': True})
     type(api_mock).has = PropertyMock(return_value={'fetchFundingRateHistory': True})
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange)
     funding_fees = exchange._calculate_funding_fees('ADA/USDT', amount, d1, d2)
-    assert funding_fees == expected_fees
+    assert pytest.approx(funding_fees, expected_fees)
 
 
 @ pytest.mark.parametrize('exchange,expected_fees', [
@@ -3590,8 +3590,8 @@ def test__calculate_funding_fees_datetime_called(
     expected_fees
 ):
     api_mock = MagicMock()
-    api_mock.fetch_ohlcv = MagicMock(return_value=mark_ohlcv)
-    api_mock.fetch_funding_rate_history = MagicMock(return_value=funding_rate_history_octohourly)
+    api_mock.fetch_ohlcv = get_mock_coro(return_value=mark_ohlcv)
+    api_mock.fetch_funding_rate_history = get_mock_coro(return_value=funding_rate_history_octohourly)
     type(api_mock).has = PropertyMock(return_value={'fetchOHLCV': True})
     type(api_mock).has = PropertyMock(return_value={'fetchFundingRateHistory': True})
 


### PR DESCRIPTION
## Summary

Update funding-fee and mark-price calculation to reuse existing async methods
This will improve speed in dry-run - and as well as enable downloading of funding-rates.

## TODO

* [x] determine correct "timeframe" for funding rate
  This is especially important for downloading - as we'd otherwise end up with a lot of "0" rows.
* [x] implement actual downloading of funding rate