### PR TITLE
Fix position adjustment not counting older orders because of missing average field value

### DIFF
--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -584,10 +584,10 @@ class LocalTrade():
                 continue
 
             tmp_amount = o.amount
-            tmp_price = o.average or o.price or 0.0
+            tmp_price = o.average or o.price
             if o.filled is not None:
                 tmp_amount = o.filled
-            if tmp_amount > 0.0 and tmp_price is not None and o.status == 'closed':
+            if tmp_amount > 0.0 and tmp_price is not None:
                 total_amount += tmp_amount
                 total_stake += tmp_price * tmp_amount
 

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -587,7 +587,7 @@ class LocalTrade():
             tmp_price = o.average or o.price or 0.0
             if o.filled is not None:
                 tmp_amount = o.filled
-            if tmp_amount > 0.0 and tmp_price is not None:
+            if tmp_amount > 0.0 and tmp_price is not None and o.status == 'closed':
                 total_amount += tmp_amount
                 total_stake += tmp_price * tmp_amount
 

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -577,18 +577,19 @@ class LocalTrade():
 
         total_amount = 0.0
         total_stake = 0.0
-        for temp_order in self.orders:
-            if (temp_order.ft_is_open or
-                    (temp_order.ft_order_side != 'buy') or
-                    (temp_order.status not in NON_OPEN_EXCHANGE_STATES)):
+        for o in self.orders:
+            if (o.ft_is_open or
+                    (o.ft_order_side != 'buy') or
+                    (o.status not in NON_OPEN_EXCHANGE_STATES)):
                 continue
 
-            tmp_amount = temp_order.amount
-            if temp_order.filled is not None:
-                tmp_amount = temp_order.filled
-            if tmp_amount > 0.0 and temp_order.average is not None:
+            tmp_amount = o.amount
+            tmp_price = o.average or o.price or 0.0
+            if o.filled is not None:
+                tmp_amount = o.filled
+            if tmp_amount > 0.0 and tmp_price is not None:
                 total_amount += tmp_amount
-                total_stake += temp_order.average * tmp_amount
+                total_stake += tmp_price * tmp_amount
 
         if total_amount > 0:
             self.open_rate = total_stake / total_amount

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -243,6 +243,8 @@ def test_dca_buying(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
     freqtrade.process()
     trade = Trade.get_trades().first()
     assert len(trade.orders) == 2
+    for o in trade.orders:
+        assert o.status == "closed"
     assert trade.stake_amount == 120
 
     # Open-rate averaged between 2.0 and 2.0 * 0.995
@@ -258,7 +260,6 @@ def test_dca_buying(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
     assert trade.orders[1].amount == 60 / ticker_usdt_modif['bid']
 
     assert trade.amount == trade.orders[0].amount + trade.orders[1].amount
-
     assert trade.nr_of_successful_buys == 2
 
     # Sell

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1661,6 +1661,33 @@ def test_recalc_trade_from_orders_ignores_bad_orders(fee):
     assert trade.fee_open_cost == 2 * o1_fee_cost
     assert trade.open_trade_value == 2 * o1_trade_val
     assert trade.nr_of_successful_buys == 2
+    # Check with 1 order
+    order_noavg = Order(
+        ft_order_side='buy',
+        ft_pair=trade.pair,
+        ft_is_open=False,
+        status="closed",
+        symbol=trade.pair,
+        order_type="market",
+        side="buy",
+        price=o1_rate,
+        average=None,
+        filled=o1_amount,
+        remaining=0,
+        cost=o1_amount,
+        order_date=trade.open_date,
+        order_filled_date=trade.open_date,
+    )
+    trade.orders.append(order_noavg)
+    trade.recalc_trade_from_orders()
+
+    # Calling recalc with single initial order should not change anything
+    assert trade.amount == 3 * o1_amount
+    assert trade.stake_amount == 3 * o1_amount
+    assert trade.open_rate == o1_rate
+    assert trade.fee_open_cost == 3 * o1_fee_cost
+    assert trade.open_trade_value == 3 * o1_trade_val
+    assert trade.nr_of_successful_buys == 3
 
 
 @pytest.mark.usefixtures("init_persistence")


### PR DESCRIPTION
## Summary

When moving from older live database to newer DCA enabled dry-mode, user encountered a bug where their orders without average price were not counted for after DCA orders kicked in.

Solve the issue: #6268 

## Quick changelog

- Fix by using price if average is not available
- Added unit-test to confirm

## What's new?

Additionally added a check to make sure order is closed.
