### PR TITLE
Use ORJSON for http responses

### DIFF
--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -2,7 +2,7 @@ import logging
 from ipaddress import IPv4Address
 from typing import Any, Dict
 
-import rapidjson
+import orjson
 import uvicorn
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -24,7 +24,7 @@ class FTJSONResponse(JSONResponse):
         Use rapidjson for responses
         Handles NaN and Inf / -Inf in a javascript way by default.
         """
-        return rapidjson.dumps(content).encode("utf-8")
+        return orjson.dumps(content, option=orjson.OPT_SERIALIZE_NUMPY)
 
 
 class ApiServer(RPCHandler):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ py_find_1st==1.1.5
 
 # Load ticker files 30% faster
 python-rapidjson==1.6
+# Properly format api responses
+orjson==3.6.8
 
 # Notify systemd
 sdnotify==0.3.2

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'pycoingecko',
         'py_find_1st',
         'python-rapidjson',
+        'orjson',
         'sdnotify',
         'colorama',
         'jinja2',

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -13,7 +13,6 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.exceptions import HTTPException
 from fastapi.testclient import TestClient
-from numpy import isnan
 from requests.auth import _basic_auth_str
 
 from freqtrade.__init__ import __version__
@@ -985,7 +984,7 @@ def test_api_status(botclient, mocker, ticker, fee, markets, is_short,
     assert_response(rc)
     resp_values = rc.json()
     assert len(resp_values) == 4
-    assert isnan(resp_values[0]['profit_abs'])
+    assert resp_values[0]['profit_abs'] is None
 
 
 def test_api_version(botclient):


### PR DESCRIPTION
## Summary
use ORJson to serialize API  responses. NaN is not a valid json object, therefore frontends will fail to properly interpret this.

There will also be changes required to frequi to properly handle this in the frontend.

closes #6727
