### PR TITLE
set stoploss at trade creation

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -521,6 +521,7 @@ class Backtesting:
                     exchange='backtesting',
                     orders=[]
                 )
+            trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss, initial=True)
 
             order = Order(
                 ft_is_open=False,


### PR DESCRIPTION
## Summary

Error when exporting the backtesting results since the stop_loss_ratio is set to nan in the trade. It's due to the position adjustment (#6079) being triggered on the same candle of the open_date (i.e. trade.open_date == current_time).

Solve the issue: #6263

## Quick changelog

- added `trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss, initial=True)` right after creating the LocalTrade object

## What's new?

See issue #6263
