### PR TITLE
Fix issue with Freqai backtesting (different results in same day with different TR)

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -454,22 +454,8 @@ class FreqaiDataKitchen:
         start = datetime.datetime.fromtimestamp(timerange.startts, tz=datetime.timezone.utc)
         stop = datetime.datetime.fromtimestamp(timerange.stopts, tz=datetime.timezone.utc)
         df = df.loc[df["date"] >= start, :]
-        df = df.loc[df["date"] <= stop, :]
-
-        return df
-
-    def slice_dataframe_backtesting(self, timerange: TimeRange, df: DataFrame) -> DataFrame:
-        """
-        Given a full dataframe, extract the user desired window
-        :param tr: timerange string that we wish to extract from df
-        :param df: Dataframe containing all candles to run the entire backtest. Here
-                   it is sliced down to just the present training period.
-        """
-
-        start = datetime.datetime.fromtimestamp(timerange.startts, tz=datetime.timezone.utc)
-        stop = datetime.datetime.fromtimestamp(timerange.stopts, tz=datetime.timezone.utc)
-        df = df.loc[df["date"] >= start, :]
-        df = df.loc[df["date"] < stop, :]
+        if not self.live:
+            df = df.loc[df["date"] < stop, :]
 
         return df
 

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -458,6 +458,21 @@ class FreqaiDataKitchen:
 
         return df
 
+    def slice_dataframe_backtesting(self, timerange: TimeRange, df: DataFrame) -> DataFrame:
+        """
+        Given a full dataframe, extract the user desired window
+        :param tr: timerange string that we wish to extract from df
+        :param df: Dataframe containing all candles to run the entire backtest. Here
+                   it is sliced down to just the present training period.
+        """
+
+        start = datetime.datetime.fromtimestamp(timerange.startts, tz=datetime.timezone.utc)
+        stop = datetime.datetime.fromtimestamp(timerange.stopts, tz=datetime.timezone.utc)
+        df = df.loc[df["date"] >= start, :]
+        df = df.loc[df["date"] < stop, :]
+
+        return df
+
     def principal_component_analysis(self) -> None:
         """
         Performs Principal Component Analysis on the data for dimensionality reduction

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -225,8 +225,8 @@ class IFreqaiModel(ABC):
             train_it += 1
             total_trains = len(dk.backtesting_timeranges)
             self.training_timerange = tr_train
-            dataframe_train = dk.slice_dataframe_backtesting(tr_train, dataframe)
-            dataframe_backtest = dk.slice_dataframe_backtesting(tr_backtest, dataframe)
+            dataframe_train = dk.slice_dataframe(tr_train, dataframe)
+            dataframe_backtest = dk.slice_dataframe(tr_backtest, dataframe)
 
             trained_timestamp = tr_train
             tr_train_startts_str = datetime.datetime.utcfromtimestamp(tr_train.startts).strftime(

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -225,8 +225,8 @@ class IFreqaiModel(ABC):
             train_it += 1
             total_trains = len(dk.backtesting_timeranges)
             self.training_timerange = tr_train
-            dataframe_train = dk.slice_dataframe(tr_train, dataframe)
-            dataframe_backtest = dk.slice_dataframe(tr_backtest, dataframe)
+            dataframe_train = dk.slice_dataframe_backtesting(tr_train, dataframe)
+            dataframe_backtest = dk.slice_dataframe_backtesting(tr_backtest, dataframe)
 
             trained_timestamp = tr_train
             tr_train_startts_str = datetime.datetime.utcfromtimestamp(tr_train.startts).strftime(


### PR DESCRIPTION
## Summary

Fixed an issue when backtesting with the same models and predictions but with different timeranges the backtesting returns different results for the same day  (breakdown day).
