### PR TITLE
Normalise PCA space

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -300,7 +300,7 @@ class FreqaiDataKitchen:
         )
 
         for item in train_max.keys():
-            if not [col for col in df_train_features.columns if col.startwith('PC')]:
+            if not [col for col in df_train_features.columns if col.startswith('PC')]:
                 self.data[item + "_max"] = train_max[item]
                 self.data[item + "_min"] = train_min[item]
             else:
@@ -327,7 +327,7 @@ class FreqaiDataKitchen:
                     - 1
                 )
 
-            if not [col for col in df_train_features.columns if col.startwith('PC')]:
+            if not [col for col in df_train_features.columns if col.startswith('PC')]:
                 self.data[f"{item}_max"] = train_labels_max  # .to_dict()
                 self.data[f"{item}_min"] = train_labels_min  # .to_dict()
             else:
@@ -344,7 +344,7 @@ class FreqaiDataKitchen:
         :param df: Dataframe to be standardized
         """
 
-        if not [col for col in df.columns if col.startwith('PC')]:
+        if not [col for col in df.columns if col.startswith('PC')]:
             id_str = ''
         else:
             # if PCA is enabled

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -288,12 +288,11 @@ class FreqaiDataKitchen:
         :data_dictionary: updated dictionary with standardized values.
         """
 
-        df = data_dictionary["train_features"]
         # standardize the data by training stats
-        train_max = df.max()
-        train_min = df.min()
-        df = (
-            2 * (df - train_min) / (train_max - train_min) - 1
+        train_max = data_dictionary["train_features"].max()
+        train_min = data_dictionary["train_features"].min()
+        data_dictionary["train_features"] = (
+            2 * (data_dictionary["train_features"] - train_min) / (train_max - train_min) - 1
         )
         data_dictionary["test_features"] = (
             2 * (data_dictionary["test_features"] - train_min) / (train_max - train_min) - 1
@@ -322,8 +321,8 @@ class FreqaiDataKitchen:
                     - 1
                 )
 
-                self.data[f"{item}_max"] = train_labels_max
-                self.data[f"{item}_min"] = train_labels_min
+            self.data[f"{item}_max"] = train_labels_max
+            self.data[f"{item}_min"] = train_labels_min
         return data_dictionary
 
     def normalize_single_dataframe(self, df: DataFrame) -> DataFrame:


### PR DESCRIPTION
Normalisation of principal component transformed features.

PCA can be enabled by the user to reduce the feature space by finding the components that describe 99.9% of the variance in the dataset. This transformation is done on normalised [-1,1] data but the transformed data is no longer normalised to [-1,1]. This PR enables normalisation of the transformed data, and ensures that transformed test and prediction data is normalised to the corresponding transformed training data. 