### PR TITLE
replace the word "abortion" with "denied" in log messages

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -634,7 +634,7 @@ class FreqtradeBot(LoggingMixin):
                 pair=pair, order_type=order_type, amount=amount, rate=enter_limit_requested,
                 time_in_force=time_in_force, current_time=datetime.now(timezone.utc),
                 entry_tag=enter_tag, side=trade_side):
-            logger.info(f"User rejected entry for {pair}.")
+            logger.info(f"User denied entry for {pair}.")
             return False
         order = self.exchange.create_order(
             pair=pair,
@@ -1465,7 +1465,7 @@ class FreqtradeBot(LoggingMixin):
                 time_in_force=time_in_force, exit_reason=exit_reason,
                 sell_reason=exit_reason,  # sellreason -> compatibility
                 current_time=datetime.now(timezone.utc)):
-            logger.info(f"User rejected exit for {trade.pair}.")
+            logger.info(f"User denied exit for {trade.pair}.")
             return False
 
         try:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -634,7 +634,7 @@ class FreqtradeBot(LoggingMixin):
                 pair=pair, order_type=order_type, amount=amount, rate=enter_limit_requested,
                 time_in_force=time_in_force, current_time=datetime.now(timezone.utc),
                 entry_tag=enter_tag, side=trade_side):
-            logger.info(f"User requested abortion of buying {pair}")
+            logger.info(f"User rejected entry for {pair}.")
             return False
         order = self.exchange.create_order(
             pair=pair,
@@ -1465,7 +1465,7 @@ class FreqtradeBot(LoggingMixin):
                 time_in_force=time_in_force, exit_reason=exit_reason,
                 sell_reason=exit_reason,  # sellreason -> compatibility
                 current_time=datetime.now(timezone.utc)):
-            logger.info(f"User requested abortion of {trade.pair} exit.")
+            logger.info(f"User rejected exit for {trade.pair}.")
             return False
 
         try:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Replace the word "abortion" with "denied" in log messages (and improve consistency with new entry/exit terminology). 

The word "abortion" is not used properly here, I can't even find a secondary definition for "abortion" that would fit. The principle connotation for abortion is clearly medical/political and thus, improper here. Further, the grammar itself of this message is bizarre. 

Perhaps we could replace "User requested abortion of buying PAIR" with "User aborted buying PAIR." But if we are going to make the change, we might as well increase the accuracy/consistency. 

The log info stems from `confirm_trade_entry/exit()`. If the confirm_trade_entry/exit returns False, then it is "denying" the entry.

So it would make most sense to say the user "denied", the entry/exit.

Either way, the use if `buying` in the message is certainly inaccurate now that we are sticking to entry/exit terminology with the new short/long features.

Let me know your thoughts. 

Solve the issue: #___

## What's new?

```bash
2022-07-05 10:49:28,417 - freqtrade.freqtradebot - INFO - User requested abortion of buying EGLD/USDT
```

Becomes

```bash
2022-07-05 10:49:28,417 - freqtrade.freqtradebot - INFO - User denied entry for EGLD/USDT.
```


