### PR TITLE
Improve PCA and pairwise distance calcs

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -511,7 +511,6 @@ class FreqaiDataKitchen:
         pairwise = pairwise.reshape(-1, 1)
         avg_mean_dist = pairwise[~np.isnan(pairwise)].mean()
 
-
         return avg_mean_dist
 
     def use_SVM_to_remove_outliers(self, predict: bool) -> None:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -454,7 +454,6 @@ class FreqaiDataKitchen:
         logger.info("reduced feature dimension by %s", n_components - n_keep_components)
         logger.info("explained variance %f", np.sum(pca2.explained_variance_ratio_))
         train_components = pca2.transform(self.data_dictionary["train_features"])
-        test_components = pca2.transform(self.data_dictionary["test_features"])
 
         self.data_dictionary["train_features"] = pd.DataFrame(
             data=train_components,
@@ -468,6 +467,7 @@ class FreqaiDataKitchen:
         self.training_features_list = self.data_dictionary["train_features"].columns
 
         if self.freqai_config.get('data_split_parameters', {}).get('test_size', 0.1) != 0:
+            test_components = pca2.transform(self.data_dictionary["test_features"])
             self.data_dictionary["test_features"] = pd.DataFrame(
                 data=test_components,
                 columns=["PC" + str(i) for i in range(0, n_keep_components)],
@@ -506,7 +506,10 @@ class FreqaiDataKitchen:
         # logger.info("computing average mean distance for all training points")
         pairwise = pairwise_distances(
             self.data_dictionary["train_features"], n_jobs=self.thread_count)
-        avg_mean_dist = pairwise.mean(axis=1).mean()
+        # remove the diagonal distances which are itself distances ~0
+        np.fill_diagonal(pairwise, np.NaN)
+        pairwise = pairwise.reshape(-1, 1)
+        avg_mean_dist = pairwise[~np.isnan(pairwise)].mean()
 
 
         return avg_mean_dist

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -510,6 +510,7 @@ class FreqaiDataKitchen:
         np.fill_diagonal(pairwise, np.NaN)
         pairwise = pairwise.reshape(-1, 1)
         avg_mean_dist = pairwise[~np.isnan(pairwise)].mean()
+
         return avg_mean_dist
 
     def use_SVM_to_remove_outliers(self, predict: bool) -> None:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -508,6 +508,7 @@ class FreqaiDataKitchen:
             self.data_dictionary["train_features"], n_jobs=self.thread_count)
         avg_mean_dist = pairwise.mean(axis=1).mean()
 
+
         return avg_mean_dist
 
     def use_SVM_to_remove_outliers(self, predict: bool) -> None:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -510,7 +510,6 @@ class FreqaiDataKitchen:
         np.fill_diagonal(pairwise, np.NaN)
         pairwise = pairwise.reshape(-1, 1)
         avg_mean_dist = pairwise[~np.isnan(pairwise)].mean()
-
         return avg_mean_dist
 
     def use_SVM_to_remove_outliers(self, predict: bool) -> None:

--- a/freqtrade/templates/FreqaiExampleStrategy.py
+++ b/freqtrade/templates/FreqaiExampleStrategy.py
@@ -174,6 +174,7 @@ class FreqaiExampleStrategy(IStrategy):
             #     .rolling(self.freqai_info["feature_parameters"]["label_period_candles"])
             #     .min()
             # )
+
         return df
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/freqtrade/templates/FreqaiExampleStrategy.py
+++ b/freqtrade/templates/FreqaiExampleStrategy.py
@@ -174,7 +174,6 @@ class FreqaiExampleStrategy(IStrategy):
             #     .rolling(self.freqai_info["feature_parameters"]["label_period_candles"])
             #     .min()
             # )
-
         return df
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Ignore the sample itself distance in the `avg_mean_dist` computation.
Fix the PCA computation when the test is empty.

