### PR TITLE
Fix eager-loading trade.orders

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -476,8 +476,6 @@ class FreqtradeBot(LoggingMixin):
         current_rate = self.exchange.get_rate(trade.pair, refresh=True, side="buy")
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        # TODO: Is there a better way to force lazy-load?
-        len(trade.orders)
         min_stake_amount = self.exchange.get_min_pair_stake_amount(trade.pair,
                                                                    current_rate,
                                                                    self.strategy.stoploss)

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -729,7 +729,7 @@ class Trade(_DECL_BASE, LocalTrade):
 
     id = Column(Integer, primary_key=True)
 
-    orders = relationship("Order", order_by="Order.id", cascade="all, delete-orphan")
+    orders = relationship("Order", order_by="Order.id", cascade="all, delete-orphan", lazy="joined")
 
     exchange = Column(String(25), nullable=False)
     pair = Column(String(25), nullable=False, index=True)


### PR DESCRIPTION
## Summary

Eager-loading orders allows access to trade.orders in all callbacks.

## Quick changelog

- Added lazy="joined" to Trade.orders

## What's new?

We can now access previous orders in all custom callbacks like custom_sell, confirm_trade_exit etc.