### PR TITLE
Change sequence of ROI/sell signal to favor sell-signal

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -484,8 +484,8 @@ Since backtesting lacks some detailed information about what happens within a ca
   - ROI applies before trailing-stop, ensuring profits are "top-capped" at ROI if both ROI and trailing stop applies
 - Sell-reason does not explain if a trade was positive or negative, just what triggered the sell (this can look odd if negative ROI values are used)
 - Evaluation sequence (if multiple signals happen on the same candle)
-  - ROI (if not stoploss)
   - Sell-signal
+  - ROI (if not stoploss)
   - Stoploss
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -703,22 +703,20 @@ class IStrategy(ABC, HyperStrategyMixin):
                             custom_reason = custom_reason[:CUSTOM_SELL_MAX_LENGTH]
                     else:
                         custom_reason = None
-            # TODO: return here if sell-signal should be favored over ROI
+            if sell_signal in (SellType.CUSTOM_SELL, SellType.SELL_SIGNAL):
+                logger.debug(f"{trade.pair} - Sell signal received. "
+                             f"sell_type=SellType.{sell_signal.name}" +
+                             (f", custom_reason={custom_reason}" if custom_reason else ""))
+                return SellCheckTuple(sell_type=sell_signal, sell_reason=custom_reason)
 
         # Start evaluations
         # Sequence:
-        # ROI (if not stoploss)
         # Sell-signal
+        # ROI (if not stoploss)
         # Stoploss
         if roi_reached and stoplossflag.sell_type != SellType.STOP_LOSS:
             logger.debug(f"{trade.pair} - Required profit reached. sell_type=SellType.ROI")
             return SellCheckTuple(sell_type=SellType.ROI)
-
-        if sell_signal != SellType.NONE:
-            logger.debug(f"{trade.pair} - Sell signal received. "
-                         f"sell_type=SellType.{sell_signal.name}" +
-                         (f", custom_reason={custom_reason}" if custom_reason else ""))
-            return SellCheckTuple(sell_type=sell_signal, sell_reason=custom_reason)
 
         if stoplossflag.sell_flag:
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -426,8 +426,6 @@ tc26 = BTContainer(data=[
 
 # Test 27: Sell with signal sell in candle 3 (ROI at signal candle)
 # Stoploss at 10% (irrelevant), ROI at 5% (will trigger) - Wins over Sell-signal
-# TODO: figure out if sell-signal should win over ROI
-# Sell-signal wins over stoploss
 tc27 = BTContainer(data=[
     # D  O     H     L     C     V    B  S
     [0, 5000, 5025, 4975, 4987, 6172, 1, 0],
@@ -436,8 +434,8 @@ tc27 = BTContainer(data=[
     [3, 5010, 5012, 4986, 5010, 6172, 0, 1],  # sell-signal
     [4, 5010, 5251, 4855, 4995, 6172, 0, 0],  # Triggers ROI, sell-signal acted on
     [5, 4995, 4995, 4950, 4950, 6172, 0, 0]],
-    stop_loss=-0.10, roi={"0": 0.05}, profit_perc=0.05, use_sell_signal=True,
-    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=4)]
+    stop_loss=-0.10, roi={"0": 0.05}, profit_perc=0.002, use_sell_signal=True,
+    trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=4)]
 )
 
 # Test 28: trailing_stop should raise so candle 3 causes a stoploss


### PR DESCRIPTION
## Summary
This PR will Reverse the evaluation logic from favoring ROI over sell-signal to preferring sell-signal.

@rokups it would be great to get your input on this - as you've been doing quite some "backtest reality checks" in the recent past.

Closes #6139

## Quick changelog

- Change logic to evaluate sell-signal before ROI
## Reasoning

In live, this will not matter, as the price will still be determined the same way.
In backtesting, sell-signal will sell at "next-candle-open" - while ROI will sell at "roi value" - which might be above the candle open.

While this PR is here - it's a proposal, and i'm not certain yet if it will be merged or not.

For now, it looks like this will be the "conservative" way - more likely selling at a lower rate during backtesting (although it can also be higher if ROI jumped "one step down" at that candle).

