### PR TITLE
Optional /whitelist args - sorted, nobase

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -187,7 +187,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/stats` | Shows Wins / losses by Exit reason as well as Avg. holding durations for buys and sells
 | `/exits` | Shows Wins / losses by Exit reason as well as Avg. holding durations for buys and sells
 | `/entries` | Shows Wins / losses by Exit reason as well as Avg. holding durations for buys and sells
-| `/whitelist` | Show the current whitelist
+| `/whitelist [sorted] [baseonly]` | Show the current whitelist. Optionally display in alphabetical order and/or with just the base currency of each pairing.
 | `/blacklist [pair]` | Show the current blacklist, or adds a pair to the blacklist.
 | `/edge` | Show validated pairs by Edge if it is enabled.
 | `/help` | Show help message

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1371,7 +1371,7 @@ class Telegram(RPCHandler):
             if context.args:
                 if "sorted" in context.args:
                     whitelist['whitelist'] = sorted(whitelist['whitelist'])
-                if "nobase" in context.args:
+                if "baseonly" in context.args:
                     whitelist['whitelist'] = [pair.split("/")[0] for pair in whitelist['whitelist']]
 
             message = f"Using whitelist `{whitelist['method']}` with {whitelist['length']} pairs\n"
@@ -1493,8 +1493,8 @@ class Telegram(RPCHandler):
             "*/fx <trade_id>|all:* `Alias to /forceexit`\n"
             f"{force_enter_text if self._config.get('force_entry_enable', False) else ''}"
             "*/delete <trade_id>:* `Instantly delete the given trade in the database`\n"
-            "*/whitelist [sorted] [nobase]:* `Show current whitelist. Optionally in "
-            "order and/or without the base currency.`\n"
+            "*/whitelist [sorted] [baseonly]:* `Show current whitelist. Optionally in "
+            "order and/or only displaying the base currency of each pairing.`\n"
             "*/blacklist [pair]:* `Show current blacklist, or adds one or more pairs "
             "to the blacklist.` \n"
             "*/blacklist_delete [pairs]| /bl_delete [pairs]:* "

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1368,6 +1368,12 @@ class Telegram(RPCHandler):
         try:
             whitelist = self._rpc._rpc_whitelist()
 
+            if context.args:
+                if "sorted" in context.args:
+                    whitelist['whitelist'] = sorted(whitelist['whitelist'])
+                if "nobase" in context.args:
+                    whitelist['whitelist'] = [pair.split("/")[0] for pair in whitelist['whitelist']]
+
             message = f"Using whitelist `{whitelist['method']}` with {whitelist['length']} pairs\n"
             message += f"`{', '.join(whitelist['whitelist'])}`"
 
@@ -1487,7 +1493,8 @@ class Telegram(RPCHandler):
             "*/fx <trade_id>|all:* `Alias to /forceexit`\n"
             f"{force_enter_text if self._config.get('force_entry_enable', False) else ''}"
             "*/delete <trade_id>:* `Instantly delete the given trade in the database`\n"
-            "*/whitelist:* `Show current whitelist` \n"
+            "*/whitelist [sorted] [nobase]:* `Show current whitelist. Optionally in "
+            "order and/or without the base currency.`\n"
             "*/blacklist [pair]:* `Show current blacklist, or adds one or more pairs "
             "to the blacklist.` \n"
             "*/blacklist_delete [pairs]| /bl_delete [pairs]:* "
@@ -1524,7 +1531,7 @@ class Telegram(RPCHandler):
             "*/weekly <n>:* `Shows statistics per week, over the last n weeks`\n"
             "*/monthly <n>:* `Shows statistics per month, over the last n months`\n"
             "*/stats:* `Shows Wins / losses by Sell reason as well as "
-            "Avg. holding durationsfor buys and sells.`\n"
+            "Avg. holding durations for buys and sells.`\n"
             "*/help:* `This help message`\n"
             "*/version:* `Show version`"
             )

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1461,20 +1461,24 @@ def test_whitelist_static(default_conf, update, mocker) -> None:
     context = MagicMock()
     context.args = ['sorted']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
 
     context = MagicMock()
-    context.args = ['nobase']
+    context.args = ['baseonly']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
-    context.args = ['nobase', 'sorted']
+    context.args = ['baseonly', 'sorted']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
+
 
 def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
@@ -1491,20 +1495,24 @@ def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     context = MagicMock()
     context.args = ['sorted']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
 
     context = MagicMock()
-    context.args = ['nobase']
+    context.args = ['baseonly']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
-    context.args = ['nobase', 'sorted']
+    context.args = ['baseonly', 'sorted']
     msg_mock.reset_mock()
+    telegram._whitelist(update=update, context=MagicMock())
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
+
 
 def test_blacklist_static(default_conf, update, mocker) -> None:
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1461,21 +1461,21 @@ def test_whitelist_static(default_conf, update, mocker) -> None:
     context = MagicMock()
     context.args = ['sorted']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
+    telegram._whitelist(update=update, context=context)
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
-            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
+            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
     context.args = ['baseonly']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
+    telegram._whitelist(update=update, context=context)
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
     context.args = ['baseonly', 'sorted']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
+    telegram._whitelist(update=update, context=context)
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
 
@@ -1495,22 +1495,22 @@ def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     context = MagicMock()
     context.args = ['sorted']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
-    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
-            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
+    telegram._whitelist(update=update, context=context)
+    assert ("Using whitelist `['VolumePairList']` with 4 pairs\n"
+            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
     context.args = ['baseonly']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
-    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+    telegram._whitelist(update=update, context=context)
+    assert ("Using whitelist `['VolumePairList']` with 4 pairs\n"
             "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
 
     context = MagicMock()
     context.args = ['baseonly', 'sorted']
     msg_mock.reset_mock()
-    telegram._whitelist(update=update, context=MagicMock())
-    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+    telegram._whitelist(update=update, context=context)
+    assert ("Using whitelist `['VolumePairList']` with 4 pairs\n"
             "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
 
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1458,6 +1458,23 @@ def test_whitelist_static(default_conf, update, mocker) -> None:
     assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
             "`ETH/BTC, LTC/BTC, XRP/BTC, NEO/BTC`" in msg_mock.call_args_list[0][0][0])
 
+    context = MagicMock()
+    context.args = ['sorted']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
+
+    context = MagicMock()
+    context.args = ['nobase']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
+
+    context = MagicMock()
+    context.args = ['nobase', 'sorted']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
 
 def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', MagicMock(return_value=True))
@@ -1471,6 +1488,23 @@ def test_whitelist_dynamic(default_conf, update, mocker) -> None:
     assert ("Using whitelist `['VolumePairList']` with 4 pairs\n"
             "`ETH/BTC, LTC/BTC, XRP/BTC, NEO/BTC`" in msg_mock.call_args_list[0][0][0])
 
+    context = MagicMock()
+    context.args = ['sorted']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH/BTC, LTC/BTC, NEO/BTC, XRP/BTC`" in sorted(msg_mock.call_args_list[0][0][0]))
+
+    context = MagicMock()
+    context.args = ['nobase']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH, LTC, XRP, NEO`" in msg_mock.call_args_list[0][0][0])
+
+    context = MagicMock()
+    context.args = ['nobase', 'sorted']
+    msg_mock.reset_mock()
+    assert ("Using whitelist `['StaticPairList']` with 4 pairs\n"
+            "`ETH, LTC, NEO, XRP`" in msg_mock.call_args_list[0][0][0])
 
 def test_blacklist_static(default_conf, update, mocker) -> None:
 


### PR DESCRIPTION
## Summary
Added two optional arguments to `/whitelist` command in Telegram:

- `sorted` for alphabetical order
- `nobase` to remove the base currency

## Quick changelog
- `/whitelist sorted` for alphabetical whitelist
- `/whitelist nobase` to remove the base currency from each pairing in the whitelist
- `/whitelist sorted nobase` for an alphabetical whitelist without base currencies listed

## Other notes
I gave the testing a go but it might need further adjustment? 😅

## Example 
<img width="359" alt="image" src="https://user-images.githubusercontent.com/51025241/183921077-89e347d7-0098-4fa1-8da0-61da5506ce7d.png">
