### PR TITLE
added support for waves.exchange

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -21,3 +21,4 @@ from freqtrade.exchange.hitbtc import Hitbtc
 from freqtrade.exchange.kraken import Kraken
 from freqtrade.exchange.kucoin import Kucoin
 from freqtrade.exchange.okex import Okex
+from freqtrade.exchange.waves import Waves

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -34,6 +34,7 @@ BAD_EXCHANGES = {
 MAP_EXCHANGE_CHILDCLASS = {
     'binanceus': 'binance',
     'binanceje': 'binance',
+    'wavesexchange': 'waves',
 }
 
 

--- a/freqtrade/exchange/waves.py
+++ b/freqtrade/exchange/waves.py
@@ -1,0 +1,28 @@
+""" Waves exchange subclass """
+import logging
+from typing import Dict, Optional
+
+from freqtrade.exchange import Exchange
+
+
+logger = logging.getLogger(__name__)
+
+
+class Waves(Exchange):
+    """
+    Waves exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+
+    Please note that this exchange is not included in the list of exchanges
+    officially supported by the Freqtrade development team. So some features
+    may still not work as expected.
+    """
+
+    _ft_has: Dict = {
+        "ohlcv_candle_limit": 1440,
+    }
+
+    # There seems to be no minumum?
+    def get_min_pair_stake_amount(self, pair: str, price: float,
+                                  stoploss: float) -> Optional[float]:
+        return 0


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

This change adds Waves.exchange support to Freqtrade.

## Quick changelog

- Add support for Waves.exchange by creating a custom class.

## What's new?

Support for Waves.exchange.  Note that in order for this to work, the latest CCXT is needed, i sent a bunch of changes to CCXT to fix support for Waves including the ability for market orders.

The changes are merged, so when Freqtrade bumps it's CCXT version it should be ok:
![Merges to CCXT for Waves.exchange support](https://cdn.discordapp.com/attachments/468667750705790986/937646976042938368/unknown.png)

Tested both testnet/mainet + backtest, dry run and even live trading.