### PR TITLE
Change new-config message for max_open_trades input

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -59,7 +59,7 @@ $ freqtrade new-config --config config_binance.json
 ? Do you want to enable Dry-run (simulated trades)?  Yes
 ? Please insert your stake currency: BTC
 ? Please insert your stake amount: 0.05
-? Please insert max_open_trades (Integer or 'unlimited'): 3
+? Please insert max_open_trades (Integer or -1 for unlimited open trades): 3
 ? Please insert your desired timeframe (e.g. 5m): 5m
 ? Please insert your display Currency (for reporting): USD
 ? Select exchange  binance

--- a/freqtrade/commands/build_config_commands.py
+++ b/freqtrade/commands/build_config_commands.py
@@ -76,12 +76,9 @@ def ask_user_config() -> Dict[str, Any]:
         {
             "type": "text",
             "name": "max_open_trades",
-            "message": f"Please insert max_open_trades (Integer or '{UNLIMITED_STAKE_AMOUNT}'):",
+            "message": "Please insert max_open_trades (Integer or -1 for unlimited open trades):",
             "default": "3",
-            "validate": lambda val: val == UNLIMITED_STAKE_AMOUNT or validate_is_int(val),
-            "filter": lambda val: '"' + UNLIMITED_STAKE_AMOUNT + '"'
-            if val == UNLIMITED_STAKE_AMOUNT
-            else val
+            "validate": lambda val: validate_is_int(val)
         },
         {
             "type": "select",


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Change new-config message for max_open_trades input from 'integer or unlimited' into 'integer or -1 for unlimited open trades' to be inline with current implementation

Solve the issue: #6319 

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

*Explain in details what this PR solve or improve. You can include visuals.* 
