### PR TITLE
Update methods wording

### DIFF
--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -222,18 +222,22 @@ class StrategyResolver(IResolver):
         if strategy:
             if strategy.config.get('trading_mode', TradingMode.SPOT) != TradingMode.SPOT:
                 # Require new method
-                if type(strategy).populate_entry_trend == IStrategy.populate_entry_trend:
+                if check_override(strategy, IStrategy, 'populate_entry_trend'):
                     raise OperationalException("`populate_entry_trend` must be implemented.")
-                if type(strategy).populate_exit_trend == IStrategy.populate_exit_trend:
+                if check_override(strategy, IStrategy, 'populate_exit_trend'):
                     raise OperationalException("`populate_exit_trend` must be implemented.")
             else:
-                # TODO: Implementing buy_trend and sell_trend should raise a deprecation.
-                if (type(strategy).populate_buy_trend == IStrategy.populate_buy_trend
-                        and type(strategy).populate_entry_trend == IStrategy.populate_entry_trend):
+                # TODO: Implementing buy_trend and sell_trend should show a deprecation warning
+                if (
+                    check_override(strategy, IStrategy, 'populate_buy_trend')
+                    and check_override(strategy, IStrategy, 'populate_entry_trend')
+                ):
                     raise OperationalException(
                         "`populate_entry_trend` or `populate_buy_trend` must be implemented.")
-                if (type(strategy).populate_sell_trend == IStrategy.populate_sell_trend
-                        and type(strategy).populate_exit_trend == IStrategy.populate_exit_trend):
+                if (
+                    check_override(strategy, IStrategy, 'populate_sell_trend')
+                    and check_override(strategy, IStrategy, 'populate_exit_trend')
+                ):
                     raise OperationalException(
                         "`populate_exit_trend` or `populate_sell_trend` must be implemented.")
 
@@ -253,3 +257,10 @@ class StrategyResolver(IResolver):
             f"Impossible to load Strategy '{strategy_name}'. This class does not exist "
             "or contains Python code errors."
         )
+
+
+def check_override(object, parentclass, attribute):
+    """
+    Checks if a object overrides the parent class attribute.
+    """
+    return getattr(type(object), attribute) == getattr(parentclass, attribute)

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -227,7 +227,16 @@ class StrategyResolver(IResolver):
                 if type(strategy).populate_exit_trend == IStrategy.populate_exit_trend:
                     raise OperationalException("`populate_exit_trend` must be implemented.")
             else:
-                # TODO: Verify if populate_buy and populate_sell are implemented
+
+                if (type(strategy).populate_buy_trend == IStrategy.populate_buy_trend
+                        and type(strategy).populate_entry_trend == IStrategy.populate_entry_trend):
+                    raise OperationalException(
+                        "`populate_entry_trend` or `populate_buy_trend` must be implemented.")
+                if (type(strategy).populate_sell_trend == IStrategy.populate_sell_trend
+                        and type(strategy).populate_exit_trend == IStrategy.populate_exit_trend):
+                    raise OperationalException(
+                        "`populate_exit_trend` or `populate_sell_trend` must be implemented.")
+
                 strategy._populate_fun_len = len(getfullargspec(strategy.populate_indicators).args)
                 strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)
                 strategy._sell_fun_len = len(getfullargspec(strategy.populate_sell_trend).args)

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -220,15 +220,23 @@ class StrategyResolver(IResolver):
         )
 
         if strategy:
-            strategy._populate_fun_len = len(getfullargspec(strategy.populate_indicators).args)
-            strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)
-            strategy._sell_fun_len = len(getfullargspec(strategy.populate_sell_trend).args)
-            if any(x == 2 for x in [
-                strategy._populate_fun_len,
-                strategy._buy_fun_len,
-                strategy._sell_fun_len
-            ]):
-                strategy.INTERFACE_VERSION = 1
+            if strategy.config.get('trading_mode', TradingMode.SPOT) != TradingMode.SPOT:
+                # Require new method
+                if type(strategy).populate_entry_trend == IStrategy.populate_entry_trend:
+                    raise OperationalException("`populate_entry_trend` must be implemented.")
+                if type(strategy).populate_exit_trend == IStrategy.populate_exit_trend:
+                    raise OperationalException("`populate_exit_trend` must be implemented.")
+            else:
+                # TODO: Verify if populate_buy and populate_sell are implemented
+                strategy._populate_fun_len = len(getfullargspec(strategy.populate_indicators).args)
+                strategy._buy_fun_len = len(getfullargspec(strategy.populate_buy_trend).args)
+                strategy._sell_fun_len = len(getfullargspec(strategy.populate_sell_trend).args)
+                if any(x == 2 for x in [
+                    strategy._populate_fun_len,
+                    strategy._buy_fun_len,
+                    strategy._sell_fun_len
+                ]):
+                    strategy.INTERFACE_VERSION = 1
 
             return strategy
 

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -227,7 +227,7 @@ class StrategyResolver(IResolver):
                 if type(strategy).populate_exit_trend == IStrategy.populate_exit_trend:
                     raise OperationalException("`populate_exit_trend` must be implemented.")
             else:
-
+                # TODO: Implementing buy_trend and sell_trend should raise a deprecation.
                 if (type(strategy).populate_buy_trend == IStrategy.populate_buy_trend
                         and type(strategy).populate_entry_trend == IStrategy.populate_entry_trend):
                     raise OperationalException(

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -177,25 +177,42 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return dataframe
 
-    @abstractmethod
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Based on TA indicators, populates the buy signal for the given dataframe
+        DEPRECATED - please migrate to populate_entry_trend
         :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
         :return: DataFrame with buy column
         """
         return dataframe
 
-    @abstractmethod
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the entry signal for the given dataframe
+        :param dataframe: DataFrame
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with entry columns populated
+        """
+        return self.populate_buy_trend(dataframe, metadata)
+
     def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
+        DEPRECATED - please migrate to populate_exit_trend
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
         :return: DataFrame with sell column
         """
         return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the exit signal for the given dataframe
+        :param dataframe: DataFrame
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with exit columns populated
+        """
+        return self.populate_sell_trend(dataframe, metadata)
 
     def bot_loop_start(self, **kwargs) -> None:
         """
@@ -1072,7 +1089,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                           "the current function headers!", DeprecationWarning)
             df = self.populate_buy_trend(dataframe)  # type: ignore
         else:
-            df = self.populate_buy_trend(dataframe, metadata)
+            df = self.populate_entry_trend(dataframe, metadata)
         if 'enter_long' not in df.columns:
             df = df.rename({'buy': 'enter_long', 'buy_tag': 'enter_tag'}, axis='columns')
 
@@ -1094,7 +1111,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                           "the current function headers!", DeprecationWarning)
             df = self.populate_sell_trend(dataframe)  # type: ignore
         else:
-            df = self.populate_sell_trend(dataframe, metadata)
+            df = self.populate_exit_trend(dataframe, metadata)
         if 'exit_long' not in df.columns:
             df = df.rename({'sell': 'exit_long'}, axis='columns')
         return df

--- a/freqtrade/templates/base_strategy.py.j2
+++ b/freqtrade/templates/base_strategy.py.j2
@@ -29,7 +29,7 @@ class {{ strategy }}(IStrategy):
 
     You must keep:
     - the lib in the section "Do not remove these libs"
-    - the methods: populate_indicators, populate_buy_trend, populate_sell_trend
+    - the methods: populate_indicators, populate_entry_trend, populate_exit_trend
     You should keep:
     - timeframe, minimal_roi, stoploss, trailing_*
     """
@@ -119,12 +119,12 @@ class {{ strategy }}(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Based on TA indicators, populates the buy signal for the given dataframe
-        :param dataframe: DataFrame populated with indicators
+        Based on TA indicators, populates the entry signal for the given dataframe
+        :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
-        :return: DataFrame with buy column
+        :return: DataFrame with entry columns populated
         """
         dataframe.loc[
             (
@@ -144,12 +144,12 @@ class {{ strategy }}(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Based on TA indicators, populates the sell signal for the given dataframe
-        :param dataframe: DataFrame populated with indicators
+        Based on TA indicators, populates the exit signal for the given dataframe
+        :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
-        :return: DataFrame with buy column
+        :return: DataFrame with exit columns populated
         """
         dataframe.loc[
             (

--- a/freqtrade/templates/sample_short_strategy.py
+++ b/freqtrade/templates/sample_short_strategy.py
@@ -30,7 +30,7 @@ class SampleShortStrategy(IStrategy):
 
     You must keep:
     - the lib in the section "Do not remove these libs"
-    - the methods: populate_indicators, populate_buy_trend, populate_sell_trend
+    - the methods: populate_indicators, populate_entry_trend, populate_exit_trend
     You should keep:
     - timeframe, minimal_roi, stoploss, trailing_*
     """
@@ -341,7 +341,7 @@ class SampleShortStrategy(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame populated with indicators
@@ -361,7 +361,7 @@ class SampleShortStrategy(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame populated with indicators

--- a/freqtrade/templates/sample_strategy.py
+++ b/freqtrade/templates/sample_strategy.py
@@ -29,7 +29,7 @@ class SampleStrategy(IStrategy):
 
     You must keep:
     - the lib in the section "Do not remove these libs"
-    - the methods: populate_indicators, populate_buy_trend, populate_sell_trend
+    - the methods: populate_indicators, populate_entry_trend, populate_exit_trend
     You should keep:
     - timeframe, minimal_roi, stoploss, trailing_*
     """
@@ -342,12 +342,12 @@ class SampleStrategy(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Based on TA indicators, populates the buy signal for the given dataframe
-        :param dataframe: DataFrame populated with indicators
+        Based on TA indicators, populates the entry signal for the given dataframe
+        :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
-        :return: DataFrame with buy column
+        :return: DataFrame with entry columns populated
         """
         dataframe.loc[
             (
@@ -371,12 +371,12 @@ class SampleStrategy(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Based on TA indicators, populates the sell signal for the given dataframe
-        :param dataframe: DataFrame populated with indicators
+        Based on TA indicators, populates the exit signal for the given dataframe
+        :param dataframe: DataFrame
         :param metadata: Additional information, like the currently traded pair
-        :return: DataFrame with sell column
+        :return: DataFrame with exit columns populated
         """
         dataframe.loc[
             (

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -92,7 +92,7 @@ def custom_stoploss(self, pair: str, trade: 'Trade', current_time: 'datetime',
     """
     return self.stoploss
 
-def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,
+def custom_exit(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,
                 current_profit: float, **kwargs) -> 'Optional[Union[str, bool]]':
     """
     Custom sell signal logic indicating that specified position should be sold. Returning a

--- a/tests/strategy/strats/broken_strats/broken_futures_strategies.py
+++ b/tests/strategy/strats/broken_strats/broken_futures_strategies.py
@@ -1,4 +1,9 @@
-# The strategy which fails to load due to non-existent dependency
+"""
+The strategies here are minimal strategies designed to fail loading in certain conditions.
+They are not operational, and don't aim to be.
+"""
+
+from datetime import datetime
 
 from pandas import DataFrame
 
@@ -14,3 +19,13 @@ class TestStrategyNoImplements(IStrategy):
 class TestStrategyNoImplementSell(TestStrategyNoImplements):
     def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         return super().populate_entry_trend(dataframe, metadata)
+
+
+class TestStrategyImplementCustomSell(TestStrategyNoImplementSell):
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return super().populate_exit_trend(dataframe, metadata)
+
+    def custom_sell(self, pair: str, trade, current_time: datetime,
+                    current_rate: float, current_profit: float,
+                    **kwargs):
+        return False

--- a/tests/strategy/strats/broken_strats/broken_futures_strategies.py
+++ b/tests/strategy/strats/broken_strats/broken_futures_strategies.py
@@ -1,0 +1,16 @@
+# The strategy which fails to load due to non-existent dependency
+
+from pandas import DataFrame
+
+from freqtrade.strategy.interface import IStrategy
+
+
+class TestStrategyNoImplements(IStrategy):
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return super().populate_indicators(dataframe, metadata)
+
+
+class TestStrategyNoImplementSell(TestStrategyNoImplements):
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return super().populate_entry_trend(dataframe, metadata)

--- a/tests/strategy/strats/strategy_test_v3.py
+++ b/tests/strategy/strats/strategy_test_v3.py
@@ -125,7 +125,7 @@ class StrategyTestV3(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
         dataframe.loc[
             (
@@ -147,7 +147,7 @@ class StrategyTestV3(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe.loc[
             (
                 (

--- a/tests/strategy/test_default_strategy.py
+++ b/tests/strategy/test_default_strategy.py
@@ -13,8 +13,8 @@ def test_strategy_test_v3_structure():
     assert hasattr(StrategyTestV3, 'stoploss')
     assert hasattr(StrategyTestV3, 'timeframe')
     assert hasattr(StrategyTestV3, 'populate_indicators')
-    assert hasattr(StrategyTestV3, 'populate_buy_trend')
-    assert hasattr(StrategyTestV3, 'populate_sell_trend')
+    assert hasattr(StrategyTestV3, 'populate_entry_trend')
+    assert hasattr(StrategyTestV3, 'populate_exit_trend')
 
 
 @pytest.mark.parametrize('is_short,side', [

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -477,7 +477,7 @@ def test_stop_loss_reached(default_conf, fee, profit, adjusted, expected, traili
     strategy.custom_stoploss = original_stopvalue
 
 
-def test_custom_sell(default_conf, fee, caplog) -> None:
+def test_custom_exit(default_conf, fee, caplog) -> None:
 
     strategy = StrategyResolver.load_strategy(default_conf)
     trade = Trade(
@@ -499,7 +499,7 @@ def test_custom_sell(default_conf, fee, caplog) -> None:
     assert res.sell_flag is False
     assert res.sell_type == SellType.NONE
 
-    strategy.custom_sell = MagicMock(return_value=True)
+    strategy.custom_exit = MagicMock(return_value=True)
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
                                low=None, high=None)
@@ -507,7 +507,7 @@ def test_custom_sell(default_conf, fee, caplog) -> None:
     assert res.sell_type == SellType.CUSTOM_SELL
     assert res.sell_reason == 'custom_sell'
 
-    strategy.custom_sell = MagicMock(return_value='hello world')
+    strategy.custom_exit = MagicMock(return_value='hello world')
 
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
@@ -517,14 +517,14 @@ def test_custom_sell(default_conf, fee, caplog) -> None:
     assert res.sell_reason == 'hello world'
 
     caplog.clear()
-    strategy.custom_sell = MagicMock(return_value='h' * 100)
+    strategy.custom_exit = MagicMock(return_value='h' * 100)
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
                                low=None, high=None)
     assert res.sell_type == SellType.CUSTOM_SELL
     assert res.sell_flag is True
     assert res.sell_reason == 'h' * 64
-    assert log_has_re('Custom sell reason returned from custom_sell is too long.*', caplog)
+    assert log_has_re('Custom sell reason returned from custom_exit is too long.*', caplog)
 
 
 @pytest.mark.parametrize('side', TRADE_SIDES)

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -417,6 +417,7 @@ def test_missing_implements(result, default_conf):
                        match=r"`populate_entry_trend` must be implemented.*"):
         StrategyResolver.load_strategy(default_conf)
 
+
 @pytest.mark.filterwarnings("ignore:deprecated")
 def test_call_deprecated_function(result, default_conf, caplog):
     default_location = Path(__file__).parent / "strats"

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -392,7 +392,7 @@ def test_deprecate_populate_indicators(result, default_conf):
 
 
 @pytest.mark.filterwarnings("ignore:deprecated")
-def test_missing_implements(result, default_conf):
+def test_missing_implements(default_conf):
     default_location = Path(__file__).parent / "strats/broken_strats"
     default_conf.update({'strategy': 'TestStrategyNoImplements',
                          'strategy_path': default_location})
@@ -406,6 +406,7 @@ def test_missing_implements(result, default_conf):
                        match=r"`populate_exit_trend` or `populate_sell_trend`.*"):
         StrategyResolver.load_strategy(default_conf)
 
+    # Futures mode is more strict ...
     default_conf['trading_mode'] = 'futures'
 
     with pytest.raises(OperationalException,
@@ -415,6 +416,12 @@ def test_missing_implements(result, default_conf):
     default_conf['strategy'] = 'TestStrategyNoImplements'
     with pytest.raises(OperationalException,
                        match=r"`populate_entry_trend` must be implemented.*"):
+        StrategyResolver.load_strategy(default_conf)
+
+    default_conf['strategy'] = 'TestStrategyImplementCustomSell'
+
+    with pytest.raises(OperationalException,
+                       match=r"Please migrate your implementation of `custom_sell`.*"):
         StrategyResolver.load_strategy(default_conf)
 
 

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -144,6 +144,16 @@ def test_strategy_can_short(caplog, default_conf):
     assert isinstance(strat, IStrategy)
 
 
+def test_strategy_implements_populate_entry(caplog, default_conf):
+    caplog.set_level(logging.INFO)
+    default_conf.update({
+        'strategy': "StrategyTestV2",
+    })
+    default_conf['trading_mode'] = 'futures'
+    with pytest.raises(OperationalException, match="`populate_entry_trend` must be implemented."):
+        StrategyResolver.load_strategy(default_conf)
+
+
 def test_strategy_override_minimal_roi(caplog, default_conf):
     caplog.set_level(logging.INFO)
     default_conf.update({

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -392,6 +392,32 @@ def test_deprecate_populate_indicators(result, default_conf):
 
 
 @pytest.mark.filterwarnings("ignore:deprecated")
+def test_missing_implements(result, default_conf):
+    default_location = Path(__file__).parent / "strats/broken_strats"
+    default_conf.update({'strategy': 'TestStrategyNoImplements',
+                         'strategy_path': default_location})
+    with pytest.raises(OperationalException,
+                       match=r"`populate_entry_trend` or `populate_buy_trend`.*"):
+        StrategyResolver.load_strategy(default_conf)
+
+    default_conf['strategy'] = 'TestStrategyNoImplementSell'
+
+    with pytest.raises(OperationalException,
+                       match=r"`populate_exit_trend` or `populate_sell_trend`.*"):
+        StrategyResolver.load_strategy(default_conf)
+
+    default_conf['trading_mode'] = 'futures'
+
+    with pytest.raises(OperationalException,
+                       match=r"`populate_exit_trend` must be implemented.*"):
+        StrategyResolver.load_strategy(default_conf)
+
+    default_conf['strategy'] = 'TestStrategyNoImplements'
+    with pytest.raises(OperationalException,
+                       match=r"`populate_entry_trend` must be implemented.*"):
+        StrategyResolver.load_strategy(default_conf)
+
+@pytest.mark.filterwarnings("ignore:deprecated")
 def test_call_deprecated_function(result, default_conf, caplog):
     default_location = Path(__file__).parent / "strats"
     del default_conf['timeframe']


### PR DESCRIPTION
## Summary
Update `populate_buy_trend` and `populate_sell_trend` wording to `populate_entry_trend` and `populate_exit_trend`.
Update `custom_sell` to `custom_exit`.

The validation logic is:
* for spot markets - don't force the migration at the moment - but continue working with fallback
* for futures markets - Force migration to new wording.

Eventually, we'll force all users to upgrade (at a very later point) - but we will have a grace-period where we'll warn (also not implemented at the moment).