### PR TITLE
Update kucoin candle limit

### DIFF
--- a/freqtrade/exchange/kucoin.py
+++ b/freqtrade/exchange/kucoin.py
@@ -25,6 +25,7 @@ class Kucoin(Exchange):
         "l2_limit_range_required": False,
         "order_time_in_force": ['gtc', 'fok', 'ioc'],
         "time_in_force_parameter": "timeInForce",
+        "ohlcv_candle_limit": 1500,
     }
 
     def stoploss_adjust(self, stop_loss: float, order: Dict) -> bool:


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary

Candle limit per kucoin api docs is 1500.

https://docs.kucoin.com/#get-klines

I did not see any tests on other exchanges for ohlcv_candle_limit changes so none were included in the PR.


## Quick changelog

- Correct kucoin ohlcv candle limit to 1500

## What's new?

* Improve kucoin candle fetch performance
