### PR TITLE
Reduce memory usage by not holding on to no longer needed data

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -246,6 +246,9 @@ class Backtesting:
         Helper function to convert a processed dataframes into lists for performance reasons.
 
         Used by backtest() - so keep this optimized for performance.
+
+        :param processed: a processed dictionary with format {pair, data}, which gets cleared to
+        optimize memory usage!
         """
         # Every change to this headers list must evaluate further usages of the resulting tuple
         # and eventually change the constants for indexes at the top
@@ -254,7 +257,8 @@ class Backtesting:
         self.progress.init_step(BacktestState.CONVERT, len(processed))
 
         # Create dict with data
-        for pair, pair_data in processed.items():
+        for pair in processed.keys():
+            pair_data = processed[pair]
             self.check_abort()
             self.progress.increment()
             if not pair_data.empty:
@@ -283,6 +287,9 @@ class Backtesting:
             # Convert from Pandas to list for performance reasons
             # (Looping Pandas is slow.)
             data[pair] = df_analyzed[headers].values.tolist()
+
+            # Do not hold on to old data to reduce memory usage
+            processed[pair] = pair_data = None
         return data
 
     def _get_close_rate(self, sell_row: Tuple, trade: LocalTrade, sell: SellCheckTuple,
@@ -519,7 +526,8 @@ class Backtesting:
         Of course try to not have ugly code. By some accessor are sometime slower than functions.
         Avoid extensive logging in this method and functions it calls.
 
-        :param processed: a processed dictionary with format {pair, data}
+        :param processed: a processed dictionary with format {pair, data}, which gets cleared to
+        optimize memory usage!
         :param start_date: backtesting timerange start datetime
         :param end_date: backtesting timerange end datetime
         :param max_open_trades: maximum number of concurrent trades, <= 0 means unlimited

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1,6 +1,7 @@
 # pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103, unused-argument
 
 import random
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock
@@ -648,7 +649,7 @@ def test_backtest_one(default_conf, fee, mocker, testdatadir) -> None:
     processed = backtesting.strategy.advise_all_indicators(data)
     min_date, max_date = get_timerange(processed)
     result = backtesting.backtest(
-        processed=processed,
+        processed=deepcopy(processed),
         start_date=min_date,
         end_date=max_date,
         max_open_trades=10,
@@ -887,7 +888,7 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
     processed = backtesting.strategy.advise_all_indicators(data)
     min_date, max_date = get_timerange(processed)
     backtest_conf = {
-        'processed': processed,
+        'processed': deepcopy(processed),
         'start_date': min_date,
         'end_date': max_date,
         'max_open_trades': 3,
@@ -909,7 +910,7 @@ def test_backtest_multi_pair(default_conf, fee, mocker, tres, pair, testdatadir)
         'NXT/BTC', '5m')[0]) == len(data['NXT/BTC']) - 1 - backtesting.strategy.startup_candle_count
 
     backtest_conf = {
-        'processed': processed,
+        'processed': deepcopy(processed),
         'start_date': min_date,
         'end_date': max_date,
         'max_open_trades': 1,


### PR DESCRIPTION
This simple change significantly reduces memory usage, which becomes extremely apparent in hyperopt. All that only by not holding on to data we no longer need.

<details>
  <summary>Before:</summary>

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   245   6505.1 MiB   6505.1 MiB           1       @profile
   246                                             def _get_ohlcv_as_lists(self, processed: Dict[str, DataFrame]) -> Dict[str, Tuple]:
   247                                                 """
   248                                                 Helper function to convert a processed dataframes into lists for performance reasons.
   249                                         
   250                                                 Used by backtest() - so keep this optimized for performance.
   251                                                 """
   252                                                 # Every change to this headers list must evaluate further usages of the resulting tuple
   253                                                 # and eventually change the constants for indexes at the top
   254   6505.1 MiB      0.0 MiB           1           headers = ['date', 'buy', 'open', 'close', 'sell', 'low', 'high', 'buy_tag', 'exit_tag']
   255   6505.1 MiB      0.0 MiB           1           data: Dict = {}
   256   6505.1 MiB      0.0 MiB           1           self.progress.init_step(BacktestState.CONVERT, len(processed))
   257                                         
   258                                                 # Create dict with data
   259  16432.8 MiB    -13.1 MiB          46           for pair, pair_data in processed.items():
   260  16162.3 MiB    -13.1 MiB          45               self.check_abort()
   261  16162.3 MiB    -13.1 MiB          45               self.progress.increment()
   262  16162.3 MiB    -13.1 MiB          45               if not pair_data.empty:
   263  16162.3 MiB    -12.8 MiB          45                   pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
   264  16162.3 MiB    -13.1 MiB          45                   pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
   265  16162.3 MiB    -13.1 MiB          45                   pair_data.loc[:, 'buy_tag'] = None  # cleanup if buy_tag is exist
   266  16162.3 MiB    -13.1 MiB          45                   pair_data.loc[:, 'exit_tag'] = None  # cleanup if exit_tag is exist
   267                                         
   268  16162.3 MiB     19.2 MiB          90               df_analyzed = self.strategy.advise_sell(
   269  16162.3 MiB    -12.8 MiB          45                   self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair}).copy()
   270                                                     # Trim startup period from analyzed dataframe
   271  16159.4 MiB   -870.8 MiB          90               df_analyzed = trim_dataframe(df_analyzed, self.timerange,
   272  16159.4 MiB      0.0 MiB          45                                            startup_candles=self.required_startup)
   273                                                     # To avoid using data from future, we use buy/sell signals shifted
   274                                                     # from the previous candle
   275  16159.3 MiB     -2.9 MiB          45               df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
   276  16159.3 MiB      0.0 MiB          45               df_analyzed.loc[:, 'sell'] = df_analyzed.loc[:, 'sell'].shift(1)
   277  16159.3 MiB      0.0 MiB          45               df_analyzed.loc[:, 'buy_tag'] = df_analyzed.loc[:, 'buy_tag'].shift(1)
   278  16159.3 MiB      0.0 MiB          45               df_analyzed.loc[:, 'exit_tag'] = df_analyzed.loc[:, 'exit_tag'].shift(1)
   279                                         
   280                                                     # Update dataprovider cache
   281  16159.3 MiB      0.0 MiB          45               self.dataprovider._set_cached_df(pair, self.timeframe, df_analyzed)
   282                                         
   283  16314.9 MiB   5765.0 MiB          45               df_analyzed = df_analyzed.drop(df_analyzed.head(1).index)
   284                                         
   285                                                     # Convert from Pandas to list for performance reasons
   286                                                     # (Looping Pandas is slow.)
   287  16432.8 MiB   4112.5 MiB          45               data[pair] = df_analyzed[headers].values.tolist()
   288  16432.8 MiB      0.0 MiB           1           return data
```

</details>
<details>
  <summary>After:</summary>

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   245   6497.1 MiB   6497.1 MiB           1       @profile
   246                                             def _get_ohlcv_as_lists(self, processed: Dict[str, DataFrame]) -> Dict[str, Tuple]:
   247                                                 """
   248                                                 Helper function to convert a processed dataframes into lists for performance reasons.
   249                                         
   250                                                 Used by backtest() - so keep this optimized for performance.
   251                                         
   252                                                 :param processed: a processed dictionary with format {pair, data}, which gets cleared to
   253                                                 optimize memory usage!
   254                                                 """
   255                                                 # Every change to this headers list must evaluate further usages of the resulting tuple
   256                                                 # and eventually change the constants for indexes at the top
   257   6497.1 MiB      0.0 MiB           1           headers = ['date', 'buy', 'open', 'close', 'sell', 'low', 'high', 'buy_tag', 'exit_tag']
   258   6497.1 MiB      0.0 MiB           1           data: Dict = {}
   259   6497.1 MiB      0.0 MiB           1           self.progress.init_step(BacktestState.CONVERT, len(processed))
   260                                         
   261                                                 # Create dict with data
   262  10456.9 MiB   -593.5 MiB          46           for pair in list(processed.keys()):
   263  10350.4 MiB   -593.5 MiB          45               pair_data = processed[pair]
   264  10350.4 MiB   -593.5 MiB          45               self.check_abort()
   265  10350.4 MiB   -593.5 MiB          45               self.progress.increment()
   266  10350.4 MiB   -593.5 MiB          45               if not pair_data.empty:
   267  10350.4 MiB   -593.5 MiB          45                   pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
   268  10350.4 MiB   -593.5 MiB          45                   pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
   269  10350.4 MiB   -593.5 MiB          45                   pair_data.loc[:, 'buy_tag'] = None  # cleanup if buy_tag is exist
   270  10350.4 MiB   -593.5 MiB          45                   pair_data.loc[:, 'exit_tag'] = None  # cleanup if exit_tag is exist
   271                                         
   272  10350.4 MiB   -985.7 MiB          90               df_analyzed = self.strategy.advise_sell(
   273  10350.4 MiB   -604.2 MiB          45                   self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair}).copy()
   274                                                     # Trim startup period from analyzed dataframe
   275  10347.2 MiB  -1209.2 MiB          90               df_analyzed = trim_dataframe(df_analyzed, self.timerange,
   276  10347.2 MiB   -269.3 MiB          45                                            startup_candles=self.required_startup)
   277                                                     # To avoid using data from future, we use buy/sell signals shifted
   278                                                     # from the previous candle
   279  10347.2 MiB   -103.8 MiB          45               df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
   280  10347.2 MiB    -36.6 MiB          45               df_analyzed.loc[:, 'sell'] = df_analyzed.loc[:, 'sell'].shift(1)
   281  10347.2 MiB    -36.6 MiB          45               df_analyzed.loc[:, 'buy_tag'] = df_analyzed.loc[:, 'buy_tag'].shift(1)
   282  10347.2 MiB    -36.6 MiB          45               df_analyzed.loc[:, 'exit_tag'] = df_analyzed.loc[:, 'exit_tag'].shift(1)
   283                                         
   284                                                     # Update dataprovider cache
   285  10347.2 MiB    -36.6 MiB          45               self.dataprovider._set_cached_df(pair, self.timeframe, df_analyzed)
   286                                         
   287  10502.9 MiB   5194.0 MiB          45               df_analyzed = df_analyzed.drop(df_analyzed.head(1).index)
   288                                         
   289                                                     # Convert from Pandas to list for performance reasons
   290                                                     # (Looping Pandas is slow.)
   291  10606.3 MiB   2607.8 MiB          45               data[pair] = df_analyzed[headers].values.tolist()
   292                                         
   293                                                     # Do not hold on to old data to reduce memory usage
   294  10456.9 MiB  -6754.7 MiB          45               processed[pair] = pair_data = DataFrame()
   295  10456.9 MiB      0.0 MiB           1           return data
```

</details>

As you can see in this example savings are over 6GB per pair per hyperopt job which adds up real fast. This test was done on `20200101-20211225` with 5m candles.