### PR TITLE
Docs: update plotting doc to show strategy option is mandatory

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -96,7 +96,7 @@ Strategy arguments:
 Example:
 
 ``` bash
-freqtrade plot-dataframe -p BTC/ETH
+freqtrade plot-dataframe -p BTC/ETH --strategy AwesomeStrategy
 ```
 
 The `-p/--pairs` argument can be used to specify pairs you would like to plot.
@@ -106,9 +106,6 @@ The `-p/--pairs` argument can be used to specify pairs you would like to plot.
 
 Specify custom indicators.
 Use `--indicators1` for the main plot and `--indicators2` for the subplot below (if values are in a different range than prices).
-
-!!! Tip
-    You will almost certainly want to specify a custom strategy! This can be done by adding `-s Classname` / `--strategy ClassName` to the command.
 
 ``` bash
 freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH --indicators1 sma ema --indicators2 macd


### PR DESCRIPTION
## Summary

Providing a strategy name is mandatory to run the plotting, yet the [documentation page](https://www.freqtrade.io/en/stable/plotting/) doesn't say so. 

## Quick changelog

- Add the `--strategy` option to the main example command
- Remove an unnecessary tip

## What's new?

If you run the `plot-dataframe` command without providing a strategy, it fails with `ERROR - No strategy set. Please use --strategy to specify the strategy class to use`. So I think the strategy option should be provided for the main example (and there's no need for that tip about "almost certainly" wanting to specify a strategy) 🙂
