### PR TITLE
Conception problem with the total_profit

### DIFF
--- a/freqtrade/freqai/RL/Base4ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base4ActionRLEnv.py
@@ -292,7 +292,8 @@ class Base4ActionRLEnv(gym.Env):
             pnl = self.get_unrealized_profit()
 
             if self._position in (Positions.Long, Positions.Short):
-                self._total_profit *= (1 + pnl)
+                #self._total_profit *= (1 + pnl)
+                self._total_profit += pnl
                 self._profits.append((self._current_tick, self._total_profit))
                 self.close_trade_profit.append(pnl)
 

--- a/freqtrade/freqai/RL/Base5ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base5ActionRLEnv.py
@@ -295,7 +295,8 @@ class Base5ActionRLEnv(gym.Env):
             pnl = self.get_unrealized_profit()
 
             if self._position in (Positions.Long, Positions.Short):
-                self._total_profit *= (1 + pnl)
+                #self._total_profit *= (1 + pnl)
+                self._total_profit += pnl
                 self._profits.append((self._current_tick, self._total_profit))
                 self.close_trade_profit.append(pnl)
 


### PR DESCRIPTION
I think here is a conception problem with the total profit, if we `*=` it with the last PnL it means we assume that the last profit effects on this one. In real life it depends on the user eg stake amount can be unlimited.
However the agent will learn better and more if we just add it with `+=`.


