### PR TITLE
Leverage stoploss

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1065,7 +1065,11 @@ class FreqtradeBot(LoggingMixin):
 
         # If enter order is fulfilled but there is no stoploss, we add a stoploss on exchange
         if not stoploss_order:
-            stoploss = self.edge.stoploss(pair=trade.pair) if self.edge else self.strategy.stoploss
+            stoploss = (
+                self.edge.stoploss(pair=trade.pair)
+                if self.edge else
+                self.strategy.stoploss / trade.leverage
+            )
             if trade.is_short:
                 stop_price = trade.open_rate * (1 - stoploss)
             else:

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -566,13 +566,14 @@ class LocalTrade():
             # Don't modify if called with initial and nothing to do
             return
 
+        leverage = self.leverage or 1.0
         if self.is_short:
-            new_loss = float(current_price * (1 + abs(stoploss)))
+            new_loss = float(current_price * (1 + abs(stoploss / leverage)))
             # If trading with leverage, don't set the stoploss below the liquidation price
             if self.isolated_liq:
                 new_loss = min(self.isolated_liq, new_loss)
         else:
-            new_loss = float(current_price * (1 - abs(stoploss)))
+            new_loss = float(current_price * (1 - abs(stoploss / leverage)))
             # If trading with leverage, don't set the stoploss below the liquidation price
             if self.isolated_liq:
                 new_loss = max(self.isolated_liq, new_loss)

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -634,7 +634,7 @@ tc39 = BTContainer(data=[
     [3, 5010, 5010, 4986, 5010, 6172, 0, 1],
     [4, 5010, 5010, 4855, 4995, 6172, 0, 0],  # Triggers stoploss + sellsignal acted on
     [5, 4995, 4995, 4950, 4950, 6172, 0, 0]],
-    stop_loss=-0.01, roi={"0": 1}, profit_perc=0.002 * 5.0, use_sell_signal=True,
+    stop_loss=-0.05, roi={"0": 1}, profit_perc=0.002 * 5.0, use_sell_signal=True,
     leverage=5.0,
     trades=[BTrade(sell_reason=SellType.SELL_SIGNAL, open_tick=1, close_tick=4)]
 )

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1128,9 +1128,6 @@ def test_handle_stoploss_on_exchange(mocker, default_conf_usdt, fee, caplog, is_
     assert trade.is_open is False
     caplog.clear()
 
-    # TODO-lev: Test 2 identical orders but one with leverage, 1 without, and test that the
-    # leveraged trade is hit, but the other trade is not
-
     mocker.patch(
         'freqtrade.exchange.Binance.stoploss',
         side_effect=ExchangeError()

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -1128,6 +1128,9 @@ def test_handle_stoploss_on_exchange(mocker, default_conf_usdt, fee, caplog, is_
     assert trade.is_open is False
     caplog.clear()
 
+    # TODO-lev: Test 2 identical orders but one with leverage, 1 without, and test that the
+    # leveraged trade is hit, but the other trade is not
+
     mocker.patch(
         'freqtrade.exchange.Binance.stoploss',
         side_effect=ExchangeError()


### PR DESCRIPTION
Stoploss accounts for leverage

----------------------

A long trade that opens 
- at a price of `1.0` pair/USDT
- **with 5.0 leverage**
- a stoploss percent of 0.05

Would have a stoploss value of 0.99 pair/USDT

-------------------

A long trade that opens 
- at a price of `1.0` pair/USDT
- **with 1.0 leverage**
- a stoploss percent of 0.05

Would have a stoploss value of 0.95 pair/USDT