### PR TITLE
Is short strat

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -127,10 +127,9 @@ class Backtesting:
         self.config['startup_candle_count'] = self.required_startup
         self.exchange.validate_required_startup_candles(self.required_startup, self.timeframe)
 
-        # TODO-lev: This should come from the configuration setting or better a
-        # TODO-lev: combination of config/strategy "use_shorts"(?) and "can_short" from the exchange
         self.trading_mode: TradingMode = config.get('trading_mode', TradingMode.SPOT)
         self.margin_mode: MarginMode = config.get('margin_mode', MarginMode.NONE)
+        # strategies which define "can_short=True" will fail to load in Spot mode.
         self._can_short = self.trading_mode != TradingMode.SPOT
 
         self.progress = BTProgress()

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -177,7 +177,8 @@ class StrategyResolver(IResolver):
             raise ImportError(
                 "Short strategies cannot run in spot markets. Please make sure that this "
                 "is the correct strategy and that your trading mode configuration is correct. "
-                "You can run this strategy by setting `can_short=False` in your strategy."
+                "You can run this strategy in spot markets by setting `can_short=False`"
+                " in your strategy. Please note that short signals will be ignored in that case."
                 )
 
     @staticmethod

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -759,7 +759,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         enter_long = latest[SignalType.ENTER_LONG.value] == 1
         exit_long = latest.get(SignalType.EXIT_LONG.value, 0) == 1
-        enter_short = latest.get(SignalType.ENTER_SHORT.value, 0) == 1
+        enter_short = latest.get(SignalType.ENTER_SHORT.value, 0 == 1)
         exit_short = latest.get(SignalType.EXIT_SHORT.value, 0) == 1
 
         enter_signal: Optional[SignalDirection] = None
@@ -768,6 +768,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             enter_signal = SignalDirection.LONG
             enter_tag_value = latest.get(SignalTagType.ENTER_TAG.value, None)
         if (self.config.get('trading_mode', TradingMode.SPOT) != TradingMode.SPOT
+                and self.can_short
                 and enter_short == 1 and not any([exit_short, enter_long])):
             enter_signal = SignalDirection.SHORT
             enter_tag_value = latest.get(SignalTagType.ENTER_TAG.value, None)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -81,6 +81,7 @@ class IStrategy(ABC, HyperStrategyMixin):
     trailing_only_offset_is_reached = False
     use_custom_stoploss: bool = False
 
+    # Can this strategy go short?
     can_short: bool = False
 
     # associated timeframe

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -760,7 +760,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         enter_long = latest[SignalType.ENTER_LONG.value] == 1
         exit_long = latest.get(SignalType.EXIT_LONG.value, 0) == 1
-        enter_short = latest.get(SignalType.ENTER_SHORT.value, 0 == 1)
+        enter_short = latest.get(SignalType.ENTER_SHORT.value, 0) == 1
         exit_short = latest.get(SignalType.EXIT_SHORT.value, 0) == 1
 
         enter_signal: Optional[SignalDirection] = None

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -81,6 +81,8 @@ class IStrategy(ABC, HyperStrategyMixin):
     trailing_only_offset_is_reached = False
     use_custom_stoploss: bool = False
 
+    can_short: bool = False
+
     # associated timeframe
     ticker_interval: str  # DEPRECATED
     timeframe: str

--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -40,6 +40,9 @@ class {{ strategy }}(IStrategy):
     # Optimal timeframe for the strategy.
     timeframe = '5m'
 
+    # Can this strategy go short?
+    can_short: bool = False
+
     # Minimal ROI designed for the strategy.
     # This attribute will be overridden if the config file contains "minimal_roi".
     minimal_roi = {

--- a/freqtrade/templates/sample_short_strategy.py
+++ b/freqtrade/templates/sample_short_strategy.py
@@ -38,6 +38,9 @@ class SampleShortStrategy(IStrategy):
     # Check the documentation or the Sample strategy to get the latest version.
     INTERFACE_VERSION = 2
 
+    # Can this strategy go short?
+    can_short: bool = True
+
     # Minimal ROI designed for the strategy.
     # This attribute will be overridden if the config file contains "minimal_roi".
     minimal_roi = {

--- a/freqtrade/templates/sample_strategy.py
+++ b/freqtrade/templates/sample_strategy.py
@@ -37,6 +37,9 @@ class SampleStrategy(IStrategy):
     # Check the documentation or the Sample strategy to get the latest version.
     INTERFACE_VERSION = 2
 
+    # Can this strategy go short?
+    can_short: bool = False
+
     # Minimal ROI designed for the strategy.
     # This attribute will be overridden if the config file contains "minimal_roi".
     minimal_roi = {
@@ -55,12 +58,6 @@ class SampleStrategy(IStrategy):
     # trailing_stop_positive = 0.01
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
-    # Hyperoptable parameters
-    buy_rsi = IntParameter(low=1, high=50, default=30, space='buy', optimize=True, load=True)
-    sell_rsi = IntParameter(low=50, high=100, default=70, space='sell', optimize=True, load=True)
-    short_rsi = IntParameter(low=51, high=100, default=70, space='sell', optimize=True, load=True)
-    exit_short_rsi = IntParameter(low=1, high=50, default=30, space='buy', optimize=True, load=True)
-
     # Optimal timeframe for the strategy.
     timeframe = '5m'
 
@@ -71,6 +68,12 @@ class SampleStrategy(IStrategy):
     use_sell_signal = True
     sell_profit_only = False
     ignore_roi_if_buy_signal = False
+
+    # Hyperoptable parameters
+    buy_rsi = IntParameter(low=1, high=50, default=30, space='buy', optimize=True, load=True)
+    sell_rsi = IntParameter(low=50, high=100, default=70, space='sell', optimize=True, load=True)
+    short_rsi = IntParameter(low=51, high=100, default=70, space='sell', optimize=True, load=True)
+    exit_short_rsi = IntParameter(low=1, high=50, default=30, space='buy', optimize=True, load=True)
 
     # Number of candles the strategy requires before producing valid signals
     startup_candle_count: int = 30

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1382,6 +1382,7 @@ def test_api_strategies(botclient):
         'InformativeDecoratorTest',
         'StrategyTestV2',
         'StrategyTestV3',
+        'StrategyTestV3Futures',
         'TestStrategyLegacyV1',
     ]}
 

--- a/tests/strategy/strats/strategy_test_v3.py
+++ b/tests/strategy/strats/strategy_test_v3.py
@@ -187,3 +187,7 @@ class StrategyTestV3(IStrategy):
             return round(orders[0].cost, 0)
 
         return None
+
+
+class StrategyTestV3Futures(StrategyTestV3):
+    can_short = True

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -78,6 +78,12 @@ def test_returns_latest_signal(ohlcv_history):
     assert _STRATEGY.get_entry_signal('ETH/BTC', '5m', mocked_history) == (None, None)
 
     _STRATEGY.config['trading_mode'] = 'futures'
+    # Short signal get's ignored as can_short is not set.
+    assert _STRATEGY.get_entry_signal(
+        'ETH/BTC', '5m', mocked_history) == (None, None)
+
+    _STRATEGY.can_short = True
+
     assert _STRATEGY.get_entry_signal(
         'ETH/BTC', '5m', mocked_history) == (SignalDirection.SHORT, 'sell_signal_01')
     assert _STRATEGY.get_exit_signal('ETH/BTC', '5m', mocked_history) == (False, False, None)
@@ -93,6 +99,7 @@ def test_returns_latest_signal(ohlcv_history):
     assert _STRATEGY.get_exit_signal(
         'ETH/BTC', '5m', mocked_history, True) == (False, True, 'sell_signal_02')
 
+    _STRATEGY.can_short = False
     _STRATEGY.config['trading_mode'] = 'spot'
 
 

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -79,8 +79,7 @@ def test_returns_latest_signal(ohlcv_history):
 
     _STRATEGY.config['trading_mode'] = 'futures'
     # Short signal get's ignored as can_short is not set.
-    assert _STRATEGY.get_entry_signal(
-        'ETH/BTC', '5m', mocked_history) == (None, None)
+    assert _STRATEGY.get_entry_signal('ETH/BTC', '5m', mocked_history) == (None, None)
 
     _STRATEGY.can_short = True
 

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -35,7 +35,7 @@ def test_search_all_strategies_no_failed():
     directory = Path(__file__).parent / "strats"
     strategies = StrategyResolver.search_all_objects(directory, enum_failed=False)
     assert isinstance(strategies, list)
-    assert len(strategies) == 5
+    assert len(strategies) == 6
     assert isinstance(strategies[0], dict)
 
 
@@ -43,10 +43,10 @@ def test_search_all_strategies_with_failed():
     directory = Path(__file__).parent / "strats"
     strategies = StrategyResolver.search_all_objects(directory, enum_failed=True)
     assert isinstance(strategies, list)
-    assert len(strategies) == 6
+    assert len(strategies) == 7
     # with enum_failed=True search_all_objects() shall find 2 good strategies
     # and 1 which fails to load
-    assert len([x for x in strategies if x['class'] is not None]) == 5
+    assert len([x for x in strategies if x['class'] is not None]) == 6
     assert len([x for x in strategies if x['class'] is None]) == 1
 
 
@@ -126,6 +126,22 @@ def test_strategy_pre_v3(result, default_conf, strategy_name):
     dataframe = strategy.advise_exit(df_indicators, metadata=metadata)
     assert 'sell' not in dataframe.columns
     assert 'exit_long' in dataframe.columns
+
+
+def test_strategy_can_short(caplog, default_conf):
+    caplog.set_level(logging.INFO)
+    default_conf.update({
+        'strategy': CURRENT_TEST_STRATEGY,
+    })
+    strat = StrategyResolver.load_strategy(default_conf)
+    assert isinstance(strat, IStrategy)
+    default_conf['strategy'] = 'StrategyTestV3Futures'
+    with pytest.raises(ImportError, match=""):
+        StrategyResolver.load_strategy(default_conf)
+
+    default_conf['trading_mode'] = 'futures'
+    strat = StrategyResolver.load_strategy(default_conf)
+    assert isinstance(strat, IStrategy)
 
 
 def test_strategy_override_minimal_roi(caplog, default_conf):


### PR DESCRIPTION
## Summary

Based on discord "polls" [here](https://discord.com/channels/700048804539400213/888978375882977350/945204005116719155) and [here](https://discord.com/channels/700048804539400213/888978375882977350/951716189166506014) - adding a new attribute to the strategy `can_short` - which will tell us "this is a short strategy".
If this argument is set, we'll fail to load this strategy in spot mode.

![image](https://user-images.githubusercontent.com/5024695/158006013-2079d0c0-7e83-4978-9faf-38b0a1899c81.png)

![image](https://user-images.githubusercontent.com/5024695/158006018-17e143b6-ebcd-4228-8f6d-ccd67474efc7.png)

Documentation for this will follow in a big "documentation" PR - which will change much more in the documentation than this.