### PR TITLE
Extract timedout from ftbot

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -413,7 +413,7 @@ It applies a tight timeout for higher priced assets, while allowing more time to
 The function must return either `True` (cancel order) or `False` (keep order alive).
 
 ``` python
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from freqtrade.persistence import Trade
 
 class AwesomeStrategy(IStrategy):
@@ -426,22 +426,24 @@ class AwesomeStrategy(IStrategy):
         'sell': 60 * 25
     }
 
-    def check_buy_timeout(self, pair: str, trade: 'Trade', order: dict, **kwargs) -> bool:
-        if trade.open_rate > 100 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(minutes=5):
+    def check_buy_timeout(self, pair: str, trade: 'Trade', order: dict, 
+                          current_time: datetime, **kwargs) -> bool:
+        if trade.open_rate > 100 and trade.open_date_utc < current_time - timedelta(minutes=5):
             return True
-        elif trade.open_rate > 10 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(minutes=3):
+        elif trade.open_rate > 10 and trade.open_date_utc < current_time - timedelta(minutes=3):
             return True
-        elif trade.open_rate < 1 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(hours=24):
+        elif trade.open_rate < 1 and trade.open_date_utc < current_time - timedelta(hours=24):
            return True
         return False
 
 
-    def check_sell_timeout(self, pair: str, trade: 'Trade', order: dict, **kwargs) -> bool:
-        if trade.open_rate > 100 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(minutes=5):
+    def check_sell_timeout(self, pair: str, trade: Trade, order: dict,
+                           current_time: datetime, **kwargs) -> bool:
+        if trade.open_rate > 100 and trade.open_date_utc < current_time - timedelta(minutes=5):
             return True
-        elif trade.open_rate > 10 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(minutes=3):
+        elif trade.open_rate > 10 and trade.open_date_utc < current_time - timedelta(minutes=3):
             return True
-        elif trade.open_rate < 1 and trade.open_date_utc < datetime.now(timezone.utc) - timedelta(hours=24):
+        elif trade.open_rate < 1 and trade.open_date_utc < current_time - timedelta(hours=24):
            return True
         return False
 ```

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -188,7 +188,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return dataframe
 
-    def check_buy_timeout(self, pair: str, trade: Trade, order: dict, **kwargs) -> bool:
+    def check_buy_timeout(self, pair: str, trade: Trade, order: dict,
+                          current_time: datetime, **kwargs) -> bool:
         """
         Check buy timeout function callback.
         This method can be used to override the buy-timeout.
@@ -201,12 +202,14 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param pair: Pair the trade is for
         :param trade: trade object.
         :param order: Order dictionary as returned from CCXT.
+        :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return bool: When True is returned, then the buy-order is cancelled.
         """
         return False
 
-    def check_sell_timeout(self, pair: str, trade: Trade, order: dict, **kwargs) -> bool:
+    def check_sell_timeout(self, pair: str, trade: Trade, order: dict,
+                           current_time: datetime, **kwargs) -> bool:
         """
         Check sell timeout function callback.
         This method can be used to override the sell-timeout.
@@ -219,6 +222,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param pair: Pair the trade is for
         :param trade: trade object.
         :param order: Order dictionary as returned from CCXT.
+        :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return bool: When True is returned, then the sell-order is cancelled.
         """
@@ -872,7 +876,8 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         return strategy_safe_wrapper(getattr(self, time_method),
                                      default_retval=False)(
-                                         pair=trade.pair, trade=trade, order=order)
+                                        pair=trade.pair, trade=trade, order=order,
+                                        current_time=current_time)
 
     def advise_all_indicators(self, data: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -872,9 +872,9 @@ class IStrategy(ABC, HyperStrategyMixin):
                         and ordertime < timeout_threshold)
             if timedout:
                 return True
-        time_method = 'check_sell_timeout' if order['side'] == 'sell' else 'check_buy_timeout'
+        time_method = self.check_sell_timeout if order['side'] == 'sell' else self.check_buy_timeout
 
-        return strategy_safe_wrapper(getattr(self, time_method),
+        return strategy_safe_wrapper(time_method,
                                      default_retval=False)(
                                         pair=trade.pair, trade=trade, order=order,
                                         current_time=current_time)


### PR DESCRIPTION
## Summary
Extract timeout handling from freqtradebot class.

Simplifies the tradebot class.

* Adds `current_time` argument for easier usage of this callback.