### PR TITLE
Fix: Refresh SL on entry order replacement

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -780,8 +780,6 @@ class Backtesting:
                     # interest_rate=interest_rate,
                     orders=[],
                 )
-            elif trade.nr_of_successful_entries == 0:
-                trade.open_rate = propose_rate
 
             trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss, initial=True)
 
@@ -814,11 +812,11 @@ class Backtesting:
                 remaining=amount,
                 cost=stake_amount + trade.fee_open,
             )
+            trade.orders.append(order)
             if pos_adjust and self._get_order_filled(order.price, row):
                 order.close_bt_order(current_time, trade)
             else:
                 trade.open_order_id = str(self.order_id_counter)
-            trade.orders.append(order)
             trade.recalc_trade_from_orders()
 
         return trade
@@ -942,8 +940,6 @@ class Backtesting:
                                   requested_rate=requested_rate,
                                   requested_stake=(order.remaining * order.price),
                                   direction='short' if trade.is_short else 'long')
-                trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss,
-                                       initial=False, refresh=True)
             else:
                 # assumption: there can't be multiple open entry orders at any given time
                 return (trade.nr_of_successful_entries == 0)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -780,6 +780,8 @@ class Backtesting:
                     # interest_rate=interest_rate,
                     orders=[],
                 )
+            elif trade.nr_of_successful_entries == 0:
+                trade.open_rate = propose_rate
 
             trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss, initial=True)
 
@@ -940,6 +942,8 @@ class Backtesting:
                                   requested_rate=requested_rate,
                                   requested_stake=(order.remaining * order.price),
                                   direction='short' if trade.is_short else 'long')
+                trade.adjust_stop_loss(trade.open_rate, self.strategy.stoploss,
+                                       initial=False, refresh=True)
             else:
                 # assumption: there can't be multiple open entry orders at any given time
                 return (trade.nr_of_successful_entries == 0)

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -153,6 +153,7 @@ class Order(_DECL_BASE):
                 and len(trade.select_filled_orders(trade.entry_side)) == 1):
             trade.open_rate = self.price
             trade.recalc_open_trade_value()
+            trade.adjust_stop_loss(trade.open_rate, trade.stop_loss_pct, refresh=True)
 
     @staticmethod
     def update_orders(orders: List['Order'], order: Dict[str, Any]):
@@ -502,7 +503,7 @@ class LocalTrade():
         if initial and not (self.stop_loss is None or self.stop_loss == 0):
             # Don't modify if called with initial and nothing to do
             return
-        refresh = False if self.nr_of_successful_entries > 0 else refresh
+        refresh = True if refresh and self.nr_of_successful_entries == 1 else False
 
         leverage = self.leverage or 1.0
         if self.is_short:

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -502,6 +502,7 @@ class LocalTrade():
         if initial and not (self.stop_loss is None or self.stop_loss == 0):
             # Don't modify if called with initial and nothing to do
             return
+        refresh = False if self.nr_of_successful_entries > 0 else refresh
 
         leverage = self.leverage or 1.0
         if self.is_short:

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -491,7 +491,7 @@ class LocalTrade():
         self.stoploss_last_update = datetime.utcnow()
 
     def adjust_stop_loss(self, current_price: float, stoploss: float,
-                         initial: bool = False) -> None:
+                         initial: bool = False, refresh: bool = False) -> None:
         """
         This adjusts the stop loss to it's most recently observed setting
         :param current_price: Current rate the asset is traded
@@ -516,8 +516,7 @@ class LocalTrade():
                 new_loss = max(self.liquidation_price, new_loss)
 
         # no stop loss assigned yet
-        if self.initial_stop_loss_pct is None:
-            logger.debug(f"{self.pair} - Assigning new stoploss...")
+        if self.initial_stop_loss_pct is None or refresh:
             self._set_stop_loss(new_loss, stoploss)
             self.initial_stop_loss = new_loss
             self.initial_stop_loss_pct = -1 * abs(stoploss)

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -762,7 +762,7 @@ tc48 = BTContainer(data=[
     [2, 4900, 5250, 4500, 5100, 6172, 0, 0],  # Order readjust
     [3, 5100, 5100, 4650, 4750, 6172, 0, 1],
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
-    stop_loss=-0.01, roi={"0": 0.10}, profit_perc=-0.087,
+    stop_loss=-0.2, roi={"0": 0.10}, profit_perc=-0.087,
     use_exit_signal=True, timeout=1000,
     custom_entry_price=4200, adjust_entry_price=5200,
     trades=[BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=1, close_tick=4, is_short=False)]
@@ -777,7 +777,7 @@ tc49 = BTContainer(data=[
     [2, 4900, 5250, 4900, 5100, 6172, 0, 0, 0, 0],  # Order readjust
     [3, 5100, 5100, 4650, 4750, 6172, 0, 0, 0, 1],
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0, 0, 0]],
-    stop_loss=-0.01, roi={"0": 0.10}, profit_perc=0.05,
+    stop_loss=-0.2, roi={"0": 0.10}, profit_perc=0.05,
     use_exit_signal=True, timeout=1000,
     custom_entry_price=5300, adjust_entry_price=5000,
     trades=[BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=1, close_tick=4, is_short=True)]
@@ -809,6 +809,35 @@ tc51 = BTContainer(data=[
     use_exit_signal=True, timeout=60,
     custom_entry_price=4200, adjust_entry_price=4100,
     trades=[]
+)
+
+# Test 52: Custom-entry-price below all candles - readjust order - stoploss
+tc52 = BTContainer(data=[
+    # D   O     H     L     C    V    EL XL ES Xs  BT
+    [0, 5000, 5050, 4950, 5000, 6172, 1, 0],
+    [1, 5000, 5500, 4951, 5000, 6172, 0, 0],  # enter trade (signal on last candle)
+    [2, 4900, 5250, 4500, 5100, 6172, 0, 0],  # Order readjust
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0],  # stoploss hit?
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
+    stop_loss=-0.03, roi={"0": 0.10}, profit_perc=-0.03,
+    use_exit_signal=True, timeout=1000,
+    custom_entry_price=4200, adjust_entry_price=5200,
+    trades=[BTrade(exit_reason=ExitType.STOP_LOSS, open_tick=1, close_tick=2, is_short=False)]
+)
+
+
+# Test 53: Custom-entry-price short above all candles - readjust order - stoploss
+tc53 = BTContainer(data=[
+    # D   O     H     L     C    V    EL XL ES Xs  BT
+    [0, 5000, 5050, 4950, 5000, 6172, 0, 0, 1, 0],
+    [1, 5000, 5200, 4951, 5000, 6172, 0, 0, 0, 0],  # enter trade (signal on last candle)
+    [2, 4900, 5250, 4900, 5100, 6172, 0, 0, 0, 0],  # Order readjust
+    [3, 5100, 5100, 4650, 4750, 6172, 0, 0, 0, 1],  # stoploss hit?
+    [4, 4750, 4950, 4350, 4750, 6172, 0, 0, 0, 0]],
+    stop_loss=-0.03, roi={"0": 0.10}, profit_perc=-0.03,
+    use_exit_signal=True, timeout=1000,
+    custom_entry_price=5300, adjust_entry_price=5000,
+    trades=[BTrade(exit_reason=ExitType.STOP_LOSS, open_tick=1, close_tick=2, is_short=True)]
 )
 
 TESTS = [
@@ -864,6 +893,8 @@ TESTS = [
     tc49,
     tc50,
     tc51,
+    tc52,
+    tc53,
 ]
 
 


### PR DESCRIPTION
## Summary

Fix backtesting behavior for entry order adjustment feature.

Solve the issue: Stoploss latched based on first order.

## Quick changelog

- Update `_enter_trade` so that `open_rate` is refreshed when a `LocalTrade` object is supplied with 0 filled orders;
- Update `check_order_replace` to refresh stoploss when entry order is replaced;
- Update `adjust_stoploss` to allow refreshing the SL
- Added testcases

## What's new?

Nothing new. Fix for BT side of PR: https://github.com/freqtrade/freqtrade/pull/6692
