### PR TITLE
Use precise

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -16,9 +16,7 @@ import arrow
 import ccxt
 import ccxt.async_support as ccxt_async
 from cachetools import TTLCache
-from ccxt import Precise
-from ccxt.base.decimal_to_precision import (ROUND_DOWN, ROUND_UP, TICK_SIZE, TRUNCATE,
-                                            decimal_to_precision)
+from ccxt import ROUND_DOWN, ROUND_UP, TICK_SIZE, TRUNCATE, Precise, decimal_to_precision
 from pandas import DataFrame
 
 from freqtrade.constants import (DEFAULT_AMOUNT_RESERVE_PERCENT, NON_OPEN_EXCHANGE_STATES, BuySell,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -16,6 +16,7 @@ import arrow
 import ccxt
 import ccxt.async_support as ccxt_async
 from cachetools import TTLCache
+from ccxt import Precise
 from ccxt.base.decimal_to_precision import (ROUND_DOWN, ROUND_UP, TICK_SIZE, TRUNCATE,
                                             decimal_to_precision)
 from pandas import DataFrame
@@ -704,10 +705,11 @@ class Exchange:
             #                                    counting_mode=self.precisionMode,
             #                                    ))
             if self.precisionMode == TICK_SIZE:
-                precision = self.markets[pair]['precision']['price']
-                missing = price % precision
-                if missing != 0:
-                    price = round(price - missing + precision, 10)
+                precision = Precise(str(self.markets[pair]['precision']['price']))
+                price_str = Precise(str(price))
+                missing = price_str.mod(precision)
+                if not missing.equals(Precise("0")):
+                    price = round(float(str(price_str.sub(missing).add(precision))), 14)
             else:
                 symbol_prec = self.markets[pair]['precision']['price']
                 big_price = price * pow(10, symbol_prec)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -707,9 +707,9 @@ class Exchange:
             if self.precisionMode == TICK_SIZE:
                 precision = Precise(str(self.markets[pair]['precision']['price']))
                 price_str = Precise(str(price))
-                missing = price_str.mod(precision)
-                if not missing.equals(Precise("0")):
-                    price = round(float(str(price_str.sub(missing).add(precision))), 14)
+                missing = price_str % precision
+                if not missing == Precise("0"):
+                    price = round(float(str(price_str - missing + precision)), 14)
             else:
                 symbol_prec = self.markets[pair]['precision']['price']
                 big_price = price * pow(10, symbol_prec)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     install_requires=[
         # from requirements.txt
-        'ccxt>=1.79.69',
+        'ccxt>=1.80.67',
         'SQLAlchemy',
         'python-telegram-bot>=13.4',
         'arrow>=0.17.0',

--- a/tests/exchange/test_ccxt_precise.py
+++ b/tests/exchange/test_ccxt_precise.py
@@ -1,0 +1,75 @@
+from ccxt import Precise
+
+
+ws = Precise('-1.123e-6')
+ws = Precise('-1.123e-6')
+xs = Precise('0.00000002')
+ys = Precise('69696900000')
+zs = Precise('0')
+
+
+def test_precise():
+    assert ys * xs == '1393.938'
+    assert xs * ys == '1393.938'
+
+    assert ys + xs == '69696900000.00000002'
+    assert xs + ys == '69696900000.00000002'
+    assert xs - ys == '-69696899999.99999998'
+    assert ys - xs == '69696899999.99999998'
+    assert xs / ys == '0'
+    assert ys / xs == '3484845000000000000'
+
+    assert ws * xs == '-0.00000000000002246'
+    assert xs * ws == '-0.00000000000002246'
+
+    assert ws + xs == '-0.000001103'
+    assert xs + ws == '-0.000001103'
+
+    assert xs - ws == '0.000001143'
+    assert ws - xs == '-0.000001143'
+
+    assert xs / ws == '-0.017809439002671415'
+    assert ws / xs == '-56.15'
+
+    assert zs * ws == '0'
+    assert zs * xs == '0'
+    assert zs * ys == '0'
+    assert ws * zs == '0'
+    assert xs * zs == '0'
+    assert ys * zs == '0'
+
+    assert zs + ws == '-0.000001123'
+    assert zs + xs == '0.00000002'
+    assert zs + ys == '69696900000'
+    assert ws + zs == '-0.000001123'
+    assert xs + zs == '0.00000002'
+    assert ys + zs == '69696900000'
+
+    assert abs(Precise('-500.1')) == '500.1'
+    assert abs(Precise('213')) == '213'
+
+    assert abs(Precise('-500.1')) == '500.1'
+    assert -Precise('213') == '-213'
+
+    assert Precise('10.1') % Precise('0.5') == '0.1'
+    assert Precise('5550') % Precise('120') == '30'
+
+    assert Precise('-0.0') == Precise('0')
+    assert Precise('5.534000') == Precise('5.5340')
+
+    assert min(Precise('-3.1415'), Precise('-2')) == '-3.1415'
+
+    assert max(Precise('3.1415'), Precise('-2')) == '3.1415'
+
+    assert Precise('2') > Precise('1.2345')
+    assert not Precise('-3.1415') > Precise('-2')
+    assert not Precise('3.1415') > Precise('3.1415')
+    assert Precise.string_gt('3.14150000000000000000001', '3.1415')
+
+    assert Precise('3.1415') >= Precise('3.1415')
+    assert Precise('3.14150000000000000000001') >= Precise('3.1415')
+
+    assert not Precise('3.1415') < Precise('3.1415')
+
+    assert Precise('3.1415') <= Precise('3.1415')
+    assert Precise('3.1415') <= Precise('3.14150000000000000000001')

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -305,6 +305,7 @@ def test_amount_to_precision(
     (234.53, 4, 0.5, 235.0),
     (0.891534, 4, 0.0001, 0.8916),
     (64968.89, 4, 0.01, 64968.89),
+    (0.000000003483, 4, 1e-12, 0.000000003483),
 
 ])
 def test_price_to_precision(default_conf, mocker, price, precision_mode, precision, expected):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

use ccxt's Precise class for precision calculation

## Quick changelog

- use Precise, bump min ccxt version