### PR TITLE
Okx history

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -79,6 +79,12 @@ def start_download_data(args: Dict[str, Any]) -> None:
                 data_format_trades=config['dataformat_trades'],
             )
         else:
+            if not exchange._ft_has.get('ohlcv_has_history', True):
+                raise OperationalException(
+                    f"Historic klines not available for {exchange.name}. "
+                    "Please use `--dl-trades` instead for this exchange "
+                    "(will unfortunately take a long time)."
+                    )
             pairs_not_available = refresh_backtest_ohlcv_data(
                 exchange, pairs=expanded_pairs, timeframes=config['timeframes'],
                 datadir=config['datadir'], timerange=timerange,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -619,7 +619,10 @@ class Exchange:
         Checks if required startup_candles is more than ohlcv_candle_limit().
         Requires a grace-period of 5 candles - so a startup-period up to 494 is allowed by default.
         """
-        candle_limit = self.ohlcv_candle_limit(timeframe, self._config['candle_type_def'], None)
+
+        candle_limit = self.ohlcv_candle_limit(
+            timeframe, self._config['candle_type_def'],
+            date_minus_candles(timeframe, startup_candles))
         # Require one more candle - to account for the still open candle.
         candle_count = startup_candles + 1
         # Allow 5 calls to the exchange per pair

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -317,7 +317,7 @@ class Exchange:
         per timeframe (e.g. bittrex), otherwise falls back to ohlcv_candle_limit
         :param timeframe: Timeframe to check
         :param candle_type: Candle-type
-        :param since_ms: Candle-type
+        :param since_ms: Starting timestamp
         :return: Candle limit as integer
         """
         return int(self._ft_has.get('ohlcv_candle_limit_per_timeframe', {}).get(

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -622,7 +622,8 @@ class Exchange:
 
         candle_limit = self.ohlcv_candle_limit(
             timeframe, self._config['candle_type_def'],
-            date_minus_candles(timeframe, startup_candles))
+            int(date_minus_candles(timeframe, startup_candles).timestamp() * 1000)
+            if timeframe else None)
         # Require one more candle - to account for the still open candle.
         candle_count = startup_candles + 1
         # Allow 5 calls to the exchange per pair

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2687,9 +2687,10 @@ def timeframe_to_msecs(timeframe: str) -> int:
 
 def timeframe_to_prev_date(timeframe: str, date: datetime = None) -> datetime:
     """
-    Use Timeframe and determine last possible candle.
+    Use Timeframe and determine the candle start date for this date.
+    Does not round when given a candle start date.
     :param timeframe: timeframe in string format (e.g. "5m")
-    :param date: date to use. Defaults to utcnow()
+    :param date: date to use. Defaults to now(utc)
     :returns: date of previous candle (with utc timezone)
     """
     if not date:
@@ -2704,7 +2705,7 @@ def timeframe_to_next_date(timeframe: str, date: datetime = None) -> datetime:
     """
     Use Timeframe and determine next candle.
     :param timeframe: timeframe in string format (e.g. "5m")
-    :param date: date to use. Defaults to utcnow()
+    :param date: date to use. Defaults to now(utc)
     :returns: date of next candle (with utc timezone)
     """
     if not date:
@@ -2712,6 +2713,23 @@ def timeframe_to_next_date(timeframe: str, date: datetime = None) -> datetime:
     new_timestamp = ccxt.Exchange.round_timeframe(timeframe, date.timestamp() * 1000,
                                                   ROUND_UP) // 1000
     return datetime.fromtimestamp(new_timestamp, tz=timezone.utc)
+
+
+def date_minus_candles(
+        timeframe: str, candle_count: int, date: Optional[datetime] = None) -> datetime:
+    """
+    subtract X candles from a date.
+    :param timeframe: timeframe in string format (e.g. "5m")
+    :param candle_count: Amount of candles to subtract.
+    :param date: date to use. Defaults to now(utc)
+
+    """
+    if not date:
+        date = datetime.now(timezone.utc)
+
+    tf_min = timeframe_to_minutes(timeframe)
+    new_date = timeframe_to_prev_date(timeframe, date) - timedelta(minutes=tf_min * candle_count)
+    return new_date
 
 
 def market_is_active(market: Dict) -> bool:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -310,7 +310,7 @@ class Exchange:
             logger.info(f"API {endpoint}: {response}")
 
     def ohlcv_candle_limit(
-            self, timeframe: str, candle_type: CandleType, since_ms: Optional[int]) -> int:
+            self, timeframe: str, candle_type: CandleType, since_ms: Optional[int] = None) -> int:
         """
         Exchange ohlcv candle limit
         Uses ohlcv_candle_limit_per_timeframe if the exchange has different limits

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -630,7 +630,8 @@ class Exchange:
             if required_candle_call_count > 5:
                 # Only allow 5 calls per pair to somewhat limit the impact
                 raise OperationalException(
-                    f"This strategy requires {startup_candles} candles to start, which is more than 5x "
+                    f"This strategy requires {startup_candles} candles to start, "
+                    "which is more than 5x "
                     f"the amount of candles {self.name} provides for {timeframe}.")
         elif required_candle_call_count > 1:
             raise OperationalException(

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -23,6 +23,7 @@ class Kraken(Exchange):
     _ft_has: Dict = {
         "stoploss_on_exchange": True,
         "ohlcv_candle_limit": 720,
+        "ohlcv_has_history": False,
         "trades_pagination": "id",
         "trades_pagination_arg": "since",
         "mark_ohlcv_timeframe": "4h",

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -41,7 +41,7 @@ class Okx(Exchange):
     net_only = True
 
     def ohlcv_candle_limit(
-                self, timeframe: str, candle_type: CandleType, since_ms: Optional[int]) -> int:
+                self, timeframe: str, candle_type: CandleType, since_ms: Optional[int] = None) -> int:
         """
         Exchange ohlcv candle limit
         Uses ohlcv_candle_limit_per_timeframe if the exchange has different limits

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -41,11 +41,13 @@ class Okx(Exchange):
     net_only = True
 
     def ohlcv_candle_limit(
-                self, timeframe: str, candle_type: CandleType, since_ms: Optional[int] = None) -> int:
+            self, timeframe: str, candle_type: CandleType, since_ms: Optional[int] = None) -> int:
         """
         Exchange ohlcv candle limit
-        Uses ohlcv_candle_limit_per_timeframe if the exchange has different limits
-        per timeframe (e.g. bittrex), otherwise falls back to ohlcv_candle_limit
+        OKX has the following behaviour:
+        * 300 candles for uptodate data
+        * 100 candles for historic data
+        * 100 candles for additional candles (not futures or spot).
         :param timeframe: Timeframe to check
         :param candle_type: Candle-type
         :param since_ms: Candle-type

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -49,7 +49,7 @@ class Okx(Exchange):
         * 100 candles for additional candles (not futures or spot).
         :param timeframe: Timeframe to check
         :param candle_type: Candle-type
-        :param since_ms: Candle-type
+        :param since_ms: Starting timestamp
         :return: Candle limit as integer
         """
         if (

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 
 import ccxt

--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -32,18 +32,19 @@ class AgeFilter(IPairList):
         self._min_days_listed = pairlistconfig.get('min_days_listed', 10)
         self._max_days_listed = pairlistconfig.get('max_days_listed', None)
 
+        candle_limit = exchange.ohlcv_candle_limit('1d', self._config['candle_type_def'])
         if self._min_days_listed < 1:
             raise OperationalException("AgeFilter requires min_days_listed to be >= 1")
-        if self._min_days_listed > exchange.ohlcv_candle_limit('1d'):
+        if self._min_days_listed > candle_limit:
             raise OperationalException("AgeFilter requires min_days_listed to not exceed "
                                        "exchange max request size "
-                                       f"({exchange.ohlcv_candle_limit('1d')})")
+                                       f"({candle_limit})")
         if self._max_days_listed and self._max_days_listed <= self._min_days_listed:
             raise OperationalException("AgeFilter max_days_listed <= min_days_listed not permitted")
-        if self._max_days_listed and self._max_days_listed > exchange.ohlcv_candle_limit('1d'):
+        if self._max_days_listed and self._max_days_listed > candle_limit:
             raise OperationalException("AgeFilter requires max_days_listed to not exceed "
                                        "exchange max request size "
-                                       f"({exchange.ohlcv_candle_limit('1d')})")
+                                       f"({candle_limit})")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -38,12 +38,12 @@ class VolatilityFilter(IPairList):
 
         self._pair_cache: TTLCache = TTLCache(maxsize=1000, ttl=self._refresh_period)
 
+        candle_limit = exchange.ohlcv_candle_limit('1d', self._config['candle_type_def'])
         if self._days < 1:
             raise OperationalException("VolatilityFilter requires lookback_days to be >= 1")
-        if self._days > exchange.ohlcv_candle_limit('1d'):
+        if self._days > candle_limit:
             raise OperationalException("VolatilityFilter requires lookback_days to not "
-                                       "exceed exchange max request size "
-                                       f"({exchange.ohlcv_candle_limit('1d')})")
+                                       f"exceed exchange max request size ({candle_limit})")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/VolumePairList.py
+++ b/freqtrade/plugins/pairlist/VolumePairList.py
@@ -84,12 +84,13 @@ class VolumePairList(IPairList):
             raise OperationalException(
                 f'key {self._sort_key} not in {SORT_VALUES}')
 
+        candle_limit = exchange.ohlcv_candle_limit(
+            self._lookback_timeframe, self._config['candle_type_def'])
         if self._lookback_period < 0:
             raise OperationalException("VolumeFilter requires lookback_period to be >= 0")
-        if self._lookback_period > exchange.ohlcv_candle_limit(self._lookback_timeframe):
+        if self._lookback_period > candle_limit:
             raise OperationalException("VolumeFilter requires lookback_period to not "
-                                       "exceed exchange max request size "
-                                       f"({exchange.ohlcv_candle_limit(self._lookback_timeframe)})")
+                                       f"exceed exchange max request size ({candle_limit})")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -33,12 +33,12 @@ class RangeStabilityFilter(IPairList):
 
         self._pair_cache: TTLCache = TTLCache(maxsize=1000, ttl=self._refresh_period)
 
+        candle_limit = exchange.ohlcv_candle_limit('1d', self._config['candle_type_def'])
         if self._days < 1:
             raise OperationalException("RangeStabilityFilter requires lookback_days to be >= 1")
-        if self._days > exchange.ohlcv_candle_limit('1d'):
+        if self._days > candle_limit:
             raise OperationalException("RangeStabilityFilter requires lookback_days to not "
-                                       "exceed exchange max request size "
-                                       f"({exchange.ohlcv_candle_limit('1d')})")
+                                       f"exceed exchange max request size ({candle_limit})")
 
     @property
     def needstickers(self) -> bool:

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -835,6 +835,23 @@ def test_download_data_trades(mocker, caplog):
         start_download_data(pargs)
 
 
+def test_download_data_data_invalid(mocker):
+    patch_exchange(mocker, id="kraken")
+    mocker.patch(
+        'freqtrade.exchange.Exchange.markets', PropertyMock(return_value={})
+    )
+    args = [
+        "download-data",
+        "--exchange", "kraken",
+        "--pairs", "ETH/BTC", "XRP/BTC",
+        "--days", "20",
+    ]
+    pargs = get_args(args)
+    pargs['config'] = None
+    with pytest.raises(OperationalException, match=r"Historic klines not available for .*"):
+        start_download_data(pargs)
+
+
 def test_start_convert_trades(mocker, caplog):
     convert_mock = mocker.patch('freqtrade.commands.data_commands.convert_trades_to_ohlcv',
                                 MagicMock(return_value=[]))

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -232,7 +232,8 @@ class TestCCXTExchange():
         assert len(ohlcv[pair_tf]) == len(exchange.klines(pair_tf))
         # assert len(exchange.klines(pair_tf)) > 200
         # Assume 90% uptime ...
-        assert len(exchange.klines(pair_tf)) > exchange.ohlcv_candle_limit(timeframe) * 0.90
+        assert len(exchange.klines(pair_tf)) > exchange.ohlcv_candle_limit(
+            timeframe, CandleType.SPOT) * 0.90
         # Check if last-timeframe is within the last 2 intervals
         now = datetime.now(timezone.utc) - timedelta(minutes=(timeframe_to_minutes(timeframe) * 2))
         assert exchange.klines(pair_tf).iloc[-1]['date'] >= timeframe_to_prev_date(timeframe, now)

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -13,6 +13,7 @@ import pytest
 
 from freqtrade.enums import CandleType
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
+from freqtrade.exchange.exchange import timeframe_to_msecs
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import get_default_conf_usdt
 
@@ -235,6 +236,38 @@ class TestCCXTExchange():
         # Check if last-timeframe is within the last 2 intervals
         now = datetime.now(timezone.utc) - timedelta(minutes=(timeframe_to_minutes(timeframe) * 2))
         assert exchange.klines(pair_tf).iloc[-1]['date'] >= timeframe_to_prev_date(timeframe, now)
+
+    def test_ccxt__async_get_candle_history(self, exchange):
+        exchange, exchangename = exchange
+        # For some weired reason, this test returns random lengths for bittrex.
+        if not exchange._ft_has['ohlcv_has_history'] or exchangename == 'bittrex':
+            return
+        pair = EXCHANGES[exchangename]['pair']
+        timeframe = EXCHANGES[exchangename]['timeframe']
+        candle_type = CandleType.SPOT
+        timeframe_ms = timeframe_to_msecs(timeframe)
+        now = timeframe_to_prev_date(
+                timeframe, datetime.now(timezone.utc))
+        for offset in (360, 120, 30, 10, 5, 2):
+            since = now - timedelta(days=offset)
+            since_ms = int(since.timestamp() * 1000)
+
+            res = exchange.loop.run_until_complete(exchange._async_get_candle_history(
+                pair=pair,
+                timeframe=timeframe,
+                since_ms=since_ms,
+                candle_type=candle_type
+            )
+            )
+            assert res
+            assert res[0] == pair
+            assert res[1] == timeframe
+            assert res[2] == candle_type
+            candles = res[3]
+            candle_count = exchange.ohlcv_candle_limit(timeframe, candle_type, since_ms) * 0.9
+            candle_count1 = (now.timestamp() * 1000 - since_ms) // timeframe_ms
+            assert len(candles) >= min(candle_count, candle_count1)
+            assert candles[0][0] == since_ms or (since_ms + timeframe_ms)
 
     def test_ccxt_fetch_funding_rate_history(self, exchange_futures):
         exchange, exchangename = exchange_futures

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -219,7 +219,7 @@ class TestCCXTExchange():
                     assert len(l2['asks']) == next_limit
                     assert len(l2['asks']) == next_limit
 
-    def test_fetch_ohlcv(self, exchange):
+    def test_ccxt_fetch_ohlcv(self, exchange):
         exchange, exchangename = exchange
         pair = EXCHANGES[exchangename]['pair']
         timeframe = EXCHANGES[exchangename]['timeframe']

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -17,9 +17,9 @@ from freqtrade.exceptions import (DDosProtection, DependencyException, InvalidOr
 from freqtrade.exchange import Binance, Bittrex, Exchange, Kraken
 from freqtrade.exchange.common import (API_FETCH_ORDER_RETRY_COUNT, API_RETRY_COUNT,
                                        calculate_backoff, remove_credentials)
-from freqtrade.exchange.exchange import (market_is_active, timeframe_to_minutes, timeframe_to_msecs,
-                                         timeframe_to_next_date, timeframe_to_prev_date,
-                                         timeframe_to_seconds)
+from freqtrade.exchange.exchange import (date_minus_candles, market_is_active, timeframe_to_minutes,
+                                         timeframe_to_msecs, timeframe_to_next_date,
+                                         timeframe_to_prev_date, timeframe_to_seconds)
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import get_mock_coro, get_patched_exchange, log_has, log_has_re, num_log_has_re
 
@@ -3429,6 +3429,17 @@ def test_timeframe_to_next_date():
 
     date = datetime(2019, 8, 12, 13, 30, 0, tzinfo=timezone.utc)
     assert timeframe_to_next_date("5m", date) == date + timedelta(minutes=5)
+
+
+def test_date_minus_candles():
+
+    date = datetime(2019, 8, 12, 13, 25, 0, tzinfo=timezone.utc)
+
+    assert date_minus_candles("5m", 3, date) == date - timedelta(minutes=15)
+    assert date_minus_candles("5m", 5, date) == date - timedelta(minutes=25)
+    assert date_minus_candles("1m", 6, date) == date - timedelta(minutes=6)
+    assert date_minus_candles("1h", 3, date) == date - timedelta(hours=3, minutes=25)
+    assert date_minus_candles("1h", 3) == timeframe_to_prev_date('1h') - timedelta(hours=3)
 
 
 @pytest.mark.parametrize(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1084,6 +1084,13 @@ def test_validate_required_startup_candles(default_conf, mocker, caplog):
     with pytest.raises(OperationalException, match=r'This strategy requires 6000.*'):
         Exchange(default_conf)
 
+    # Emulate kraken mode
+    ex._ft_has['ohlcv_has_history'] = False
+    with pytest.raises(OperationalException,
+                       match=r'This strategy requires 2500.*, '
+                             r'which is more than the amount.*'):
+        ex.validate_required_startup_candles(2500, '5m')
+
 
 def test_exchange_has(default_conf, mocker):
     exchange = get_patched_exchange(mocker, default_conf)

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -939,6 +939,7 @@ def test_validate_timeframes_emulated_ohlcvi_2(default_conf, mocker):
 
 
 def test_validate_timeframes_not_in_config(default_conf, mocker):
+    # TODO: this test does not assert ...
     del default_conf["timeframe"]
     api_mock = MagicMock()
     id_mock = PropertyMock(return_value='test_exchange')
@@ -954,6 +955,7 @@ def test_validate_timeframes_not_in_config(default_conf, mocker):
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs')
     mocker.patch('freqtrade.exchange.Exchange.validate_stakecurrency')
     mocker.patch('freqtrade.exchange.Exchange.validate_pricing')
+    mocker.patch('freqtrade.exchange.Exchange.validate_required_startup_candles')
     Exchange(default_conf)
 
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1882,7 +1882,7 @@ def test_get_historic_ohlcv(default_conf, mocker, caplog, exchange_name, candle_
     exchange._async_get_candle_history = Mock(wraps=mock_candle_hist)
     # one_call calculation * 1.8 should do 2 calls
 
-    since = 5 * 60 * exchange.ohlcv_candle_limit('5m') * 1.8
+    since = 5 * 60 * exchange.ohlcv_candle_limit('5m', CandleType.SPOT) * 1.8
     ret = exchange.get_historic_ohlcv(
         pair,
         "5m",
@@ -1948,7 +1948,7 @@ def test_get_historic_ohlcv_as_df(default_conf, mocker, exchange_name, candle_ty
     exchange._async_get_candle_history = Mock(wraps=mock_candle_hist)
     # one_call calculation * 1.8 should do 2 calls
 
-    since = 5 * 60 * exchange.ohlcv_candle_limit('5m') * 1.8
+    since = 5 * 60 * exchange.ohlcv_candle_limit('5m', CandleType.SPOT) * 1.8
     ret = exchange.get_historic_ohlcv_as_df(
         pair,
         "5m",
@@ -2002,7 +2002,7 @@ async def test__async_get_historic_ohlcv(default_conf, mocker, caplog, exchange_
         )
     # Required candles
     candles = (end_ts - start_ts) / 300_000
-    exp = candles // exchange.ohlcv_candle_limit('5m') + 1
+    exp = candles // exchange.ohlcv_candle_limit('5m', CandleType.SPOT) + 1
 
     # Depending on the exchange, this should be called between 1 and 6 times.
     assert exchange._api_async.fetch_ohlcv.call_count == exp
@@ -3349,7 +3349,7 @@ def test_ohlcv_candle_limit(default_conf, mocker, exchange_name):
             expected = exchange._ft_has['ohlcv_candle_limit_per_timeframe'][timeframe]
             # This should only run for bittrex
             assert exchange_name == 'bittrex'
-        assert exchange.ohlcv_candle_limit(timeframe) == expected
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT) == expected
 
 
 def test_timeframe_to_minutes():

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -20,14 +20,17 @@ def test_okx_ohlcv_candle_limit(default_conf, mocker):
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES) == 300
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.MARK) == 100
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUNDING_RATE) == 100
+
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, start_time) == 100
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES, start_time) == 100
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.MARK, start_time) == 100
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUNDING_RATE, start_time) == 100
         one_call = int((datetime.now(timezone.utc) - timedelta(
             minutes=290 * timeframe_to_minutes(timeframe))).timestamp() * 1000)
+
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, one_call) == 300
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES, one_call) == 300
+
         one_call = int((datetime.now(timezone.utc) - timedelta(
             minutes=320 * timeframe_to_minutes(timeframe))).timestamp() * 1000)
         assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, one_call) == 100

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -1,10 +1,37 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
 from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.enums.candletype import CandleType
+from freqtrade.exchange.exchange import timeframe_to_minutes
 from tests.conftest import get_patched_exchange
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
+
+
+def test_okx_ohlcv_candle_limit(default_conf, mocker):
+    exchange = get_patched_exchange(mocker, default_conf, id='okx')
+    timeframes = ('1m', '5m', '1h')
+    start_time = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+
+    for timeframe in timeframes:
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT) == 300
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES) == 300
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.MARK) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUNDING_RATE) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, start_time) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES, start_time) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.MARK, start_time) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUNDING_RATE, start_time) == 100
+        one_call = int((datetime.now(timezone.utc) - timedelta(
+            minutes=290 * timeframe_to_minutes(timeframe))).timestamp() * 1000)
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, one_call) == 300
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES, one_call) == 300
+        one_call = int((datetime.now(timezone.utc) - timedelta(
+            minutes=320 * timeframe_to_minutes(timeframe))).timestamp() * 1000)
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.SPOT, one_call) == 100
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES, one_call) == 100
 
 
 def test_get_maintenance_ratio_and_amt_okx(


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

OKX historic Ohlcv endpoints act strangely, returning 100 or 300 requests, depending on the starting-time provided, and depending on the candle type.

## Quick changelog

* Fail when trying to download candle data for kraken
* Make okx candle-limit detection more intelligent