### PR TITLE
trade-adjustment for short trades

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -593,7 +593,7 @@ Additional orders also result in additional fees and those orders don't count to
 This callback is **not** called when there is an open order (either buy or sell) waiting for execution, or when you have reached the maximum amount of extra buys that you have set on `max_entry_position_adjustment`.
 `adjust_trade_position()` is called very frequently for the duration of a trade, so you must keep your implementation as performant as possible.
 
-Position adjustments will always be applied in the direction of the trade, so a positive value will always increase your position, no matter if it's a long or short trade. 
+Position adjustments will always be applied in the direction of the trade, so a positive value will always increase your position, no matter if it's a long or short trade.
 
 !!! Note "About stake size"
     Using fixed stake size means it will be the amount used for the first order, just like without position adjustment.

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -593,6 +593,8 @@ Additional orders also result in additional fees and those orders don't count to
 This callback is **not** called when there is an open order (either buy or sell) waiting for execution, or when you have reached the maximum amount of extra buys that you have set on `max_entry_position_adjustment`.
 `adjust_trade_position()` is called very frequently for the duration of a trade, so you must keep your implementation as performant as possible.
 
+Position adjustments will always be applied in the direction of the trade, so a positive value will always increase your position, no matter if it's a long or short trade. 
+
 !!! Note "About stake size"
     Using fixed stake size means it will be the amount used for the first order, just like without position adjustment.
     If you wish to buy additional orders with DCA, then make sure to leave enough funds in the wallet for that.
@@ -663,7 +665,7 @@ class DigDeeperStrategy(IStrategy):
             return None
 
         filled_buys = trade.select_filled_orders('buy')
-        count_of_buys = trade.nr_of_successful_buys
+        count_of_entries = trade.nr_of_successful_entries
         # Allow up to 3 additional increasingly larger buys (4 in total)
         # Initial buy is 1x
         # If that falls to -5% profit, we buy 1.25x more, average profit should increase to roughly -2.2%
@@ -676,7 +678,7 @@ class DigDeeperStrategy(IStrategy):
             # This returns first order stake size
             stake_amount = filled_buys[0].cost
             # This then calculates current safety order size
-            stake_amount = stake_amount * (1 + (count_of_buys * 0.25))
+            stake_amount = stake_amount * (1 + (count_of_entries * 0.25))
             return stake_amount
         except Exception as exception:
             return None

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -593,7 +593,7 @@ Additional orders also result in additional fees and those orders don't count to
 This callback is **not** called when there is an open order (either buy or sell) waiting for execution, or when you have reached the maximum amount of extra buys that you have set on `max_entry_position_adjustment`.
 `adjust_trade_position()` is called very frequently for the duration of a trade, so you must keep your implementation as performant as possible.
 
-Position adjustments will always be applied in the direction of the trade, so a positive value will always increase your position, no matter if it's a long or short trade.
+Position adjustments will always be applied in the direction of the trade, so a positive value will always increase your position, no matter if it's a long or short trade. Modifications to leverage are not possible.
 
 !!! Note "About stake size"
     Using fixed stake size means it will be the amount used for the first order, just like without position adjustment.

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -726,6 +726,7 @@ class FreqtradeBot(LoggingMixin):
             amount = safe_value_fallback(order, 'filled', 'amount')
             enter_limit_filled_price = safe_value_fallback(order, 'average', 'price')
 
+        # TODO: this might be unnecessary, as we're calling it in update_trade_state.
         interest_rate, isolated_liq = self.leverage_prep(
             leverage=leverage,
             pair=pair,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -510,7 +510,7 @@ class FreqtradeBot(LoggingMixin):
         """
         # TODO-lev: Check what changes are necessary for DCA in relation to shorts.
         if self.strategy.max_entry_position_adjustment > -1:
-            count_of_buys = trade.nr_of_successful_buys
+            count_of_buys = trade.nr_of_successful_entries
             if count_of_buys > self.strategy.max_entry_position_adjustment:
                 logger.debug(f"Max adjustment entries for {trade.pair} has been reached.")
                 return

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -533,7 +533,7 @@ class FreqtradeBot(LoggingMixin):
 
         if stake_amount is not None and stake_amount > 0.0:
             # We should increase our position
-            self.execute_entry(trade.pair, stake_amount, trade=trade)
+            self.execute_entry(trade.pair, stake_amount, trade=trade, is_short=trade.is_short)
 
         if stake_amount is not None and stake_amount < 0.0:
             # We should decrease our position

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1599,8 +1599,8 @@ class FreqtradeBot(LoggingMixin):
         Trade.commit()
 
         if order['status'] in constants.NON_OPEN_EXCHANGE_STATES:
-            # If a buy order was closed, force update on stoploss on exchange
-            if order.get('side', None) == 'buy':
+            # If a entry order was closed, force update on stoploss on exchange
+            if order.get('side', None) == trade.enter_side:
                 trade = self.cancel_stoploss_on_exchange(trade)
             # Updating wallets when order is closed
             self.wallets.update()
@@ -1610,7 +1610,7 @@ class FreqtradeBot(LoggingMixin):
                 self._notify_exit(trade, '', True)
             self.handle_protections(trade.pair)
         elif send_msg and not trade.open_order_id:
-            # Buy fill
+            # Enter fill
             self._notify_enter(trade, order, fill=True)
 
         return False

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -464,11 +464,11 @@ class Backtesting:
 
         # Check if we need to adjust our current positions
         if self.strategy.position_adjustment_enable:
-            check_adjust_buy = True
+            check_adjust_entry = True
             if self.strategy.max_entry_position_adjustment > -1:
-                count_of_buys = trade.nr_of_successful_buys
-                check_adjust_buy = (count_of_buys <= self.strategy.max_entry_position_adjustment)
-            if check_adjust_buy:
+                entry_count = trade.nr_of_successful_entries
+                check_adjust_entry = (entry_count <= self.strategy.max_entry_position_adjustment)
+            if check_adjust_entry:
                 trade = self._get_adjust_trade_entry_for_candle(trade, sell_row)
 
         sell_candle_time: datetime = sell_row[DATE_IDX].to_pydatetime()
@@ -729,7 +729,7 @@ class Backtesting:
         for pair in open_trades.keys():
             if len(open_trades[pair]) > 0:
                 for trade in open_trades[pair]:
-                    if trade.open_order_id and trade.nr_of_successful_buys == 0:
+                    if trade.open_order_id and trade.nr_of_successful_entries == 0:
                         # Ignore trade if buy-order did not fill yet
                         continue
                     sell_row = data[pair][-1]
@@ -782,7 +782,7 @@ class Backtesting:
             if timedout:
                 if order.side == 'buy':
                     self.timedout_entry_orders += 1
-                    if trade.nr_of_successful_buys == 0:
+                    if trade.nr_of_successful_entries == 0:
                         # Remove trade due to buy timeout expiration.
                         return True
                     else:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -639,17 +639,20 @@ class Backtesting:
             # If not pos adjust, trade is None
             return trade
 
-        max_leverage = self.exchange.get_max_leverage(pair, stake_amount)
-        leverage = strategy_safe_wrapper(self.strategy.leverage, default_retval=1.0)(
-            pair=pair,
-            current_time=current_time,
-            current_rate=row[OPEN_IDX],
-            proposed_leverage=1.0,
-            max_leverage=max_leverage,
-            side=direction,
-        ) if self._can_short else 1.0
-        # Cap leverage between 1.0 and max_leverage.
-        leverage = min(max(leverage, 1.0), max_leverage)
+        if not pos_adjust:
+            max_leverage = self.exchange.get_max_leverage(pair, stake_amount)
+            leverage = strategy_safe_wrapper(self.strategy.leverage, default_retval=1.0)(
+                pair=pair,
+                current_time=current_time,
+                current_rate=row[OPEN_IDX],
+                proposed_leverage=1.0,
+                max_leverage=max_leverage,
+                side=direction,
+            ) if self._can_short else 1.0
+            # Cap leverage between 1.0 and max_leverage.
+            leverage = min(max(leverage, 1.0), max_leverage)
+        else:
+            leverage = trade.leverage if trade else 1.0
 
         order_type = self.strategy.order_types['buy']
         time_in_force = self.strategy.order_time_in_force['buy']

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -867,7 +867,7 @@ class LocalTrade():
 
     def recalc_trade_from_orders(self):
         # We need at least 2 entry orders for averaging amounts and rates.
-        if len(self.select_filled_orders('buy')) < 2:
+        if len(self.select_filled_orders(self.enter_side)) < 2:
             # Just in case, still recalc open trade value
             self.recalc_open_trade_value()
             return

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -889,6 +889,8 @@ class LocalTrade():
                 total_stake += tmp_price * tmp_amount
 
         if total_amount > 0:
+            # TODO-lev: This should update leverage as well -
+            # as averaged trades might have different leverage
             self.open_rate = total_stake / total_amount
             self.stake_amount = total_stake
             self.amount = total_amount
@@ -937,9 +939,27 @@ class LocalTrade():
                 o.status in NON_OPEN_EXCHANGE_STATES]
 
     @property
+    def nr_of_successful_entries(self) -> int:
+        """
+        Helper function to count the number of entry orders that have been filled.
+        :return: int count of entry orders that have been filled for this trade.
+        """
+
+        return len(self.select_filled_orders(self.enter_side))
+
+    @property
+    def nr_of_successful_exits(self) -> int:
+        """
+        Helper function to count the number of exit orders that have been filled.
+        :return: int count of exit orders that have been filled for this trade.
+        """
+        return len(self.select_filled_orders(self.exit_side))
+
+    @property
     def nr_of_successful_buys(self) -> int:
         """
         Helper function to count the number of buy orders that have been filled.
+        WARNING: Please use nr_of_successful_entries for short support.
         :return: int count of buy orders that have been filled for this trade.
         """
 
@@ -949,6 +969,7 @@ class LocalTrade():
     def nr_of_successful_sells(self) -> int:
         """
         Helper function to count the number of sell orders that have been filled.
+        WARNING: Please use nr_of_successful_exits for short support.
         :return: int count of sell orders that have been filled for this trade.
         """
         return len(self.select_filled_orders('sell'))

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -889,8 +889,7 @@ class LocalTrade():
                 total_stake += tmp_price * tmp_amount
 
         if total_amount > 0:
-            # TODO-lev: This should update leverage as well -
-            # as averaged trades might have different leverage
+            # Leverage not updated, as we don't allow changing leverage through DCA at the moment.
             self.open_rate = total_stake / total_amount
             self.stake_amount = total_stake
             self.amount = total_amount

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -891,7 +891,7 @@ class LocalTrade():
         if total_amount > 0:
             # Leverage not updated, as we don't allow changing leverage through DCA at the moment.
             self.open_rate = total_stake / total_amount
-            self.stake_amount = total_stake
+            self.stake_amount = total_stake / (self.leverage or 1.0)
             self.amount = total_amount
             self.fee_open_cost = self.fee_open * self.stake_amount
             self.recalc_open_trade_value()

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -769,8 +769,10 @@ class RPC:
         # check if valid pair
 
         # check if pair already has an open pair
-        trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
+        trade: Trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
+        is_short = (order_side == SignalDirection.SHORT)
         if trade:
+            is_short = trade.is_short
             if not self._freqtrade.strategy.position_adjustment_enable:
                 raise RPCException(f'position for {pair} already open - id: {trade.id}')
 
@@ -784,7 +786,7 @@ class RPC:
                 'forcebuy', self._freqtrade.strategy.order_types['buy'])
         if self._freqtrade.execute_entry(pair, stake_amount, price,
                                          ordertype=order_type, trade=trade,
-                                         is_short=(order_side == SignalDirection.SHORT),
+                                         is_short=is_short,
                                          enter_tag=enter_tag,
                                          ):
             Trade.commit()

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -261,11 +261,11 @@ class RPC:
                     profit_str
                 ]
                 if self._config.get('position_adjustment_enable', False):
-                    max_buy_str = ''
+                    max_entry_str = ''
                     if self._config.get('max_entry_position_adjustment', -1) > 0:
-                        max_buy_str = f"/{self._config['max_entry_position_adjustment'] + 1}"
-                    filled_buys = trade.nr_of_successful_buys
-                    detail_trade.append(f"{filled_buys}{max_buy_str}")
+                        max_entry_str = f"/{self._config['max_entry_position_adjustment'] + 1}"
+                    filled_entries = trade.nr_of_successful_entries
+                    detail_trade.append(f"{filled_entries}{max_entry_str}")
                 trades_list.append(detail_trade)
             profitcol = "Profit"
             if self._fiat_converter:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -696,19 +696,18 @@ class RPC:
             if trade.open_order_id:
                 order = self._freqtrade.exchange.fetch_order(trade.open_order_id, trade.pair)
 
-                if order['side'] == 'buy':
+                if order['side'] == trade.enter_side:
                     fully_canceled = self._freqtrade.handle_cancel_enter(
                         trade, order, CANCEL_REASON['FORCE_SELL'])
 
-                if order['side'] == 'sell':
+                if order['side'] == trade.exit_side:
                     # Cancel order - so it is placed anew with a fresh price.
                     self._freqtrade.handle_cancel_exit(trade, order, CANCEL_REASON['FORCE_SELL'])
 
             if not fully_canceled:
                 # Get current rate and execute sell
-                closing_side = "buy" if trade.is_short else "sell"
                 current_rate = self._freqtrade.exchange.get_rate(
-                    trade.pair, refresh=False, side=closing_side)
+                    trade.pair, refresh=False, side=trade.exit_side)
                 sell_reason = SellCheckTuple(sell_type=SellType.FORCE_SELL)
                 order_type = ordertype or self._freqtrade.strategy.order_types.get(
                     "forcesell", self._freqtrade.strategy.order_types["sell"])

--- a/tests/strategy/strats/strategy_test_v3.py
+++ b/tests/strategy/strats/strategy_test_v3.py
@@ -183,7 +183,7 @@ class StrategyTestV3(IStrategy):
                               current_profit: float, min_stake: float, max_stake: float, **kwargs):
 
         if current_profit < -0.0075:
-            orders = trade.select_filled_orders('buy')
+            orders = trade.select_filled_orders(trade.enter_side)
             return round(orders[0].cost, 0)
 
         return None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -214,7 +214,6 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, mocker, balance_rati
 
 
 def test_dca_buying(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
-    # TODO-lev: this should also check with different leverages per entry order!
     default_conf_usdt['position_adjustment_enable'] = True
 
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
@@ -286,7 +285,6 @@ def test_dca_buying(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
 
 
 def test_dca_short(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
-    # TODO-lev: this should also check with different leverages per entry order!
     default_conf_usdt['position_adjustment_enable'] = True
 
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -2372,7 +2372,6 @@ def test_recalc_trade_from_orders(fee):
 
 
 @pytest.mark.parametrize('is_short', [True, False])
-# TODO-lev: this should also check with different leverages per entry order!
 def test_recalc_trade_from_orders_ignores_bad_orders(fee, is_short):
 
     o1_amount = 100

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -2418,6 +2418,7 @@ def test_recalc_trade_from_orders_ignores_bad_orders(fee):
     assert trade.fee_open_cost == o1_fee_cost
     assert trade.open_trade_value == o1_trade_val
     assert trade.nr_of_successful_buys == 1
+    assert trade.nr_of_successful_entries == 1
 
     order2 = Order(
         ft_order_side='buy',
@@ -2554,6 +2555,7 @@ def test_recalc_trade_from_orders_ignores_bad_orders(fee):
     assert trade.fee_open_cost == 3 * o1_fee_cost
     assert trade.open_trade_value == 3 * o1_trade_val
     assert trade.nr_of_successful_buys == 3
+    assert trade.nr_of_successful_entries == 3
 
 
 @pytest.mark.usefixtures("init_persistence")


### PR DESCRIPTION
## Summary
Improve trade-adjustment support to also support different trade directions (-> short).

This is still lacking leverage support (needs to be tested) - and has therefore some new TODO-lev's.

TODO:
* [x]  check that liquidation-price is properly updated (needs update after a buy fills)