### PR TITLE
runmode has type `freqtrade.enums.runmode.RunMode` but is used as type `None`

### DIFF
--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -28,7 +28,7 @@ class Configuration:
     Reuse this class for the bot, backtesting, hyperopt and every script that required configuration
     """
 
-    def __init__(self, args: Dict[str, Any], runmode: RunMode = None) -> None:
+    def __init__(self, args: Dict[str, Any], runmode: Optional[RunMode] = None) -> None:
         self.args = args
         self.config: Optional[Dict[str, Any]] = None
         self.runmode = runmode


### PR DESCRIPTION
**"filename"**: "freqtrade/configuration/configuration.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " runmode is declared to have type `freqtrade.enums.runmode.RunMode` but is used as type `None`.",
**"warning_line"**: 31
**"fix"**: Add Optional type

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
