### PR TITLE
Extra filename option when loading strategy params

### DIFF
--- a/freqtrade/strategy/hyper.py
+++ b/freqtrade/strategy/hyper.py
@@ -112,10 +112,13 @@ class HyperStrategyMixin:
         self._ft_load_params(protection_params, 'protection', hyperopt)
 
     def load_params_from_file(self) -> Dict:
-        filename_str = getattr(self, '__file__', '')
-        if not filename_str:
-            return {}
+        filename_str = self.__class__.__name__
         filename = Path(filename_str).with_suffix('.json')
+        if not filename.is_file():
+            filename_str = getattr(self, '__file__', '')
+            if not filename_str:
+                return {}
+            filename = Path(filename_str).with_suffix('.json')
 
         if filename.is_file():
             logger.info(f"Loading parameters from file {filename}")


### PR DESCRIPTION
NO tests were added
What do you guys think?
## Summary
Load strategy params from `strategy-class-name.json` file

## What's new?

This allows us to create small strategy variations in the same strategy file, while loading params from different .json files
ex:
`SampleStrategy.py`
```python
class SampleStrategy1(IStrategy):
    static_param_1 = 0.01
    ...
    ...
  
class SampleStrategy2(SampleStrategy1):
    static_param_1 = 0.02

class SampleStrateg3(SampleStrategy1):
    static_param_1 = 0.03
```
Would allow for this:
```
/strategies
 |
 |- SampleStrategy.py
 |- SampleStrategy1.json
 |- SampleStrategy1.json
 |- SampleStrategy3.json
```
Instead of this:
```
/strategies
 |
 |- SampleStrategy1.py
 |- SampleStrategy2.py
 |- SampleStrategy3.py
 |- SampleStrategy1.json
 |- SampleStrategy1.json
 |- SampleStrategy3.json
```


