### PR TITLE
Okx cache tiers

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2280,6 +2280,8 @@ class Exchange:
     def cache_leverage_tiers(self, tiers: Dict[str, List[Dict]], stake_currency: str) -> None:
 
         filename = self._config['datadir'] / "futures" / f"leverage_tiers_{stake_currency}.json"
+        if not filename.parent.is_dir():
+            filename.parent.mkdir(parents=True)
         data = {
             "updated": datetime.now(timezone.utc),
             "data": tiers,
@@ -2293,7 +2295,6 @@ class Exchange:
             updated = tiers.get('updated')
             if updated:
                 updated_dt = parser.parse(updated)
-                print(updated_dt)
                 if updated_dt < datetime.now(timezone.utc) - timedelta(days=1):
                     logger.info("Cached leverage tiers are outdated. Will update.")
                     return None

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -137,6 +137,10 @@ def exchange_futures(request, exchange_conf, class_mocker):
             'freqtrade.exchange.binance.Binance.fill_leverage_tiers')
         class_mocker.patch('freqtrade.exchange.exchange.Exchange.fetch_trading_fees')
         class_mocker.patch('freqtrade.exchange.okx.Okx.additional_exchange_init')
+        class_mocker.patch('freqtrade.exchange.exchange.Exchange.load_cached_leverage_tiers',
+                           return_value=None)
+        class_mocker.patch('freqtrade.exchange.exchange.Exchange.cache_leverage_tiers')
+
         exchange = ExchangeResolver.load_exchange(
             request.param, exchange_conf, validate=True, load_leverage_tiers=True)
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -4791,6 +4791,20 @@ def test_load_leverage_tiers(mocker, default_conf, leverage_tiers, exchange_name
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize('exchange_name', EXCHANGES)
+async def test_get_market_leverage_tiers(mocker, default_conf, exchange_name):
+    default_conf['exchange']['name'] = exchange_name
+    await async_ccxt_exception(
+        mocker,
+        default_conf,
+        MagicMock(),
+        "get_market_leverage_tiers",
+        "fetch_market_leverage_tiers",
+        symbol='BTC/USDT:USDT'
+    )
+
+
 def test_parse_leverage_tier(mocker, default_conf):
     exchange = get_patched_exchange(mocker, default_conf)
 


### PR DESCRIPTION

## Summary

Okx tier initialization takes too long to effectively backtest.
tiers will not change this often, so we can cache them (for the moment, for at least 1 day).

