### PR TITLE
give extra info on rate origin for confirm_trade_*

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -550,7 +550,7 @@ class AwesomeStrategy(IStrategy):
         :param pair: Pair that's about to be bought/shorted.
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in target (base) currency that's going to be traded.
-        :param rate: Rate that's going to be used when using limit orders
+        :param rate: Rate that's going to be used when using limit orders or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param current_time: datetime object, containing the current datetime
         :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
@@ -599,7 +599,7 @@ class AwesomeStrategy(IStrategy):
         :param trade: trade object.
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in base currency.
-        :param rate: Rate that's going to be used when using limit orders
+        :param rate: Rate that's going to be used when using limit orders or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param exit_reason: Exit reason.
             Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -550,7 +550,8 @@ class AwesomeStrategy(IStrategy):
         :param pair: Pair that's about to be bought/shorted.
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in target (base) currency that's going to be traded.
-        :param rate: Rate that's going to be used when using limit orders or current rate for market orders.
+        :param rate: Rate that's going to be used when using limit orders 
+                     or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param current_time: datetime object, containing the current datetime
         :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
@@ -599,7 +600,8 @@ class AwesomeStrategy(IStrategy):
         :param trade: trade object.
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in base currency.
-        :param rate: Rate that's going to be used when using limit orders or current rate for market orders.
+        :param rate: Rate that's going to be used when using limit orders
+                     or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param exit_reason: Exit reason.
             Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -289,6 +289,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in target (base) currency that's going to be traded.
         :param rate: Rate that's going to be used when using limit orders
+                     or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param current_time: datetime object, containing the current datetime
         :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
@@ -316,6 +317,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param order_type: Order type (as configured in order_types). usually limit or market.
         :param amount: Amount in base currency.
         :param rate: Rate that's going to be used when using limit orders
+                     or current rate for market orders.
         :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
         :param exit_reason: Exit reason.
             Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',

--- a/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/subtemplates/strategy_methods_advanced.j2
@@ -161,6 +161,7 @@ def confirm_trade_entry(self, pair: str, order_type: str, amount: float, rate: f
     :param order_type: Order type (as configured in order_types). usually limit or market.
     :param amount: Amount in target (base) currency that's going to be traded.
     :param rate: Rate that's going to be used when using limit orders
+                 or current rate for market orders.
     :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
     :param current_time: datetime object, containing the current datetime
     :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.
@@ -188,6 +189,7 @@ def confirm_trade_exit(self, pair: str, trade: 'Trade', order_type: str, amount:
     :param order_type: Order type (as configured in order_types). usually limit or market.
     :param amount: Amount in base currency.
     :param rate: Rate that's going to be used when using limit orders
+                 or current rate for market orders.
     :param time_in_force: Time in force. Defaults to GTC (Good-til-cancelled).
     :param exit_reason: Exit reason.
         Can be any of ['roi', 'stop_loss', 'stoploss_on_exchange', 'trailing_stop_loss',


### PR DESCRIPTION
Documentation :
-> Take into consideration the market buy/sell rates use case for the confirm_trade_entry and confirm_trade_exit callback function explanation