### PR TITLE
set_margin_mode BadRequest error squelch

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1894,6 +1894,8 @@ class Exchange:
         except (ccxt.NetworkError, ccxt.ExchangeError) as e:
             raise TemporaryError(
                 f'Could not set leverage due to {e.__class__.__name__}. Message: {e}') from e
+        except ccxt.BadRequest:
+            return
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
 


### PR DESCRIPTION
Solves the issue with setting the margin mode to what it's already set to

This issue is only fixed in JS on CCXT, I don't know when it will be fixed for python, I would like asssign the error to e, and then check what the message of e is and only squelch it if the message is the specific error message that we don't like, but I don't know how to instantiate an instance of Exchange with api keys for testing and then run the method