### PR TITLE
Sorted whitelist in rpc

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -884,7 +884,7 @@ class RPC:
         """ Returns the currently active whitelist"""
         res = {'method': self._freqtrade.pairlists.name_list,
                'length': len(self._freqtrade.active_pair_whitelist),
-               'whitelist': self._freqtrade.active_pair_whitelist
+               'whitelist': sorted(self._freqtrade.active_pair_whitelist)
                }
         return res
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -1183,7 +1183,7 @@ def test_rpc_whitelist(mocker, default_conf) -> None:
     ret = rpc._rpc_whitelist()
     assert len(ret['method']) == 1
     assert 'StaticPairList' in ret['method']
-    assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']
+    assert ret['whitelist'] == sorted(default_conf['exchange']['pair_whitelist'])
 
 
 def test_rpc_whitelist_dynamic(mocker, default_conf) -> None:
@@ -1199,7 +1199,7 @@ def test_rpc_whitelist_dynamic(mocker, default_conf) -> None:
     assert len(ret['method']) == 1
     assert 'VolumePairList' in ret['method']
     assert ret['length'] == 4
-    assert ret['whitelist'] == default_conf['exchange']['pair_whitelist']
+    assert ret['whitelist'] == sorted(default_conf['exchange']['pair_whitelist'])
 
 
 def test_rpc_blacklist(mocker, default_conf) -> None:


### PR DESCRIPTION
## Summary
Added `sorted()` to line 883 so that when executing `/whitelist` command the pairings will be in alphabetical order making it faster to manually identify whether the pair you are confirming/looking for is present.

## Quick changelog
883: `'whitelist': sorted(self._freqtrade.active_pair_whitelist)`

## For the future
Separate the quote asset that's repeated `n` pairing times, on the assumption that only one quote asset can be used per freqtrade instance to save the redundant data taking up so much space.