### PR TITLE
📝 Docs - Added `Any` import

### DIFF
--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -13,7 +13,7 @@ A sample of this can be found below, which is identical to the Default Hyperopt 
 
 ``` python
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from pandas import DataFrame
 


### PR DESCRIPTION
## Summary

Just a small PR that adds the `typing - Any` import in the example of the "Creating and using a custom loss function" section of the Advanced HyperOpt docs.

## Quick changelog

Added `Any` import in Advanced HyperOpt docs