### PR TITLE
Fix ETH duplicate in CoinGecko

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -77,6 +77,9 @@ class CryptoToFiatConverter:
             else:
                 return None
         found = [x for x in self._coinlistings if x['symbol'] == crypto_symbol]
+        if crypto_symbol == 'eth':
+            found = [x for x in self._coinlistings if x['id'] == 'ethereum']
+
         if len(found) == 1:
             return found[0]['id']
 

--- a/tests/rpc/test_fiat_convert.py
+++ b/tests/rpc/test_fiat_convert.py
@@ -148,10 +148,13 @@ def test_fiat_multiple_coins(mocker, caplog):
         {'id': 'helium', 'symbol': 'hnt', 'name': 'Helium'},
         {'id': 'hymnode', 'symbol': 'hnt', 'name': 'Hymnode'},
         {'id': 'bitcoin', 'symbol': 'btc', 'name': 'Bitcoin'},
+        {'id': 'ethereum', 'symbol': 'eth', 'name': 'Ethereum'},
+        {'id': 'ethereum-wormhole', 'symbol': 'eth', 'name': 'Ethereum Wormhole'},
     ]
 
     assert fiat_convert._get_gekko_id('btc') == 'bitcoin'
     assert fiat_convert._get_gekko_id('hnt') is None
+    assert fiat_convert._get_gekko_id('eth') == 'ethereum'
 
     assert log_has('Found multiple mappings in goingekko for hnt.', caplog)
 


### PR DESCRIPTION
## Summary

Fix for duplicate entry for "ETH" in CoinGecko

## Quick changelog

- Select 'ethereum' on CoinGecko for stake_currency 'ETH'