### PR TITLE
Auto buy BNB and self._log_responses patch

### DIFF
--- a/config_examples/config_binance.example.json
+++ b/config_examples/config_binance.example.json
@@ -26,6 +26,13 @@
     },
     "exchange": {
         "name": "binance",
+        "reduced_fees_strategy": {
+            "enable": true,
+            "process_throttle_secs": 3600,
+            "currency": "BNB",
+            "BNB_maximum": 0.35,
+            "BNB_minimum": 0.012
+        },
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
         "ccxt_config": {},
@@ -90,4 +97,3 @@
     "internals": {
         "process_throttle_secs": 5
     }
-}

--- a/config_examples/config_bittrex.example.json
+++ b/config_examples/config_bittrex.example.json
@@ -26,6 +26,13 @@
     },
     "exchange": {
         "name": "bittrex",
+        "reduced_fees_strategy": {
+            "enable": true,
+            "process_throttle_secs": 3600,
+            "currency": "BNB",
+            "BNB_maximum": 0.35,
+            "BNB_minimum": 0.012
+        },
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
         "ccxt_config": {"enableRateLimit": true},

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -396,7 +396,7 @@ class Exchange:
             # Note: ccxt has BaseCurrency/QuoteCurrency format for pairs
             if self.markets and pair not in self.markets:
                 raise OperationalException(
-                    f'Pair {pair} is not available on {self.name}. '
+                    f'Pair {pair} is not available on {self.name}. ' 
                     f'Please remove {pair} from your whitelist.')
 
                 # From ccxt Documentation:
@@ -738,11 +738,9 @@ class Exchange:
             balances = self._api.fetch_balance(self)
             if (balances["free"] > self._BNB_min and self._name == "binance" and
                self._avoid_duplicate_order is False):
-                print("in line 741")
                 self.create_order(pair, ordertype, side, (self._BNB_max - balances["free"]), rate)
                 self._avoid_duplicate_order = True
             else:
-                print("in line 744")
                 self._avoid_duplicate_order = False
             dry_order = self.create_dry_run_order(pair, ordertype, side, amount, rate)
             return dry_order


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Explain in one sentence the goal of this PR

1. Automatically buy BNB for trading fees (only in dry run) based on analysis of typical FreqTrade users.
2. Fixed the self._log_responses variable misnomer, I see that in the fully updated version it's been fixed to be self.log_responses, however I believe that changing the instances of its use to self._log_responses more conforms with naming protocols.

+ Potential early stage solution to the issue: #5562 
+ Variable misnomer patch (self._log_responses in exchange.py)


These edits were made to explore the possibility of buying BNB automatically in order to pay the minimum in trading fees. It was only implemented in dry-run mode however. This was done with changes made to the create_order method in exchange.py, changes to config_bittrex.example.json, and changes to config_binance.example.json. Additionally when testing with Travis CI I noticed that there was an inconsistency with the usage of self._log_responses in exhange.py so I changed the instances of its use to self._log_responses as opposed to self.log_responses.
