### PR TITLE
Leverage tiers async

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,9 +78,21 @@ def get_args(args):
 
 
 # Source: https://stackoverflow.com/questions/29881236/how-to-mock-asyncio-coroutines
-def get_mock_coro(return_value):
+# TODO: This should be replaced with AsyncMock once support for python 3.7 is dropped.
+def get_mock_coro(return_value=None, side_effect=None):
     async def mock_coro(*args, **kwargs):
-        return return_value
+        if side_effect:
+            if isinstance(side_effect, list):
+                effect = side_effect.pop(0)
+            else:
+                effect = side_effect
+            if isinstance(effect, Exception):
+                raise effect
+            if callable(effect):
+                return effect(*args, **kwargs)
+            return effect
+        else:
+            return return_value
 
     return Mock(wraps=mock_coro)
 

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -6,7 +6,7 @@ import pytest
 from freqtrade.enums import MarginMode, TradingMode
 from freqtrade.enums.candletype import CandleType
 from freqtrade.exchange.exchange import timeframe_to_minutes
-from tests.conftest import get_patched_exchange
+from tests.conftest import get_mock_coro, get_patched_exchange
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
 
 
@@ -273,7 +273,7 @@ def test_load_leverage_tiers_okx(default_conf, mocker, markets):
         'fetchLeverageTiers': False,
         'fetchMarketLeverageTiers': True,
     })
-    api_mock.fetch_market_leverage_tiers = MagicMock(side_effect=[
+    api_mock.fetch_market_leverage_tiers = get_mock_coro(side_effect=[
         [
             {
                 'tier': 1,


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Load okx leverage tiers async

@samgermain maybe you could have a look at this (or rather - at the ratelimits for this) - if you run `freqtrade list-pairs --exchange okx --trading-mode futures` with this (requires a minimal exchange defining stake_currency to USDT).

I get something between 5 and 7 DDOS errors during this load - which suggests that the weight for this endpoint is slightly wrong.