### PR TITLE
Suppress additional logs for pairs in blacklist

### DIFF
--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -2,7 +2,7 @@
 PairList manager class
 """
 import logging
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from cachetools import TTLCache, cached
 
@@ -23,7 +23,7 @@ class PairListManager():
         self._config = config
         self._whitelist = self._config['exchange'].get('pair_whitelist')
         self._blacklist = self._config['exchange'].get('pair_blacklist', [])
-        self._logged_blacklist_pairs = set()
+        self._logged_blacklist_pairs: Set[str] = set()
         self._pairlist_handlers: List[IPairList] = []
         self._tickers_needed = False
         for pairlist_handler_config in self._config.get('pairlists', None):

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -42,7 +42,7 @@ class PairListManager(LoggingMixin):
         if not self._pairlist_handlers:
             raise OperationalException("No Pairlist Handlers defined")
 
-        refresh_period = config.get('refresh_period', 1800)
+        refresh_period = config.get('pairlist_refresh_period', 3600)
         LoggingMixin.__init__(self, logger, refresh_period)
 
     @property

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -2,12 +2,14 @@
 PairList manager class
 """
 import logging
-from typing import Dict, List, Set
+from functools import partial
+from typing import Dict, List
 
 from cachetools import TTLCache, cached
 
 from freqtrade.constants import ListPairsWithTimeframes
 from freqtrade.exceptions import OperationalException
+from freqtrade.mixins import LoggingMixin
 from freqtrade.plugins.pairlist.IPairList import IPairList
 from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.resolvers import PairListResolver
@@ -16,14 +18,13 @@ from freqtrade.resolvers import PairListResolver
 logger = logging.getLogger(__name__)
 
 
-class PairListManager():
+class PairListManager(LoggingMixin):
 
     def __init__(self, exchange, config: dict) -> None:
         self._exchange = exchange
         self._config = config
         self._whitelist = self._config['exchange'].get('pair_whitelist')
         self._blacklist = self._config['exchange'].get('pair_blacklist', [])
-        self._logged_blacklist_pairs: Set[str] = set()
         self._pairlist_handlers: List[IPairList] = []
         self._tickers_needed = False
         for pairlist_handler_config in self._config.get('pairlists', None):
@@ -40,6 +41,9 @@ class PairListManager():
 
         if not self._pairlist_handlers:
             raise OperationalException("No Pairlist Handlers defined")
+
+        refresh_period = config.get('refresh_period', 1800)
+        LoggingMixin.__init__(self, logger, refresh_period)
 
     @property
     def whitelist(self) -> List[str]:
@@ -108,11 +112,10 @@ class PairListManager():
         except ValueError as err:
             logger.error(f"Pair blacklist contains an invalid Wildcard: {err}")
             return []
+        log_once = partial(self.log_once, logmethod=logmethod)
         for pair in pairlist.copy():
             if pair in blacklist:
-                if pair not in self._logged_blacklist_pairs:
-                    logmethod(f"Pair {pair} in your blacklist. Removing it from whitelist...")
-                    self._logged_blacklist_pairs.add(pair)
+                log_once(f"Pair {pair} in your blacklist. Removing it from whitelist...")
                 pairlist.remove(pair)
         return pairlist
 

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -24,6 +24,7 @@ class PairListManager():
         self._config = config
         self._whitelist = self._config['exchange'].get('pair_whitelist')
         self._blacklist = self._config['exchange'].get('pair_blacklist', [])
+        self._logged_blacklist_pairs = set()
         self._pairlist_handlers: List[IPairList] = []
         self._tickers_needed = False
         for pairlist_handler_config in self._config.get('pairlists', None):
@@ -108,9 +109,11 @@ class PairListManager():
         except ValueError as err:
             logger.error(f"Pair blacklist contains an invalid Wildcard: {err}")
             return []
-        for pair in deepcopy(pairlist):
+        for pair in pairlist.copy():
             if pair in blacklist:
-                logmethod(f"Pair {pair} in your blacklist. Removing it from whitelist...")
+                if pair not in self._logged_blacklist_pairs:
+                    logmethod(f"Pair {pair} in your blacklist. Removing it from whitelist...")
+                    self._logged_blacklist_pairs.add(pair)
                 pairlist.remove(pair)
         return pairlist
 

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -2,7 +2,6 @@
 PairList manager class
 """
 import logging
-from copy import deepcopy
 from typing import Dict, List
 
 from cachetools import TTLCache, cached

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -18,9 +18,6 @@ from tests.conftest import (create_mock_trades, get_patched_exchange, get_patche
                             log_has, log_has_re)
 
 
-logger = logging.getLogger(__name__)
-
-
 @pytest.fixture(scope="function")
 def whitelist_conf(default_conf):
     default_conf['stake_currency'] = 'BTC'
@@ -222,6 +219,7 @@ def test_invalid_blacklist(mocker, markets, static_pl_conf, caplog):
 
 
 def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_conf, caplog):
+    logger = logging.getLogger(__name__)
     freqtrade = get_patched_freqtradebot(mocker, static_pl_conf)
     mocker.patch.multiple(
         'freqtrade.exchange.Exchange',
@@ -230,6 +228,9 @@ def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_c
     )
     freqtrade.pairlists.refresh_pairlist()
     whitelist = ['ETH/BTC', 'TKN/BTC']
+    caplog.clear()
+    caplog.set_level(logging.INFO)
+
     # Ensure all except those in whitelist are removed.
     assert set(whitelist) == set(freqtrade.pairlists.whitelist)
     assert static_pl_conf['exchange']['pair_blacklist'] == freqtrade.pairlists.blacklist


### PR DESCRIPTION
All preliminary checks made and no issue found.
Output of pytest: 1737 passed, 1 skipped, 42 deselected, 64 warnings in 155.08s (0:02:35).
Output of flake8: .
Output of mypy: Success: no issues found in 152 source files.
Output of isort: Skipped 5 files

## Summary

Suppresses the continuous logs which are generated at every tick for removing pairs from the blacklist: it just logs them the first time.

## Quick changelog

- Add test case for checking removal of logs for pains in blacklist
- Add type annotation to new logs suppression code
- Remove unused import
- Suppress additional logs for pairs in blacklist

## What's new?

Every time that there's freqtrade "ticks", pairs in the blacklist are
checked and a warning message is displayed.
So, the logs are continuously flooded with the same warnings.

For example:
```
2021-07-26 06:24:45 freqtrade.plugins.pairlistmanager: WARNING -
Pair XTZUP/USDT in your blacklist. Removing it from whitelist...
2021-07-26 06:24:45 freqtrade.plugins.pairlistmanager: WARNING -
Pair SUSHIUP/USDT in your blacklist. Removing it from whitelist...
2021-07-26 06:24:45 freqtrade.plugins.pairlistmanager: WARNING -
Pair XTZDOWN/USDT in your blacklist. Removing it from whitelist...
2021-07-26 06:24:50 freqtrade.plugins.pairlistmanager: WARNING -
Pair XTZUP/USDT in your blacklist. Removing it from whitelist...
2021-07-26 06:24:50 freqtrade.plugins.pairlistmanager: WARNING -
Pair SUSHIUP/USDT in your blacklist. Removing it from whitelist...
2021-07-26 06:24:50 freqtrade.plugins.pairlistmanager: WARNING -
Pair XTZDOWN/USDT in your blacklist. Removing it from whitelist...
```

This patch shows the warning only the first time, by keeping track
of which pairs in the blacklist were already logged.

It also removes an unused import, adds a type annotation for the set which is used for keep track of the pairs which were already logged, and introduces a specific test case for it.