### PR TITLE
Fix gateio fee handling for futures

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -93,6 +93,7 @@ class Exchange:
         self._api: ccxt.Exchange = None
         self._api_async: ccxt_async.Exchange = None
         self._markets: Dict = {}
+        self._trading_fees: Dict[str, Any] = {}
         self._leverage_tiers: Dict[str, List[Dict]] = {}
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
@@ -453,7 +454,7 @@ class Exchange:
             self._load_async_markets()
             self._last_markets_refresh = arrow.utcnow().int_timestamp
             if self._ft_has['needs_trading_fees']:
-                self.trading_fees = self.fetch_trading_fees()
+                self._trading_fees = self.fetch_trading_fees()
 
         except ccxt.BaseError:
             logger.exception('Unable to initialize markets.')

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -75,6 +75,7 @@ class Exchange:
         "mark_ohlcv_price": "mark",
         "mark_ohlcv_timeframe": "8h",
         "ccxt_futures_name": "swap",
+        "needs_trading_fees": False,  # use fetch_trading_fees to cache fees
     }
     _ft_has: Dict = {}
     _ft_has_futures: Dict = {}
@@ -451,6 +452,9 @@ class Exchange:
             self._markets = self._api.load_markets()
             self._load_async_markets()
             self._last_markets_refresh = arrow.utcnow().int_timestamp
+            if self._ft_has['needs_trading_fees']:
+                self.trading_fees = self.fetch_trading_fees()
+
         except ccxt.BaseError:
             logger.exception('Unable to initialize markets.')
 

--- a/freqtrade/exchange/gateio.py
+++ b/freqtrade/exchange/gateio.py
@@ -66,7 +66,7 @@ class Gateio(Exchange):
                         if pair_fees.get(takerOrMaker) is not None:
                             trades[idx]['fee'] = {
                                 'currency': self.get_pair_quote_currency(pair),
-                                'cost': abs(trade['cost']) * pair_fees[takerOrMaker],
+                                'cost': trade['cost'] * pair_fees[takerOrMaker],
                                 'rate': pair_fees[takerOrMaker],
                             }
         return trades

--- a/freqtrade/exchange/gateio.py
+++ b/freqtrade/exchange/gateio.py
@@ -57,7 +57,7 @@ class Gateio(Exchange):
             # An alternative also contianing fees would be
             # privateFuturesGetSettleAccountBook({"settle": "usdt"})
 
-            pair_fees = self.trading_fees.get(pair, {})
+            pair_fees = self._trading_fees.get(pair, {})
             if pair_fees and pair_fees['taker'] is not None:
                 order['fee'] = {
                     'currency': self.get_pair_quote_currency(pair),

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1564,6 +1564,7 @@ class FreqtradeBot(LoggingMixin):
         if not order_obj:
             raise DependencyException(
                 f"Order_obj not found for {order_id}. This should not have happened.")
+
         self.handle_order_fee(trade, order_obj, order)
 
         trade.update_trade(order_obj)

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -134,7 +134,7 @@ def exchange_futures(request, exchange_conf, class_mocker):
 
         class_mocker.patch(
             'freqtrade.exchange.binance.Binance.fill_leverage_tiers')
-
+        class_mocker.patch('freqtrade.exchange.exchange.Exchange.fetch_trading_fees')
         exchange = ExchangeResolver.load_exchange(request.param, exchange_conf, validate=True)
 
         yield exchange, request.param

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1628,7 +1628,7 @@ def test_fetch_trading_fees(default_conf, mocker):
     api_mock = MagicMock()
     tick = {
         '1INCH/USDT:USDT': {
-            'info': {'user_id': '6266643',
+            'info': {'user_id': '',
                      'taker_fee': '0.0018',
                      'maker_fee': '0.0018',
                      'gt_discount': False,
@@ -1642,7 +1642,7 @@ def test_fetch_trading_fees(default_conf, mocker):
             'maker': 0.0,
             'taker': 0.0005},
         'ETH/USDT:USDT': {
-            'info': {'user_id': '6266643',
+            'info': {'user_id': '',
                      'taker_fee': '0.0018',
                      'maker_fee': '0.0018',
                      'gt_discount': False,

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1663,11 +1663,9 @@ def test_fetch_trading_fees(default_conf, mocker):
     api_mock.fetch_trading_fees = MagicMock(return_value=tick)
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
-    # retrieve original ticker
-    tradingfees = exchange.fetch_trading_fees()
 
-    assert '1INCH/USDT:USDT' in tradingfees
-    assert 'ETH/USDT:USDT' in tradingfees
+    assert '1INCH/USDT:USDT' in exchange.trading_fees
+    assert 'ETH/USDT:USDT' in exchange.trading_fees
     assert api_mock.fetch_trading_fees.call_count == 1
 
     api_mock.fetch_trading_fees.reset_mock()

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1624,6 +1624,64 @@ def test_fetch_positions(default_conf, mocker, exchange_name):
                            "fetch_positions", "fetch_positions")
 
 
+def test_fetch_trading_fees(default_conf, mocker):
+    api_mock = MagicMock()
+    tick = {
+        '1INCH/USDT:USDT': {
+            'info': {'user_id': '6266643',
+                     'taker_fee': '0.0018',
+                     'maker_fee': '0.0018',
+                     'gt_discount': False,
+                     'gt_taker_fee': '0',
+                     'gt_maker_fee': '0',
+                     'loan_fee': '0.18',
+                     'point_type': '1',
+                     'futures_taker_fee': '0.0005',
+                     'futures_maker_fee': '0'},
+            'symbol': '1INCH/USDT:USDT',
+            'maker': 0.0,
+            'taker': 0.0005},
+        'ETH/USDT:USDT': {
+            'info': {'user_id': '6266643',
+                     'taker_fee': '0.0018',
+                     'maker_fee': '0.0018',
+                     'gt_discount': False,
+                     'gt_taker_fee': '0',
+                     'gt_maker_fee': '0',
+                     'loan_fee': '0.18',
+                     'point_type': '1',
+                     'futures_taker_fee': '0.0005',
+                     'futures_maker_fee': '0'},
+            'symbol': 'ETH/USDT:USDT',
+            'maker': 0.0,
+            'taker': 0.0005}
+    }
+    exchange_name = 'gateio'
+    default_conf['dry_run'] = False
+    default_conf['trading_mode'] = TradingMode.FUTURES
+    default_conf['margin_mode'] = MarginMode.ISOLATED
+    api_mock.fetch_trading_fees = MagicMock(return_value=tick)
+    mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
+    # retrieve original ticker
+    tradingfees = exchange.fetch_trading_fees()
+
+    assert '1INCH/USDT:USDT' in tradingfees
+    assert 'ETH/USDT:USDT' in tradingfees
+    assert api_mock.fetch_trading_fees.call_count == 1
+
+    api_mock.fetch_trading_fees.reset_mock()
+
+    ccxt_exceptionhandlers(mocker, default_conf, api_mock, exchange_name,
+                           "fetch_trading_fees", "fetch_trading_fees")
+
+    api_mock.fetch_trading_fees = MagicMock(return_value={})
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
+    exchange.fetch_trading_fees()
+    mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
+    assert exchange.fetch_trading_fees() == {}
+
+
 def test_fetch_bids_asks(default_conf, mocker):
     api_mock = MagicMock()
     tick = {'ETH/BTC': {

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1664,8 +1664,8 @@ def test_fetch_trading_fees(default_conf, mocker):
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, id=exchange_name)
 
-    assert '1INCH/USDT:USDT' in exchange.trading_fees
-    assert 'ETH/USDT:USDT' in exchange.trading_fees
+    assert '1INCH/USDT:USDT' in exchange._trading_fees
+    assert 'ETH/USDT:USDT' in exchange._trading_fees
     assert api_mock.fetch_trading_fees.call_count == 1
 
     api_mock.fetch_trading_fees.reset_mock()

--- a/tests/exchange/test_gateio.py
+++ b/tests/exchange/test_gateio.py
@@ -73,10 +73,10 @@ def test_stoploss_adjust_gateio(mocker, default_conf, sl1, sl2, sl3, side):
     assert exchange.stoploss_adjust(sl1, order, side)
     assert not exchange.stoploss_adjust(sl2, order, side)
 
+
 @pytest.mark.parametrize('takerormaker,rate,cost', [
     ('taker', 0.0005, 0.0001554325),
     ('maker', 0.0, 0.0),
-
 ])
 def test_fetch_my_trades_gateio(mocker, default_conf, takerormaker, rate, cost):
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)

--- a/tests/exchange/test_gateio.py
+++ b/tests/exchange/test_gateio.py
@@ -101,7 +101,7 @@ def test_fetch_order_gateio(mocker, default_conf):
         'amount': 1,  # 1 contract
     })
     exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id='gateio')
-    exchange.trading_fees = tick
+    exchange._trading_fees = tick
     order = exchange.fetch_order('22255', 'ETH/USDT:USDT')
 
     assert order['fee']


### PR DESCRIPTION
## Summary
Futures orders do incurr a fee when they are executed.
This is however not part of the api response in some cases (it appears for users without a ref id).

Therefore updating of fees is failing.

## Quick changelog

- Download trading_fees (private endpoint - per user)
- use trading_fees to inject this to the gateio order
