### PR TITLE
Fix #6179

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -270,8 +270,8 @@ class Backtesting:
             df_analyzed = self.strategy.advise_sell(
                 self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair}).copy()
             # Trim startup period from analyzed dataframe
-            df_analyzed = trim_dataframe(df_analyzed, self.timerange,
-                                         startup_candles=self.required_startup)
+            df_analyzed = processed[pair] = pair_data = trim_dataframe(
+                df_analyzed, self.timerange, startup_candles=self.required_startup)
             # To avoid using data from future, we use buy/sell signals shifted
             # from the previous candle
             df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
@@ -287,9 +287,6 @@ class Backtesting:
             # Convert from Pandas to list for performance reasons
             # (Looping Pandas is slow.)
             data[pair] = df_analyzed[headers].values.tolist()
-
-            # Do not hold on to old data to reduce memory usage
-            processed[pair] = pair_data = None
         return data
 
     def _get_close_rate(self, sell_row: Tuple, trade: LocalTrade, sell: SellCheckTuple,


### PR DESCRIPTION
```

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   245   9469.3 MiB   9469.3 MiB           1       @profile
   246                                             def _get_ohlcv_as_lists(self, processed: Dict[str, DataFrame]) -> Dict[str, Tuple]:
   247                                                 """
   248                                                 Helper function to convert a processed dataframes into lists for performance reasons.
   249                                         
   250                                                 Used by backtest() - so keep this optimized for performance.
   251                                         
   252                                                 :param processed: a processed dictionary with format {pair, data}, which gets cleared to
   253                                                 optimize memory usage!
   254                                                 """
   255                                                 # Every change to this headers list must evaluate further usages of the resulting tuple
   256                                                 # and eventually change the constants for indexes at the top
   257   9469.3 MiB      0.0 MiB           1           headers = ['date', 'buy', 'open', 'close', 'sell', 'low', 'high', 'buy_tag', 'exit_tag']
   258   9469.3 MiB      0.0 MiB           1           data: Dict = {}
   259   9469.3 MiB      0.0 MiB           1           self.progress.init_step(BacktestState.CONVERT, len(processed))
   260                                         
   261                                                 # Create dict with data
   262  14123.8 MiB   -516.0 MiB          46           for pair in processed.keys():
   263  14007.8 MiB   -516.0 MiB          45               pair_data = processed[pair]
   264  14007.8 MiB   -516.0 MiB          45               self.check_abort()
   265  14007.8 MiB   -516.0 MiB          45               self.progress.increment()
   266  14007.8 MiB   -516.0 MiB          45               if not pair_data.empty:
   267  14007.8 MiB   -515.6 MiB          45                   pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
   268  14007.8 MiB   -516.0 MiB          45                   pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
   269  14007.8 MiB   -515.6 MiB          45                   pair_data.loc[:, 'buy_tag'] = None  # cleanup if buy_tag is exist
   270  14007.8 MiB   -515.5 MiB          45                   pair_data.loc[:, 'exit_tag'] = None  # cleanup if exit_tag is exist
   271                                         
   272  14016.1 MiB   -525.7 MiB          90               df_analyzed = self.strategy.advise_sell(
   273  14014.3 MiB   -273.8 MiB          45                   self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair}).copy()
   274                                                     # Trim startup period from analyzed dataframe
   275  14016.1 MiB -10492.3 MiB          90               df_analyzed = processed[pair] = pair_data = trim_dataframe(
   276  14016.1 MiB   -112.9 MiB          45                   df_analyzed, self.timerange, startup_candles=self.required_startup)
   277                                                     # To avoid using data from future, we use buy/sell signals shifted
   278                                                     # from the previous candle
   279  13770.8 MiB  -9164.0 MiB          45               df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
   280  13770.8 MiB      0.0 MiB          45               df_analyzed.loc[:, 'sell'] = df_analyzed.loc[:, 'sell'].shift(1)
   281  13770.8 MiB      0.0 MiB          45               df_analyzed.loc[:, 'buy_tag'] = df_analyzed.loc[:, 'buy_tag'].shift(1)
   282  13770.8 MiB      0.0 MiB          45               df_analyzed.loc[:, 'exit_tag'] = df_analyzed.loc[:, 'exit_tag'].shift(1)
   283                                         
   284                                                     # Update dataprovider cache
   285  13770.8 MiB      0.0 MiB          45               self.dataprovider._set_cached_df(pair, self.timeframe, df_analyzed)
   286                                         
   287  14025.3 MiB   9388.7 MiB          45               df_analyzed = df_analyzed.drop(df_analyzed.head(1).index)
   288                                         
   289                                                     # Convert from Pandas to list for performance reasons
   290                                                     # (Looping Pandas is slow.)
   291  14123.8 MiB   3457.7 MiB          45               data[pair] = df_analyzed[headers].values.tolist()
   292  14123.8 MiB      0.0 MiB           1           return data
```

Also for the sake of curiosity i tried without `.copy()`:

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   245   9469.2 MiB   9469.2 MiB           1       @profile
   246                                             def _get_ohlcv_as_lists(self, processed: Dict[str, DataFrame]) -> Dict[str, Tuple]:
   247                                                 """
   248                                                 Helper function to convert a processed dataframes into lists for performance reasons.
   249                                         
   250                                                 Used by backtest() - so keep this optimized for performance.
   251                                         
   252                                                 :param processed: a processed dictionary with format {pair, data}, which gets cleared to
   253                                                 optimize memory usage!
   254                                                 """
   255                                                 # Every change to this headers list must evaluate further usages of the resulting tuple
   256                                                 # and eventually change the constants for indexes at the top
   257   9469.2 MiB      0.0 MiB           1           headers = ['date', 'buy', 'open', 'close', 'sell', 'low', 'high', 'buy_tag', 'exit_tag']
   258   9469.2 MiB      0.0 MiB           1           data: Dict = {}
   259   9469.2 MiB      0.0 MiB           1           self.progress.init_step(BacktestState.CONVERT, len(processed))
   260                                         
   261                                                 # Create dict with data
   262  14063.8 MiB   -483.4 MiB          46           for pair in processed.keys():
   263  13914.3 MiB   -483.4 MiB          45               pair_data = processed[pair]
   264  13914.3 MiB   -483.4 MiB          45               self.check_abort()
   265  13914.3 MiB   -483.4 MiB          45               self.progress.increment()
   266  13914.3 MiB   -483.4 MiB          45               if not pair_data.empty:
   267  13914.3 MiB   -482.9 MiB          45                   pair_data.loc[:, 'buy'] = 0  # cleanup if buy_signal is exist
   268  13914.3 MiB   -483.4 MiB          45                   pair_data.loc[:, 'sell'] = 0  # cleanup if sell_signal is exist
   269  13914.3 MiB   -483.0 MiB          45                   pair_data.loc[:, 'buy_tag'] = None  # cleanup if buy_tag is exist
   270  13914.3 MiB   -482.6 MiB          45                   pair_data.loc[:, 'exit_tag'] = None  # cleanup if exit_tag is exist
   271                                         
   272  13914.3 MiB  -9952.1 MiB          90               df_analyzed = self.strategy.advise_sell(
   273  13926.9 MiB   -213.5 MiB          45                   self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair}) #.copy()
   274                                                     # Trim startup period from analyzed dataframe
   275  13693.0 MiB  -8877.9 MiB          90               df_analyzed = processed[pair] = pair_data = trim_dataframe(
   276  13677.2 MiB      0.0 MiB          45                   df_analyzed, self.timerange, startup_candles=self.required_startup)
   277                                                     # To avoid using data from future, we use buy/sell signals shifted
   278                                                     # from the previous candle
   279  13693.0 MiB      0.0 MiB          45               df_analyzed.loc[:, 'buy'] = df_analyzed.loc[:, 'buy'].shift(1)
   280  13693.0 MiB      0.0 MiB          45               df_analyzed.loc[:, 'sell'] = df_analyzed.loc[:, 'sell'].shift(1)
   281  13693.0 MiB      0.0 MiB          45               df_analyzed.loc[:, 'buy_tag'] = df_analyzed.loc[:, 'buy_tag'].shift(1)
   282  13693.0 MiB      0.0 MiB          45               df_analyzed.loc[:, 'exit_tag'] = df_analyzed.loc[:, 'exit_tag'].shift(1)
   283                                         
   284                                                     # Update dataprovider cache
   285  13693.0 MiB      0.0 MiB          45               self.dataprovider._set_cached_df(pair, self.timeframe, df_analyzed)
   286                                         
   287  13947.5 MiB   9387.4 MiB          45               df_analyzed = df_analyzed.drop(df_analyzed.head(1).index)
   288                                         
   289                                                     # Convert from Pandas to list for performance reasons
   290                                                     # (Looping Pandas is slow.)
   291  14063.8 MiB   3435.7 MiB          45               data[pair] = df_analyzed[headers].values.tolist()
   292  14063.8 MiB      0.0 MiB           1           return data
```

Pretty much same thing.