### PR TITLE
cleanup funding fee tests

### DIFF
--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -728,6 +728,8 @@ class LocalTrade():
 
         elif (trading_mode == TradingMode.FUTURES):
             funding_fees = self.funding_fees or 0.0
+            # Positive funding_fees -> Trade has gained from fees.
+            # Negative funding_fees -> Trade had to pay the fees.
             if self.is_short:
                 return float(self._calc_base_close(amount, rate, fee)) - funding_fees
             else:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -549,11 +549,11 @@ def test_update_market_order(market_buy_order_usdt, market_sell_order_usdt, fee,
         ("kraken", True, 3, 59.850, 66.231165, -6.381165, -0.3198578, margin, 0.0),
 
         ("binance", False, 1, 60.15, 65.835,  5.685, 0.09451371, futures, 0.0),
-        ("binance", False, 1, 60.15, 64.835,  4.685, 0.07788861, futures, 1.0),
+        ("binance", False, 1, 60.15, 66.835,  6.685, 0.11113881, futures, 1.0),
         ("binance", True, 1, 59.85,  66.165, -6.315, -0.10551378, futures, 0.0),
-        ("binance", True, 1, 59.85,  65.165, -5.315, -0.08880535, futures, -1.0),
-        ("binance", False, 3, 60.15, 66.835,  6.685, 0.33341646, futures, -1.0),
-        ("binance", True, 3, 59.85,  67.165, -7.315, -0.36666667, futures, 1.0),
+        ("binance", True, 1, 59.85,  67.165, -7.315, -0.12222222, futures, -1.0),
+        ("binance", False, 3, 60.15, 64.835,  4.685, 0.23366583, futures, -1.0),
+        ("binance", True, 3, 59.85,  65.165, -5.315, -0.26641604, futures, 1.0),
     ])
 @pytest.mark.usefixtures("init_persistence")
 def test_calc_open_close_trade_price(
@@ -789,72 +789,72 @@ def test_calc_close_trade_price(
 
 @pytest.mark.parametrize(
     'exchange,is_short,lev,close_rate,fee_close,profit,profit_ratio,trading_mode,funding_fees', [
-        ('binance', False, 1, 2.1, 0.0025, 2.6925, 0.04476309226932673, spot, 0),
-        ('binance', False, 3, 2.1, 0.0025, 2.69166667, 0.13424771421446402, margin, 0),
-        ('binance', True, 1, 2.1, 0.0025, -3.308815781249997, -0.05528514254385963, margin, 0),
-        ('binance', True, 3, 2.1, 0.0025, -3.308815781249997, -0.1658554276315789, margin, 0),
+        ('binance', False, 1, 2.1, 0.0025, 2.6925, 0.044763092, spot, 0),
+        ('binance', False, 3, 2.1, 0.0025, 2.69166667, 0.134247714, margin, 0),
+        ('binance', True, 1, 2.1, 0.0025, -3.3088157, -0.055285142, margin, 0),
+        ('binance', True, 3, 2.1, 0.0025, -3.3088157, -0.16585542, margin, 0),
 
-        ('binance', False, 1, 1.9, 0.0025, -3.2925, -0.05473815461346632, margin, 0),
-        ('binance', False, 3, 1.9, 0.0025, -3.29333333, -0.16425602643391513, margin, 0),
-        ('binance', True, 1, 1.9, 0.0025, 2.7063095312499996, 0.045218204365079395, margin, 0),
-        ('binance', True, 3, 1.9, 0.0025, 2.7063095312499996, 0.13565461309523819, margin, 0),
+        ('binance', False, 1, 1.9, 0.0025, -3.2925, -0.054738154, margin, 0),
+        ('binance', False, 3, 1.9, 0.0025, -3.29333333, -0.164256026, margin, 0),
+        ('binance', True, 1, 1.9, 0.0025, 2.70630953, 0.0452182043, margin, 0),
+        ('binance', True, 3, 1.9, 0.0025, 2.70630953, 0.135654613, margin, 0),
 
-        ('binance', False, 1, 2.2, 0.0025, 5.685, 0.0945137157107232, margin, 0),
-        ('binance', False, 3, 2.2, 0.0025, 5.68416667, 0.2834995845386534, margin, 0),
-        ('binance', True, 1, 2.2, 0.0025, -6.316378437499999, -0.1055368159983292, margin, 0),
-        ('binance', True, 3, 2.2, 0.0025, -6.316378437499999, -0.3166104479949876, margin, 0),
+        ('binance', False, 1, 2.2, 0.0025, 5.685, 0.09451371, margin, 0),
+        ('binance', False, 3, 2.2, 0.0025, 5.68416667, 0.28349958, margin, 0),
+        ('binance', True, 1, 2.2, 0.0025, -6.3163784, -0.10553681, margin, 0),
+        ('binance', True, 3, 2.2, 0.0025, -6.3163784, -0.31661044, margin, 0),
 
-        # # Kraken
-        ('kraken', False, 1, 2.1, 0.0025, 2.6925, 0.04476309226932673, spot, 0),
-        ('kraken', False, 3, 2.1, 0.0025, 2.6525, 0.13229426433915248, margin, 0),
-        ('kraken', True, 1, 2.1, 0.0025, -3.3706575, -0.05631842105263152, margin, 0),
-        ('kraken', True, 3, 2.1, 0.0025, -3.3706575, -0.16895526315789455, margin, 0),
+        # Kraken
+        ('kraken', False, 1, 2.1, 0.0025, 2.6925, 0.044763092, spot, 0),
+        ('kraken', False, 3, 2.1, 0.0025, 2.6525, 0.132294264, margin, 0),
+        ('kraken', True, 1, 2.1, 0.0025, -3.3706575, -0.056318421, margin, 0),
+        ('kraken', True, 3, 2.1, 0.0025, -3.3706575, -0.168955263, margin, 0),
 
-        ('kraken', False, 1, 1.9, 0.0025, -3.2925, -0.05473815461346632, margin, 0),
-        ('kraken', False, 3, 1.9, 0.0025, -3.3325, -0.16620947630922667, margin, 0),
-        ('kraken', True, 1, 1.9, 0.0025, 2.6503575, 0.04428333333333334, margin, 0),
-        ('kraken', True, 3, 1.9, 0.0025, 2.6503575, 0.13285000000000002, margin, 0),
+        ('kraken', False, 1, 1.9, 0.0025, -3.2925, -0.054738154, margin, 0),
+        ('kraken', False, 3, 1.9, 0.0025, -3.3325, -0.166209476, margin, 0),
+        ('kraken', True, 1, 1.9, 0.0025, 2.6503575, 0.044283333, margin, 0),
+        ('kraken', True, 3, 1.9, 0.0025, 2.6503575, 0.132850000, margin, 0),
 
-        ('kraken', False, 1, 2.2, 0.0025, 5.685, 0.0945137157107232, margin, 0),
-        ('kraken', False, 3, 2.2, 0.0025, 5.645, 0.2815461346633419, margin, 0),
-        ('kraken', True, 1, 2.2, 0.0025, -6.381165, -0.106619298245614, margin, 0),
-        ('kraken', True, 3, 2.2, 0.0025, -6.381165, -0.319857894736842, margin, 0),
+        ('kraken', False, 1, 2.2, 0.0025, 5.685, 0.09451371, margin, 0),
+        ('kraken', False, 3, 2.2, 0.0025, 5.645, 0.28154613, margin, 0),
+        ('kraken', True, 1, 2.2, 0.0025, -6.381165, -0.1066192, margin, 0),
+        ('kraken', True, 3, 2.2, 0.0025, -6.381165, -0.3198578, margin, 0),
 
-        ('binance', False, 1, 2.1, 0.003, 2.6610000000000014, 0.04423940149625927, spot, 0),
-        ('binance', False, 1, 1.9, 0.003, -3.320999999999998, -0.05521197007481293, spot, 0),
-        ('binance', False, 1, 2.2, 0.003, 5.652000000000008, 0.09396508728179565, spot, 0),
+        ('binance', False, 1, 2.1, 0.003, 2.66100000, 0.044239401, spot, 0),
+        ('binance', False, 1, 1.9, 0.003, -3.3209999, -0.055211970, spot, 0),
+        ('binance', False, 1, 2.2, 0.003, 5.6520000, 0.093965087, spot, 0),
 
         # # FUTURES, funding_fee=1
-        ('binance', False, 1, 2.1, 0.0025, 3.6925, 0.06138819617622615, futures, 1),
-        ('binance', False, 3, 2.1, 0.0025, 3.6925, 0.18416458852867845, futures, 1),
-        ('binance', True, 1, 2.1, 0.0025, -2.3074999999999974, -0.038554720133667564, futures, 1),
-        ('binance', True, 3, 2.1, 0.0025, -2.3074999999999974, -0.11566416040100269, futures, 1),
+        ('binance', False, 1, 2.1, 0.0025, 3.6925, 0.06138819, futures, 1),
+        ('binance', False, 3, 2.1, 0.0025, 3.6925, 0.18416458, futures, 1),
+        ('binance', True, 1, 2.1, 0.0025, -2.3074999, -0.03855472, futures, 1),
+        ('binance', True, 3, 2.1, 0.0025, -2.3074999, -0.11566416, futures, 1),
 
-        ('binance', False, 1, 1.9, 0.0025, -2.2925, -0.0381130507065669, futures, 1),
-        ('binance', False, 3, 1.9, 0.0025, -2.2925, -0.1143391521197007, futures, 1),
-        ('binance', True, 1, 1.9, 0.0025, 3.707500000000003, 0.06194653299916464, futures, 1),
-        ('binance', True, 3, 1.9, 0.0025, 3.707500000000003, 0.18583959899749392, futures, 1),
+        ('binance', False, 1, 1.9, 0.0025, -2.2925, -0.03811305, futures, 1),
+        ('binance', False, 3, 1.9, 0.0025, -2.2925, -0.11433915, futures, 1),
+        ('binance', True, 1, 1.9, 0.0025, 3.7075, 0.06194653, futures, 1),
+        ('binance', True, 3, 1.9, 0.0025, 3.7075, 0.18583959, futures, 1),
 
-        ('binance', False, 1, 2.2, 0.0025, 6.685, 0.11113881961762262, futures, 1),
-        ('binance', False, 3, 2.2, 0.0025, 6.685, 0.33341645885286786, futures, 1),
-        ('binance', True, 1, 2.2, 0.0025, -5.315000000000005, -0.08880534670008355, futures, 1),
-        ('binance', True, 3, 2.2, 0.0025, -5.315000000000005, -0.26641604010025066, futures, 1),
+        ('binance', False, 1, 2.2, 0.0025, 6.685, 0.11113881, futures, 1),
+        ('binance', False, 3, 2.2, 0.0025, 6.685, 0.33341645, futures, 1),
+        ('binance', True, 1, 2.2, 0.0025, -5.315, -0.08880534, futures, 1),
+        ('binance', True, 3, 2.2, 0.0025, -5.315, -0.26641604, futures, 1),
 
         # FUTURES, funding_fee=-1
-        ('binance', False, 1, 2.1, 0.0025, 1.6925000000000026, 0.028137988362427313, futures, -1),
-        ('binance', False, 3, 2.1, 0.0025, 1.6925000000000026, 0.08441396508728194, futures, -1),
-        ('binance', True, 1, 2.1, 0.0025, -4.307499999999997, -0.07197159565580624, futures, -1),
-        ('binance', True, 3, 2.1, 0.0025, -4.307499999999997, -0.21591478696741873, futures, -1),
+        ('binance', False, 1, 2.1, 0.0025, 1.6925, 0.02813798, futures, -1),
+        ('binance', False, 3, 2.1, 0.0025, 1.6925, 0.08441396, futures, -1),
+        ('binance', True, 1, 2.1, 0.0025, -4.307499, -0.07197159, futures, -1),
+        ('binance', True, 3, 2.1, 0.0025, -4.307499, -0.21591478, futures, -1),
 
-        ('binance', False, 1, 1.9, 0.0025, -4.292499999999997, -0.07136325852036574, futures, -1),
-        ('binance', False, 3, 1.9, 0.0025, -4.292499999999997, -0.2140897755610972, futures, -1),
-        ('binance', True, 1, 1.9, 0.0025, 1.7075000000000031, 0.02852965747702596, futures, -1),
-        ('binance', True, 3, 1.9, 0.0025, 1.7075000000000031, 0.08558897243107788, futures, -1),
+        ('binance', False, 1, 1.9, 0.0025, -4.292499, -0.07136325, futures, -1),
+        ('binance', False, 3, 1.9, 0.0025, -4.292499, -0.21408977, futures, -1),
+        ('binance', True, 1, 1.9, 0.0025, 1.7075, 0.02852965, futures, -1),
+        ('binance', True, 3, 1.9, 0.0025, 1.7075, 0.08558897, futures, -1),
 
-        ('binance', False, 1, 2.2, 0.0025, 4.684999999999995, 0.07788861180382378, futures, -1),
-        ('binance', False, 3, 2.2, 0.0025, 4.684999999999995, 0.23366583541147135, futures, -1),
-        ('binance', True, 1, 2.2, 0.0025, -7.315000000000005, -0.12222222222222223, futures, -1),
-        ('binance', True, 3, 2.2, 0.0025, -7.315000000000005, -0.3666666666666667, futures, -1),
+        ('binance', False, 1, 2.2, 0.0025, 4.684999, 0.07788861, futures, -1),
+        ('binance', False, 3, 2.2, 0.0025, 4.684999, 0.23366583, futures, -1),
+        ('binance', True, 1, 2.2, 0.0025, -7.315, -0.12222222, futures, -1),
+        ('binance', True, 3, 2.2, 0.0025, -7.315, -0.36666666, futures, -1),
     ])
 @pytest.mark.usefixtures("init_persistence")
 def test_calc_profit(
@@ -1099,8 +1099,8 @@ def test_calc_profit(
     )
     trade.open_order_id = 'something'
 
-    assert trade.calc_profit(rate=close_rate) == round(profit, 8)
-    assert trade.calc_profit_ratio(rate=close_rate) == round(profit_ratio, 8)
+    assert pytest.approx(trade.calc_profit(rate=close_rate)) == round(profit, 8)
+    assert pytest.approx(trade.calc_profit_ratio(rate=close_rate)) == round(profit_ratio, 8)
 
 
 @pytest.mark.usefixtures("init_persistence")

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -538,20 +538,22 @@ def test_update_market_order(market_buy_order_usdt, market_sell_order_usdt, fee,
 
 @pytest.mark.parametrize(
     'exchange,is_short,lev,open_value,close_value,profit,profit_ratio,trading_mode,funding_fees', [
-        ("binance", False, 1, 60.15, 65.835, 5.685, 0.0945137157107232, spot, 0.0),
-        ("binance", True, 1, 59.850, 66.1663784375, -6.3163784375, -0.105536815998329, margin, 0.0),
-        ("binance", False, 3, 60.15, 65.83416667, 5.68416667, 0.2834995845386534, margin, 0.0),
-        ("binance", True, 3, 59.85, 66.1663784375, -6.3163784375, -0.3166104479949876, margin, 0.0),
+        ("binance", False, 1, 60.15, 65.835, 5.685, 0.09451371, spot, 0.0),
+        ("binance", True, 1, 59.850, 66.1663784375, -6.3163784375, -0.1055368, margin, 0.0),
+        ("binance", False, 3, 60.15, 65.83416667, 5.68416667, 0.28349958, margin, 0.0),
+        ("binance", True, 3, 59.85, 66.1663784375, -6.3163784375, -0.31661044, margin, 0.0),
 
-        ("kraken", False, 1, 60.15, 65.835, 5.685, 0.0945137157107232, spot, 0.0),
-        ("kraken", True, 1, 59.850, 66.231165, -6.381165, -0.106619298245614, margin, 0.0),
-        ("kraken", False, 3, 60.15, 65.795, 5.645, 0.2815461346633419, margin, 0.0),
-        ("kraken", True, 3, 59.850, 66.231165, -6.381165000000003, -0.319857894736842, margin, 0.0),
+        ("kraken", False, 1, 60.15, 65.835, 5.685, 0.09451371, spot, 0.0),
+        ("kraken", True, 1, 59.850, 66.231165, -6.381165, -0.1066192, margin, 0.0),
+        ("kraken", False, 3, 60.15, 65.795, 5.645, 0.28154613, margin, 0.0),
+        ("kraken", True, 3, 59.850, 66.231165, -6.381165, -0.3198578, margin, 0.0),
 
-        ("binance", False, 1, 60.15, 66.835,  6.685, 0.11113881961762262, futures, 1.0),
-        ("binance", True, 1, 59.85,  67.165, -7.315, -0.12222222222222223, futures, -1.0),
-        ("binance", False, 3, 60.15, 64.835,  4.685, 0.23366583541147135, futures, -1.0),
-        ("binance", True, 3, 59.85,  65.165, -5.315, -0.26641604010025066, futures, 1.0),
+        ("binance", False, 1, 60.15, 65.835,  5.685, 0.09451371, futures, 0.0),
+        ("binance", False, 1, 60.15, 64.835,  4.685, 0.07788861, futures, 1.0),
+        ("binance", True, 1, 59.85,  66.165, -6.315, -0.10551378, futures, 0.0),
+        ("binance", True, 1, 59.85,  65.165, -5.315, -0.08880535, futures, -1.0),
+        ("binance", False, 3, 60.15, 66.835,  6.685, 0.33341646, futures, -1.0),
+        ("binance", True, 3, 59.85,  67.165, -7.315, -0.36666667, futures, 1.0),
     ])
 @pytest.mark.usefixtures("init_persistence")
 def test_calc_open_close_trade_price(
@@ -584,7 +586,7 @@ def test_calc_open_close_trade_price(
     assert isclose(trade._calc_open_trade_value(), open_value)
     assert isclose(trade.calc_close_trade_value(), close_value)
     assert isclose(trade.calc_profit(), round(profit, 8))
-    assert isclose(trade.calc_profit_ratio(), round(profit_ratio, 8))
+    assert pytest.approx(trade.calc_profit_ratio()) == profit_ratio
 
 
 @pytest.mark.usefixtures("init_persistence")


### PR DESCRIPTION
## Summary
While working on funding-fee implementation of backtesting, i noticed that the calculation is reversed.

Funding fees will eat into profit (lower profit) - so on a long, the (fictive) sell price must be lowered, while on a short, it must be raised (it'll negatively impact profit).


@samgermain would be good to see your opinion on this - as this calc was initially your contribution