### PR TITLE
Attempt fix for #6261

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -357,6 +357,15 @@ class Backtesting:
                     # use Open rate if open_rate > calculated sell rate
                     return sell_row[OPEN_IDX]
 
+                if (
+                    trade_dur == 0
+                    and trade.open_rate < sell_row[OPEN_IDX]  # trade-open > open_rate
+                    and sell_row[OPEN_IDX] > sell_row[CLOSE_IDX]  # Red candle
+                ):
+                    # ROI on opening candles with custom pricing can only
+                    # trigger if the entry was at Open or lower.
+                    # details: https: // github.com/freqtrade/freqtrade/issues/6261
+                    raise ValueError("Opening candle ROI on red candles.")
                 # Use the maximum between close_rate and low as we
                 # cannot sell outside of a candle.
                 # Applies when a new ROI setting comes in place and the whole candle is above that.
@@ -414,7 +423,10 @@ class Backtesting:
             trade.close_date = sell_candle_time
 
             trade_dur = int((trade.close_date_utc - trade.open_date_utc).total_seconds() // 60)
-            closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
+            try:
+                closerate = self._get_close_rate(sell_row, trade, sell, trade_dur)
+            except ValueError:
+                return None
             # call the custom exit price,with default value as previous closerate
             current_profit = trade.calc_profit_ratio(closerate)
             order_type = self.strategy.order_types['sell']

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -359,12 +359,15 @@ class Backtesting:
 
                 if (
                     trade_dur == 0
-                    and trade.open_rate < sell_row[OPEN_IDX]  # trade-open > open_rate
+                    # Red candle (for longs), TODO: green candle (for shorts)
                     and sell_row[OPEN_IDX] > sell_row[CLOSE_IDX]  # Red candle
+                    and trade.open_rate < sell_row[OPEN_IDX]  # trade-open below open_rate
+                    and close_rate > sell_row[CLOSE_IDX]
                 ):
                     # ROI on opening candles with custom pricing can only
                     # trigger if the entry was at Open or lower.
                     # details: https: // github.com/freqtrade/freqtrade/issues/6261
+                    # If open_rate is < open, only allow sells below the close on red candles.
                     raise ValueError("Opening candle ROI on red candles.")
                 # Use the maximum between close_rate and low as we
                 # cannot sell outside of a candle.

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -577,10 +577,24 @@ tc36 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=2)]
 )
 
-
-# Test 37: Custom exit price below all candles
-# Price adjusted to candle Low.
+# Test 37: Custom-entry-price around candle low
+# Would cause immediate ROI exit below close
+# details: https://github.com/freqtrade/freqtrade/issues/6261
 tc37 = BTContainer(data=[
+    # D   O     H     L     C    V    B  S   BT
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5400, 5500, 4951, 5100, 6172, 0, 0],    # Enter and immediate ROI
+    [2, 4900, 5250, 4500, 5100, 6172, 0, 0],
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0],
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.10, roi={"0": 0.01}, profit_perc=0.01,
+    custom_entry_price=4952,
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1)]
+)
+
+# Test 38: Custom exit price below all candles
+# Price adjusted to candle Low.
+tc38 = BTContainer(data=[
     # D   O     H     L     C    V    B  S   BT
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
     [1, 5000, 5500, 4951, 5000, 6172, 0, 0],
@@ -593,9 +607,9 @@ tc37 = BTContainer(data=[
     trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=3)]
 )
 
-# Test 38: Custom exit price above all candles
+# Test 39: Custom exit price above all candles
 # causes sell signal timeout
-tc38 = BTContainer(data=[
+tc39 = BTContainer(data=[
     # D   O     H     L     C    V    B  S   BT
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
     [1, 5000, 5500, 4951, 5000, 6172, 0, 0],
@@ -649,6 +663,7 @@ TESTS = [
     tc36,
     tc37,
     tc38,
+    tc39,
 ]
 
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -562,9 +562,9 @@ tc35 = BTContainer(data=[
 )
 
 # Test 36: Custom-entry-price around candle low
-# Causes immediate ROI exit. This is currently expected behavior (#6261)
-# https://github.com/freqtrade/freqtrade/issues/6261
-# But may change at a later point.
+# Would cause immediate ROI exit, but since the trade was entered
+# below open, we treat this as cheating, and delay the sell by 1 candle.
+# details: https://github.com/freqtrade/freqtrade/issues/6261
 tc36 = BTContainer(data=[
     # D   O     H     L     C    V    B  S   BT
     [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
@@ -574,7 +574,7 @@ tc36 = BTContainer(data=[
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
     stop_loss=-0.10, roi={"0": 0.01}, profit_perc=0.01,
     custom_entry_price=4952,
-    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=1)]
+    trades=[BTrade(sell_reason=SellType.ROI, open_tick=1, close_tick=2)]
 )
 
 


### PR DESCRIPTION
## Summary
Don't accept 0 duration ROI with custom pricing on red candles with price < open.

closes #6261

