### PR TITLE
Custom exit - call it independent of profit

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -88,11 +88,11 @@ Allows to define custom exit signals, indicating that specified position should 
 
 For example you could implement a 1:2 risk-reward ROI with `custom_exit()`.
 
-Using custom_exit() signals in place of stoploss though *is not recommended*. It is a inferior method to using `custom_stoploss()` in this regard - which also allows you to keep the stoploss on exchange.
+Using `custom_exit()` signals in place of stoploss though *is not recommended*. It is a inferior method to using `custom_stoploss()` in this regard - which also allows you to keep the stoploss on exchange.
 
 !!! Note
     Returning a (none-empty) `string` or `True` from this method is equal to setting exit signal on a candle at specified time. This method is not called when exit signal is set already, or if exit signals are disabled (`use_exit_signal=False`). `string` max length is 64 characters. Exceeding this limit will cause the message to be truncated to 64 characters.
-    `custom_exit()` will ignore `exit_profit_only`, and will always be called unless `use_exit_signal=False` or if there is an enter signal.
+    `custom_exit()` will ignore `exit_profit_only`, and will always be called unless `use_exit_signal=False`, even if there is a new enter signal.
 
 An example of how we can use different indicators depending on the current profit and also exit trades that were open longer than one day:
 

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -91,7 +91,8 @@ For example you could implement a 1:2 risk-reward ROI with `custom_exit()`.
 Using custom_exit() signals in place of stoploss though *is not recommended*. It is a inferior method to using `custom_stoploss()` in this regard - which also allows you to keep the stoploss on exchange.
 
 !!! Note
-    Returning a (none-empty) `string` or `True` from this method is equal to setting exit signal on a candle at specified time. This method is not called when exit signal is set already, or if exit signals are disabled (`use_exit_signal=False` or `exit_profit_only=True` while profit is below `exit_profit_offset`). `string` max length is 64 characters. Exceeding this limit will cause the message to be truncated to 64 characters.
+    Returning a (none-empty) `string` or `True` from this method is equal to setting exit signal on a candle at specified time. This method is not called when exit signal is set already, or if exit signals are disabled (`use_exit_signal=False`). `string` max length is 64 characters. Exceeding this limit will cause the message to be truncated to 64 characters.
+    `custom_exit()` will ignore `exit_profit_only`, and will always be called unless `use_exit_signal=False` or if there is an enter signal.
 
 An example of how we can use different indicators depending on the current profit and also exit trades that were open longer than one day:
 

--- a/docs/strategy_migration.md
+++ b/docs/strategy_migration.md
@@ -145,6 +145,9 @@ Please refer to the [Strategy documentation](strategy-customization.md#exit-sign
 
 ### `custom_sell`
 
+`custom_sell` has been renamed to `custom_exit`.
+It's now also being called for every iteration, independent of current profit and `exit_profit_only` settings.
+
 ``` python hl_lines="2"
 class AwesomeStrategy(IStrategy):
     def custom_sell(self, pair: str, trade: 'Trade', current_time: 'datetime', current_rate: float,

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -885,7 +885,6 @@ class IStrategy(ABC, HyperStrategyMixin):
             if exit_ and not enter:
                 exit_signal = ExitType.EXIT_SIGNAL
             else:
-                trade_type = "exit_short" if trade.is_short else "sell"
                 custom_reason = strategy_safe_wrapper(self.custom_exit, default_retval=False)(
                     pair=trade.pair, trade=trade, current_time=current_time,
                     current_rate=current_rate, current_profit=current_profit)
@@ -893,7 +892,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                     exit_signal = ExitType.CUSTOM_EXIT
                     if isinstance(custom_reason, str):
                         if len(custom_reason) > CUSTOM_EXIT_MAX_LENGTH:
-                            logger.warning(f'Custom {trade_type} reason returned from '
+                            logger.warning(f'Custom exit reason returned from '
                                            f'custom_exit is too long and was trimmed'
                                            f'to {CUSTOM_EXIT_MAX_LENGTH} characters.')
                             custom_reason = custom_reason[:CUSTOM_EXIT_MAX_LENGTH]

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -881,8 +881,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if self.use_exit_signal and not enter:
-            if exit_:
+        if self.use_exit_signal:
+            if exit_ and not enter:
                 exit_signal = ExitType.EXIT_SIGNAL
             else:
                 trade_type = "exit_short" if trade.is_short else "sell"

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -881,10 +881,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         current_rate = rate
         current_profit = trade.calc_profit_ratio(current_rate)
 
-        if (self.exit_profit_only and current_profit <= self.exit_profit_offset):
-            # exit_profit_only and profit doesn't reach the offset - ignore sell signal
-            pass
-        elif self.use_exit_signal and not enter:
+        if self.use_exit_signal and not enter:
             if exit_:
                 exit_signal = ExitType.EXIT_SIGNAL
             else:
@@ -902,7 +899,11 @@ class IStrategy(ABC, HyperStrategyMixin):
                             custom_reason = custom_reason[:CUSTOM_EXIT_MAX_LENGTH]
                     else:
                         custom_reason = None
-            if exit_signal in (ExitType.CUSTOM_EXIT, ExitType.EXIT_SIGNAL):
+            if (
+                exit_signal == ExitType.CUSTOM_EXIT
+                or (exit_signal == ExitType.EXIT_SIGNAL
+                    and (not self.exit_profit_only or current_profit > self.exit_profit_offset))
+            ):
                 logger.debug(f"{trade.pair} - Sell signal received. "
                              f"exit_type=ExitType.{exit_signal.name}" +
                              (f", custom_reason={custom_reason}" if custom_reason else ""))

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -523,7 +523,7 @@ def test_custom_exit(default_conf, fee, caplog) -> None:
     assert res.exit_type == ExitType.CUSTOM_EXIT
     assert res.exit_flag is True
     assert res.exit_reason == 'h' * 64
-    assert log_has_re('Custom sell reason returned from custom_exit is too long.*', caplog)
+    assert log_has_re('Custom exit reason returned from custom_exit is too long.*', caplog)
 
 
 @pytest.mark.parametrize('side', TRADE_SIDES)


### PR DESCRIPTION
## Summary
Call `custom_exit()` even if `exit_profit_only` is enabled.

