### PR TITLE
Add support for fudging unavailable funding rates, allowing backtesti…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,6 +230,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `dataformat_trades` | Data format to use to store historical trades data. <br> *Defaults to `jsongz`*. <br> **Datatype:** String
 | `position_adjustment_enable` | Enables the strategy to use position adjustments (additional buys or sells). [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `false`.*<br> **Datatype:** Boolean
 | `max_entry_position_adjustment` | Maximum additional order(s) for each open trade on top of the first entry Order. Set it to `-1` for unlimited additional orders. [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `-1`.*<br> **Datatype:** Positive Integer or -1
+| `futures_funding_rate` | User-specified funding rate to be used when historical funding rates are not available from the exchange. This does not overwrite real historical rates. It is recommended that this be set to 0 unless you are testing a specific coin and you understand how the funding rate will affect freqtrade's profit calculations. [More information here](configuration.md) <br>*Defaults to None.*<br> **Datatype:** Float
 
 ### Parameters in the strategy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,7 +230,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `dataformat_trades` | Data format to use to store historical trades data. <br> *Defaults to `jsongz`*. <br> **Datatype:** String
 | `position_adjustment_enable` | Enables the strategy to use position adjustments (additional buys or sells). [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `false`.*<br> **Datatype:** Boolean
 | `max_entry_position_adjustment` | Maximum additional order(s) for each open trade on top of the first entry Order. Set it to `-1` for unlimited additional orders. [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `-1`.*<br> **Datatype:** Positive Integer or -1
-| `futures_funding_rate` | User-specified funding rate to be used when historical funding rates are not available from the exchange. This does not overwrite real historical rates. It is recommended that this be set to 0 unless you are testing a specific coin and you understand how the funding rate will affect freqtrade's profit calculations. [More information here](configuration.md) <br>*Defaults to None.*<br> **Datatype:** Float
+| `futures_funding_rate` | User-specified funding rate to be used when historical funding rates are not available from the exchange. This does not overwrite real historical rates. It is recommended that this be set to 0 unless you are testing a specific coin and you understand how the funding rate will affect freqtrade's profit calculations. [More information here](leverage.md) <br>*Defaults to None.*<br> **Datatype:** Float
 
 ### Parameters in the strategy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,7 +230,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `dataformat_trades` | Data format to use to store historical trades data. <br> *Defaults to `jsongz`*. <br> **Datatype:** String
 | `position_adjustment_enable` | Enables the strategy to use position adjustments (additional buys or sells). [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `false`.*<br> **Datatype:** Boolean
 | `max_entry_position_adjustment` | Maximum additional order(s) for each open trade on top of the first entry Order. Set it to `-1` for unlimited additional orders. [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `-1`.*<br> **Datatype:** Positive Integer or -1
-| `futures_funding_rate` | User-specified funding rate to be used when historical funding rates are not available from the exchange. This does not overwrite real historical rates. It is recommended that this be set to 0 unless you are testing a specific coin and you understand how the funding rate will affect freqtrade's profit calculations. [More information here](leverage.md) <br>*Defaults to None.*<br> **Datatype:** Float
+| `futures_funding_rate` | User-specified funding rate to be used when historical funding rates are not available from the exchange. This does not overwrite real historical rates. It is recommended that this be set to 0 unless you are testing a specific coin and you understand how the funding rate will affect freqtrade's profit calculations. [More information here](leverage.md#unavailable-funding-rates) <br>*Defaults to None.*<br> **Datatype:** Float
 
 ### Parameters in the strategy
 

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -105,7 +105,7 @@ Possible values are any floats between 0.0 and 0.99
 
 For futures data, exchanges commonly provide the futures candles, the marks, and the funding rates. However, it is common that whilst candles and marks might be available, the funding rates are not. This can affect backtesting timeranges, i.e. you may only be able to test recent timeranges and not earlier, experiencing the `No data found. Terminating.` error. To get around this, add the `futures_funding_rate` config option as listed in [configuration.md](configuration.md), and it is recommended that you set this to `0`, unless you know a given specific funding rate for your pair, exchange and timerange. Setting this to anything other than `0` can have drastic effects on your profit calculations within strategy, e.g. within the `custom_exit`, `custom_stoploss`, etc functions.
 
-!!! Warning This will mean your backtests are inaccurate.
+!!! Warning "This will mean your backtests are inaccurate."
     This will not overwrite funding rates that are available from the exchange, but bear in mind that setting a false funding rate will mean backtesting results will be inaccurate for historical timeranges where funding rates are not available.
     
 ### Developer

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -107,7 +107,7 @@ For futures data, exchanges commonly provide the futures candles, the marks, and
 
 !!! Warning "This will mean your backtests are inaccurate."
     This will not overwrite funding rates that are available from the exchange, but bear in mind that setting a false funding rate will mean backtesting results will be inaccurate for historical timeranges where funding rates are not available.
-    
+
 ### Developer
 
 #### Margin mode

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -101,6 +101,12 @@ Possible values are any floats between 0.0 and 0.99
 !!! Danger "A `liquidation_buffer` of 0.0, or a low `liquidation_buffer` is likely to result in liquidations, and liquidation fees"
     Currently Freqtrade is able to calculate liquidation prices, but does not calculate liquidation fees. Setting your `liquidation_buffer` to 0.0, or using a low `liquidation_buffer` could result in your positions being liquidated. Freqtrade does not track liquidation fees, so liquidations will result in inaccurate profit/loss results for your bot. If you use a low `liquidation_buffer`, it is recommended to use `stoploss_on_exchange` if your exchange supports this.
 
+## Unavailable funding rates
+
+For futures data, exchanges commonly provide the futures candles, the marks, and the funding rates. However, it is common that whilst candles and marks might be available, the funding rates are not. This can affect backtesting timeranges, i.e. you may only be able to test recent timeranges and not earlier, experiencing the `No data found. Terminating.` error. To get around this, add the `futures_funding_rate` config option as listed in [configuration.md](configuration.md), and it is recommended that you set this to `0`, unless you know a given specific funding rate for your pair, exchange and timerange. Setting this to anything other than `0` can have drastic effects on your profit calculations within strategy, e.g. within the `custom_exit`, `custom_stoploss`, etc functions.
+
+!!! This will not overwrite funding rates that are available from the exchange.
+
 ### Developer
 
 #### Margin mode

--- a/docs/leverage.md
+++ b/docs/leverage.md
@@ -105,8 +105,9 @@ Possible values are any floats between 0.0 and 0.99
 
 For futures data, exchanges commonly provide the futures candles, the marks, and the funding rates. However, it is common that whilst candles and marks might be available, the funding rates are not. This can affect backtesting timeranges, i.e. you may only be able to test recent timeranges and not earlier, experiencing the `No data found. Terminating.` error. To get around this, add the `futures_funding_rate` config option as listed in [configuration.md](configuration.md), and it is recommended that you set this to `0`, unless you know a given specific funding rate for your pair, exchange and timerange. Setting this to anything other than `0` can have drastic effects on your profit calculations within strategy, e.g. within the `custom_exit`, `custom_stoploss`, etc functions.
 
-!!! This will not overwrite funding rates that are available from the exchange.
-
+!!! Warning This will mean your backtests are inaccurate.
+    This will not overwrite funding rates that are available from the exchange, but bear in mind that setting a false funding rate will mean backtesting results will be inaccurate for historical timeranges where funding rates are not available.
+    
 ### Developer
 
 #### Margin mode

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -69,7 +69,7 @@ def load_data(datadir: Path,
               fail_without_data: bool = False,
               data_format: str = 'json',
               candle_type: CandleType = CandleType.SPOT,
-              user_futures_funding_rate = None,
+              user_futures_funding_rate: int = None,
               ) -> Dict[str, DataFrame]:
     """
     Load ohlcv history data for a list of pairs.
@@ -104,7 +104,7 @@ def load_data(datadir: Path,
         else:
             if candle_type is CandleType.FUNDING_RATE and user_futures_funding_rate is not None:
                 logger.warn(f"{pair} using user specified [{user_futures_funding_rate}]")
-                result[pair] = DataFrame(columns=["open","close","high","low","volume"])
+                result[pair] = DataFrame(columns=["open", "close", "high", "low", "volume"])
 
     if fail_without_data and not result:
         raise OperationalException("No data found. Terminating.")

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -68,7 +68,8 @@ def load_data(datadir: Path,
               startup_candles: int = 0,
               fail_without_data: bool = False,
               data_format: str = 'json',
-              candle_type: CandleType = CandleType.SPOT
+              candle_type: CandleType = CandleType.SPOT,
+              user_futures_funding_rate = None,
               ) -> Dict[str, DataFrame]:
     """
     Load ohlcv history data for a list of pairs.
@@ -100,6 +101,10 @@ def load_data(datadir: Path,
                                  )
         if not hist.empty:
             result[pair] = hist
+        else:
+            if candle_type is CandleType.FUNDING_RATE and user_futures_funding_rate is not None:
+                logger.warn(f"{pair} using user specified [{user_futures_funding_rate}]")
+                result[pair] = DataFrame(columns=["open","close","high","low","volume"])
 
     if fail_without_data and not result:
         raise OperationalException("No data found. Terminating.")

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2437,9 +2437,11 @@ class Exchange:
 
             else:
                 # Fill up missing funding_rate candles with fallback value
-                return mark_rates.merge(
+                combined = mark_rates.merge(
                     funding_rates, on='date', how="outer", suffixes=["_mark", "_fund"]
-                    )['open_fund'].fillna(futures_funding_rate)
+                    )
+                combined['open_fund'] = combined['open_fund'].fillna(futures_funding_rate)
+                return combined
 
     def calculate_funding_fees(
         self,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2420,7 +2420,7 @@ class Exchange:
         :param mark_rates: Dataframe containing Mark rates (Type mark_ohlcv_price)
         """
 
-        return funding_rates.merge(mark_rates, on='date', how="inner", suffixes=["_fund", "_mark"])
+        return mark_rates.merge(funding_rates, on='date', how="inner", suffixes=["_mark", "_fund"])
 
     def calculate_funding_fees(
         self,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -294,9 +294,15 @@ class Backtesting:
 
                     self.futures_data[pair] = mark_rates_dict[pair]
                 else:
-                    self.futures_data[pair] = mark_rates_dict[pair].merge(
-                        funding_rates_dict[pair], on='date',
-                        how="inner", suffixes=["_fund", "_mark"])
+                    if "futures_funding_rate" in self.config:
+                        self.futures_data[pair] = mark_rates_dict[pair].merge(
+                            funding_rates_dict[pair], on='date',
+                            how="outer", suffixes=["_fund", "_mark"]).fillna(
+                                self.config.get('futures_funding_rate'))
+                    else:
+                        self.futures_data[pair] = mark_rates_dict[pair].merge(
+                            funding_rates_dict[pair], on='date',
+                            how="inner", suffixes=["_fund", "_mark"])
 
             if unavailable_pairs:
                 raise OperationalException(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -280,10 +280,6 @@ class Backtesting:
                         and len(funding_rates_dict[pair]) == 0
                         and "futures_funding_rate" in self.config):
                     mark_rates_dict[pair]["open_fund"] = self.config.get('futures_funding_rate')
-                    mark_rates_dict[pair]["close_fund"] = 0.0
-                    mark_rates_dict[pair]["high_fund"] = 0.0
-                    mark_rates_dict[pair]["low_fund"] = 0.0
-                    mark_rates_dict[pair]["volume_fund"] = 0.0
                     mark_rates_dict[pair].rename(
                         columns={'open': 'open_mark',
                                  'close': 'close_mark',
@@ -297,7 +293,7 @@ class Backtesting:
                     if "futures_funding_rate" in self.config:
                         self.futures_data[pair] = mark_rates_dict[pair].merge(
                             funding_rates_dict[pair], on='date',
-                            how="outer", suffixes=["_mark", "_fund"]).fillna(
+                            how="outer", suffixes=["_mark", "_fund"])['open_fund'].fillna(
                                 self.config.get('futures_funding_rate'))
                     else:
                         self.futures_data[pair] = mark_rates_dict[pair].merge(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -276,30 +276,11 @@ class Backtesting:
                     unavailable_pairs.append(pair)
                     continue
 
-                if (pair in mark_rates_dict
-                        and len(funding_rates_dict[pair]) == 0
-                        and "futures_funding_rate" in self.config):
-                    mark_rates_dict[pair]["open_fund"] = self.config.get('futures_funding_rate')
-                    mark_rates_dict[pair].rename(
-                        columns={'open': 'open_mark',
-                                 'close': 'close_mark',
-                                 'high': 'high_mark',
-                                 'low': 'low_mark',
-                                 'volume': 'volume_mark'},
-                        inplace=True)
-
-                    self.futures_data[pair] = mark_rates_dict[pair]
-                else:
-                    if "futures_funding_rate" in self.config:
-                        self.futures_data[pair] = mark_rates_dict[pair].merge(
-                            funding_rates_dict[pair], on='date',
-                            how="outer", suffixes=["_mark", "_fund"])['open_fund'].fillna(
-                                self.config.get('futures_funding_rate'))
-                    else:
-                        self.futures_data[pair] = self.exchange.combine_funding_and_mark(
-                            funding_rates=funding_rates_dict[pair],
-                            mark_rates=mark_rates_dict[pair]
-                        )
+                self.futures_data[pair] = self.exchange.combine_funding_and_mark(
+                    funding_rates=funding_rates_dict[pair],
+                    mark_rates=mark_rates_dict[pair],
+                    futures_funding_rate=self.config.get('futures_funding_rate'),
+                )
 
             if unavailable_pairs:
                 raise OperationalException(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -279,7 +279,7 @@ class Backtesting:
                 self.futures_data[pair] = self.exchange.combine_funding_and_mark(
                     funding_rates=funding_rates_dict[pair],
                     mark_rates=mark_rates_dict[pair],
-                    futures_funding_rate=self.config.get('futures_funding_rate'),
+                    futures_funding_rate=self.config.get('futures_funding_rate', None),
                 )
 
             if unavailable_pairs:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -297,12 +297,12 @@ class Backtesting:
                     if "futures_funding_rate" in self.config:
                         self.futures_data[pair] = mark_rates_dict[pair].merge(
                             funding_rates_dict[pair], on='date',
-                            how="outer", suffixes=["_fund", "_mark"]).fillna(
+                            how="outer", suffixes=["_mark", "_fund"]).fillna(
                                 self.config.get('futures_funding_rate'))
                     else:
                         self.futures_data[pair] = mark_rates_dict[pair].merge(
                             funding_rates_dict[pair], on='date',
-                            how="inner", suffixes=["_fund", "_mark"])
+                            how="inner", suffixes=["_mark", "_fund"])
 
             if unavailable_pairs:
                 raise OperationalException(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -296,9 +296,10 @@ class Backtesting:
                             how="outer", suffixes=["_mark", "_fund"])['open_fund'].fillna(
                                 self.config.get('futures_funding_rate'))
                     else:
-                        self.futures_data[pair] = mark_rates_dict[pair].merge(
-                            funding_rates_dict[pair], on='date',
-                            how="inner", suffixes=["_mark", "_fund"])
+                        self.futures_data[pair] = self.exchange.combine_funding_and_mark(
+                            funding_rates=funding_rates_dict[pair],
+                            mark_rates=mark_rates_dict[pair]
+                        )
 
             if unavailable_pairs:
                 raise OperationalException(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -277,25 +277,26 @@ class Backtesting:
                     continue
 
                 if (pair in mark_rates_dict
-                    and len(funding_rates_dict[pair]) == 0
-                    and "futures_funding_rate" in self.config):
+                        and len(funding_rates_dict[pair]) == 0
+                        and "futures_funding_rate" in self.config):
                     mark_rates_dict[pair]["open_fund"] = self.config.get('futures_funding_rate')
                     mark_rates_dict[pair]["close_fund"] = 0.0
                     mark_rates_dict[pair]["high_fund"] = 0.0
                     mark_rates_dict[pair]["low_fund"] = 0.0
                     mark_rates_dict[pair]["volume_fund"] = 0.0
                     mark_rates_dict[pair].rename(
-                        columns = {'open':'open_mark', 
-                                   'close':'close_mark',
-                                   'high':'high_mark',
-                                   'low':'low_mark',
-                                   'volume':'volume_mark'},
-                        inplace = True)
+                        columns={'open': 'open_mark',
+                                 'close': 'close_mark',
+                                 'high': 'high_mark',
+                                 'low': 'low_mark',
+                                 'volume': 'volume_mark'},
+                        inplace=True)
 
                     self.futures_data[pair] = mark_rates_dict[pair]
                 else:
                     self.futures_data[pair] = mark_rates_dict[pair].merge(
-                        funding_rates_dict[pair], on='date', how="inner", suffixes=["_fund", "_mark"])
+                        funding_rates_dict[pair], on='date',
+                        how="inner", suffixes=["_fund", "_mark"])
 
             if unavailable_pairs:
                 raise OperationalException(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3912,6 +3912,70 @@ def test_calculate_funding_fees(
         ) == kraken_fee
 
 
+@pytest.mark.parametrize(
+    'mark_price,funding_rate,futures_funding_rate', [
+        (1000, 0.001, None),
+        (1000, 0.001, 0.01),
+        (1000, 0.001, 0.0),
+        (1000, 0.001, -0.01),
+    ])
+def test_combine_funding_and_mark(
+    default_conf,
+    mocker,
+    funding_rate,
+    mark_price,
+    futures_funding_rate,
+):
+    exchange = get_patched_exchange(mocker, default_conf)
+    prior2_date = timeframe_to_prev_date('1h', datetime.now(timezone.utc) - timedelta(hours=2))
+    prior_date = timeframe_to_prev_date('1h', datetime.now(timezone.utc) - timedelta(hours=1))
+    trade_date = timeframe_to_prev_date('1h', datetime.now(timezone.utc))
+    funding_rates = DataFrame([
+        {'date': prior2_date, 'open': funding_rate},
+        {'date': prior_date, 'open': funding_rate},
+        {'date': trade_date, 'open': funding_rate},
+    ])
+    mark_rates = DataFrame([
+        {'date': prior2_date, 'open': mark_price},
+        {'date': prior_date, 'open': mark_price},
+        {'date': trade_date, 'open': mark_price},
+    ])
+
+    df = exchange.combine_funding_and_mark(funding_rates, mark_rates, futures_funding_rate)
+    assert 'open_mark' in df.columns
+    assert 'open_fund' in df.columns
+    assert len(df) == 3
+
+    funding_rates = DataFrame([
+        {'date': trade_date, 'open': funding_rate},
+    ])
+    mark_rates = DataFrame([
+        {'date': prior2_date, 'open': mark_price},
+        {'date': prior_date, 'open': mark_price},
+        {'date': trade_date, 'open': mark_price},
+    ])
+    df = exchange.combine_funding_and_mark(funding_rates, mark_rates, futures_funding_rate)
+
+    if futures_funding_rate is not None:
+        assert len(df) == 3
+        assert df.iloc[0]['open_fund'] == futures_funding_rate
+        assert df.iloc[1]['open_fund'] == futures_funding_rate
+        assert df.iloc[2]['open_fund'] == funding_rate
+    else:
+        assert len(df) == 1
+
+    # Empty funding rates
+    funding_rates = DataFrame([], columns=['date', 'open'])
+    df = exchange.combine_funding_and_mark(funding_rates, mark_rates, futures_funding_rate)
+    if futures_funding_rate is not None:
+        assert len(df) == 3
+        assert df.iloc[0]['open_fund'] == futures_funding_rate
+        assert df.iloc[1]['open_fund'] == futures_funding_rate
+        assert df.iloc[2]['open_fund'] == futures_funding_rate
+    else:
+        assert len(df) == 0
+
+
 def test_get_or_calculate_liquidation_price(mocker, default_conf):
 
     api_mock = MagicMock()


### PR DESCRIPTION
…ng of timeranges where futures candles are available, but rates are not

## Summary

This is to allow backtesting of longer historical timeranges when using futures data. It is often the case that futures candles and marks are available from exchanges, but the funding rates are not. This breaks backtesting for anything but the most recent months. This PR introduces the `futures_funding_rate` config option that will substitute a user-specified value to allow backtesting to work. Realistically, this should be set to 0.

## Quick changelog

- Change history_utils.py to support the case that if hist.empty isn't true, allow creation of an empty dataframe to hold funding rates
- Change backtesting.py to detect when no rates are available and populate the empty dataframe with the user-specified value
- amend docs
