### PR TITLE
Fix input shape for LighGBMClassifier

### DIFF
--- a/freqtrade/freqai/prediction_models/LightGBMClassifier.py
+++ b/freqtrade/freqai/prediction_models/LightGBMClassifier.py
@@ -26,13 +26,18 @@ class LightGBMClassifier(BaseClassifierModel):
 
         if self.freqai_info.get('data_split_parameters', {}).get('test_size', 0.1) == 0:
             eval_set = None
+            test_weights = None
         else:
-            eval_set = (data_dictionary["test_features"], data_dictionary["test_labels"])
-        X = data_dictionary["train_features"]
-        y = data_dictionary["train_labels"]
+            eval_set = (data_dictionary["test_features"].to_numpy(),
+                        data_dictionary["test_labels"].to_numpy()[:, 0])
+            test_weights = data_dictionary["test_weights"]
+        X = data_dictionary["train_features"].to_numpy()
+        y = data_dictionary["train_labels"].to_numpy()[:, 0]
+        train_weights = data_dictionary["train_weights"]
 
         model = LGBMClassifier(**self.model_training_parameters)
 
-        model.fit(X=X, y=y, eval_set=eval_set)
+        model.fit(X=X, y=y, eval_set=eval_set, sample_weight=train_weights,
+                  eval_sample_weight=[test_weights])
 
         return model

--- a/freqtrade/freqai/prediction_models/LightGBMRegressor.py
+++ b/freqtrade/freqai/prediction_models/LightGBMRegressor.py
@@ -27,13 +27,17 @@ class LightGBMRegressor(BaseRegressionModel):
 
         if self.freqai_info.get('data_split_parameters', {}).get('test_size', 0.1) == 0:
             eval_set = None
+            eval_weights = None
         else:
             eval_set = (data_dictionary["test_features"], data_dictionary["test_labels"])
+            eval_weights = data_dictionary["test_weights"]
         X = data_dictionary["train_features"]
         y = data_dictionary["train_labels"]
+        train_weights = data_dictionary["train_weights"]
 
         model = LGBMRegressor(**self.model_training_parameters)
 
-        model.fit(X=X, y=y, eval_set=eval_set)
+        model.fit(X=X, y=y, eval_set=eval_set, sample_weight=train_weights,
+                  eval_sample_weight=[eval_weights])
 
         return model


### PR DESCRIPTION
Ameliorate the following warning:

```
freqtrade/.env/lib/python3.10/site-packages/sklearn/preprocessing/_label.py:98: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().
  y = column_or_1d(y, warn=True)
  ```
  
  And add `sample_weight` and `eval_sample_weight` arguments to LightGBMClassifier/Regressor prediction models. 
