### PR TITLE
Spreadfilter log % fix

### DIFF
--- a/freqtrade/plugins/pairlist/SpreadFilter.py
+++ b/freqtrade/plugins/pairlist/SpreadFilter.py
@@ -47,7 +47,7 @@ class SpreadFilter(IPairList):
             spread = 1 - ticker['bid'] / ticker['ask']
             if spread > self._max_spread_ratio:
                 self.log_once(f"Removed {pair} from whitelist, because spread "
-                              f"{spread * 100:.3%} > {self._max_spread_ratio:.3%}",
+                              f"{spread:.3%} > {self._max_spread_ratio:.3%}",
                               logger.info)
                 return False
             else:


### PR DESCRIPTION
Both the following are same
```
print(f'{3:.3%}')
print(f'{3 *100 :.3}%')
# 300.000%
```

Here both are mixed.