### PR TITLE
Add bot_loop_start() call in plotting.py

### DIFF
--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -634,6 +634,7 @@ def load_and_plot_trades(config: Dict[str, Any]):
     exchange = ExchangeResolver.load_exchange(config['exchange']['name'], config)
     IStrategy.dp = DataProvider(config, exchange)
     strategy.bot_start()
+    strategy.bot_loop_start()
     plot_elements = init_plotscript(config, list(exchange.markets), strategy.startup_candle_count)
     timerange = plot_elements['timerange']
     trades = plot_elements['trades']


### PR DESCRIPTION
## Summary
plotting.py was missing a call to strategy.bot_loop_start() resulting in strategies using this callback to not work.

<!-- Explain in one sentence the goal of this PR -->
Made changes and confirmed plotting now works for strategies using bot_loop_start() callback.

Solve the issue: #6776

## Quick changelog

- add strategy.bot_loop_start() callback to plotting.py

## What's new?

Strategies that use bot_loop_start() callback can now use the `plot-dataframe` CIL command. 
