### PR TITLE
ROI and exit_tags matched to enter_tags

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -138,7 +138,7 @@ CONF_SCHEMA = {
         'minimal_roi': {
             'type': 'object',
             'patternProperties': {
-                '^[0-9.]+$': {'type': 'number'}
+                '^[0-9a-zA-Z.]+$': {'type': ['number', 'dict']}
             },
             'minProperties': 1
         },

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -922,19 +922,18 @@ class FreqtradeBot(LoggingMixin):
             analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
                                                                       self.strategy.timeframe)
 
-
             (enter, exit_, exit_tag) = self.strategy.get_exit_signal(
                 trade.pair,
                 self.strategy.timeframe,
                 analyzed_df,
-                is_short=trade.is_short,
+                is_short=trade.is_short
             )
 
         logger.debug('checking exit')
         exit_rate = self.exchange.get_rate(
             trade.pair, side='exit', is_short=trade.is_short, refresh=True)
 
-        enter_tag = '' # TODO
+        enter_tag = # TODO
         if self._check_and_execute_exit(
             trade=trade,
             exit_rate=exit_rate,
@@ -1119,7 +1118,6 @@ class FreqtradeBot(LoggingMixin):
             exit_=exit_,
             force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0,
             enter_tag=enter_tag,
-            exit_tag=exit_tag,
         )
 
         if should_exit.exit_flag:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -922,18 +922,19 @@ class FreqtradeBot(LoggingMixin):
             analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(trade.pair,
                                                                       self.strategy.timeframe)
 
+
             (enter, exit_, exit_tag) = self.strategy.get_exit_signal(
                 trade.pair,
                 self.strategy.timeframe,
                 analyzed_df,
-                is_short=trade.is_short
+                is_short=trade.is_short,
             )
 
         logger.debug('checking exit')
         exit_rate = self.exchange.get_rate(
             trade.pair, side='exit', is_short=trade.is_short, refresh=True)
 
-        enter_tag = # TODO
+        enter_tag = '' # TODO
         if self._check_and_execute_exit(
             trade=trade,
             exit_rate=exit_rate,
@@ -1118,6 +1119,7 @@ class FreqtradeBot(LoggingMixin):
             exit_=exit_,
             force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0,
             enter_tag=enter_tag,
+            exit_tag=exit_tag,
         )
 
         if should_exit.exit_flag:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -932,7 +932,16 @@ class FreqtradeBot(LoggingMixin):
         logger.debug('checking exit')
         exit_rate = self.exchange.get_rate(
             trade.pair, side='exit', is_short=trade.is_short, refresh=True)
-        if self._check_and_execute_exit(trade, exit_rate, enter, exit_, exit_tag):
+
+        enter_tag = # TODO
+        if self._check_and_execute_exit(
+            trade=trade,
+            exit_rate=exit_rate,
+            enter=enter,
+            exit_=exit_,
+            enter_tag=enter_tag,
+            exit_tag=exit_tag,
+        ):
             return True
 
         logger.debug(f'Found no {exit_signal_type} signal for %s.', trade)
@@ -1089,8 +1098,15 @@ class FreqtradeBot(LoggingMixin):
                     logger.warning(f"Could not create trailing stoploss order "
                                    f"for pair {trade.pair}.")
 
-    def _check_and_execute_exit(self, trade: Trade, exit_rate: float,
-                                enter: bool, exit_: bool, exit_tag: Optional[str]) -> bool:
+    def _check_and_execute_exit(
+        self,
+        trade: Trade,
+        exit_rate: float,
+        enter: bool,
+        exit_: bool,
+        enter_tag: Optional[str],
+        exit_tag: Optional[str],
+    ) -> bool:
         """
         Check and execute trade exit
         """
@@ -1100,7 +1116,8 @@ class FreqtradeBot(LoggingMixin):
             datetime.now(timezone.utc),
             enter=enter,
             exit_=exit_,
-            force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0
+            force_stoploss=self.edge.stoploss(trade.pair) if self.edge else 0,
+            enter_tag=enter_tag,
         )
 
         if should_exit.exit_flag:

--- a/freqtrade/resolvers/strategy_resolver.py
+++ b/freqtrade/resolvers/strategy_resolver.py
@@ -143,8 +143,14 @@ class StrategyResolver(IResolver):
         # Sort and apply type conversions
         if hasattr(strategy, 'minimal_roi'):
             strategy.minimal_roi = dict(sorted(
-                {int(key): value for (key, value) in strategy.minimal_roi.items()}.items(),
-                key=lambda t: t[0]))
+                {
+                    {int(k): v for (k, v) in value.items()}
+                    if type(value is dict)
+                    else int(key): value
+                    for (key, value) in strategy.minimal_roi.items()
+                }.items(),
+                key=lambda t: t[0]
+            ))
         if hasattr(strategy, 'stoploss'):
             strategy.stoploss = float(strategy.stoploss)
         return strategy

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -160,7 +160,7 @@ class ShowConfig(BaseModel):
     available_capital: Optional[float]
     stake_currency_decimals: int
     max_open_trades: int
-    minimal_roi: Dict[str, Any]
+    minimal_roi: Dict[str, Union[Dict[str, float], float]]
     stoploss: Optional[float]
     trailing_stop: Optional[bool]
     trailing_stop_positive: Optional[float]

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -120,8 +120,6 @@ class IStrategy(ABC, HyperStrategyMixin):
     # Definition of plot_config. See plotting documentation for more details.
     plot_config: Dict = {}
 
-    tags: Dict[str, List[str]] = {}
-
     def __init__(self, config: dict) -> None:
         self.config = config
         # Dict to determine if analysis is necessary
@@ -845,8 +843,7 @@ class IStrategy(ABC, HyperStrategyMixin):
     def should_exit(self, trade: Trade, rate: float, current_time: datetime, *,
                     enter: bool, exit_: bool,
                     low: float = None, high: float = None,
-                    force_stoploss: float = 0, enter_tag: Optional[str] = None,
-                    exit_tag: Optional[str]) -> ExitCheckTuple:
+                    force_stoploss: float = 0, enter_tag: Optional[str] = None) -> ExitCheckTuple:
         """
         This function evaluates if one of the conditions required to trigger an exit order
         has been reached, which can either be a stop-loss, ROI or exit-signal.
@@ -887,10 +884,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if ((enter_tag in self.tags and exit_tag not in self.tags[enter_tag])):
-            # sell_profit_only and profit doesn't reach the offset - ignore sell signal
-            pass
-        elif self.use_exit_signal:
+        if self.use_exit_signal:
             if exit_ and not enter:
                 exit_signal = ExitType.EXIT_SIGNAL
             else:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -120,6 +120,8 @@ class IStrategy(ABC, HyperStrategyMixin):
     # Definition of plot_config. See plotting documentation for more details.
     plot_config: Dict = {}
 
+    tags: Dict[str, List[str]] = {}
+
     def __init__(self, config: dict) -> None:
         self.config = config
         # Dict to determine if analysis is necessary
@@ -843,7 +845,8 @@ class IStrategy(ABC, HyperStrategyMixin):
     def should_exit(self, trade: Trade, rate: float, current_time: datetime, *,
                     enter: bool, exit_: bool,
                     low: float = None, high: float = None,
-                    force_stoploss: float = 0, enter_tag: Optional[str] = None) -> ExitCheckTuple:
+                    force_stoploss: float = 0, enter_tag: Optional[str] = None,
+                    exit_tag: Optional[str]) -> ExitCheckTuple:
         """
         This function evaluates if one of the conditions required to trigger an exit order
         has been reached, which can either be a stop-loss, ROI or exit-signal.
@@ -884,7 +887,10 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if self.use_exit_signal:
+        if ((enter_tag in self.tags and exit_tag not in self.tags[enter_tag])):
+            # sell_profit_only and profit doesn't reach the offset - ignore sell signal
+            pass
+        elif self.use_exit_signal:
             if exit_ and not enter:
                 exit_signal = ExitType.EXIT_SIGNAL
             else:


### PR DESCRIPTION
## Summary

Enables the ability to set roi and sell signals for trades, dependent on what the buy signal for that trade was

## Quick changelog

- interface.minimal_roi can now be indexed by the enter_tag, so the property could look like
- 
```
{
    '0': '0.02',  # default roi, used if there is no enter_tag, or the enter_tag is not a key within interface.minimal_roi
    '30': '0.00',    # default roi
    'bb_lower': {    # if the enter_tag for the trade is `'bb_lower'`
        '0': '0.03',
        '30': '0.00',
    },
    'bb_upper_short': {    # if the enter_tag for the trade is `'bb_upper_short'`
        '0': '0.05',
        '30': '0.00',
    }
}
```

- using `interface.tags`(name can change) you can set all the allowable exit signals for trades that were triggered by specific `enter_signals`

e.g.

```
tags = {
    'bb_lower': ['bb_upper'],
    'bb_upper_short': ['bb_lower', 'low_rsi']
}
```

If the enter_tag is not a key within `tags` then any sell_signal can be used for this trade