### PR TITLE
Report profit only on filled entries.

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -178,7 +178,6 @@ class RPC:
                 else:
                     current_rate = trade.close_rate
                 if len(trade.select_filled_orders(trade.entry_side)) > 0:
-                    logger.warning(trade.select_filled_orders(trade.entry_side))
                     current_profit = trade.calc_profit_ratio(current_rate)
                     current_profit_abs = trade.calc_profit(current_rate)
                     current_profit_fiat: Optional[float] = None


### PR DESCRIPTION
## Summary

Perform profit reporting only when at least one entry order is filled.

Solves the issue: Not really an issue but `adjust_entry_price` PR(https://github.com/freqtrade/freqtrade/pull/6692) can make it more common that profit is reported although order is still awaiting fill.

## Quick changelog

- `_rpc_trade_status` and `_rpc_status_table` to report 0 profit when no filled orders in the trade(s);
- `_rpc_status_table` to allow reporting of 0 fiat profit.

## What's new?

Nothing new. Just adjustment of existing logic.
