### PR TITLE
Remove non-decimal numerical separators

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -188,12 +188,12 @@ There is however nothing preventing you from using GPU-enabled indicators within
 Per default Hyperopt called without the `-e`/`--epochs` command line option will only
 run 100 epochs, means 100 evaluations of your triggers, guards, ... Too few
 to find a great result (unless if you are very lucky), so you probably
-have to run it for 10.000 or more. But it will take an eternity to
+have to run it for 10000 or more. But it will take an eternity to
 compute.
 
 Since hyperopt uses Bayesian search, running for too many epochs may not produce greater results.
 
-It's therefore recommended to run between 500-1000 epochs over and over until you hit at least 10.000 epochs in total (or are satisfied with the result). You can best judge by looking at the results - if the bot keeps discovering better strategies, it's best to keep on going.
+It's therefore recommended to run between 500-1000 epochs over and over until you hit at least 10000 epochs in total (or are satisfied with the result). You can best judge by looking at the results - if the bot keeps discovering better strategies, it's best to keep on going.
 
 ```bash
 freqtrade hyperopt --hyperopt-loss SharpeHyperOptLossDaily --strategy SampleStrategy -e 1000
@@ -217,9 +217,9 @@ already 8\*10^9\*10 evaluations. A roughly total of 80 billion evaluations.
 Did you run 100 000 evaluations? Congrats, you've done roughly 1 / 100 000 th
 of the search space, assuming that the bot never tests the same parameters more than once.
 
-* The time it takes to run 1000 hyperopt epochs depends on things like: The available cpu, hard-disk, ram, timeframe, timerange, indicator settings, indicator count, amount of coins that hyperopt test strategies on and the resulting trade count - which can be 650 trades in a year or 10.0000 trades depending if the strategy aims for big profits by trading rarely or for many low profit trades. 
+* The time it takes to run 1000 hyperopt epochs depends on things like: The available cpu, hard-disk, ram, timeframe, timerange, indicator settings, indicator count, amount of coins that hyperopt test strategies on and the resulting trade count - which can be 650 trades in a year or 100000 trades depending if the strategy aims for big profits by trading rarely or for many low profit trades. 
 
-Example: 4% profit 650 times vs 0,3% profit a trade 10.000 times in a year. If we assume you set the --timerange to 365 days. 
+Example: 4% profit 650 times vs 0,3% profit a trade 10000 times in a year. If we assume you set the --timerange to 365 days. 
 
 Example:
 `freqtrade --config config.json --strategy SampleStrategy --hyperopt SampleHyperopt -e 1000 --timerange 20190601-20200601`


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Prevent confusion due to the presence of digit separators which is not a decimal point. Some locales use `.` to represent the decimal point. Others use `,`.

Solve the issue: #___

## Quick changelog

- Remove non-decimal digit separators

## What's new?

*Explain in details what this PR solve or improve. You can include visuals.* 
