### PR TITLE
Cancel orders which can no longer be found after several days

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -4,7 +4,7 @@ Freqtrade is the main module of this bot. It contains the class Freqtrade()
 import copy
 import logging
 import traceback
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 from math import isclose
 from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple
@@ -301,6 +301,15 @@ class FreqtradeBot(LoggingMixin):
 
                 self.update_trade_state(order.trade, order.order_id, fo,
                                         stoploss_order=(order.ft_order_side == 'stoploss'))
+
+            except InvalidOrderException as e:
+                logger.warning(f"Error updating Order {order.order_id} due to {e}.")
+                if order.order_date_utc - timedelta(days=5) < datetime.now(timezone.utc):
+                    logger.warning(
+                        "Order is older than 5 days. Assuming order was fully cancelled.")
+                    fo = order.to_ccxt_object()
+                    fo['status'] = 'canceled'
+                    self.handle_timedout_order(fo, order.trade)
 
             except ExchangeError as e:
 

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -4802,9 +4802,18 @@ def test_startup_update_open_orders(mocker, default_conf_usdt, fee, caplog, is_s
     assert len(Order.get_open_orders()) == 2
 
     caplog.clear()
-    mocker.patch('freqtrade.exchange.Exchange.fetch_order', side_effect=InvalidOrderException)
+    mocker.patch('freqtrade.exchange.Exchange.fetch_order', side_effect=ExchangeError)
     freqtrade.startup_update_open_orders()
     assert log_has_re(r"Error updating Order .*", caplog)
+
+    mocker.patch('freqtrade.exchange.Exchange.fetch_order', side_effect=InvalidOrderException)
+    hto_mock = mocker.patch('freqtrade.freqtradebot.FreqtradeBot.handle_timedout_order')
+    # Orders which are no longer found after X days should be assumed as canceled.
+    freqtrade.startup_update_open_orders()
+    assert log_has_re(r"Order is older than \d days.*", caplog)
+    assert hto_mock.call_count == 2
+    assert hto_mock.call_args_list[0][0][0]['status'] == 'canceled'
+    assert hto_mock.call_args_list[1][0][0]['status'] == 'canceled'
 
 
 @pytest.mark.usefixtures("init_persistence")


### PR DESCRIPTION
## Summary
After a longer "down" period, orders may no longer be found via the API as some exchanges delete cancelled, unfilled orders.

As such, this can lead to repeated "order not found" messages (in a loop) - effectively blocking this trade until manual handling.

As such, the new handling will be:
if the order is older than 5 days, and the order is no longer available via the API, assume the order as fully cancelled.
This may also delete the trade - and will use regular order cancel notifications.