### PR TITLE
Gateio fee fix

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1644,11 +1644,7 @@ class Exchange:
             return fee.get('rate')
         fee_curr = fee.get('currency')
         if fee_curr is None:
-            # Auto-currency only in futures mode
-            if self.trading_mode == TradingMode.FUTURES:
-                fee_curr = self.get_pair_quote_currency(symbol)
-            else:
-                return None
+            return None
         # Calculate fee based on order details
         if fee_curr == self.get_pair_base_currency(symbol):
             # Base currency - divide by amount

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1616,7 +1616,8 @@ class Exchange:
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
 
-    def order_has_fee(self, order: Dict) -> bool:
+    @staticmethod
+    def order_has_fee(order: Dict) -> bool:
         """
         Verifies if the passed in order dict has the needed keys to extract fees,
         and that these keys (currency, cost) are not empty.
@@ -1627,8 +1628,7 @@ class Exchange:
             return False
         return ('fee' in order and order['fee'] is not None
                 and (order['fee'].keys() >= {'currency', 'cost'})
-                and (order['fee']['currency'] is not None
-                     or self.trading_mode == TradingMode.FUTURES)
+                and order['fee']['currency'] is not None
                 and order['fee']['cost'] is not None
                 )
 

--- a/freqtrade/exchange/gateio.py
+++ b/freqtrade/exchange/gateio.py
@@ -32,7 +32,8 @@ class Gateio(Exchange):
     }
 
     _ft_has_futures: Dict = {
-        "needs_trading_fees": True
+        "needs_trading_fees": True,
+        "fee_cost_in_contracts": False,  # Set explicitly to false for clarity
     }
 
     _supported_trading_mode_margin_pairs: List[Tuple[TradingMode, MarginMode]] = [

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -28,6 +28,7 @@ class Okx(Exchange):
     }
     _ft_has_futures: Dict = {
         "tickers_have_quoteVolume": False,
+        "fee_cost_in_contracts": True,
     }
 
     _supported_trading_mode_margin_pairs: List[Tuple[TradingMode, MarginMode]] = [

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1777,7 +1777,6 @@ class FreqtradeBot(LoggingMixin):
         fee_abs = 0.0
         fee_cost = 0.0
         trade_base_currency = self.exchange.get_pair_base_currency(trade.pair)
-
         fee_rate_array: List[float] = []
         for exectrade in trades:
             amount += exectrade['amount']

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1777,12 +1777,19 @@ class FreqtradeBot(LoggingMixin):
         fee_abs = 0.0
         fee_cost = 0.0
         trade_base_currency = self.exchange.get_pair_base_currency(trade.pair)
+
         fee_rate_array: List[float] = []
         for exectrade in trades:
             amount += exectrade['amount']
             if self.exchange.order_has_fee(exectrade):
+                # Prefer singular fee
+                fees = [exectrade['fee']]
+            else:
+                fees = exectrade.get('fees', [])
+            for fee in fees:
+
                 fee_cost_, fee_currency, fee_rate_ = self.exchange.extract_cost_curr_rate(
-                    exectrade['fee'], exectrade['symbol'], exectrade['cost'], exectrade['amount']
+                    fee, exectrade['symbol'], exectrade['cost'], exectrade['amount']
                 )
                 fee_cost += fee_cost_
                 if fee_rate_ is not None:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1742,7 +1742,8 @@ class FreqtradeBot(LoggingMixin):
         trade_base_currency = self.exchange.get_pair_base_currency(trade.pair)
         # use fee from order-dict if possible
         if self.exchange.order_has_fee(order):
-            fee_cost, fee_currency, fee_rate = self.exchange.extract_cost_curr_rate(order)
+            fee_cost, fee_currency, fee_rate = self.exchange.extract_cost_curr_rate(
+                order['fee'], order['symbol'], order['cost'], order_obj.safe_filled)
             logger.info(f"Fee for Trade {trade} [{order_obj.ft_order_side}]: "
                         f"{fee_cost:.8g} {fee_currency} - rate: {fee_rate}")
             if fee_rate is None or fee_rate < 0.02:
@@ -1780,7 +1781,9 @@ class FreqtradeBot(LoggingMixin):
         for exectrade in trades:
             amount += exectrade['amount']
             if self.exchange.order_has_fee(exectrade):
-                fee_cost_, fee_currency, fee_rate_ = self.exchange.extract_cost_curr_rate(exectrade)
+                fee_cost_, fee_currency, fee_rate_ = self.exchange.extract_cost_curr_rate(
+                    exectrade['fee'], exectrade['symbol'], exectrade['cost'], exectrade['amount']
+                )
                 fee_cost += fee_cost_
                 if fee_rate_ is not None:
                     fee_rate_array.append(fee_rate_)

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -821,7 +821,7 @@ class LocalTrade():
             self.open_rate = total_stake / total_amount
             self.stake_amount = total_stake / (self.leverage or 1.0)
             self.amount = total_amount
-            self.fee_open_cost = self.fee_open * self.stake_amount
+            self.fee_open_cost = self.fee_open * total_stake
             self.recalc_open_trade_value()
             if self.stop_loss_pct is not None and self.open_rate is not None:
                 self.adjust_stop_loss(self.open_rate, self.stop_loss_pct)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.0
 pandas==1.4.3
 pandas-ta==0.3.14b
 
-ccxt==1.89.96
+ccxt==1.90.38
 # Pin cryptography for now due to rust build errors with piwheels
 cryptography==37.0.2
 aiohttp==3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.0
 pandas==1.4.3
 pandas-ta==0.3.14b
 
-ccxt==1.90.38
+ccxt==1.90.40
 # Pin cryptography for now due to rust build errors with piwheels
 cryptography==37.0.2
 aiohttp==3.8.1

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3544,7 +3544,7 @@ def test_order_has_fee(order, expected) -> None:
 def test_extract_cost_curr_rate(mocker, default_conf, order, expected) -> None:
     mocker.patch('freqtrade.exchange.Exchange.calculate_fee_rate', MagicMock(return_value=0.01))
     ex = get_patched_exchange(mocker, default_conf)
-    assert ex.extract_cost_curr_rate(order) == expected
+    assert ex.extract_cost_curr_rate(order['fee'], order['symbol'], cost=20, amount=1) == expected
 
 
 @pytest.mark.parametrize("order,unknown_fee_rate,expected", [
@@ -3590,7 +3590,8 @@ def test_calculate_fee_rate(mocker, default_conf, order, expected, unknown_fee_r
 
     ex = get_patched_exchange(mocker, default_conf)
 
-    assert ex.calculate_fee_rate(order) == expected
+    assert ex.calculate_fee_rate(order['fee'], order['symbol'],
+                                 cost=order['cost'], amount=order['amount']) == expected
 
 
 @pytest.mark.parametrize('retrycount,max_retries,expected', [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3529,8 +3529,10 @@ def test_market_is_active(market, expected_result) -> None:
     ({'fee': {'currency': 'ETH/BTC', 'cost': None}}, False),
     ({'fee': {'currency': 'ETH/BTC', 'cost': 0.01}}, True),
 ])
-def test_order_has_fee(order, expected) -> None:
-    assert Exchange.order_has_fee(order) == expected
+def test_order_has_fee(mocker, default_conf, order, expected) -> None:
+    ex = get_patched_exchange(mocker, default_conf)
+
+    assert ex.order_has_fee(order) == expected
 
 
 @pytest.mark.parametrize("order,expected", [

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3584,6 +3584,9 @@ def test_extract_cost_curr_rate(mocker, default_conf, order, expected) -> None:
       'fee': {'currency': 'POINT', 'cost': 2.0, 'rate': None}}, 1, 4.0),
     ({'symbol': 'POINT/BTC', 'amount': 0.04, 'cost': 0.5,
       'fee': {'currency': 'POINT', 'cost': 2.0, 'rate': None}}, 2, 8.0),
+    # Missing currency
+    ({'symbol': 'ETH/BTC', 'amount': 0.04, 'cost': 0.05,
+        'fee': {'currency': None, 'cost': 0.005}}, None, None),
 ])
 def test_calculate_fee_rate(mocker, default_conf, order, expected, unknown_fee_rate) -> None:
     mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', return_value={'last': 0.081})

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3529,10 +3529,8 @@ def test_market_is_active(market, expected_result) -> None:
     ({'fee': {'currency': 'ETH/BTC', 'cost': None}}, False),
     ({'fee': {'currency': 'ETH/BTC', 'cost': 0.01}}, True),
 ])
-def test_order_has_fee(mocker, default_conf, order, expected) -> None:
-    ex = get_patched_exchange(mocker, default_conf)
-
-    assert ex.order_has_fee(order) == expected
+def test_order_has_fee(order, expected) -> None:
+    assert Exchange.order_has_fee(order) == expected
 
 
 @pytest.mark.parametrize("order,expected", [


### PR DESCRIPTION
## Summary
Gateio Fees do not use contract size. 
The logic in ccxt for this changed recently, which caused an endless loop of "could not find fees".
This PR aims to fix that.

Closes #7043
closes #7042
