### PR TITLE
Should exit list

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -530,8 +530,9 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Exit-reason does not explain if a trade was positive or negative, just what triggered the exit (this can look odd if negative ROI values are used)
 - Evaluation sequence (if multiple signals happen on the same candle)
   - Exit-signal
-  - ROI (if not stoploss)
   - Stoploss
+  - ROI
+  - Trailing stoploss
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.
 Also, keep in mind that past results don't guarantee future success.

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -563,6 +563,14 @@ class AwesomeStrategy(IStrategy):
 
 `confirm_trade_exit()` can be used to abort a trade exit (sell) at the latest second (maybe because the price is not what we expect).
 
+`confirm_trade_exit()` may be called multiple times within one iteration for the same trade if different exit-reasons apply.
+The exit-reasons (if applicable) will be in the following sequence:
+
+* `exit_signal` / `custom_exit`
+* `stop_loss`
+* `roi`
+* `trailing_stop_loss`
+
 ``` python
 from freqtrade.persistence import Trade
 
@@ -604,6 +612,9 @@ class AwesomeStrategy(IStrategy):
         return True
 
 ```
+
+!!! Warning
+    `confirm_trade_exit()` can prevent stoploss exits, causing significant losses as this would ignore stoploss exits.
 
 ## Adjust trade position
 

--- a/freqtrade/enums/exitchecktuple.py
+++ b/freqtrade/enums/exitchecktuple.py
@@ -15,3 +15,6 @@ class ExitCheckTuple:
     @property
     def exit_flag(self):
         return self.exit_type != ExitType.NONE
+
+    def __eq__(self, other):
+        return self.exit_type == other.exit_type and self.exit_reason == other.exit_reason

--- a/freqtrade/enums/exitchecktuple.py
+++ b/freqtrade/enums/exitchecktuple.py
@@ -18,3 +18,6 @@ class ExitCheckTuple:
 
     def __eq__(self, other):
         return self.exit_type == other.exit_type and self.exit_reason == other.exit_reason
+
+    def __repr__(self):
+        return f"ExitCheckTuple({self.exit_type}, {self.exit_reason})"

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1117,7 +1117,7 @@ class FreqtradeBot(LoggingMixin):
         for should_exit in exits:
             if should_exit.exit_flag:
                 logger.info(f'Exit for {trade.pair} detected. Reason: {should_exit.exit_type}'
-                            f'Tag: {exit_tag if exit_tag is not None else "None"}')
+                            f'{f" Tag: {exit_tag}" if exit_tag is not None else ""}')
                 exited = self.execute_trade_exit(trade, exit_rate, should_exit, exit_tag=exit_tag)
                 if exited:
                     return True
@@ -1407,7 +1407,7 @@ class FreqtradeBot(LoggingMixin):
         :param trade: Trade instance
         :param limit: limit rate for the sell order
         :param exit_check: CheckTuple with signal and reason
-        :return: True if it succeeds (supported) False (not supported)
+        :return: True if it succeeds False
         """
         trade.funding_fees = self.exchange.get_funding_fees(
             pair=trade.pair,
@@ -1454,7 +1454,7 @@ class FreqtradeBot(LoggingMixin):
                 time_in_force=time_in_force, exit_reason=exit_reason,
                 sell_reason=exit_reason,  # sellreason -> compatibility
                 current_time=datetime.now(timezone.utc)):
-            logger.info(f"User requested abortion of exiting {trade.pair}")
+            logger.info(f"User requested abortion of {trade.pair} exit.")
             return False
 
         try:

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -942,15 +942,22 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         # Sequence:
         # Exit-signal
-        # ROI (if not stoploss)
         # Stoploss
-        if roi_reached and stoplossflag.exit_type != ExitType.STOP_LOSS:
+        # ROI
+        # Trailing stoploss
+
+        if stoplossflag.exit_type == ExitType.STOP_LOSS:
+
+            logger.debug(f"{trade.pair} - Stoploss hit. exit_type={stoplossflag.exit_type}")
+            exits.append(stoplossflag)
+
+        if roi_reached:
             logger.debug(f"{trade.pair} - Required profit reached. exit_type=ExitType.ROI")
             exits.append(ExitCheckTuple(exit_type=ExitType.ROI))
 
-        if stoplossflag.exit_flag:
+        if stoplossflag.exit_type == ExitType.TRAILING_STOP_LOSS:
 
-            logger.debug(f"{trade.pair} - Stoploss hit. exit_type={stoplossflag.exit_type}")
+            logger.debug(f"{trade.pair} - Trailing stoploss hit.")
             exits.append(stoplossflag)
 
         return exits

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -495,34 +495,33 @@ def test_custom_exit(default_conf, fee, caplog) -> None:
                                enter=False, exit_=False,
                                low=None, high=None)
 
-    assert res.exit_flag is False
-    assert res.exit_type == ExitType.NONE
+    assert res == []
 
     strategy.custom_exit = MagicMock(return_value=True)
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
                                low=None, high=None)
-    assert res.exit_flag is True
-    assert res.exit_type == ExitType.CUSTOM_EXIT
-    assert res.exit_reason == 'custom_exit'
+    assert res[0].exit_flag is True
+    assert res[0].exit_type == ExitType.CUSTOM_EXIT
+    assert res[0].exit_reason == 'custom_exit'
 
     strategy.custom_exit = MagicMock(return_value='hello world')
 
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
                                low=None, high=None)
-    assert res.exit_type == ExitType.CUSTOM_EXIT
-    assert res.exit_flag is True
-    assert res.exit_reason == 'hello world'
+    assert res[0].exit_type == ExitType.CUSTOM_EXIT
+    assert res[0].exit_flag is True
+    assert res[0].exit_reason == 'hello world'
 
     caplog.clear()
     strategy.custom_exit = MagicMock(return_value='h' * 100)
     res = strategy.should_exit(trade, 1, now,
                                enter=False, exit_=False,
                                low=None, high=None)
-    assert res.exit_type == ExitType.CUSTOM_EXIT
-    assert res.exit_flag is True
-    assert res.exit_reason == 'h' * 64
+    assert res[0].exit_type == ExitType.CUSTOM_EXIT
+    assert res[0].exit_flag is True
+    assert res[0].exit_reason == 'h' * 64
     assert log_has_re('Custom exit reason returned from custom_exit is too long.*', caplog)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,8 +52,8 @@ def test_may_execute_exit_stoploss_on_exchange_multi(default_conf, ticker, fee,
         side_effect=[stoploss_order_closed, stoploss_order_open, stoploss_order_open])
     # Sell 3rd trade (not called for the first trade)
     should_sell_mock = MagicMock(side_effect=[
-        ExitCheckTuple(exit_type=ExitType.NONE),
-        ExitCheckTuple(exit_type=ExitType.EXIT_SIGNAL)]
+        [],
+        [ExitCheckTuple(exit_type=ExitType.EXIT_SIGNAL)]]
     )
     cancel_order_mock = MagicMock()
     mocker.patch('freqtrade.exchange.Binance.stoploss', stoploss)
@@ -160,11 +160,11 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, mocker, balance_rati
         _notify_exit=MagicMock(),
     )
     should_sell_mock = MagicMock(side_effect=[
-        ExitCheckTuple(exit_type=ExitType.NONE),
-        ExitCheckTuple(exit_type=ExitType.EXIT_SIGNAL),
-        ExitCheckTuple(exit_type=ExitType.NONE),
-        ExitCheckTuple(exit_type=ExitType.NONE),
-        ExitCheckTuple(exit_type=ExitType.NONE)]
+        [],
+        [ExitCheckTuple(exit_type=ExitType.EXIT_SIGNAL)],
+        [],
+        [],
+        []]
     )
     mocker.patch("freqtrade.strategy.interface.IStrategy.should_exit", should_sell_mock)
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Evaluate multiple exit reasons in sequence, allowing `custom_trade_exit()` to reject selected onces, while still receiving the other exits.

closes #5020

## Quick changelog

- `should_exit()` now returns an array of exits, which are evaluated in sequence (the first successful will exit the trade).
