### PR TITLE
Hide some lines for /status when a trade is closed

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -442,7 +442,7 @@ class Telegram(RPCHandler):
                 r['num_entries'] = len(r['filled_entry_orders'])
                 r['sell_reason'] = r.get('sell_reason', "")
                 lines = [
-                    "*Trade ID:* `{trade_id}` `(since {open_date_hum})`",
+                    "*Trade ID:* `{trade_id}`" + ("` (since {open_date_hum})`" if r['is_open'] else ""),
                     "*Current Pair:* {pair}",
                     "*Amount:* `{amount} ({stake_amount} {base_currency})`",
                     "*Buy Tag:* `{buy_tag}`" if r['buy_tag'] else "",
@@ -460,27 +460,28 @@ class Telegram(RPCHandler):
                     "*Close Rate:* `{close_rate:.8f}`" if r['close_rate'] else "",
                     "*Open Date:* `{open_date}`",
                     "*Close Date:* `{close_date}`" if r['close_date'] else "",
-                    "*Current Rate:* `{current_rate:.8f}`",
+                    "*Current Rate:* `{current_rate:.8f}`" if r['is_open'] else "",
                     ("*Current Profit:* " if r['is_open'] else "*Close Profit: *")
                     + "`{profit_ratio:.2%}`",
                 ])
 
-                if (r['stop_loss_abs'] != r['initial_stop_loss_abs']
-                        and r['initial_stop_loss_ratio'] is not None):
-                    # Adding initial stoploss only if it is different from stoploss
-                    lines.append("*Initial Stoploss:* `{initial_stop_loss_abs:.8f}` "
-                                 "`({initial_stop_loss_ratio:.2%})`")
+                if r['is_open']:
+                    if (r['stop_loss_abs'] != r['initial_stop_loss_abs']
+                            and r['initial_stop_loss_ratio'] is not None):
+                        # Adding initial stoploss only if it is different from stoploss
+                        lines.append("*Initial Stoploss:* `{initial_stop_loss_abs:.8f}` "
+                                    "`({initial_stop_loss_ratio:.2%})`")
 
-                # Adding stoploss and stoploss percentage only if it is not None
-                lines.append("*Stoploss:* `{stop_loss_abs:.8f}` " +
-                             ("`({stop_loss_ratio:.2%})`" if r['stop_loss_ratio'] else ""))
-                lines.append("*Stoploss distance:* `{stoploss_current_dist:.8f}` "
-                             "`({stoploss_current_dist_ratio:.2%})`")
-                if r['open_order']:
-                    if r['sell_order_status']:
-                        lines.append("*Open Order:* `{open_order}` - `{sell_order_status}`")
-                    else:
-                        lines.append("*Open Order:* `{open_order}`")
+                    # Adding stoploss and stoploss percentage only if it is not None
+                    lines.append("*Stoploss:* `{stop_loss_abs:.8f}` " +
+                                ("`({stop_loss_ratio:.2%})`" if r['stop_loss_ratio'] else ""))
+                    lines.append("*Stoploss distance:* `{stoploss_current_dist:.8f}` "
+                                "`({stoploss_current_dist_ratio:.2%})`")
+                    if r['open_order']:
+                        if r['sell_order_status']:
+                            lines.append("*Open Order:* `{open_order}` - `{sell_order_status}`")
+                        else:
+                            lines.append("*Open Order:* `{open_order}`")
 
                 if len(r['filled_entry_orders']) > 1:
                     lines_detail = self._prepare_buy_details(

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -370,7 +370,7 @@ class Telegram(RPCHandler):
         else:
             return "\N{CROSS MARK}"
 
-    def _prepare_buy_details(self, filled_orders, base_currency):
+    def _prepare_buy_details(self, filled_orders, base_currency, is_open):
         """
         Prepare details of trade with buy adjustment enabled
         """
@@ -400,8 +400,9 @@ class Telegram(RPCHandler):
                 hours, remainder = divmod(dur_buys.seconds, 3600)
                 minutes, seconds = divmod(remainder, 60)
                 lines.append("*Buy #{}:* at {:.2%} avg profit".format(x+1, minus_on_buy))
-                lines.append("({})".format(current_buy_datetime
-                                           .humanize(granularity=["day", "hour", "minute"])))
+                if is_open:
+                    lines.append("({})".format(current_buy_datetime
+                                               .humanize(granularity=["day", "hour", "minute"])))
                 lines.append("*Buy Amount:* {} ({:.8f} {})"
                              .format(cur_buy_amount, order["cost"], base_currency))
                 lines.append("*Average Buy Price:* {} ({:.2%} from 1st buy rate)"
@@ -483,7 +484,7 @@ class Telegram(RPCHandler):
                             lines.append("*Open Order:* `{open_order}`")
 
                 lines_detail = self._prepare_buy_details(
-                    r['filled_entry_orders'], r['base_currency'])
+                    r['filled_entry_orders'], r['base_currency'], r['is_open'])
                 lines.extend((lines_detail if (len(r['filled_entry_orders']) > 1) else ""))
 
                 # Filter empty lines using list-comprehension

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -450,9 +450,7 @@ class Telegram(RPCHandler):
                 ]
 
                 if position_adjust:
-                    max_buy_str = ''
-                    if max_entries > 0:
-                        max_buy_str = f"/{max_entries + 1}"
+                    max_buy_str = (f"/{max_entries + 1}" if (max_entries > 0) else "")
                     lines.append("*Number of Buy(s):* `{num_entries}`" + max_buy_str)
 
                 lines.extend([

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -435,6 +435,7 @@ class Telegram(RPCHandler):
 
             results = self._rpc._rpc_trade_status(trade_ids=trade_ids)
             position_adjust = self._config.get('position_adjustment_enable', False)
+            max_entries = self._config.get('max_entry_position_adjustment', -1)
             messages = []
             for r in results:
                 r['open_date_hum'] = arrow.get(r['open_date']).humanize()

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -450,7 +450,10 @@ class Telegram(RPCHandler):
                 ]
 
                 if position_adjust:
-                    lines.append("*Number of Buy(s):* `{num_entries}`")
+                    max_buy_str = ''
+                    if max_entries > 0:
+                        max_buy_str = f"/{max_entries + 1}"
+                    lines.append("*Number of Buy(s):* `{num_entries}`" + max_buy_str)
 
                 lines.extend([
                     "*Open Rate:* `{open_rate:.8f}`",

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -442,7 +442,8 @@ class Telegram(RPCHandler):
                 r['num_entries'] = len(r['filled_entry_orders'])
                 r['sell_reason'] = r.get('sell_reason', "")
                 lines = [
-                    "*Trade ID:* `{trade_id}`" + ("` (since {open_date_hum})`" if r['is_open'] else ""),
+                    "*Trade ID:* `{trade_id}`" +
+                    ("` (since {open_date_hum})`" if r['is_open'] else ""),
                     "*Current Pair:* {pair}",
                     "*Amount:* `{amount} ({stake_amount} {base_currency})`",
                     "*Buy Tag:* `{buy_tag}`" if r['buy_tag'] else "",
@@ -468,23 +469,22 @@ class Telegram(RPCHandler):
                             and r['initial_stop_loss_ratio'] is not None):
                         # Adding initial stoploss only if it is different from stoploss
                         lines.append("*Initial Stoploss:* `{initial_stop_loss_abs:.8f}` "
-                                    "`({initial_stop_loss_ratio:.2%})`")
+                                     "`({initial_stop_loss_ratio:.2%})`")
 
                     # Adding stoploss and stoploss percentage only if it is not None
                     lines.append("*Stoploss:* `{stop_loss_abs:.8f}` " +
-                                ("`({stop_loss_ratio:.2%})`" if r['stop_loss_ratio'] else ""))
+                                 ("`({stop_loss_ratio:.2%})`" if r['stop_loss_ratio'] else ""))
                     lines.append("*Stoploss distance:* `{stoploss_current_dist:.8f}` "
-                                "`({stoploss_current_dist_ratio:.2%})`")
+                                 "`({stoploss_current_dist_ratio:.2%})`")
                     if r['open_order']:
                         if r['sell_order_status']:
                             lines.append("*Open Order:* `{open_order}` - `{sell_order_status}`")
                         else:
                             lines.append("*Open Order:* `{open_order}`")
 
-                if len(r['filled_entry_orders']) > 1:
-                    lines_detail = self._prepare_buy_details(
-                        r['filled_entry_orders'], r['base_currency'])
-                    lines.extend(lines_detail)
+                lines_detail = self._prepare_buy_details(
+                    r['filled_entry_orders'], r['base_currency'])
+                lines.extend((lines_detail if (len(r['filled_entry_orders']) > 1) else ""))
 
                 # Filter empty lines using list-comprehension
                 messages.append("\n".join([line for line in lines if line]).format(**r))


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Hide some lines for /status when a trade is closed, such as Current Rate, Stoploss, etc, and add max entries limit

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?
- Remove all "since xxx" message
- Remove all stoplosses info
- Remove Current rate

Old /status message
```
Trade ID: 1 (since 9 hours ago)
Current Pair: THETA/BUSD
Amount: 9.2 (29.5366 BUSD)
Buy Tag: 2 
Sell Reason: sell_profit_w_4_4 ( 2 )
Number of Buy(s): 2
Open Rate: 3.21050000
Close Rate: 3.37200000
Open Date: 2022-02-05 16:55:35
Close Date: 2022-02-06 01:35:37
Current Rate: 3.37200000
Close Profit: 4.82%
Stoploss: 0.00000000 (-100.00%)
Stoploss distance: -3.37200000 (-100.00%)
  
Buy #1:
Buy Amount: 4.6 (14.85340000 BUSD)
Average Buy Price: 3.229
  
Buy #2: at -1.15% avg profit
(0 days 9 hours and 17 minutes ago)
Buy Amount: 4.6 (14.68320000 BUSD)
Average Buy Price: 3.192 (-1.15% from 1st buy rate)
Order filled at: 2022-02-05 17:18:30
(0d 0h 21m 46s from previous buy)
```

New one
```
Trade ID: 1
Current Pair: THETA/BUSD
Amount: 9.2 (29.5366 BUSD)
Buy Tag: 2 
Sell Reason: sell_profit_w_4_4 ( 2 )
Number of Buy(s): 2/7
Open Rate: 3.21050000
Close Rate: 3.37200000
Open Date: 2022-02-05 16:55:35
Close Date: 2022-02-06 01:35:37
Close Profit: 4.82%
  
Buy #1:
Buy Amount: 4.6 (14.85340000 BUSD)
Average Buy Price: 3.229
  
Buy #2: at -1.15% avg profit
Buy Amount: 4.6 (14.68320000 BUSD)
Average Buy Price: 3.192 (-1.15% from 1st buy rate)
Order filled at: 2022-02-05 17:18:30
(0d 0h 21m 46s from previous buy)
```
