### PR TITLE
Remove asyncio warnings due to deprecation on 3.10 

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -422,6 +422,7 @@ class Hyperopt:
         self.backtesting.exchange.close()
         self.backtesting.exchange._api = None  # type: ignore
         self.backtesting.exchange._api_async = None  # type: ignore
+        self.backtesting.exchange.loop = None  # type: ignore
         # self.backtesting.exchange = None  # type: ignore
         self.backtesting.pairlists = None  # type: ignore
 

--- a/freqtrade/rpc/api_server/uvicorn_threaded.py
+++ b/freqtrade/rpc/api_server/uvicorn_threaded.py
@@ -47,7 +47,7 @@ class UvicornServer(uvicorn.Server):
         else:
             asyncio.set_event_loop(uvloop.new_event_loop())
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             # When running in a thread, we'll not have an eventloop yet.
             loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary

Remove asyncio warnings due to deprecation of `asycnio.get_event_loop()`.

The only warnings left are emitted by uvicorn - which i assume will be fixed with some future update.