### PR TITLE
New release 2022.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Freqtrade rules
 config*.json
 *.sqlite
+*.sqlite-shm
+*.sqlite-wal
 logfile.txt
 user_data/*
 !user_data/strategy/sample_strategy.py

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,5 +1,5 @@
 """ Freqtrade bot """
-__version__ = '2022.2'
+__version__ = '2022.2.1'
 
 if __version__ == 'develop':
 

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -195,6 +195,7 @@ class Order(_DECL_BASE):
         return {
             'amount': self.amount,
             'average': round(self.average, 8) if self.average else 0,
+            'safe_price': self.safe_price,
             'cost': self.cost if self.cost else 0,
             'filled': self.filled,
             'ft_order_side': self.ft_order_side,

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -384,10 +384,10 @@ class Telegram(RPCHandler):
             cur_entry_average = order["safe_price"]
             lines.append("  ")
             if x == 0:
-                lines.append("*Entry #{}:*".format(x+1))
-                lines.append("*Entry Amount:* {} ({:.8f} {})"
-                             .format(cur_entry_amount, order["cost"], base_currency))
-                lines.append("*Average Entry Price:* {}".format(cur_entry_average))
+                lines.append(f"*Entry #{x+1}:*")
+                lines.append(
+                    f"*Entry Amount:* {cur_entry_amount} ({order['cost']:.8f} {base_currency})")
+                lines.append(f"*Average Entry Price:* {cur_entry_average}")
             else:
                 sumA = 0
                 sumB = 0
@@ -404,17 +404,16 @@ class Telegram(RPCHandler):
                 days = dur_entry.days
                 hours, remainder = divmod(dur_entry.seconds, 3600)
                 minutes, seconds = divmod(remainder, 60)
-                lines.append("*Entry #{}:* at {:.2%} avg profit".format(x+1, minus_on_entry))
+                lines.append(f"*Entry #{x+1}:* at {minus_on_entry:.2%} avg profit")
                 if is_open:
                     lines.append("({})".format(cur_entry_datetime
                                                .humanize(granularity=["day", "hour", "minute"])))
-                lines.append("*Entry Amount:* {} ({:.8f} {})"
-                             .format(cur_entry_amount, order["cost"], base_currency))
-                lines.append("*Average Entry Price:* {} ({:.2%} from 1st entry rate)"
-                             .format(cur_entry_average, price_to_1st_entry))
-                lines.append("*Order filled at:* {}".format(order["order_filled_date"]))
-                lines.append("({}d {}h {}m {}s from previous entry)"
-                             .format(days, hours, minutes, seconds))
+                lines.append(
+                    f"*Entry Amount:* {cur_entry_amount} ({order['cost']:.8f} {base_currency})")
+                lines.append(f"*Average Entry Price:* {cur_entry_average} "
+                             f"({price_to_1st_entry:.2%} from 1st entry rate)")
+                lines.append(f"*Order filled at:* {order['order_filled_date']}")
+                lines.append(f"({days}d {hours}h {minutes}m {seconds}s from previous entry)")
         return lines
 
     @authorized_only

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -110,7 +110,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'open_order': None,
         'exchange': 'binance',
         'filled_entry_orders': [{
-            'amount': 91.07468123, 'average': 1.098e-05,
+            'amount': 91.07468123, 'average': 1.098e-05, 'safe_price': 1.098e-05,
             'cost': 0.0009999999999054, 'filled': 91.07468123, 'ft_order_side': 'buy',
             'order_date': ANY, 'order_timestamp': ANY, 'order_filled_date': ANY,
             'order_filled_timestamp': ANY, 'order_type': 'limit', 'price': 1.098e-05,
@@ -185,7 +185,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
         'open_order': None,
         'exchange': 'binance',
         'filled_entry_orders': [{
-            'amount': 91.07468123, 'average': 1.098e-05,
+            'amount': 91.07468123, 'average': 1.098e-05, 'safe_price': 1.098e-05,
             'cost': 0.0009999999999054, 'filled': 91.07468123, 'ft_order_side': 'buy',
             'order_date': ANY, 'order_timestamp': ANY, 'order_filled_date': ANY,
             'order_filled_timestamp': ANY, 'order_type': 'limit', 'price': 1.098e-05,

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -236,6 +236,8 @@ def test_telegram_status_multi_entry(default_conf, update, mocker, fee) -> None:
     create_mock_trades(fee)
     trades = Trade.get_open_trades()
     trade = trades[0]
+    # Average may be empty on some exchanges
+    trade.orders[0].average = 0
     trade.orders.append(Order(
         order_id='5412vbb',
         ft_order_side='buy',
@@ -246,7 +248,7 @@ def test_telegram_status_multi_entry(default_conf, update, mocker, fee) -> None:
         order_type="market",
         side="buy",
         price=trade.open_rate * 0.95,
-        average=trade.open_rate * 0.95,
+        average=0,
         filled=trade.amount,
         remaining=0,
         cost=trade.amount,

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -6,7 +6,7 @@ import time
 from copy import deepcopy
 from math import isclose
 from typing import List
-from unittest.mock import ANY, MagicMock, PropertyMock
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import arrow
 import pytest
@@ -2220,9 +2220,14 @@ def test_check_handle_timedout_sell_usercustom(default_conf_usdt, ticker_usdt, l
 
     et_mock = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.execute_trade_exit')
     caplog.clear()
-
     # 2nd canceled trade ...
     open_trade.open_order_id = limit_sell_order_old['id']
+
+    # If cancelling fails - no emergency sell!
+    with patch('freqtrade.freqtradebot.FreqtradeBot.handle_cancel_exit', return_value=False):
+        freqtrade.check_handle_timedout()
+        assert et_mock.call_count == 0
+
     freqtrade.check_handle_timedout()
     assert log_has_re('Emergencyselling trade.*', caplog)
     assert et_mock.call_count == 1
@@ -2564,13 +2569,17 @@ def test_handle_cancel_exit_limit(mocker, default_conf_usdt, fee) -> None:
     send_msg_mock.reset_mock()
 
     order['amount'] = 2
-    assert freqtrade.handle_cancel_exit(trade, order, reason
-                                        ) == CANCEL_REASON['PARTIALLY_FILLED_KEEP_OPEN']
+    assert not freqtrade.handle_cancel_exit(trade, order, reason)
     # Assert cancel_order was not called (callcount remains unchanged)
     assert cancel_order_mock.call_count == 1
     assert send_msg_mock.call_count == 1
-    assert freqtrade.handle_cancel_exit(trade, order, reason
-                                        ) == CANCEL_REASON['PARTIALLY_FILLED_KEEP_OPEN']
+    assert (send_msg_mock.call_args_list[0][0][0]['reason']
+            == CANCEL_REASON['PARTIALLY_FILLED_KEEP_OPEN'])
+
+    assert not freqtrade.handle_cancel_exit(trade, order, reason)
+
+    send_msg_mock.call_args_list[0][0][0]['reason'] = CANCEL_REASON['PARTIALLY_FILLED_KEEP_OPEN']
+
     # Message should not be iterated again
     assert trade.sell_order_status == CANCEL_REASON['PARTIALLY_FILLED_KEEP_OPEN']
     assert send_msg_mock.call_count == 1
@@ -2589,7 +2598,7 @@ def test_handle_cancel_exit_cancel_exception(mocker, default_conf_usdt) -> None:
     order = {'remaining': 1,
              'amount': 1,
              'status': "open"}
-    assert freqtrade.handle_cancel_exit(trade, order, reason) == 'error cancelling order'
+    assert not freqtrade.handle_cancel_exit(trade, order, reason)
 
 
 def test_execute_trade_exit_up(default_conf_usdt, ticker_usdt, fee, ticker_usdt_sell_up, mocker


### PR DESCRIPTION
## Highlighted changes

* Remove shift in backtesting columns - so buy/sell/tag columns are available correctly via dataprovider
* Added `/health` endpoint, showing the time of the last completed bot-cycle.
* Improved "status" message when using multiple trade entries.
* Improved sorting for `PerformanceFilter` for pairs without prior result (prior pairlist-ordering is kept for these pairs).
* Changed sqlite mode to "wal" - fixing rare concurrency issues.
* Backtesting improvements
  * dataframes retrieved via dataprovider no longer have shifted signals
  * Timeout handling - this will change how custom-pricing works in backtesting. `check_buy_timeout()` and `check_sell_timeout()` are now called in backtesting for orders with prices outside of the opening candle.

### How to update

As always, you can update your bot using one of the following commands:

#### docker-compose

```bash
docker-compose pull
docker-compose up -d
```

#### Installation via setup script

```
# Deactivate venv and run 
./setup.sh --update
```

#### Plain native installation

```
git pull
pip install -U -r requirements.txt
```

<details>
<summary>Expand full changelog</summary>

```
f9d10a7fa Version bump 2022.2.1
7883160ce Update to fstrings
018c62005 Fix 0 Division error on exchanges without average
a0b42c7aa gitignore  sqlite temporary files
5826698c0 Don't emergencysell partial sold exit
e88b022cd Version bump 2022.2
4b7271df4 Improve wording, add Picture detailing what must be installed.
3b1b66bee Prevent backtest starting when not in webserver mode
42df65d4e Make sure backtesting is cleaned up in tests
731eb9971 Update mock-trade creation to rollback first
5a4f30d1b Don't specially handle empty results.
1f9ed0bef Add test for wal mode
02ce0dc02 Set journal mode to wal for sqlite databases
b9a99bd0b Bump python-rapidjson from 1.5 to 1.6
7b6a0f7a1 Bump uvicorn from 0.17.4 to 0.17.5
d354f1f84 Bump mkdocs-material from 8.1.11 to 8.2.1
317487fef Bump ccxt from 1.72.98 to 1.73.70
dc8e9bab4 Bump fastapi from 0.73.0 to 0.74.0
d1cded353 Bump filelock from 3.4.2 to 3.6.0
21b5f56f7 Bump types-requests from 2.27.9 to 2.27.10
fddacfeda Remove returntype
a24586cd4 Update migrations for new column
6fb5b22a8 Some cleanup
dc7bcf5dd Update failing test
db540dc99 Orders should also store fee if in receiving currency
e9f451406 Use correct order id
874c161f7 Update more tests to use order_obj to update trade
508e677d7 Fix some tests to call update_trade with order object
1b1216fc8 Rename update_trade method
c13eed217 use Order object to update trade
d610b6305 Improve /balance output by removing trailing zeros
a7a25bb28 Update "round coin value" to trim trailing zeros
a32aed222 Update FTX stoploss code to avoid exception for stoploss-market orders
3785f04be Handle empty min stake amount as observed on FTX
0bbbe2e96 Add test for #6429
60d1e7fc6 fix stake amt
95d4a11bb add precision
eb88c0f71 fixed stake amount
e60553b8f Add max_entry_position hyperopt to docs
e7bfb4fd5 Add test case for "sell below close" case
b043697d7 Update config_full.example.json
78a93b605 noqa
3787b747a Simplify api schema by not using union types
64b98989d Update open candle ROI condition
7b2e33b0b corrects typo
30f6dbfc4 Attempt fix for #6261
acd7f26a9 update tc36 to properly cover #6261
5cc6c2afe Bump pytest-asyncio from 0.17.2 to 0.18.1
5062c17ac Bump pandas from 1.4.0 to 1.4.1
04c20afec Bump nbconvert from 6.4.1 to 6.4.2
7f8e956b4 Bump types-requests from 2.27.8 to 2.27.9
22036d69d Bump mkdocs-material from 8.1.10 to 8.1.11
b18e44bc4 Bump pytest from 7.0.0 to 7.0.1
1674beed9 Bump ccxt from 1.72.36 to 1.72.98
03d4002be Bump pymdown-extensions from 9.1 to 9.2
be8accebd Bump plotly from 5.5.0 to 5.6.0
ca6291479 Bump prompt-toolkit from 3.0.26 to 3.0.28
b1b8167b5 Update stop documentation
c769e9757 Improve "order refind" to also work for stoploss orders
119d4d520 select_order should use ft_order_side, not the exchange specific one
08803524b align variable naming to use current_time
c9cfc246f Sort /forcebuy pairs alphabetically, add cancel button
6511b3bec fix: rename buy_tag to entry_tag
d563bfc3d feature: add buy tag to forcebuy
6a5910386 update wallets in backtesting to ensure a fresh wallet is used
be84a028c Avoid mixed types in the api for /stats
af984bdc0 Update comment regarting NaT replacement
7252cf47f Update url to include campaign tracking
45c03f144 Docstrings are evaluated, while comments are not
a6a041526 Update intro message
1ba9b70af Improve index/readme wording
6d3803fa2 Add TokenBot promo
4e2f06fe9 Simplify band-aid code
6191288ff Add test for NaT problematic
1d10d2c87 Okex -> okx
172e018d2 Add probit to list of non-working exchanges
dcf8ad36f Backtesting should not allow unrealistic (automatic-filling) orders.
926b01798 Fix freqUI charts not displaying when dtype(datetime) column has NaT values
118ae8a3d Fix api_schemas/json_encoders by manually converting NaT values to empty Strings
b192c8273 Only call "custom_exit_price" for limit orders
d2dbe8f8d Improve doc wording
85767d0d7 Add timedout_*_orders to tests
036c2888b Track timedout entry/exit orders
380e383ee Add log_Responses to full config example
4bce64b42 commented method deletition
92d1f2b94 fix tests
7811a36ae max_drawdown_abs calc fix & .DS_Store deletition
5047492f5 gitignore .ds_store files
8cdb6e077 DRAWDOWN_MULT back to a higher value as built-in for safer HOs first
f31fa07b3 Bump numpy from 1.22.1 to 1.22.2
2893d0b50 proper var name
94b546228 Bump python-telegram-bot from 13.10 to 13.11
b8af4bf8f Bump mkdocs-material from 8.1.9 to 8.1.10
110a270a0 Bump uvicorn from 0.17.1 to 0.17.4
576d5a5b4 Bump types-requests from 2.27.7 to 2.27.8
1e4368328 Bump ccxt from 1.71.73 to 1.72.36
22e395af8 Bump pytest from 6.2.5 to 7.0.0
e24c837e1 Bump scipy from 1.7.3 to 1.8.0
099a03f19 flake8
6d91a5ecb Change "buy" and "sell" to "entry" and "exit"
7d3b80fbd isort fix and leftover cleaning
6b5f63d4d change profit_ratio by profit_abs
ee2a7a968 Add tests for /status on closed trades
5eb502985 Performancefilter - improve sorting
ef086d438 Update PerformanceFilter test to run with USDT pairs
c19f3950d Add losing trade to usdt_mock_trades
0b01fcf04 Add ProfitDrawdownHyperoptLoss method
b657d2d8d Add Github funding
7232324eb Update missing doc segment
da73e754b Explicit map coingecko symbol to ID for bnb and sol
8f2425e49 Add rudimentary tests for pg-specific stuff
644442e2f Track timedout orders
17d748dd4 Improve handling of left_open_trades
2a3ab1ef6 1 more line to be hidden
6b9696057 Update documentation to require python3.8 everywhere
4cf514e29 fix flake8
131b2d68d reduce complexity (flake8)
0477070fa hide some lines if trade is closed
c4a54cc9c refinement of status
cfaf13c90 update
82006ff1d Update setup.sh
22173851d Detail tests for custom exit pricing
2a59ef731 Add detail tests for timeout behaviour
808cefe52 Update order_selection logic
9bf86bbe2 Extract backtesting row validation to separate function
58fad7277 Update wallets when necessary
e08006ea2 Adjust tests to use order Object
4ea79a32e Use Order object for ft_timeout check
1e603985c Extract backtesting order cancelling
6637dacd7 Extract protections in backtesting
7ac44380f Extract backtest order closing to models class
090554f19 Try fill backtest order imediately for adjusted order
f4149ee46 Force ROI to be within candle
44e616c26 Add unfilledtimeout to required props for backtesting
49cecf1cb Small cosmetic fix
9140679bf Backtest order timeout continued.
15698dd1c Fix errors so it runs, implement timeout handling.
f7a1cabe2 Add first version to fill orders "later" in backtesting
c12e5a3b6 Initial idea backtesting order timeout
761f7fdef fix: linter
e84a58de2 fix: don't use different configuration keys, just add as 2nd argument
a3e045f69 Plotting: add alias `--backtest-filename` for `--export-filename`
f8faf748d Simplify prepare_buy_details
1e6362deb Add test for new /status telegram message
29879bb41 Update wording to entry/exit
15d538956 Update /health endpoint to be in local timezone
5d0c2bcb4 Shift candles after pushing them to dataprovider
4b9d55dbe Add test for backtest dataprovider
1f26709ac changes
e72c3ec19 Commit just to force tests to run again.
78986a0de I sort managed to fit it on another row. Impressive.
acf6e9459 Fix unittest.
bf62fc9b2 Add /health endpoint that returns last_process timestamp, fix issue #6009
480ed90a0 create to_json function for Order
bd4014e1e Small cleanup
05046b9ee Add more info on status message
3d94d7df5 Update migrations for mariadb
c265f3932 Update sequences for postgres
19948a6f8 Try fix sequence migrations
5dca183b7 Combine order and Trade migrations to better facilitate migrations in advanced DB systems
```

</details>
