### PR TITLE
taker or maker passed correctly for entry and exit orders

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -583,11 +583,9 @@ class FreqtradeBot(LoggingMixin):
         '''
         order_type = self.config['order_types'][side]
         if order_type == 'limit':
-            enter_side = 'ask' if is_short else 'bid'
-            exit_side = 'bid' if is_short else 'ask'
             if (
-                side == 'entry' and self.config['bid_strategy']['price_side'] == enter_side or
-                side == 'exit' and self.config['ask_strategy']['price_side'] == exit_side
+                side == 'entry' and self.config['entry_pricing']['price_side'] == 'same' or
+                side == 'exit' and self.config['exit_pricing']['price_side'] == 'same'
             ):
                 taker_or_maker = 'maker'
             else:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -570,6 +570,35 @@ class FreqtradeBot(LoggingMixin):
             logger.info(f"Bids to asks delta for {pair} does not satisfy condition.")
             return False
 
+    def get_fee(
+        self,
+        pair: str,
+        side: str,
+        is_short: bool = False,
+    ):
+        '''
+        :param pair: Unified CCXT symbol
+        :param side: One of entry, exit or stoploss
+        :param is_short: True for short trades
+        '''
+        order_type = self.config['order_types'][side]
+        if order_type == 'limit':
+            enter_side = 'ask' if is_short else 'bid'
+            exit_side = 'bid' if is_short else 'ask'
+            if (
+                side == 'entry' and self.config['bid_strategy']['price_side'] == enter_side or
+                side == 'exit' and self.config['ask_strategy']['price_side'] == exit_side
+            ):
+                taker_or_maker = 'maker'
+            else:
+                taker_or_maker = 'taker'
+        else:
+            taker_or_maker = 'taker'
+        return self.exchange.get_fee(
+            symbol=pair,
+            taker_or_maker=taker_or_maker
+        )
+
     def execute_entry(
         self,
         pair: str,
@@ -664,12 +693,10 @@ class FreqtradeBot(LoggingMixin):
             enter_limit_filled_price = safe_value_fallback(order, 'average', 'price')
 
         # Fee is applied twice because we make a LIMIT_BUY and LIMIT_SELL
-        fee = self.exchange.get_fee(symbol=pair, taker_or_maker='maker')
         base_currency = self.exchange.get_pair_base_currency(pair)
         open_date = datetime.now(timezone.utc)
         funding_fees = self.exchange.get_funding_fees(
             pair=pair, amount=amount, is_short=is_short, open_date=open_date)
-        # This is a new trade
         if trade is None:
             trade = Trade(
                 pair=pair,
@@ -679,8 +706,8 @@ class FreqtradeBot(LoggingMixin):
                 amount=amount,
                 is_open=True,
                 amount_requested=amount_requested,
-                fee_open=fee,
-                fee_close=fee,
+                fee_open=self.get_fee(pair, 'entry'),
+                fee_close=self.get_fee(pair, 'exit'),
                 open_rate=enter_limit_filled_price,
                 open_rate_requested=enter_limit_requested,
                 open_date=open_date,

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -682,9 +682,10 @@ class LocalTrade():
             self.fee_open_cost = fee_cost
             self.fee_open_currency = fee_currency
             if fee_rate is not None:
+                current_rate_ratio = self.fee_close / self.fee_open
                 self.fee_open = fee_rate
-                # Assume close-fee will fall into the same fee category and take an educated guess
-                self.fee_close = fee_rate
+                # The new open/close fees will be as proportional as the old fees
+                self.fee_close = fee_rate * current_rate_ratio
         elif self.exit_side == side and self.fee_close_currency is None:
             self.fee_close_cost = fee_cost
             self.fee_close_currency = fee_currency

--- a/freqtrade/persistence/models.py
+++ b/freqtrade/persistence/models.py
@@ -285,9 +285,11 @@ class LocalTrade():
     fee_open: float = 0.0
     fee_open_cost: Optional[float] = None
     fee_open_currency: str = ''
+    fee_open_is_maker: str = True
     fee_close: float = 0.0
     fee_close_cost: Optional[float] = None
     fee_close_currency: str = ''
+    fee_close_is_maker: str = True
     open_rate: float = 0.0
     open_rate_requested: Optional[float] = None
     # open_trade_value - calculated via _calc_open_trade_value
@@ -682,7 +684,12 @@ class LocalTrade():
             self.fee_open_cost = fee_cost
             self.fee_open_currency = fee_currency
             if fee_rate is not None:
-                current_rate_ratio = self.fee_close / self.fee_open
+                if self.fee_open_is_maker == self.fee_close_is_maker:
+                    current_rate_ratio = 1
+                elif self.fee_open_is_maker and not self.fee_close_is_maker:
+                    current_rate_ratio = 2
+                elif not self.fee_open_is_maker and self.fee_close_is_maker:
+                    current_rate_ratio = 0.5
                 self.fee_open = fee_rate
                 # The new open/close fees will be as proportional as the old fees
                 self.fee_close = fee_rate * current_rate_ratio
@@ -1080,9 +1087,11 @@ class Trade(_DECL_BASE, LocalTrade):
     fee_open = Column(Float, nullable=False, default=0.0)
     fee_open_cost = Column(Float, nullable=True)
     fee_open_currency = Column(String(25), nullable=True)
+    fee_open_is_maker = Column(Boolean, default=True)
     fee_close = Column(Float, nullable=False, default=0.0)
     fee_close_cost = Column(Float, nullable=True)
     fee_close_currency = Column(String(25), nullable=True)
+    fee_close_is_maker = Column(Boolean, default=True)
     open_rate: float = Column(Float)
     open_rate_requested = Column(Float)
     # open_trade_value - calculated via _calc_open_trade_value

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -786,7 +786,7 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_order,
         get_min_pair_stake_amount=MagicMock(return_value=1),
         get_max_pair_stake_amount=MagicMock(return_value=500000),
         get_fee=MagicMock(side_effect=(
-            lambda symbol, taker_or_maker: fee if taker_or_maker == 'maker' else fee*2
+            lambda symbol, taker_or_maker: fee if taker_or_maker == 'maker' else fee * 2
         )),
         get_funding_fees=MagicMock(return_value=0),
         name=exchange_name,
@@ -822,7 +822,7 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_order,
     assert trade.is_open is True
     assert trade.open_order_id == '22'
     assert trade.open_fee == fee
-    assert trade.close_fee == fee*2
+    assert trade.close_fee == fee * 2
 
     # Test calling with price
     open_order['id'] = '33'
@@ -858,7 +858,7 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_order,
     assert trade.open_rate == 10
     assert trade.stake_amount == round(order['price'] * order['filled'] / leverage, 8)
     assert pytest.approx(trade.liquidation_price) == liq_price
-    assert trade.open_fee == fee*2
+    assert trade.open_fee == fee * 2
     assert trade.close_fee == fee
 
     # In case of rejected or expired order and partially filled


### PR DESCRIPTION
Freqtrade statically passes `maker` to get fees for an order, this new method isn't perfect (limit orders can still be taker orders) but its better than what was there before. I couldn't figure out the places to update the fee if it's a stoploss order, all I could see was stoploss on exchange, which should only be for live anyway

I can't get the test to pass because Trade.open_fee returns the MagicMock instead of the actual return value

```
    def _calc_open_trade_value(self) -> float:
        """
        Calculate the open_rate including open_fee.
        :return: Price in of the open trade incl. Fees
        """
        buy_trade = Decimal(self.amount) * Decimal(self.open_rate)
>       fees = buy_trade * Decimal(self.fee_open)
E       TypeError: conversion from MagicMock to Decimal is not supported

freqtrade/persistence/models.py:568: TypeError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/sam/Documents/dev/freqtrade/freqtrade/freqtrade/persistence/models.py(568)_calc_open_trade_value()
-> fees = buy_trade * Decimal(self.fee_open)
(Pdb) self.fee_open
<MagicMock id='4929478464'>
(Pdb) self.fee_open.return_value
0.0025
```