### PR TITLE
Python 310 main version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
@@ -70,7 +70,7 @@ jobs:
       if: matrix.python-version == '3.9'
 
     - name: Coveralls
-      if: (runner.os == 'Linux' && matrix.python-version == '3.8')
+      if: (runner.os == 'Linux' && matrix.python-version == '3.9')
       env:
         # Coveralls token. Not used as secret due to github not providing secrets to forked repositories
         COVERALLS_REPO_TOKEN: 6D1m0xupS3FgutfuGao8keFf9Hc0FpIXu
@@ -157,23 +157,8 @@ jobs:
         pip install -e .
 
     - name: Tests
-      if: (runner.os != 'Linux' || matrix.python-version != '3.8')
       run: |
         pytest --random-order
-
-    - name: Tests (with cov)
-      if: (runner.os == 'Linux' && matrix.python-version == '3.8')
-      run: |
-        pytest --random-order --cov=freqtrade --cov-config=.coveragerc
-
-    - name: Coveralls
-      if: (runner.os == 'Linux' && matrix.python-version == '3.8')
-      env:
-        # Coveralls token. Not used as secret due to github not providing secrets to forked repositories
-        COVERALLS_REPO_TOKEN: 6D1m0xupS3FgutfuGao8keFf9Hc0FpIXu
-      run: |
-        # Allow failure for coveralls
-        coveralls -v  || true
 
     - name: Backtesting
       run: |
@@ -273,7 +258,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: pre-commit dependencies
       run: |
@@ -292,7 +277,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Documentation build
       run: |
@@ -358,7 +343,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Extract branch name
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: pre-commit dependencies
       run: |
@@ -292,7 +292,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Documentation build
       run: |
@@ -358,7 +358,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Extract branch name
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.9-slim-bullseye as base
+FROM python:3.10.4-slim-bullseye as base
 
 # Setup env
 ENV LANG C.UTF-8

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM python:3.9.9-slim-bullseye as base
+FROM python:3.9.12-slim-bullseye as base
 
 # Setup env
 ENV LANG C.UTF-8

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ tests_require =
     pytest-mock
 
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ function check_installed_python() {
         exit 2
     fi
 
-    for v in 9 10 8
+    for v in 10 9 8
     do
         PYTHON="python3.${v}"
         which $PYTHON


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Default python version to 3.10.

The bug that caused us to downgrade all docker images was fixed in 3.10.2 (https://bugs.python.org/issue46347).


## Quick changelog

- Update docker image to 3.10
- use latest 3.9 image for raspberry
- Update Ci to run on latest versions
- add ubuntu 22.04 runner