### PR TITLE
Pass dimensions to generate_estimator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,3 @@ target/
 !config_examples/config_ftx.example.json
 !config_examples/config_full.example.json
 !config_examples/config_kraken.example.json
-docker-compose.yml
-.DS_Store
-user_data/data/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ target/
 !config_examples/config_ftx.example.json
 !config_examples/config_full.example.json
 !config_examples/config_kraken.example.json
+docker-compose.yml
+.DS_Store
+user_data/data/.gitkeep

--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -105,7 +105,7 @@ You can define your own estimator for Hyperopt by implementing `generate_estimat
 ```python
 class MyAwesomeStrategy(IStrategy):
     class HyperOpt:
-        def generate_estimator():
+        def generate_estimator(dimensions, **kwargs):
             return "RF"
 
 ```
@@ -119,11 +119,32 @@ Example for `ExtraTreesRegressor` ("ET") with additional parameters:
 ```python
 class MyAwesomeStrategy(IStrategy):
     class HyperOpt:
-        def generate_estimator():
+        def generate_estimator(dimensions, **kwargs):
             from skopt.learning import ExtraTreesRegressor
             # Corresponds to "ET" - but allows additional parameters.
             return ExtraTreesRegressor(n_estimators=100)
 
+```
+
+The `dimensions` parameter is the list of `skopt.space.Dimension` objects corresponding to the parameters to be optimized. It can be used to create isotropic kernels for the `skopt.learning.GaussianProcessRegressor` estimator. Here's an example:
+
+```python
+class MyAwesomeStrategy(IStrategy):
+    class HyperOpt:
+        def generate_estimator(dimensions, **kwargs):
+            from skopt.utils import cook_estimator
+            from skopt.learning.gaussian_process.kernels import (Matern, ConstantKernel)
+            kernel_bounds = (0.0001, 10000)
+            kernel = (
+                ConstantKernel(1.0, kernel_bounds) * 
+                Matern(length_scale=np.ones(len(dimensions)), length_scale_bounds=[kernel_bounds for d in dimensions], nu=2.5)
+            )
+            kernel += (
+                ConstantKernel(1.0, kernel_bounds) * 
+                Matern(length_scale=np.ones(len(dimensions)), length_scale_bounds=[kernel_bounds for d in dimensions], nu=1.5)
+            )
+
+            return cook_estimator("GP", space=dimensions, kernel=kernel, n_restarts_optimizer=2)
 ```
 
 !!! Note

--- a/docs/advanced-hyperopt.md
+++ b/docs/advanced-hyperopt.md
@@ -105,7 +105,7 @@ You can define your own estimator for Hyperopt by implementing `generate_estimat
 ```python
 class MyAwesomeStrategy(IStrategy):
     class HyperOpt:
-        def generate_estimator(dimensions, **kwargs):
+        def generate_estimator(dimensions: List['Dimension'], **kwargs):
             return "RF"
 
 ```
@@ -119,7 +119,7 @@ Example for `ExtraTreesRegressor` ("ET") with additional parameters:
 ```python
 class MyAwesomeStrategy(IStrategy):
     class HyperOpt:
-        def generate_estimator(dimensions, **kwargs):
+        def generate_estimator(dimensions: List['Dimension'], **kwargs):
             from skopt.learning import ExtraTreesRegressor
             # Corresponds to "ET" - but allows additional parameters.
             return ExtraTreesRegressor(n_estimators=100)
@@ -131,7 +131,7 @@ The `dimensions` parameter is the list of `skopt.space.Dimension` objects corres
 ```python
 class MyAwesomeStrategy(IStrategy):
     class HyperOpt:
-        def generate_estimator(dimensions, **kwargs):
+        def generate_estimator(dimensions: List['Dimension'], **kwargs):
             from skopt.utils import cook_estimator
             from skopt.learning.gaussian_process.kernels import (Matern, ConstantKernel)
             kernel_bounds = (0.0001, 10000)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -367,7 +367,7 @@ class Hyperopt:
         }
 
     def get_optimizer(self, dimensions: List[Dimension], cpu_count) -> Optimizer:
-        estimator = self.custom_hyperopt.generate_estimator(dimensions)
+        estimator = self.custom_hyperopt.generate_estimator(dimensions=dimensions)
 
         acq_optimizer = "sampling"
         if isinstance(estimator, str):

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -367,7 +367,7 @@ class Hyperopt:
         }
 
     def get_optimizer(self, dimensions: List[Dimension], cpu_count) -> Optimizer:
-        estimator = self.custom_hyperopt.generate_estimator()
+        estimator = self.custom_hyperopt.generate_estimator(dimensions)
 
         acq_optimizer = "sampling"
         if isinstance(estimator, str):

--- a/freqtrade/optimize/hyperopt_auto.py
+++ b/freqtrade/optimize/hyperopt_auto.py
@@ -91,5 +91,5 @@ class HyperOptAuto(IHyperOpt):
     def trailing_space(self) -> List['Dimension']:
         return self._get_func('trailing_space')()
 
-    def generate_estimator(self, dimensions) -> EstimatorType:
+    def generate_estimator(self, dimensions: List['Dimension']) -> EstimatorType:
         return self._get_func('generate_estimator')(dimensions)

--- a/freqtrade/optimize/hyperopt_auto.py
+++ b/freqtrade/optimize/hyperopt_auto.py
@@ -91,5 +91,5 @@ class HyperOptAuto(IHyperOpt):
     def trailing_space(self) -> List['Dimension']:
         return self._get_func('trailing_space')()
 
-    def generate_estimator(self, dimensions: List['Dimension']) -> EstimatorType:
-        return self._get_func('generate_estimator')(dimensions)
+    def generate_estimator(self, dimensions: List['Dimension'], **kwargs) -> EstimatorType:
+        return self._get_func('generate_estimator')(dimensions=dimensions, **kwargs)

--- a/freqtrade/optimize/hyperopt_auto.py
+++ b/freqtrade/optimize/hyperopt_auto.py
@@ -91,5 +91,5 @@ class HyperOptAuto(IHyperOpt):
     def trailing_space(self) -> List['Dimension']:
         return self._get_func('trailing_space')()
 
-    def generate_estimator(self) -> EstimatorType:
-        return self._get_func('generate_estimator')()
+    def generate_estimator(self, dimensions) -> EstimatorType:
+        return self._get_func('generate_estimator')(dimensions)

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -40,7 +40,7 @@ class IHyperOpt(ABC):
         IHyperOpt.ticker_interval = str(config['timeframe'])  # DEPRECATED
         IHyperOpt.timeframe = str(config['timeframe'])
 
-    def generate_estimator(self) -> EstimatorType:
+    def generate_estimator(self, dimensions, **kwargs) -> EstimatorType:
         """
         Return base_estimator.
         Can be any of "GP", "RF", "ET", "GBRT" or an instance of a class

--- a/freqtrade/optimize/hyperopt_interface.py
+++ b/freqtrade/optimize/hyperopt_interface.py
@@ -40,7 +40,7 @@ class IHyperOpt(ABC):
         IHyperOpt.ticker_interval = str(config['timeframe'])  # DEPRECATED
         IHyperOpt.timeframe = str(config['timeframe'])
 
-    def generate_estimator(self, dimensions, **kwargs) -> EstimatorType:
+    def generate_estimator(self, dimensions: List[Dimension], **kwargs) -> EstimatorType:
         """
         Return base_estimator.
         Can be any of "GP", "RF", "ET", "GBRT" or an instance of a class


### PR DESCRIPTION
## Summary

The number of optimizable dimensions is needed within `generate_estimator` in order to create isotropic kernels for the GaussianProcessRegressor

## Quick changelog

- passing `dimensions` to `generate_estimator` in `hyperopt.py`
- passing `dimensions` to `generate_estimator` in `hyperopt_auto.py`

## What's new?

Example:
```
def generate_estimator(dimensions):
	from skopt.learning import GaussianProcessRegressor
	from skopt.utils import cook_estimator
	from skopt.learning.gaussian_process.kernels import (RBF, Matern, RationalQuadratic, ExpSineSquared, DotProduct, ConstantKernel, WhiteKernel)
	kernel_bounds = (0.0001, 10000)
	kernel = ConstantKernel(1.0, kernel_bounds) * Matern(
							length_scale=np.ones(len(dimensions)),
                				length_scale_bounds=[kernel_bounds for d in dimensions], nu=2.5)
	kernel += ConstantKernel(1.0, kernel_bounds) * Matern(
                				length_scale=np.ones(len(dimensions)),
               				length_scale_bounds=[kernel_bounds for d in dimensions], nu=1.5)

	return cook_estimator("GP", space=dimensions, kernel=kernel, n_restarts_optimizer=2)
```

I'm not sure if there's a better way to achieve this. 

TODO: Update docs accordingly

