### PR TITLE
Validate pairdata warnings

### DIFF
--- a/freqtrade/data/history/idatahandler.py
+++ b/freqtrade/data/history/idatahandler.py
@@ -235,15 +235,15 @@ class IDataHandler(ABC):
         :param timerange: Timerange specified for start and end dates
         """
 
-        if timerange.starttype == 'date':
-            start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc)
-            if pairdata.iloc[0]['date'] > start:
-                logger.warning(f"Missing data at start for pair {pair} at {timeframe}, "
+        start = datetime.fromtimestamp(timerange.startts, tz=timezone.utc) if timerange.starttype == 'date' else None
+        stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc) if timerange.stoptype == 'date' else None
+        if start is not None:
+            if pairdata.iloc[0]['date'] > start and (stop is None or pairdata.iloc[0]['date'] <= stop):
+                logger.warning(f"Missing data at start for pair {pair} for {timeframe}, "
                                f"data starts at {pairdata.iloc[0]['date']:%Y-%m-%d %H:%M:%S}")
-        if timerange.stoptype == 'date':
-            stop = datetime.fromtimestamp(timerange.stopts, tz=timezone.utc)
-            if pairdata.iloc[-1]['date'] < stop:
-                logger.warning(f"Missing data at end for pair {pair} at {timeframe}, "
+        if stop is not None:
+            if pairdata.iloc[-1]['date'] < stop and (start is None or pairdata.iloc[-1]['date'] >= start):
+                logger.warning(f"Missing data at end for pair {pair} for {timeframe}, "
                                f"data ends at {pairdata.iloc[-1]['date']:%Y-%m-%d %H:%M:%S}")
 
 


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Explain in one sentence the goal of this PR
Give no warning if pairdata starts after timerange end or stops before timerange start because then it is not used.

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

*Explain in details what this PR solve or improve. You can include visuals.* 
