### PR TITLE
Don't allow data from the future to be stored (waves.exchange)

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1290,6 +1290,10 @@ class Exchange:
                     p, _, new_data = res
                     if p == pair:
                         data.extend(new_data)
+        # Some exchanges show data past the current time and set all values to null.
+        current_time = arrow.utcnow().int_timestamp * 1000
+        data = filter(lambda item: item[0] < current_time, data)
+        
         # Sort data again after extending the result - above calls return in "async order"
         data = sorted(data, key=lambda x: x[0])
         return pair, timeframe, data


### PR DESCRIPTION
## Summary

In this change we cut off all data past the current time when `download-data` is executed.

## Quick changelog

- Filter data past current time

## What's new?

When running `download-data` with Waves.exchange, the exchange APi returns data past the current time at the end of the candles list, having all values set to `null`, causing Freqtrade to interpolate over it and keep the same value over and over.

Example:
```
2022-02-01 16:16:48,748 - freqtrade.strategy.interface - DEBUG - Populating indicators for pair WX/USDN.
                          date      open      high       low     close  volume  SHB          macd
0    2022-01-23 16:20:00+00:00       NaN       NaN       NaN       NaN     0.0  0.0           NaN
1    2022-01-23 16:25:00+00:00       NaN       NaN       NaN       NaN     0.0  0.0           NaN
2    2022-01-23 16:30:00+00:00       NaN       NaN       NaN       NaN     0.0  0.0           NaN
3    2022-01-23 16:35:00+00:00       NaN       NaN       NaN       NaN     0.0  0.0           NaN
4    2022-01-23 16:40:00+00:00       NaN       NaN       NaN       NaN     0.0  0.0           NaN
...                        ...       ...       ...       ...       ...     ...  ...           ...
2665 2022-02-01 22:25:00+00:00  1.203377  1.203377  1.203377  1.203377     0.0  0.0  6.661338e-16
2666 2022-02-01 22:30:00+00:00  1.203377  1.203377  1.203377  1.203377     0.0  0.0  6.661338e-16
2667 2022-02-01 22:35:00+00:00  1.203377  1.203377  1.203377  1.203377     0.0  0.0  6.661338e-16
2668 2022-02-01 22:40:00+00:00  1.203377  1.203377  1.203377  1.203377     0.0  0.0  6.661338e-16
2669 2022-02-01 22:45:00+00:00  1.203377  1.203377  1.203377  1.203377     0.0  0.0  6.661338e-16
```

Note that at the time, it wasn't `2022-02-01 22:45:00` yet. I now fixed this by using Python's native `filter` function.
There's no breaking changes noticed, except if you have your clock set wrong (but if you do that, you can't really access SSL protected sites to begin with, which is basically every exchange, so that would have broken something already).