### PR TITLE
[WIP] Add order count to telegram status table

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -238,19 +238,25 @@ class RPC:
                         profit_str += f" ({fiat_profit:.2f})"
                         fiat_profit_sum = fiat_profit if isnan(fiat_profit_sum) \
                             else fiat_profit_sum + fiat_profit
+                
+                # count the number of filled orders for the trade so far
+                filled_buys = trade.select_filled_orders('buy')
+                count_of_buys = len(filled_buys)
+                
                 trades_list.append([
                     trade.id,
                     trade.pair + ('*' if (trade.open_order_id is not None
                                           and trade.close_rate_requested is None) else '')
                                + ('**' if (trade.close_rate_requested is not None) else ''),
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
-                    profit_str
+                    profit_str, # added a comma
+                    str(count_of_buys) if count_of_buys > 1 else '-' # added the count of filled orders. It can be cluttered to see a bunch of 1's so I tried the hyphen for first orders. This won't be a useful column for Strategies that do not use DCA at all, not sure how we can make this go away for those.
                 ])
             profitcol = "Profit"
             if self._fiat_converter:
                 profitcol += " (" + fiat_display_currency + ")"
 
-            columns = ['ID', 'Pair', 'Since', profitcol]
+            columns = ['ID', 'Pair', 'Since', profitcol, 'Buys'] # added the 'Buys' column to count filled orders.  'Qty' seems ambiguous and might be confused with 'Amount'. But it's not a perfect name.
             return trades_list, columns, fiat_profit_sum
 
     def _rpc_daily_profit(

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -238,25 +238,31 @@ class RPC:
                         profit_str += f" ({fiat_profit:.2f})"
                         fiat_profit_sum = fiat_profit if isnan(fiat_profit_sum) \
                             else fiat_profit_sum + fiat_profit
-                
-                # count the number of filled orders for the trade so far
+
+                # Count the number of filled orders for the trade so far
                 filled_buys = trade.select_filled_orders('buy')
                 count_of_buys = len(filled_buys)
-                
+
                 trades_list.append([
                     trade.id,
                     trade.pair + ('*' if (trade.open_order_id is not None
                                           and trade.close_rate_requested is None) else '')
                                + ('**' if (trade.close_rate_requested is not None) else ''),
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
-                    profit_str, # added a comma
-                    str(count_of_buys) if count_of_buys > 1 else '-' # added the count of filled orders. It can be cluttered to see a bunch of 1's so I tried the hyphen for first orders. This won't be a useful column for Strategies that do not use DCA at all, not sure how we can make this go away for those.
+                    profit_str,  # added a comma
+                    # Added the count of filled orders. It can be cluttered to see a bunch
+                    # of 1's so I tried the hyphen for first orders. This won't be a useful
+                    # column for Strategies that do not use DCA at all, not sure how we can
+                    # make this go away for those.
+                    str(count_of_buys) if count_of_buys > 1 else '-'
                 ])
             profitcol = "Profit"
             if self._fiat_converter:
                 profitcol += " (" + fiat_display_currency + ")"
 
-            columns = ['ID', 'Pair', 'Since', profitcol, 'Buys'] # added the 'Buys' column to count filled orders.  'Qty' seems ambiguous and might be confused with 'Amount'. But it's not a perfect name.
+            # Added the 'Buys' column to count filled orders.  'Qty' seems ambiguous and might
+            # be confused with 'Amount'. But it's not a perfect name.
+            columns = ['ID', 'Pair', 'Since', profitcol, 'Buys']
             return trades_list, columns, fiat_profit_sum
 
     def _rpc_daily_profit(


### PR DESCRIPTION
Unit tests - pending.
Flake8 - compliant.
iSort - skipped 9 files, not sure yet what that means.
mypy - no errors related to this PR.

## Summary

This PR supports the new "Adjust Position Size" code by adding an additional Column to the Telegram /status table report, showing the user the # of filled orders making up the total trade position.


## Quick changelog

- Added code to rpc.py bringing in the count of filled orders, and added a column to the final output table showing the result if > 1.

## What's new?

The benefit of this PR is intended to be an increase in awareness for the user about where in the Dollar Cost Averaging logic we currently are.

Currently there is no easy way via the /status table command, to see how many times the Strategy has added to the base position, and this may cause a general unawareness of risk and lack of understanding about invested capital.

Adding the Count allows the user to understand whether they are on track to lower the average entry price, or whether the strategy might be holding off on new purchases due to some other safeties in place at the time.

## Newly introduced problems

There is a problem this PR introduces which is that it clutters the screen for strategies where this information is not relevant - ie: those without any position adjustment logic.  I have not yet designed a way to automatically toggle this column on or off.

However I do have the following idea for this:

We could check the "entire" trade list and if there are "no trades with more than 1 filled order" then we could have the new "Buys" column completely hidden until at least 1 trade meets the criteria of having count_of_buys > 1.

## Screenshots

This screenshot shows the new table format with the column header as "DCA" which is another option, but I elected to go with "Buys" for the PR to make it more generic for folks that are not trying to Dollar Cost Average necessarily when they buy more of a position.

I have also shown the screenshot with the option of having the rows "blank" when there is only the first original Buy.  In the PR Code I've used a Hyphen (-) instead.

Additionally in the screenshot I've used (count_of_buys - 1) so that the column show only the count of "extra buys" rather than the total count.

These differences highlight some of the different ways this could be implemented.

<img width="632" alt="Screen Shot 2022-01-16 at 12 53 05 PM" src="https://user-images.githubusercontent.com/75510364/149675751-8992673e-cfd2-423c-9ded-680309a04040.png">
