### PR TITLE
docs for shorting

### DIFF
--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -22,6 +22,8 @@ Shorting is not possible when trading with [`trading_mode`](#understand-tradingm
 
 For a strategy to short, the strategy class must set the class variable `can_short = True`
 
+Please read [strategy customization](https://www.freqtrade.io/en/latest/strategy-customization/#entry-signal-rules) for instructions on how to set signals to enter and exit short trades
+
 ## Understand `trading_mode`
 
 The possible values are: `spot` (default), `margin`(*Currently unavailable*) or `futures`.

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -13,6 +13,9 @@
     Please only use advanced trading modes when you know how freqtrade (and your strategy) works.
     Also, never risk more than what you can afford to lose.
 
+
+Please read the [strategy migration guide](https://www.freqtrade.io/en/latest/strategy_migration/#strategy-migration-between-v2-and-v3) to migrate your strategy from a freqtrade v2 strategy, to v3 strategy that can short and trade futures
+
 ## Shorting
 
 Shorting is not possible when trading with [`trading_mode`](#understand-tradingmode) set to `spot`. To short trade, `trading_mode` must be set to `margin`(currently unavailable) or [`futures`](#futures), with [`margin_mode`](#margin-mode) set to `cross`(currently unavailable) or [`isolated`](#isolated-margin-mode)

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -13,6 +13,12 @@
     Please only use advanced trading modes when you know how freqtrade (and your strategy) works.
     Also, never risk more than what you can afford to lose.
 
+## Shorting
+
+Shorting is not possible when trading with [`trading_mode`](#understand-tradingmode) set to `spot`. To short trade, `trading_mode` must be set to `margin`(currently unavailable) or [`futures`](#futures), with [`margin_mode`](#margin-mode) set to `cross`(currently unavailable) or [`isolated`](#isolated-margin-mode)
+
+For a strategy to short, the strategy class must set the class variable `can_short = True`
+
 ## Understand `trading_mode`
 
 The possible values are: `spot` (default), `margin`(*Currently unavailable*) or `futures`.

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -13,8 +13,7 @@
     Please only use advanced trading modes when you know how freqtrade (and your strategy) works.
     Also, never risk more than what you can afford to lose.
 
-
-Please read the [strategy migration guide](https://www.freqtrade.io/en/latest/strategy_migration/#strategy-migration-between-v2-and-v3) to migrate your strategy from a freqtrade v2 strategy, to v3 strategy that can short and trade futures
+Please read the [strategy migration guide](strategy_migration.md#strategy-migration-between-v2-and-v3) to migrate your strategy from a freqtrade v2 strategy, to v3 strategy that can short and trade futures.
 
 ## Shorting
 
@@ -22,7 +21,7 @@ Shorting is not possible when trading with [`trading_mode`](#understand-tradingm
 
 For a strategy to short, the strategy class must set the class variable `can_short = True`
 
-Please read [strategy customization](https://www.freqtrade.io/en/latest/strategy-customization/#entry-signal-rules) for instructions on how to set signals to enter and exit short trades
+Please read [strategy customization](strategy-customization.md#entry-signal-rules) for instructions on how to set signals to enter and exit short trades.
 
 ## Understand `trading_mode`
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -205,7 +205,7 @@ Edit the method `populate_entry_trend()` in your strategy file to update your en
 
 It's important to always return the dataframe without removing/modifying the columns `"open", "high", "low", "close", "volume"`, otherwise these fields would contain something unexpected.
 
-This method will also define a new column, `"enter_long"`, which needs to contain 1 for entries, and 0 for "no action". `enter_long` column is a mandatory column that must be set even if the strategy is shorting only.
+This method will also define a new column, `"enter_long"` (`"enter_short"` for shorts), which needs to contain 1 for entries, and 0 for "no action". `enter_long` column is a mandatory column that must be set even if the strategy is shorting only.
 
 Sample from `user_data/strategies/sample_strategy.py`:
 
@@ -268,7 +268,7 @@ Please note that the sell-signal is only used if `use_sell_signal` is set to tru
 
 It's important to always return the dataframe without removing/modifying the columns `"open", "high", "low", "close", "volume"`, otherwise these fields would contain something unexpected.
 
-This method will also define a new column, `"exit_long"`, which needs to contain 1 for sells, and 0 for "no action".
+This method will also define a new column, `"exit_long"` (`"exit_short"` for shorts), which needs to contain 1 for exits, and 0 for "no action".
 
 Sample from `user_data/strategies/sample_strategy.py`:
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -205,7 +205,7 @@ Edit the method `populate_entry_trend()` in your strategy file to update your en
 
 It's important to always return the dataframe without removing/modifying the columns `"open", "high", "low", "close", "volume"`, otherwise these fields would contain something unexpected.
 
-This method will also define a new column, `"enter_long"` (`"enter_short"` for shorts), which needs to contain 1 for entries, and 0 for "no action". `enter_long` column is a mandatory column that must be set even if the strategy is shorting only.
+This method will also define a new column, `"enter_long"` (`"enter_short"` for shorts), which needs to contain 1 for entries, and 0 for "no action". `enter_long` is a mandatory column that must be set even if the strategy is shorting only.
 
 Sample from `user_data/strategies/sample_strategy.py`:
 


### PR DESCRIPTION
## Summary

Adds docs for whats required to short

## Quick changelog

- docs for can_short strategy setting
- docs for allowed `trading_mode` and `margin_mode` when shorting
