### PR TITLE
Reduce kucoin logs

### DIFF
--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -80,9 +80,9 @@ def retrier_async(f):
         try:
             return await f(*args, **kwargs)
         except TemporaryError as ex:
-            logger.warning('%s() returned exception: "%s"', f.__name__, ex)
+            msg = f'{f.__name__}() returned exception: "{ex}". '
             if count > 0:
-                logger.warning('retrying %s() still for %s times', f.__name__, count)
+                logger.warning(msg + f'Retrying still for {count} times.')
                 count -= 1
                 kwargs['count'] = count
                 if isinstance(ex, DDosProtection):
@@ -98,7 +98,7 @@ def retrier_async(f):
                         await asyncio.sleep(backoff_delay)
                 return await wrapper(*args, **kwargs)
             else:
-                logger.warning('Giving up retrying: %s()', f.__name__)
+                logger.warning(msg + 'Giving up.')
                 raise ex
     return wrapper
 
@@ -111,9 +111,9 @@ def retrier(_func=None, retries=API_RETRY_COUNT):
             try:
                 return f(*args, **kwargs)
             except (TemporaryError, RetryableOrderError) as ex:
-                logger.warning('%s() returned exception: "%s"', f.__name__, ex)
+                msg = f'{f.__name__}() returned exception: "{ex}". '
                 if count > 0:
-                    logger.warning('retrying %s() still for %s times', f.__name__, count)
+                    logger.warning(msg + f'Retrying still for {count} times.')
                     count -= 1
                     kwargs.update({'count': count})
                     if isinstance(ex, (DDosProtection, RetryableOrderError)):
@@ -123,7 +123,7 @@ def retrier(_func=None, retries=API_RETRY_COUNT):
                         time.sleep(backoff_delay)
                     return wrapper(*args, **kwargs)
                 else:
-                    logger.warning('Giving up retrying: %s()', f.__name__)
+                    logger.warning(msg + 'Giving up.')
                     raise ex
         return wrapper
     # Support both @retrier and @retrier(retries=2) syntax

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -1,12 +1,15 @@
 import asyncio
 import logging
 import time
-from functools import wraps
+from functools import partial, wraps
 
 from freqtrade.exceptions import DDosProtection, RetryableOrderError, TemporaryError
+from freqtrade.mixins import LoggingMixin
 
 
 logger = logging.getLogger(__name__)
+logging_mixin = LoggingMixin(logger)
+log_once_warning = partial(logging_mixin.log_once, logmethod=logger.warning)
 
 
 # Maximum default retry count.
@@ -84,7 +87,7 @@ def retrier_async(f):
                     if "kucoin" in str(ex) and "429000" in str(ex):
                         # Temporary fix for 429000 error on kucoin
                         # see https://github.com/freqtrade/freqtrade/issues/5700 for details.
-                        logger.warning(
+                        log_once_warning(
                             f"Kucoin 429 error, avoid triggering DDosProtection backoff delay. "
                             f"{count} tries left before giving up")
                     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import logging
 import re
 from copy import deepcopy
 from datetime import datetime, timedelta
-from functools import reduce
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, PropertyMock
 
@@ -49,44 +48,35 @@ def pytest_configure(config):
         setattr(config.option, 'markexpr', 'not longrun')
 
 
-def log_contains(line, logs, count=False):
-    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'spamfoobar')
-    # and we want to check if line ('foo', for example) is contained in the tuple.
-    return any(line in logger_name or line in message
-               for logger_name, level, message in logs.record_tuples)
+def log_contains(line, logs):
+    """Check if line is contained in some caplog's message."""
+    return any(line in message for message in logs.messages)
 
 
 def log_has(line, logs):
-    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
-    # and we want to match line against foobar in the tuple
-    return reduce(lambda a, b: a or b,
-                  filter(lambda x: x[2] == line, logs.record_tuples),
-                  False)
+    """Check if line is found on some caplog's message."""
+    return any(line == message for message in logs.messages)
 
 
 def log_has_re(line, logs):
-    return reduce(lambda a, b: a or b,
-                  filter(lambda x: re.match(line, x[2]), logs.record_tuples),
-                  False)
+    """Check if line matches some caplog's message."""
+    return any(re.match(line, message) for message in logs.messages)
 
 
-def num_log_contains(line, logs, count=False):
-    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'spamfoobar')
-    # and we want to check how many times line ('foo', for example) is contained in the tuples.
-    return sum(line in logger_name or line in message
-               for logger_name, level, message in logs.record_tuples)
+def num_log_contains(line, logs):
+    """Check how many times line is contained in caplog's messages."""
+    # We want to check how many times line ('foo', for example) is contained in caplog's messages.
+    return sum(line in message for message in logs.messages)
 
 
-def num_log_has(line, logs, count=False):
-    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
-    # and we want to check how many times line is presente in the tuples.
+def num_log_has(line, logs):
+    """Check how many times line is found in caplog's messages."""
     return sum(line == logger_name or line == message
                for logger_name, level, message in logs.record_tuples)
 
 
-def num_log_has_re(line, logs, count=False):
-    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
-    # and we want to check how many times line matches in the tuples.
+def num_log_has_re(line, logs):
+    """Check how many times line matches caplog's messages."""
     return sum(re.match(line, logger_name) or re.match(line, message)
                for logger_name, level, message in logs.record_tuples)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,13 @@ def pytest_configure(config):
         setattr(config.option, 'markexpr', 'not longrun')
 
 
+def log_contains(line, logs, count=False):
+    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'spamfoobar')
+    # and we want to check if line ('foo', for example) is contained in the tuple.
+    return any(line in logger_name or line in message
+               for logger_name, level, message in logs.record_tuples)
+
+
 def log_has(line, logs):
     # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
     # and we want to match line against foobar in the tuple
@@ -61,6 +68,27 @@ def log_has_re(line, logs):
     return reduce(lambda a, b: a or b,
                   filter(lambda x: re.match(line, x[2]), logs.record_tuples),
                   False)
+
+
+def num_log_contains(line, logs, count=False):
+    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'spamfoobar')
+    # and we want to check how many times line ('foo', for example) is contained in the tuples.
+    return sum(line in logger_name or line in message
+               for logger_name, level, message in logs.record_tuples)
+
+
+def num_log_has(line, logs, count=False):
+    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
+    # and we want to check how many times line is presente in the tuples.
+    return sum(line == logger_name or line == message
+               for logger_name, level, message in logs.record_tuples)
+
+
+def num_log_has_re(line, logs, count=False):
+    # caplog mocker returns log as a tuple: ('freqtrade.something', logging.WARNING, 'foobar')
+    # and we want to check how many times line matches in the tuples.
+    return sum(re.match(line, logger_name) or re.match(line, message)
+               for logger_name, level, message in logs.record_tuples)
 
 
 def get_args(args):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,14 +71,12 @@ def num_log_contains(line, logs):
 
 def num_log_has(line, logs):
     """Check how many times line is found in caplog's messages."""
-    return sum(line == logger_name or line == message
-               for logger_name, level, message in logs.record_tuples)
+    return sum(line == message for logger_name, level, message in logs.record_tuples)
 
 
 def num_log_has_re(line, logs):
     """Check how many times line matches caplog's messages."""
-    return sum(re.match(line, logger_name) or re.match(line, message)
-               for logger_name, level, message in logs.record_tuples)
+    return sum(re.match(line, message) for logger_name, level, message in logs.record_tuples)
 
 
 def get_args(args):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,11 +48,6 @@ def pytest_configure(config):
         setattr(config.option, 'markexpr', 'not longrun')
 
 
-def log_contains(line, logs):
-    """Check if line is contained in some caplog's message."""
-    return any(line in message for message in logs.messages)
-
-
 def log_has(line, logs):
     """Check if line is found on some caplog's message."""
     return any(line == message for message in logs.messages)
@@ -63,20 +58,14 @@ def log_has_re(line, logs):
     return any(re.match(line, message) for message in logs.messages)
 
 
-def num_log_contains(line, logs):
-    """Check how many times line is contained in caplog's messages."""
-    # We want to check how many times line ('foo', for example) is contained in caplog's messages.
-    return sum(line in message for message in logs.messages)
-
-
 def num_log_has(line, logs):
     """Check how many times line is found in caplog's messages."""
-    return sum(line == message for logger_name, level, message in logs.record_tuples)
+    return sum(line == message for message in logs.messages)
 
 
 def num_log_has_re(line, logs):
     """Check how many times line matches caplog's messages."""
-    return sum(re.match(line, message) for logger_name, level, message in logs.record_tuples)
+    return sum(bool(re.match(line, message)) for message in logs.messages)
 
 
 def get_args(args):

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1758,24 +1758,8 @@ async def test__async_kucoin_get_candle_history(default_conf, mocker, caplog):
             exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kucoin")
             await exchange._async_get_candle_history(
                 'ETH/BTC', "5m", (arrow.utcnow().int_timestamp - 2000) * 1000, count=1)
-    assert num_log_contains('_async_get_candle_history() returned exception: "kucoin GET ',
-                            caplog) == 1
-    assert num_log_contains('retrying _async_get_candle_history() still for ', caplog) == 1
     assert num_log_contains("Kucoin 429 error, avoid triggering DDosProtection backoff delay",
                             caplog) == 1
-    assert num_log_contains('Giving up retrying: _async_get_candle_history()', caplog) == 1
-
-    mocker.patch('freqtrade.exchange.common.calculate_backoff', MagicMock(return_value=0.01))
-    for _ in range(3):
-        with pytest.raises(DDosProtection, match=r'XYZ Too Many Requests'):
-            api_mock.fetch_ohlcv = MagicMock(side_effect=ccxt.DDoSProtection(
-                "kucoin GET https://openapi-v2.kucoin.com/api/v1/market/candles?"
-                "symbol=ETH-BTC&type=5min&startAt=1640268735&endAt=1640418735"
-                "XYZ Too Many Requests" '{"code":"XYZ000","msg":"Too Many Requests"}'))
-            exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kucoin")
-            await exchange._async_get_candle_history(
-                'ETH/BTC', "5m", (arrow.utcnow().int_timestamp - 2000) * 1000, count=1)
-    assert num_log_contains('Applying DDosProtection backoff delay: ', caplog) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1741,6 +1741,28 @@ async def test__async_get_candle_history(default_conf, mocker, caplog, exchange_
 
 
 @pytest.mark.asyncio
+async def test__async_kucoin_get_candle_history(default_conf, mocker, caplog):
+    caplog.set_level(logging.INFO)
+    api_mock = MagicMock()
+
+    assert not log_has_re('Kucoin 429 error, avoid triggering DDosProtection backoff delay.*',
+                          caplog)
+
+    for _ in range(3):
+        with pytest.raises(DDosProtection, match=r'429 Too Many Requests'):
+            api_mock.fetch_ohlcv = MagicMock(side_effect=ccxt.DDoSProtection(
+                "kucoin GET https://openapi-v2.kucoin.com/api/v1/market/candles?"
+                "symbol=ETH-BTC&type=5min&startAt=1640268735&endAt=1640418735"
+                "429 Too Many Requests" '{"code":"429000","msg":"Too Many Requests"}'))
+            exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kucoin")
+            await exchange._async_get_candle_history(
+                'ETH/BTC', "5m", (arrow.utcnow().int_timestamp - 2000) * 1000, count=1)
+    logs_found = sum('Kucoin 429 error, avoid triggering DDosProtection backoff delay' in message
+                     for message in caplog.messages)
+    assert logs_found == 1
+
+
+@pytest.mark.asyncio
 async def test__async_get_candle_history_empty(default_conf, mocker, caplog):
     """ Test empty exchange result """
     ohlcv = []

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1757,7 +1757,30 @@ async def test__async_kucoin_get_candle_history(default_conf, mocker, caplog):
             exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kucoin")
             await exchange._async_get_candle_history(
                 'ETH/BTC', "5m", (arrow.utcnow().int_timestamp - 2000) * 1000, count=1)
-    logs_found = sum('Kucoin 429 error, avoid triggering DDosProtection backoff delay' in message
+    logs_found = sum('_async_get_candle_history() returned exception: "kucoin GET ' in message
+                     for message in caplog.messages)
+    assert logs_found == 1
+    logs_found = sum('retrying _async_get_candle_history() still for ' in message
+                     for message in caplog.messages)
+    assert logs_found == 1
+    logs_found = sum("Kucoin 429 error, avoid triggering DDosProtection backoff delay" in message
+                     for message in caplog.messages)
+    assert logs_found == 1
+    logs_found = sum(message == 'Giving up retrying: _async_get_candle_history()'
+                     for message in caplog.messages)
+    assert logs_found == 1
+
+    mocker.patch('freqtrade.exchange.common.calculate_backoff', MagicMock(return_value=0.01))
+    for _ in range(3):
+        with pytest.raises(DDosProtection, match=r'XYZ Too Many Requests'):
+            api_mock.fetch_ohlcv = MagicMock(side_effect=ccxt.DDoSProtection(
+                "kucoin GET https://openapi-v2.kucoin.com/api/v1/market/candles?"
+                "symbol=ETH-BTC&type=5min&startAt=1640268735&endAt=1640418735"
+                "XYZ Too Many Requests" '{"code":"XYZ000","msg":"Too Many Requests"}'))
+            exchange = get_patched_exchange(mocker, default_conf, api_mock, id="kucoin")
+            await exchange._async_get_candle_history(
+                'ETH/BTC', "5m", (arrow.utcnow().int_timestamp - 2000) * 1000, count=1)
+    logs_found = sum('Applying DDosProtection backoff delay: ' in message
                      for message in caplog.messages)
     assert logs_found == 1
 

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -15,7 +15,7 @@ from freqtrade.plugins.pairlist.pairlist_helpers import expand_pairlist
 from freqtrade.plugins.pairlistmanager import PairListManager
 from freqtrade.resolvers import PairListResolver
 from tests.conftest import (create_mock_trades, get_patched_exchange, get_patched_freqtradebot,
-                            log_has, log_has_re)
+                            log_has, log_has_re, num_log_has)
 
 
 @pytest.fixture(scope="function")
@@ -240,16 +240,14 @@ def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_c
     new_whitelist = freqtrade.pairlists.verify_blacklist(whitelist + ['BLK/BTC'], logger.warning)
     # Ensure that the pair is removed from the white list, and properly logged.
     assert set(whitelist) == set(new_whitelist)
-    matches = sum(1 for message in caplog.messages
-                  if message == 'Pair BLK/BTC in your blacklist. Removing it from whitelist...')
-    assert matches == 1
+    assert num_log_has('Pair BLK/BTC in your blacklist. Removing it from whitelist...',
+                       caplog) == 1
 
     new_whitelist = freqtrade.pairlists.verify_blacklist(whitelist + ['BLK/BTC'], logger.warning)
     # Ensure that the pair is not logged anymore when being removed from the pair list.
     assert set(whitelist) == set(new_whitelist)
-    matches = sum(1 for message in caplog.messages
-                  if message == 'Pair BLK/BTC in your blacklist. Removing it from whitelist...')
-    assert matches == 1
+    assert num_log_has('Pair BLK/BTC in your blacklist. Removing it from whitelist...',
+                       caplog) == 1
 
 
 def test_refresh_pairlist_dynamic(mocker, shitcoinmarkets, tickers, whitelist_conf):

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -237,15 +237,11 @@ def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_c
     # Ensure that log message wasn't generated.
     assert not log_has('Pair BLK/BTC in your blacklist. Removing it from whitelist...', caplog)
 
-    new_whitelist = freqtrade.pairlists.verify_blacklist(whitelist + ['BLK/BTC'], logger.warning)
-    # Ensure that the pair is removed from the white list, and properly logged.
-    assert set(whitelist) == set(new_whitelist)
-    assert num_log_has('Pair BLK/BTC in your blacklist. Removing it from whitelist...',
-                       caplog) == 1
-
-    new_whitelist = freqtrade.pairlists.verify_blacklist(whitelist + ['BLK/BTC'], logger.warning)
-    # Ensure that the pair is not logged anymore when being removed from the pair list.
-    assert set(whitelist) == set(new_whitelist)
+    for _ in range(3):
+        new_whitelist = freqtrade.pairlists.verify_blacklist(
+            whitelist + ['BLK/BTC'], logger.warning)
+        # Ensure that the pair is removed from the white list, and properly logged.
+        assert set(whitelist) == set(new_whitelist)
     assert num_log_has('Pair BLK/BTC in your blacklist. Removing it from whitelist...',
                        caplog) == 1
 


### PR DESCRIPTION
All preliminary checks made and no issue found.

## Summary

Reduces several logs which are generated by the KuCoin exchange, when using its APIs to fetch che candles status.

## Quick changelog

- Reduce KuCoin logs on DDosProtection error messages
- More logs are reduced, for KuCoin, on the retrier_async decorator
- New test functions introduced to check logs

## What's new?

KuCoin APIs generate A LOT of error messages.
Consequently, logs are flooded with lines like:
```
2021-12-25 22:30:23 freqtrade.exchange.common: WARNING -
_async_get_candle_history() returned exception:
"kucoin GET https://openapi-v2.kucoin.com/api/v1/market/candles?
symbol=PDEX-USDT&type=5min&startAt=1640317818&endAt=1640467818
429 Too Many Requests {"code":"429000","msg":"Too Many Requests"}"
2021-12-25 22:30:23 freqtrade.exchange.common: WARNING -
retrying _async_get_candle_history() still for 3 times
2021-12-25 22:30:23 freqtrade.exchange.common: WARNING -
Kucoin 429 error, avoid triggering DDosProtection backoff delay.
2 tries left before giving up
2021-12-25 22:30:24 freqtrade.exchange.common: WARNING -
_async_get_candle_history() returned exception:
"kucoin GET https://openapi-v2.kucoin.com/api/v1/market/candles?
symbol=UBX-USDT&type=5min&startAt=1640317821&endAt=1640467821
429 Too Many Requests {"code":"429000","msg":"Too Many Requests"}"
```

Messages like:
- Kucoin 429 error, avoid triggering DDosProtection backoff delay.
- _async_get_candle_history() returned exception
- retrying _async_get_candle_history() still for
- Giving up retrying: _async_get_candle_history()
- Applying DDosProtection backoff delay

are logged only once for a certain period of time (default is 3600 seconds).
A new test case, test__async_kucoin_get_candle_history, is introduce to check that the above messages are logged only once for the KuCoin exchange.

Finally, new functions log_contains, num_log_contains, num_log_has and num_log_has_re
are introduced in the conftest module to help and simplify checking:
- if logs contain a string;
- count how many messages contain a string;
- count how many messages are the given string;
- count how many messages matchs a regex.

A couple of existing tests are changed using the new functions.

IMO it would be even better to replace the existing log_contains, log_has, log_has_re with the corresponding new num_* functions (so, having only 3 functions for logs checking), because they are logically equivalent to the current ones (since the num_* functions return 0 if no log matches and >= 1 if some log matches, which are logically equivalent to a "false" and a "true" condition in Python).
I've also a question about those log functions: does it make sense to check both the logger_name and the message from the logs, instead of just checking the message (which both simplifies the implementation, and make it also faster)? Is there some special test that requires to check the logger_name?