### PR TITLE
feature: add buy tag to forcebuy

### DIFF
--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -280,6 +280,7 @@ class ForceBuyPayload(BaseModel):
     price: Optional[float]
     ordertype: Optional[OrderTypeValues]
     stakeamount: Optional[float]
+    buy_tag: Optional[str]
 
 
 class ForceSellPayload(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -280,7 +280,7 @@ class ForceBuyPayload(BaseModel):
     price: Optional[float]
     ordertype: Optional[OrderTypeValues]
     stakeamount: Optional[float]
-    buy_tag: Optional[str]
+    entry_tag: Optional[str]
 
 
 class ForceSellPayload(BaseModel):

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -136,8 +136,9 @@ def show_config(rpc: Optional[RPC] = Depends(get_rpc_optional), config=Depends(g
 def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
     ordertype = payload.ordertype.value if payload.ordertype else None
     stake_amount = payload.stakeamount if payload.stakeamount else None
+    buy_tag = payload.buy_tag if payload.buy_tag else None
 
-    trade = rpc._rpc_forcebuy(payload.pair, payload.price, ordertype, stake_amount)
+    trade = rpc._rpc_forcebuy(payload.pair, payload.price, ordertype, stake_amount, buy_tag)
 
     if trade:
         return ForceBuyResponse.parse_obj(trade.to_json())

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -136,9 +136,9 @@ def show_config(rpc: Optional[RPC] = Depends(get_rpc_optional), config=Depends(g
 def forcebuy(payload: ForceBuyPayload, rpc: RPC = Depends(get_rpc)):
     ordertype = payload.ordertype.value if payload.ordertype else None
     stake_amount = payload.stakeamount if payload.stakeamount else None
-    buy_tag = payload.buy_tag if payload.buy_tag else None
+    entry_tag = payload.entry_tag if payload.entry_tag else None
 
-    trade = rpc._rpc_forcebuy(payload.pair, payload.price, ordertype, stake_amount, buy_tag)
+    trade = rpc._rpc_forcebuy(payload.pair, payload.price, ordertype, stake_amount, entry_tag)
 
     if trade:
         return ForceBuyResponse.parse_obj(trade.to_json())

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -717,7 +717,8 @@ class RPC:
             return {'result': f'Created sell order for trade {trade_id}.'}
 
     def _rpc_forcebuy(self, pair: str, price: Optional[float], order_type: Optional[str] = None,
-                      stake_amount: Optional[float] = None) -> Optional[Trade]:
+                      stake_amount: Optional[float] = None,
+                      buy_tag: Optional[str] = None) -> Optional[Trade]:
         """
         Handler for forcebuy <asset> <price>
         Buys a pair trade at the given or current price
@@ -751,7 +752,7 @@ class RPC:
             order_type = self._freqtrade.strategy.order_types.get(
                 'forcebuy', self._freqtrade.strategy.order_types['buy'])
         if self._freqtrade.execute_entry(pair, stake_amount, price,
-                                         ordertype=order_type, trade=trade):
+                                         ordertype=order_type, trade=trade, buy_tag=buy_tag):
             Trade.commit()
             trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
             return trade


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Adding the possibility to provide a buy tag for forcebuy

## Quick changelog

- when calling forcebuy method from API you can include the buy tag as well

## What's new?

See above
