### PR TITLE
minor spelling correction to build_config_commands.py

### DIFF
--- a/freqtrade/commands/build_config_commands.py
+++ b/freqtrade/commands/build_config_commands.py
@@ -86,7 +86,7 @@ def ask_user_config() -> Dict[str, Any]:
         {
             "type": "select",
             "name": "timeframe_in_config",
-            "message": "Tim",
+            "message": "Time",
             "choices": ["Have the strategy define timeframe.", "Override in configuration."]
         },
         {


### PR DESCRIPTION
line 89: "Tim"->"Time"