### PR TITLE
Add proposed leverage for the judgment of min_stake_amount and max_stake_amount

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -776,7 +776,7 @@ class FreqtradeBot(LoggingMixin):
         side: str, trade_side: str,
         entry_tag: Optional[str],
         trade: Optional[Trade],
-        leverage: Optional[float] = 1.0
+        leverage: float = 1.0
     ) -> Tuple[float, float]:
 
         if price:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -615,7 +615,7 @@ class FreqtradeBot(LoggingMixin):
                 proposed_leverage=proposed_leverage,
                 max_leverage=max_leverage,
                 side=trade_side,
-            )
+            ) if self.trading_mode != TradingMode.SPOT else 1.0
             # Cap leverage between 1.0 and max_leverage.
             leverage = min(max(leverage, proposed_leverage), max_leverage)
         else:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -481,7 +481,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param side: 'long' or 'short' - indicating the direction of the proposed trade
         :return: A leverage amount, which is between 1.0 and max_leverage.
         """
-        return 1.0
+        return proposed_leverage
 
     def informative_pairs(self) -> ListPairsWithTimeframes:
         """


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Add proposed leverage for the judgment of min_stake_amount and max_stake_amount

## Quick changelog

- Use leverage in config to assist in judging min_stake_amount and max_stake_amount

## What's new?

When balance is less than min_stake_amount. And xleverage is greater than min_stake_amount later. You can set leverage in the config file to adjust min_stake_amount and max_stake_amount. This is useful in small amount tests
