### PR TITLE
Simplify and align liquidation price handling

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1584,6 +1584,10 @@ class FreqtradeBot(LoggingMixin):
                     open_rate=trade.open_rate,
                     is_short=trade.is_short
                 ))
+                if not self.edge:
+                    # TODO: should shorting/leverage be supported by Edge,
+                    # then this will need to be fixed.
+                    trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss, initial=True)
 
             # Updating wallets when order is closed
             self.wallets.update()

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -398,8 +398,6 @@ class LocalTrade():
     def __init__(self, **kwargs):
         for key in kwargs:
             setattr(self, key, kwargs[key])
-        if self.isolated_liq:
-            self.set_isolated_liq(isolated_liq=self.isolated_liq)
         self.recalc_open_trade_value()
         if self.trading_mode == TradingMode.MARGIN and self.interest_rate is None:
             raise OperationalException(
@@ -516,15 +514,6 @@ class LocalTrade():
         """
         if not isolated_liq:
             return
-        if self.stop_loss is not None:
-            if self.is_short:
-                self.stop_loss = min(self.stop_loss, isolated_liq)
-            else:
-                self.stop_loss = max(self.stop_loss, isolated_liq)
-        else:
-            self.initial_stop_loss = isolated_liq
-            self.stop_loss = isolated_liq
-
         self.isolated_liq = isolated_liq
 
     def _set_stop_loss(self, stop_loss: float, percent: float):
@@ -596,7 +585,7 @@ class LocalTrade():
 
         logger.debug(
             f"{self.pair} - Stoploss adjusted. current_price={current_price:.8f}, "
-            f"open_rate={self.open_rate:.8f}, max_rate={self.max_rate:.8f}, "
+            f"open_rate={self.open_rate:.8f}, max_rate={self.max_rate or self.open_rate:.8f}, "
             f"initial_stop_loss={self.initial_stop_loss:.8f}, "
             f"stop_loss={self.stop_loss:.8f}. "
             f"Trailing stoploss saved us: "

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -3897,7 +3897,7 @@ def test_trailing_stop_loss_positive(
     freqtrade.enter_positions()
 
     trade = Trade.query.first()
-    trade.is_short = is_short
+    assert trade.is_short == is_short
     oobj = Order.parse_from_ccxt_object(limit_order[eside], limit_order[eside]['symbol'], eside)
     trade.update_trade(oobj)
     caplog.set_level(logging.DEBUG)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -117,28 +117,30 @@ def test_set_stop_loss_isolated_liq(fee):
     )
     trade.set_isolated_liq(0.09)
     assert trade.isolated_liq == 0.09
-    assert trade.stop_loss == 0.09
-    assert trade.initial_stop_loss == 0.09
+    assert trade.stop_loss is None
+    assert trade.initial_stop_loss is None
 
     trade._set_stop_loss(0.1, (1.0/9.0))
     assert trade.isolated_liq == 0.09
     assert trade.stop_loss == 0.1
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.1
 
     trade.set_isolated_liq(0.08)
     assert trade.isolated_liq == 0.08
     assert trade.stop_loss == 0.1
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.1
 
     trade.set_isolated_liq(0.11)
-    assert trade.isolated_liq == 0.11
-    assert trade.stop_loss == 0.11
-    assert trade.initial_stop_loss == 0.09
-
     trade._set_stop_loss(0.1, 0)
     assert trade.isolated_liq == 0.11
     assert trade.stop_loss == 0.11
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.1
+
+    # lower stop doesn't move stoploss
+    trade._set_stop_loss(0.1, 0)
+    assert trade.isolated_liq == 0.11
+    assert trade.stop_loss == 0.11
+    assert trade.initial_stop_loss == 0.1
 
     trade.stop_loss = None
     trade.isolated_liq = None
@@ -156,28 +158,30 @@ def test_set_stop_loss_isolated_liq(fee):
 
     trade.set_isolated_liq(0.09)
     assert trade.isolated_liq == 0.09
-    assert trade.stop_loss == 0.09
-    assert trade.initial_stop_loss == 0.09
+    assert trade.stop_loss is None
+    assert trade.initial_stop_loss is None
 
     trade._set_stop_loss(0.08, (1.0/9.0))
     assert trade.isolated_liq == 0.09
     assert trade.stop_loss == 0.08
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.08
 
     trade.set_isolated_liq(0.1)
     assert trade.isolated_liq == 0.1
     assert trade.stop_loss == 0.08
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.08
 
     trade.set_isolated_liq(0.07)
-    assert trade.isolated_liq == 0.07
-    assert trade.stop_loss == 0.07
-    assert trade.initial_stop_loss == 0.09
-
     trade._set_stop_loss(0.1, (1.0/8.0))
     assert trade.isolated_liq == 0.07
     assert trade.stop_loss == 0.07
-    assert trade.initial_stop_loss == 0.09
+    assert trade.initial_stop_loss == 0.08
+
+    # Stop doesn't move stop higher
+    trade._set_stop_loss(0.1, (1.0/9.0))
+    assert trade.isolated_liq == 0.07
+    assert trade.stop_loss == 0.07
+    assert trade.initial_stop_loss == 0.08
 
 
 @pytest.mark.parametrize('exchange,is_short,lev,minutes,rate,interest,trading_mode', [


### PR DESCRIPTION
## Summary
Align liquidation price assignment.
Current behaviour will fail to properly set stoploss if the order doesn't fill immediately (is a limit order).

with closes #6493 (in combination with a merge from develop, which fixed a similar problem there).

## Quick changelog

* Simplify liquidation price code
* streamline liquidation / stoploss setting based on the bot flow