### PR TITLE
remove `random_state` condition when sampling random points

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -436,8 +436,7 @@ class Hyperopt:
                 asked = unique_list(self.opt.ask(n_points=n_points * 5))
                 is_random = [False for _ in range(len(asked))]
             else:
-                asked = unique_list(self.opt.space.rvs(
-                    n_samples=n_points * 5, random_state=self.random_state + i))
+                asked = unique_list(self.opt.space.rvs(n_samples=n_points * 5))
                 is_random = [True for _ in range(len(asked))]
             is_random_non_tried += [rand for x, rand in zip(asked, is_random)
                                     if x not in self.opt.Xi


### PR DESCRIPTION
## Summary

remove `random_state` condition otherwise the random sample always draws the same set of points at each iteration

## Quick changelog

- don't pass `random_state` argument to self.opt.space.rvs

## What's new?

