### PR TITLE
Add amount_to_contracts and order_contracts_to_amount to exchange.stoploss

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -402,7 +402,7 @@ class Exchange:
         return trades
 
     def _order_contracts_to_amount(self, order: Dict) -> Dict:
-        if 'symbol' in order:
+        if 'symbol' in order and order['symbol'] is not None:
             contract_size = self._get_contract_size(order['symbol'])
             if contract_size != 1:
                 for prop in ['amount', 'cost', 'filled', 'remaining']:
@@ -1108,10 +1108,10 @@ class Exchange:
             self._lev_prep(pair, leverage, side)
             order = self._api.create_order(symbol=pair, type=ordertype, side=side,
                                            amount=amount, price=rate, params=params)
+            self._log_exchange_response('create_stoploss_order', order)
             order = self._order_contracts_to_amount(order)
             logger.info(f"stoploss {user_order_type} order added for {pair}. "
                         f"stop price: {stop_price}. limit: {rate}")
-            self._log_exchange_response('create_stoploss_order', order)
             return order
         except ccxt.InsufficientFunds as e:
             raise InsufficientFundsError(

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1103,11 +1103,12 @@ class Exchange:
             if self.trading_mode == TradingMode.FUTURES:
                 params['reduceOnly'] = True
 
-            amount = self.amount_to_precision(pair, amount)
+            amount = self.amount_to_precision(pair, self._amount_to_contracts(pair, amount))
 
             self._lev_prep(pair, leverage, side)
             order = self._api.create_order(symbol=pair, type=ordertype, side=side,
                                            amount=amount, price=rate, params=params)
+            order = self._order_contracts_to_amount(order)
             logger.info(f"stoploss {user_order_type} order added for {pair}. "
                         f"stop price: {stop_price}. limit: {rate}")
             self._log_exchange_response('create_stoploss_order', order)

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -4111,10 +4111,36 @@ def test__order_contracts_to_amount(
             'trades': None,
             'info': {},
         },
+        {
+            # Realistic stoploss order on gateio.
+            'id': '123456380',
+            'clientOrderId': '12345638203',
+            'timestamp': None,
+            'datetime': None,
+            'lastTradeTimestamp': None,
+            'status': None,
+            'symbol': None,
+            'type': None,
+            'timeInForce': None,
+            'postOnly': None,
+            'side': None,
+            'price': None,
+            'stopPrice': None,
+            'average': None,
+            'amount': None,
+            'cost': None,
+            'filled': None,
+            'remaining': None,
+            'fee': None,
+            'fees': [],
+            'trades': None,
+            'info': {},
+        },
     ]
 
     order1 = exchange._order_contracts_to_amount(orders[0])
     order2 = exchange._order_contracts_to_amount(orders[1])
+    exchange._order_contracts_to_amount(orders[2])
     assert order1['amount'] == 30.0 * contract_size
     assert order2['amount'] == 40.0 * contract_size
 


### PR DESCRIPTION
I believe we only need to add these methods when we're actually interacting with the exchange, we convert the amount to the number of contracts, but after making the order, we immediately convert the contracts back to the amount, so the number only needs to change for that brief period that we're actually making the order. It's not needed within `create_dry_run_order` then because we're not actually sending an order to the exchange, there's no need to convert it, and then convert it back immediately, because that step where we send the amount that the exchange reads isn't there