### PR TITLE
Backtest result reuse

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -462,6 +462,10 @@ The output will show a table containing the realized absolute Profit (in stake c
 
 To save time, by default backtest will reuse a cached result when backtested strategy and config match that of previous backtest. To force a new backtest despite existing result for identical run specify `--no-cache` parameter.
 
+!!! Warning
+    Caching is automatically disabled for open-ended timeranges (`--timerange 20210101-`), as freqtrade cannot ensure reliably that the underlying data didn't change. It can also use cached results where it shouldn't if the original backtest had missing data at the end, which was fixed by downloading more data.
+    In this instance, please use `--no-cache` once to get a fresh backtest.
+
 ### Further backtest-result analysis
 
 To further analyze your backtest results, you can [export the trades](#exporting-trades-to-file).

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -76,6 +76,7 @@ optional arguments:
                         _today.json`
   --breakdown {day,week,month} [{day,week,month} ...]
                         Show backtesting breakdown per [day, week, month].
+  --no-cache            Do not reuse cached backtest results.
 
 Common arguments:
   -v, --verbose         Verbose mode (-vv for more, -vvv to get all messages).
@@ -456,6 +457,10 @@ freqtrade backtesting --strategy MyAwesomeStrategy --breakdown day month
 ```
 
 The output will show a table containing the realized absolute Profit (in stake currency) for the given timeperiod, as well as wins, draws and losses that materialized (closed) on this day.
+
+### Backtest result caching
+
+To save time, by default backtest will reuse a cached result when backtested strategy and config match that of previous backtest. To force a new backtest despite existing result for identical run specify `--no-cache` parameter.
 
 ### Further backtest-result analysis
 

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -24,7 +24,7 @@ ARGS_COMMON_OPTIMIZE = ["timeframe", "timerange", "dataformat_ohlcv",
 ARGS_BACKTEST = ARGS_COMMON_OPTIMIZE + ["position_stacking", "use_max_market_positions",
                                         "enable_protections", "dry_run_wallet", "timeframe_detail",
                                         "strategy_list", "export", "exportfilename",
-                                        "backtest_breakdown"]
+                                        "backtest_breakdown", "no_backtest_cache"]
 
 ARGS_HYPEROPT = ARGS_COMMON_OPTIMIZE + ["hyperopt", "hyperopt_path",
                                         "position_stacking", "use_max_market_positions",

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -205,6 +205,11 @@ AVAILABLE_CLI_OPTIONS = {
         nargs='+',
         choices=constants.BACKTEST_BREAKDOWNS
     ),
+    "no_backtest_cache": Arg(
+        '--no-cache',
+        help='Do not reuse cached backtest results.',
+        action='store_true'
+    ),
     # Edge
     "stoploss_range": Arg(
         '--stoplosses',

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -276,6 +276,9 @@ class Configuration:
         self._args_to_config(config, argname='backtest_breakdown',
                              logstring='Parameter --breakdown detected ...')
 
+        self._args_to_config(config, argname='no_backtest_cache',
+                             logstring='Parameter --no-cache detected ...')
+
         self._args_to_config(config, argname='disableparamexport',
                              logstring='Parameter --disableparamexport detected: {} ...')
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -2,11 +2,13 @@
 Various tool function for Freqtrade and scripts
 """
 import gzip
+import hashlib
 import logging
 import re
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator, List
+from typing import Any, Iterator, List, Union
 from typing.io import IO
 from urllib.parse import urlparse
 
@@ -228,3 +230,32 @@ def parse_db_uri_for_logging(uri: str):
         return uri
     pwd = parsed_db_uri.netloc.split(':')[1].split('@')[0]
     return parsed_db_uri.geturl().replace(f':{pwd}@', ':*****@')
+
+
+def get_strategy_run_id(strategy) -> str:
+    """
+    Generate unique identification hash for a backtest run. Identical config and strategy file will
+    always return an identical hash.
+    :param strategy: strategy object.
+    :return: hex string id.
+    """
+    digest = hashlib.sha1()
+    config = deepcopy(strategy.config)
+
+    # Options that have no impact on results of individual backtest.
+    not_important_keys = ('strategy_list', 'original_config', 'telegram', 'api_server')
+    for k in not_important_keys:
+        if k in config:
+            del config[k]
+
+    digest.update(rapidjson.dumps(config, default=str,
+                                  number_mode=rapidjson.NM_NATIVE).encode('utf-8'))
+    with open(strategy.__file__, 'rb') as fp:
+        digest.update(fp.read())
+    return digest.hexdigest().lower()
+
+
+def get_backtest_metadata_filename(filename: Union[Path, str]) -> Path:
+    """Return metadata filename for specified backtest results file."""
+    filename = Path(filename)
+    return filename.parent / Path(f'{filename.stem}.meta{filename.suffix}')

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -753,6 +753,7 @@ class Backtesting:
         }
 
         # Load previous result that will be updated incrementally.
+        # This can be circumvented in certain instances in combination with downloading more data
         if self.timerange.stopts == 0 or datetime.fromtimestamp(
            self.timerange.stopts, tz=timezone.utc) > datetime.now(tz=timezone.utc):
             self.config['no_backtest_cache'] = True

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -753,7 +753,8 @@ class Backtesting:
         }
 
         # Load previous result that will be updated incrementally.
-        if self.config.get('timerange', '-').endswith('-'):
+        if self.timerange.stopts == 0 or datetime.fromtimestamp(
+           self.timerange.stopts, tz=timezone.utc) > datetime.now(tz=timezone.utc):
             self.config['no_backtest_cache'] = True
             logger.warning('Backtest result caching disabled due to use of open-ended timerange.')
 

--- a/freqtrade/optimize/edge_cli.py
+++ b/freqtrade/optimize/edge_cli.py
@@ -34,7 +34,7 @@ class EdgeCli:
         self.config['stake_amount'] = constants.UNLIMITED_STAKE_AMOUNT
         self.exchange = ExchangeResolver.load_exchange(self.config['exchange']['name'], self.config)
         self.strategy = StrategyResolver.load_strategy(self.config)
-        self.strategy.dp = DataProvider(config, None)
+        self.strategy.dp = DataProvider(config, self.exchange)
 
         validate_config_consistency(self.config)
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1261,9 +1261,8 @@ def test_backtest_start_multi_strat_caching(default_conf, mocker, caplog, testda
     mocker.patch('freqtrade.plugins.pairlistmanager.PairListManager.whitelist',
                  PropertyMock(return_value=['UNITTEST/BTC']))
     mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', backtestmock)
-    mocker.patch('freqtrade.optimize.backtesting', show_backtest_result=MagicMock())
+    mocker.patch('freqtrade.optimize.backtesting.show_backtest_results', MagicMock())
 
-    path_glob = MagicMock(return_value=['not important'])
     load_backtest_metadata = MagicMock(return_value={
         'StrategyTestV2': {'run_id': '1'},
         'TestStrategyLegacyV1': {'run_id': 'changed'}
@@ -1280,12 +1279,11 @@ def test_backtest_start_multi_strat_caching(default_conf, mocker, caplog, testda
             'strategy_comparison': [{'key': 'TestStrategyLegacyV1'}]
         }
     ])
-    get_strategy_run_id = MagicMock(side_effect=['1', '2', '2'])
-    mocker.patch('pathlib.Path.glob', path_glob)
+    mocker.patch('pathlib.Path.glob', return_value=['not important'])
     mocker.patch.multiple('freqtrade.data.btanalysis',
                           load_backtest_metadata=load_backtest_metadata,
                           load_backtest_stats=load_backtest_stats)
-    mocker.patch('freqtrade.misc.get_strategy_run_id', get_strategy_run_id)
+    mocker.patch('freqtrade.optimize.backtesting.get_strategy_run_id', side_effect=['1', '2', '2'])
 
     patched_configuration_load_config_file(mocker, default_conf)
 

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -84,6 +84,7 @@ def test_generate_backtest_stats(default_conf, testdatadir, tmpdir):
         'rejected_signals': 20,
         'backtest_start_time': Arrow.utcnow().int_timestamp,
         'backtest_end_time': Arrow.utcnow().int_timestamp,
+        'run_id': '123',
         }
         }
     timerange = TimeRange.parse_timerange('1510688220-1510700340')
@@ -132,6 +133,7 @@ def test_generate_backtest_stats(default_conf, testdatadir, tmpdir):
         'rejected_signals': 20,
         'backtest_start_time': Arrow.utcnow().int_timestamp,
         'backtest_end_time': Arrow.utcnow().int_timestamp,
+        'run_id': '124',
         }
     }
 
@@ -178,16 +180,16 @@ def test_store_backtest_stats(testdatadir, mocker):
 
     dump_mock = mocker.patch('freqtrade.optimize.optimize_reports.file_dump_json')
 
-    store_backtest_stats(testdatadir, {})
+    store_backtest_stats(testdatadir, {'metadata': {}})
 
-    assert dump_mock.call_count == 2
+    assert dump_mock.call_count == 3
     assert isinstance(dump_mock.call_args_list[0][0][0], Path)
     assert str(dump_mock.call_args_list[0][0][0]).startswith(str(testdatadir/'backtest-result'))
 
     dump_mock.reset_mock()
     filename = testdatadir / 'testresult.json'
-    store_backtest_stats(filename, {})
-    assert dump_mock.call_count == 2
+    store_backtest_stats(filename, {'metadata': {}})
+    assert dump_mock.call_count == 3
     assert isinstance(dump_mock.call_args_list[0][0][0], Path)
     # result will be testdatadir / testresult-<timestamp>.json
     assert str(dump_mock.call_args_list[0][0][0]).startswith(str(testdatadir / 'testresult'))


### PR DESCRIPTION
## Summary

Implemented reuse of old backtest results when backtest parameters did not change.

## Quick changelog

- Avoid running a backtest and instead reuse old result if backtest parameters did not change.
- Extra file `backtest-result-*.meta.json` is written with backtest run id (hash derived from config + strategy file).
- New command line parameter `--no-cache` for `backtest` subcommand, opting out from cached result reuse.

## What's new?

When we develop a new version of strategy we usually backtest using `--strategy-list` so we can compare against previous versions. In such case we most likely backtest multiple times using same config and old strategy files do not change. This means we can reuse old backtest result instead of redoing same backtest over and over. This is what was implemented here.
