### PR TITLE
Plug mem leak, add training timer

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -421,7 +421,7 @@ class FreqaiDataDrawer:
             )
 
         # if self.live:
-        self.model_dictionary[dk.model_filename] = model
+        self.model_dictionary[coin] = model
         self.pair_dict[coin]["model_filename"] = dk.model_filename
         self.pair_dict[coin]["data_path"] = str(dk.data_path)
         self.save_drawer_to_disk()
@@ -460,8 +460,8 @@ class FreqaiDataDrawer:
         )
 
         # try to access model in memory instead of loading object from disk to save time
-        if dk.live and dk.model_filename in self.model_dictionary:
-            model = self.model_dictionary[dk.model_filename]
+        if dk.live and coin in self.model_dictionary:
+            model = self.model_dictionary[coin]
         elif not dk.keras:
             model = load(dk.data_path / f"{dk.model_filename}_model.joblib")
         else:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -873,13 +873,6 @@ class FreqaiDataKitchen:
             data_load_timerange.stopts = int(time)
             retrain = True
 
-        # logger.info(
-        #     f"downloading data for "
-        #     f"{(data_load_timerange.stopts-data_load_timerange.startts)/SECONDS_IN_DAY:.2f} "
-        #     " days. "
-        #     f"Extension of {additional_seconds/SECONDS_IN_DAY:.2f} days"
-        # )
-
         return retrain, trained_timerange, data_load_timerange
 
     def set_new_model_names(self, pair: str, trained_timerange: TimeRange):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

The `dk.model_filename` string contains the last trained timestamp, which is useful for creating folder/files on disk. However, we also use this for adding entries to our `dd.model_dictionary` which *should* only hold the newest models in RAM (to improve inference performance). However, FreqAI was using a unique key to add each entry - thus resulting in an ever expanding dictionary:

`self.model_dictionary[dk.model_filename] = model`

The solution was quite simple:

`self.model_dictionary[coin] = model`

We use this opportunity to include the training timer, which was constructed to help aid in the investigation of the memleak. This `training_timer()` computes the sum of time spent training one full loop through the pair whitelist. It logs the information for the user to see.