### PR TITLE
change develop versioning

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,5 +1,5 @@
 """ Freqtrade bot """
-__version__ = 'develop'
+__version__ = '2022.2.1-develop'
 
 if __version__.endswith('develop'):
     try:
@@ -29,5 +29,4 @@ if __version__.endswith('develop'):
             versionfile = Path('./freqtrade_commit')
             if versionfile.is_file():
                 __version__ = f"docker-{versionfile.read_text()[:8]}"
-        except Exception:
-            pass
+        except Exception: pass

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,12 +1,11 @@
 """ Freqtrade bot """
 __version__ = 'develop'
 
-if __version__ == 'develop':
-
+if __version__.endswith('develop'):
     try:
         import subprocess
 
-        __version__ = 'develop-' + subprocess.check_output(
+        __version__ = __version__ + '-' + subprocess.check_output(
             ['git', 'log', '--format="%h"', '-n 1'],
             stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
 

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,7 +1,7 @@
 """ Freqtrade bot """
-__version__ = '2022.2.1-develop'
+__version__ = '2022.2.1-dev'
 
-if __version__.endswith('develop'):
+if __version__.endswith('dev'):
     try:
         import subprocess
 


### PR DESCRIPTION
…on number

## Example of what should happen:

Running `pip install -e .`:
```shell
  Running setup.py develop for freqtrade
Successfully installed freqtrade-2022.2.1.dev0
```

## What actually happens now:
```shell
  Running setup.py develop for freqtrade
Successfully installed freqtrade-develop
```

## Summary

I had troubles installing the `develop` branch locally as editable (`pip install -e .`) when using `poetry`. after some research I found out that using `"develop"` as version number is not the canonical way to do it:

from: https://peps.python.org/pep-0440/#developmental-releases
and https://peps.python.org/pep-0440/#implicit-development-release-number

I glanced that there might be 2 steps required to "fix" this:
1. use `dev` instead of `develop`
   > If used as part of a project’s development cycle, these developmental releases are indicated by including a developmental release segment in the version identifier:
`X.Y.devN    # Developmental release`

2. additionally it might be better to append the current version number also in the develop branch. `X.Y.` in aboves quote. I'm thinking if this might bring trouble with git branches. But it seems to me, this should be fixed whenever branches get merged or rebased.


After changing to `-dev` notation schema, when I use `pip install -e .` it automatically adds `0` to the version, as described here:
> Development releases allow omitting the numeral in which case it is implicitly assumed to be 0. The normal form for this is to include the 0 explicitly. This allows versions such as 1.2.dev which is normalized to 1.2.dev0.
from: https://peps.python.org/pep-0440/#implicit-development-release-number

This indicates to me, that is is working now in a canonical way.


