### PR TITLE
test_ccxt__get_contract_size

### DIFF
--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -351,3 +351,14 @@ class TestCCXTExchange():
                 futures_leverage = futures.get_max_leverage(futures_pair, 20)
                 assert (isinstance(futures_leverage, float) or isinstance(futures_leverage, int))
                 assert futures_leverage >= 1.0
+
+    def test_ccxt__get_contract_size(self, exchange_futures):
+        futures, futures_name = exchange_futures
+        if futures:
+            futures_pair = EXCHANGES[futures_name].get(
+                'futures_pair',
+                EXCHANGES[futures_name]['pair']
+            )
+            contract_size = futures._get_contract_size(futures_pair)
+            assert (isinstance(contract_size, float) or isinstance(contract_size, int))
+            assert contract_size >= 0.0


### PR DESCRIPTION
It looks like FTX is the only exchange that's failing, and it looks like FTX isn't using the unified symbols for some reason, it's still using the symbol like `BTC-PERP`, which was updated on CCXT a while ago

![](https://i.imgur.com/eymWdps.png)