### PR TITLE
Make the recommendation for Binance/Kucoin blacklisting more accurate.

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -61,8 +61,8 @@ Binance supports [time_in_force](configuration.md#understand-order_time_in_force
 
 ### Binance Blacklist
 
-For Binance, please add `"BNB/<STAKE>"` to your blacklist to avoid issues.
-Accounts having BNB accounts use this to pay for fees - if your first trade happens to be on `BNB`, further trades will consume this position and make the initial BNB trade unsellable as the expected amount is not there anymore.
+For Binance, it is suggested to add `"BNB/<STAKE>"` to your blacklist to avoid issues, unless you are willing to maintain enough extra `BNB` on the account or, unless you're willing to disable using `BNB` for fees. 
+Binance accounts may use `BNB` for fees, and if a trade happens to be on `BNB`, further trades may consume this position and make the initial BNB trade unsellable as the expected amount is not there anymore.
 
 ### Binance Futures
 
@@ -205,8 +205,8 @@ Kucoin supports [time_in_force](configuration.md#understand-order_time_in_force)
 
 ### Kucoin Blacklists
 
-For Kucoin, please add `"KCS/<STAKE>"` to your blacklist to avoid issues.
-Accounts having KCS accounts use this to pay for fees - if your first trade happens to be on `KCS`, further trades will consume this position and make the initial KCS trade unsellable as the expected amount is not there anymore.
+For Kucoin, it is suggested to add `"KCS/<STAKE>"` to your blacklist to avoid issues, unless you are willing to maintain enough extra `KCS` on the account or, unless you're willing to disable using `KCS` for fees. 
+Kucoin accounts may use `KCS` for fees, and if a trade happens to be on `KCS`, further trades may consume this position and make the initial `KCS` trade unsellable as the expected amount is not there anymore.
 
 ## Huobi
 


### PR DESCRIPTION
Now that a recent bug regarding selling `BNB` is fixed, it should be safe to trade it, but with a warning that the user may have to manually maintain extra `BNB`. 
Also the old text implied those features are always enabled so this text makes it clear those fee-related features can be also disabled.
I'm not sure if it's still true that an "eaten by fees" position becomes unsellable but I left that as it is (also I assumed Kucoin is similar).