### PR TITLE
Add leverage strategy to new-strategy command

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -426,8 +426,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                  proposed_leverage: float, max_leverage: float, side: str,
                  **kwargs) -> float:
         """
-        Customize leverage for each new trade. This method is not called when edge module is
-        enabled.
+        Customize leverage for each new trade. This method is only called in futures mode.
 
         :param pair: Pair that's currently analyzed
         :param current_time: datetime object, containing the current datetime

--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -129,13 +129,15 @@ class {{ strategy }}(IStrategy):
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
             'enter_long'] = 1
-        # Uncomment to use shorts (remember to set margin in trading mode in configuration)
-        '''dataframe.loc[
+        # Uncomment to use shorts (Only used in futures/margin mode. Check the documentation for more info)
+        """
+        dataframe.loc[
             (
                 {{ sell_trend | indent(16) }}
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
-            'enter_short'] = 1'''
+            'enter_short'] = 1
+        """
 
         return dataframe
 
@@ -152,12 +154,14 @@ class {{ strategy }}(IStrategy):
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
             'exit_long'] = 1
-        # Uncomment to use shorts (remember to set margin in trading mode in configuration)
-        '''dataframe.loc[
+        # Uncomment to use shorts (Only used in futures/margin mode. Check the documentation for more info)
+        """
+        dataframe.loc[
             (
                 {{ buy_trend | indent(16) }}
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
-            'exit_short'] = 1'''
+            'exit_short'] = 1
+        """
         return dataframe
     {{ additional_methods | indent(4) }}

--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -129,6 +129,13 @@ class {{ strategy }}(IStrategy):
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
             'enter_long'] = 1
+        # Uncomment to use shorts (remember to set margin in trading mode in configuration)
+        '''dataframe.loc[
+            (
+                {{ sell_trend | indent(16) }}
+                (dataframe['volume'] > 0)  # Make sure Volume is not 0
+            ),
+            'enter_short'] = 1'''
 
         return dataframe
 
@@ -145,5 +152,12 @@ class {{ strategy }}(IStrategy):
                 (dataframe['volume'] > 0)  # Make sure Volume is not 0
             ),
             'exit_long'] = 1
+        # Uncomment to use shorts (remember to set margin in trading mode in configuration)
+        '''dataframe.loc[
+            (
+                {{ buy_trend | indent(16) }}
+                (dataframe['volume'] > 0)  # Make sure Volume is not 0
+            ),
+            'exit_short'] = 1'''
         return dataframe
     {{ additional_methods | indent(4) }}

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -232,3 +232,19 @@ def adjust_trade_position(self, trade: 'Trade', current_time: 'datetime',
     :return float: Stake amount to adjust your trade
     """
     return None
+
+def leverage(self, pair: str, current_time: datetime, current_rate: float,
+                proposed_leverage: float, max_leverage: float, side: str,
+                **kwargs) -> float:
+    """
+    Customize leverage for each new trade. This method is only called in futures mode.
+
+    :param pair: Pair that's currently analyzed
+    :param current_time: datetime object, containing the current datetime
+    :param current_rate: Rate, calculated based on pricing settings in ask_strategy.
+    :param proposed_leverage: A leverage proposed by the bot.
+    :param max_leverage: Max leverage allowed on this pair
+    :param side: 'long' or 'short' - indicating the direction of the proposed trade
+    :return: A leverage amount, which is between 1.0 and max_leverage.
+    """
+    return 1.0


### PR DESCRIPTION
## Summary

Add leverage strategy to new-strategy command.

## Quick changelog

- Modify base template adding new shorts signal.

## What's new?

It's important to note that both 'long' and 'short' calls have been added in this example strategy, 'short' signals are commented out.

TODO:
Test passed, but check if something new is needed.