### PR TITLE
Entry callbacks - provide buy_tag

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -362,8 +362,8 @@ class AwesomeStrategy(IStrategy):
 
     # ... populate_* methods
 
-    def custom_entry_price(self, pair: str, current_time: datetime,
-                           proposed_rate, **kwargs) -> float:
+    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float, 
+                           entry_tag: Optional[str], **kwargs) -> float:
 
         dataframe, last_updated = self.dp.get_analyzed_dataframe(pair=pair,
                                                                 timeframe=self.timeframe)
@@ -502,7 +502,8 @@ class AwesomeStrategy(IStrategy):
     # ... populate_* methods
 
     def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                            time_in_force: str, current_time: datetime, **kwargs) -> bool:
+                            time_in_force: str, current_time: datetime, entry_tag: Optional[str], 
+                            **kwargs) -> bool:
         """
         Called right before placing a buy order.
         Timing for this function is critical, so avoid doing heavy computations or
@@ -620,7 +621,7 @@ class DigDeeperStrategy(IStrategy):
     # This is called when placing the initial order (opening trade)
     def custom_stake_amount(self, pair: str, current_time: datetime, current_rate: float,
                             proposed_stake: float, min_stake: float, max_stake: float,
-                            **kwargs) -> float:
+                            entry_tag: Optional[str], **kwargs) -> float:
         
         # We need to leave most of the funds for possible further DCA orders
         # This also applies to fixed stakes

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -531,7 +531,7 @@ class FreqtradeBot(LoggingMixin):
         pos_adjust = trade is not None
 
         enter_limit_requested, stake_amount = self.get_valid_enter_price_and_stake(
-            pair, price, stake_amount, trade)
+            pair, price, stake_amount, buy_tag, trade)
 
         if not stake_amount:
             return False
@@ -550,7 +550,8 @@ class FreqtradeBot(LoggingMixin):
         if not pos_adjust and not strategy_safe_wrapper(
                 self.strategy.confirm_trade_entry, default_retval=True)(
                 pair=pair, order_type=order_type, amount=amount, rate=enter_limit_requested,
-                time_in_force=time_in_force, current_time=datetime.now(timezone.utc)):
+                time_in_force=time_in_force, current_time=datetime.now(timezone.utc),
+                entry_tag=buy_tag):
             logger.info(f"User requested abortion of buying {pair}")
             return False
         amount = self.exchange.amount_to_precision(pair, amount)
@@ -660,6 +661,7 @@ class FreqtradeBot(LoggingMixin):
 
     def get_valid_enter_price_and_stake(
             self, pair: str, price: Optional[float], stake_amount: float,
+            entry_tag: Optional[str],
             trade: Optional[Trade]) -> Tuple[float, float]:
         if price:
             enter_limit_requested = price
@@ -669,7 +671,7 @@ class FreqtradeBot(LoggingMixin):
             custom_entry_price = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                                        default_retval=proposed_enter_rate)(
                 pair=pair, current_time=datetime.now(timezone.utc),
-                proposed_rate=proposed_enter_rate)
+                proposed_rate=proposed_enter_rate, entry_tag=entry_tag)
 
             enter_limit_requested = self.get_valid_price(custom_entry_price, proposed_enter_rate)
         if not enter_limit_requested:
@@ -682,7 +684,7 @@ class FreqtradeBot(LoggingMixin):
                                                  default_retval=stake_amount)(
                 pair=pair, current_time=datetime.now(timezone.utc),
                 current_rate=enter_limit_requested, proposed_stake=stake_amount,
-                min_stake=min_stake_amount, max_stake=max_stake_amount)
+                min_stake=min_stake_amount, max_stake=max_stake_amount, entry_tag=entry_tag)
         stake_amount = self.wallets.validate_stake_amount(pair, stake_amount, min_stake_amount)
         return enter_limit_requested, stake_amount
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -398,6 +398,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         Custom trade adjustment logic, returning the stake amount that a trade should be increased.
         This means extra buy orders with additional fees.
+        Only called when `position_adjustment_enable` is set to True.
 
         For full documentation please go to https://www.freqtrade.io/en/latest/strategy-advanced/
 

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -238,7 +238,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         return False
 
     def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                            time_in_force: str, current_time: datetime, **kwargs) -> bool:
+                            time_in_force: str, current_time: datetime, entry_tag: Optional[str],
+                            **kwargs) -> bool:
         """
         Called right before placing a buy order.
         Timing for this function is critical, so avoid doing heavy computations or
@@ -254,6 +255,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param rate: Rate that's going to be used when using limit orders
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param current_time: datetime object, containing the current datetime
+        :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return bool: When True is returned, then the buy-order is placed on the exchange.
             False aborts the process
@@ -311,7 +313,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         return self.stoploss
 
     def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
-                           **kwargs) -> float:
+                           entry_tag: Optional[str], **kwargs) -> float:
         """
         Custom entry price logic, returning the new entry price.
 
@@ -322,6 +324,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param pair: Pair that's currently analyzed
         :param current_time: datetime object, containing the current datetime
         :param proposed_rate: Rate, calculated based on pricing settings in ask_strategy.
+        :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         :return float: New entry price value if provided
         """
@@ -373,7 +376,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
     def custom_stake_amount(self, pair: str, current_time: datetime, current_rate: float,
                             proposed_stake: float, min_stake: float, max_stake: float,
-                            **kwargs) -> float:
+                            entry_tag: Optional[str], **kwargs) -> float:
         """
         Customize stake size for each new trade. This method is not called when edge module is
         enabled.
@@ -384,6 +387,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param proposed_stake: A stake amount proposed by the bot.
         :param min_stake: Minimal stake size allowed by exchange.
         :param max_stake: Balance available for trading.
+        :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
         :return: A stake size, which is between min_stake and max_stake.
         """
         return proposed_stake

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -14,7 +14,7 @@ def bot_loop_start(self, **kwargs) -> None:
 
 def custom_stake_amount(self, pair: str, current_time: 'datetime', current_rate: float,
                         proposed_stake: float, min_stake: float, max_stake: float,
-                        **kwargs) -> float:
+                        entry_tag: Optional[str], **kwargs) -> float:
     """
     Customize stake size for each new trade. This method is not called when edge module is
     enabled.
@@ -25,6 +25,7 @@ def custom_stake_amount(self, pair: str, current_time: 'datetime', current_rate:
     :param proposed_stake: A stake amount proposed by the bot.
     :param min_stake: Minimal stake size allowed by exchange.
     :param max_stake: Balance available for trading.
+    :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
     :return: A stake size, which is between min_stake and max_stake.
     """
     return proposed_stake
@@ -78,7 +79,8 @@ def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', curre
     return None
 
 def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                        time_in_force: str, current_time: 'datetime', **kwargs) -> bool:
+                        time_in_force: str, current_time: 'datetime', entry_tag: Optional[str],
+                        **kwargs) -> bool:
     """
     Called right before placing a buy order.
     Timing for this function is critical, so avoid doing heavy computations or
@@ -94,6 +96,7 @@ def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: f
     :param rate: Rate that's going to be used when using limit orders
     :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
     :param current_time: datetime object, containing the current datetime
+    :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
     :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
     :return bool: When True is returned, then the buy-order is placed on the exchange.
         False aborts the process

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -12,9 +12,47 @@ def bot_loop_start(self, **kwargs) -> None:
     """
     pass
 
+def custom_entry_price(self, pair: str, current_time: 'datetime', proposed_rate: float,
+                       entry_tag: 'Optional[str]', **kwargs) -> float:
+    """
+    Custom entry price logic, returning the new entry price.
+
+    For full documentation please go to https://www.freqtrade.io/en/latest/strategy-advanced/
+
+    When not implemented by a strategy, returns None, orderbook is used to set entry price
+
+    :param pair: Pair that's currently analyzed
+    :param current_time: datetime object, containing the current datetime
+    :param proposed_rate: Rate, calculated based on pricing settings in ask_strategy.
+    :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
+    :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+    :return float: New entry price value if provided
+    """
+    return proposed_rate
+
+def custom_exit_price(self, pair: str, trade: 'Trade',
+                      current_time: 'datetime', proposed_rate: float,
+                      current_profit: float, **kwargs) -> float:
+    """
+    Custom exit price logic, returning the new exit price.
+
+    For full documentation please go to https://www.freqtrade.io/en/latest/strategy-advanced/
+
+    When not implemented by a strategy, returns None, orderbook is used to set exit price
+
+    :param pair: Pair that's currently analyzed
+    :param trade: trade object.
+    :param current_time: datetime object, containing the current datetime
+    :param proposed_rate: Rate, calculated based on pricing settings in ask_strategy.
+    :param current_profit: Current profit (as ratio), calculated based on current_rate.
+    :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+    :return float: New exit price value if provided
+    """
+    return proposed_rate
+
 def custom_stake_amount(self, pair: str, current_time: 'datetime', current_rate: float,
                         proposed_stake: float, min_stake: float, max_stake: float,
-                        entry_tag: Optional[str], **kwargs) -> float:
+                        entry_tag: 'Optional[str]', **kwargs) -> float:
     """
     Customize stake size for each new trade. This method is not called when edge module is
     enabled.
@@ -79,7 +117,7 @@ def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', curre
     return None
 
 def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: float,
-                        time_in_force: str, current_time: 'datetime', entry_tag: Optional[str],
+                        time_in_force: str, current_time: 'datetime', entry_tag: 'Optional[str]',
                         **kwargs) -> bool:
     """
     Called right before placing a buy order.
@@ -170,3 +208,26 @@ def check_sell_timeout(self, pair: str, trade: 'Trade', order: dict, **kwargs) -
     :return bool: When True is returned, then the sell-order is cancelled.
     """
     return False
+
+def adjust_trade_position(self, trade: 'Trade', current_time: 'datetime',
+                          current_rate: float, current_profit: float, min_stake: float,
+                          max_stake: float, **kwargs) -> 'Optional[float]':
+    """
+    Custom trade adjustment logic, returning the stake amount that a trade should be increased.
+    This means extra buy orders with additional fees.
+    Only called when `position_adjustment_enable` is set to True.
+
+    For full documentation please go to https://www.freqtrade.io/en/latest/strategy-advanced/
+
+    When not implemented by a strategy, returns None
+
+    :param trade: trade object.
+    :param current_time: datetime object, containing the current datetime
+    :param current_rate: Current buy rate.
+    :param current_profit: Current profit (as ratio), calculated based on current_rate.
+    :param min_stake: Minimal stake size allowed by exchange.
+    :param max_stake: Balance available for trading.
+    :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+    :return float: Stake amount to adjust your trade
+    """
+    return None

--- a/tests/strategy/test_default_strategy.py
+++ b/tests/strategy/test_default_strategy.py
@@ -37,7 +37,7 @@ def test_strategy_test_v2(result, fee):
 
     assert strategy.confirm_trade_entry(pair='ETH/BTC', order_type='limit', amount=0.1,
                                         rate=20000, time_in_force='gtc',
-                                        current_time=datetime.utcnow()) is True
+                                        current_time=datetime.utcnow(), entry_tag=None) is True
     assert strategy.confirm_trade_exit(pair='ETH/BTC', trade=trade, order_type='limit', amount=0.1,
                                        rate=20000, time_in_force='gtc', sell_reason='roi',
                                        current_time=datetime.utcnow()) is True


### PR DESCRIPTION
## Summary

Add `entry_tag` for the "trade entry" callbacks `custom_entry_price`, `custom_stake_amount` and `confirm_trade_entry`.

## Quick summary

* add entry_tag to callbacks
* Update advanced strategy template with missing callback functions
* Update documentation