### PR TITLE
increase okex candle limit

### DIFF
--- a/freqtrade/exchange/okex.py
+++ b/freqtrade/exchange/okex.py
@@ -14,5 +14,5 @@ class Okex(Exchange):
     """
 
     _ft_has: Dict = {
-        "ohlcv_candle_limit": 100,
+        "ohlcv_candle_limit": 300,
     }


### PR DESCRIPTION
okex has increased the number of candles-sticks they will reply with up to 300. The behaviour is as follows:

```
import ccxt
okex = ccxt.okex()
okex.fetchOHLCV('BTC/USDT', '1m', None, 100) # returns 100 candles
okex.fetchOHLCV('BTC/USDT', '1m', None, 300) # returns 300 candles
okex.fetchOHLCV('BTC/USDT', '1m', None, 301) # returns 300 candles
```

https://www.okex.com/docs-v5/en/#rest-api-market-data-get-candlesticks

earlier this year the limit was 100

https://web.archive.org/web/20211106094508/https://www.okex.com/docs-v5/en/#rest-api-market-data-get-candlesticks