### PR TITLE
Fixes CoinGecko typos in fiat_convert

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -63,7 +63,7 @@ class CryptoToFiatConverter:
         except RequestException as request_exception:
             if "429" in str(request_exception):
                 logger.warning(
-                    "Too many requests for Coingecko API, backing off and trying again later.")
+                    "Too many requests for CoinGecko API, backing off and trying again later.")
                 # Set backoff timestamp to 60 seconds in the future
                 self._backoff = datetime.datetime.now().timestamp() + 60
                 return
@@ -96,7 +96,7 @@ class CryptoToFiatConverter:
 
         if len(found) > 0:
             # Wrong!
-            logger.warning(f"Found multiple mappings in goingekko for {crypto_symbol}.")
+            logger.warning(f"Found multiple mappings in CoinGecko for {crypto_symbol}.")
             return None
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:
@@ -160,7 +160,7 @@ class CryptoToFiatConverter:
 
     def _find_price(self, crypto_symbol: str, fiat_symbol: str) -> float:
         """
-        Call CoinGekko API to retrieve the price in the FIAT
+        Call CoinGecko API to retrieve the price in the FIAT
         :param crypto_symbol: Crypto-currency you want to convert (e.g btc)
         :param fiat_symbol: FIAT currency you want to convert to (e.g usd)
         :return: float, price of the crypto-currency in Fiat

--- a/tests/rpc/test_fiat_convert.py
+++ b/tests/rpc/test_fiat_convert.py
@@ -137,7 +137,7 @@ def test_fiat_too_many_requests_response(mocker, caplog):
     assert len(fiat_convert._coinlistings) == 0
     assert fiat_convert._backoff > datetime.datetime.now().timestamp()
     assert log_has(
-        'Too many requests for Coingecko API, backing off and trying again later.',
+        'Too many requests for CoinGecko API, backing off and trying again later.',
         caplog
     )
 
@@ -156,7 +156,7 @@ def test_fiat_multiple_coins(mocker, caplog):
     assert fiat_convert._get_gekko_id('hnt') is None
     assert fiat_convert._get_gekko_id('eth') == 'ethereum'
 
-    assert log_has('Found multiple mappings in goingekko for hnt.', caplog)
+    assert log_has('Found multiple mappings in CoinGecko for hnt.', caplog)
 
 
 def test_fiat_invalid_response(mocker, caplog):


### PR DESCRIPTION
## Summary

Fixes log messages containing wrong naming for CoinGecko.

Solve the issue: #NaN

## Quick changelog

- Ensures consistent naming for CoinGecko in fiat_convert.py
- Ensures consistent naming for CoinGecko in test_fiat_convert.py

