### PR TITLE
fix asyncio.set_event_loop() missetting when FreqAI is active

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -482,6 +482,7 @@ class Exchange:
 
     def reload_markets(self) -> None:
         """Reload markets both sync and async if refresh interval has passed """
+        asyncio.set_event_loop(self.loop) 
         # Check whether markets have to be reloaded
         if (self._last_markets_refresh > 0) and (
                 self._last_markets_refresh + self.markets_refresh_interval

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -482,7 +482,7 @@ class Exchange:
 
     def reload_markets(self) -> None:
         """Reload markets both sync and async if refresh interval has passed """
-        asyncio.set_event_loop(self.loop) 
+        asyncio.set_event_loop(self.loop)
         # Check whether markets have to be reloaded
         if (self._last_markets_refresh > 0) and (
                 self._last_markets_refresh + self.markets_refresh_interval


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

FreqAI resets `asyncio.set_event_loop` when it creates a temporary secondary exchange. When the primary exchange calls `reload_markets()` the incorrect event loop is set, leading to the error:

`ValueError: The future belongs to a different loop than the one specified as the loop argument`

We solve this by ensuring the proper event loop is set at the start of `reload_markets()`:

```python
    def reload_markets(self) -> None:
        """Reload markets both sync and async if refresh interval has passed """
        asyncio.set_event_loop(self.loop) 
        # Check whether markets have to be reloaded
        if (self._last_markets_refresh > 0) and (
                self._last_markets_refresh + self.markets_refresh_interval
                > arrow.utcnow().int_timestamp):
            return None
        logger.debug("Performing scheduled market reload..")
        try:
            self._markets = self._api.load_markets(reload=True)
            # Also reload async markets to avoid issues with newly listed pairs
            self._load_async_markets(reload=True)
            self._last_markets_refresh = arrow.utcnow().int_timestamp
            self.fill_leverage_tiers()
        except ccxt.BaseError:
            logger.exception("Could not reload markets.")
```

