### PR TITLE
setup.sh install gettext for mac

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,9 @@ function install_macos() {
         echo_block "Installing Brew"
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     fi
+
+    brew install gettext
+
     #Gets number after decimal in python version
     version=$(egrep -o 3.\[0-9\]+ <<< $PYTHON | sed 's/3.//g')
 


### PR DESCRIPTION
I uninstalled all my brew installations and tried running the setup script, and got that the package `gettext` needs to be installed on mac