### PR TITLE
add "# Buys" column to status table

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -242,7 +242,7 @@ class RPC:
                     trade.id,
                     trade.pair + ('*' if (trade.open_order_id is not None
                                           and trade.close_rate_requested is None) else '')
-                               + ('**' if (trade.close_rate_requested is not None) else ''),
+                    + ('**' if (trade.close_rate_requested is not None) else ''),
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
                     profit_str
                 ]

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -238,19 +238,26 @@ class RPC:
                         profit_str += f" ({fiat_profit:.2f})"
                         fiat_profit_sum = fiat_profit if isnan(fiat_profit_sum) \
                             else fiat_profit_sum + fiat_profit
-                trades_list.append([
+                detail_trade = [
                     trade.id,
                     trade.pair + ('*' if (trade.open_order_id is not None
                                           and trade.close_rate_requested is None) else '')
                                + ('**' if (trade.close_rate_requested is not None) else ''),
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
                     profit_str
-                ])
+                ]
+                if self._config.get('position_adjustment_enable', False):
+                    filled_buys = trade.select_filled_orders('buy')
+                    detail_trade.append(str(len(filled_buys)))
+                trades_list.append(detail_trade)
             profitcol = "Profit"
             if self._fiat_converter:
                 profitcol += " (" + fiat_display_currency + ")"
 
-            columns = ['ID', 'Pair', 'Since', profitcol]
+            if self._config.get('position_adjustment_enable', False):
+                columns = ['ID', 'Pair', 'Since', profitcol, '# Buys']
+            else:
+                columns = ['ID', 'Pair', 'Since', profitcol]
             return trades_list, columns, fiat_profit_sum
 
     def _rpc_daily_profit(

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -214,10 +214,16 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker) -> None:
     result, headers, fiat_profit_sum = rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
     assert "Since" in headers
     assert "Pair" in headers
+    assert len(result[0]) == 4
     assert 'instantly' == result[0][2]
     assert 'ETH/BTC' in result[0][1]
     assert '-0.41% (-0.06)' == result[0][3]
     assert '-0.06' == f'{fiat_profit_sum:.2f}'
+
+    rpc._config['position_adjustment_enable'] = True
+    result, headers, fiat_profit_sum = rpc._rpc_status_table(default_conf['stake_currency'], 'USD')
+    assert "# Buys" in headers
+    assert len(result[0]) == 5
 
     mocker.patch('freqtrade.exchange.Exchange.get_rate',
                  MagicMock(side_effect=ExchangeError("Pair 'ETH/BTC' not available")))


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Add "# Buys" column to status table, if the user enable position adjustment. If not, then the "# Buys" column won't be added. And the value there will be total number of buy(s), so even with the first buy, the number there will show 1


Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

For bot that have position adjustment enabled, add another column at the end of the status table named '# Buys', to show current total buys of each trades.

Bot without position adjustment
![image](https://user-images.githubusercontent.com/13656154/150083798-e5c0f7fc-c048-4e4d-9b21-899df1a6251f.png)

Bot with position adjustment (the bot in the screenshot below is using old draft code, so the column name is different)
![image](https://user-images.githubusercontent.com/13656154/150083885-1999562c-c703-4c22-8694-56f27bb0fe3b.png)

