### PR TITLE
fix hyperopt df preprocessing

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -423,7 +423,7 @@ class Hyperopt:
         # Trim startup period from analyzed dataframe to get correct dates for output.
         processed = trim_dataframes(preprocessed, self.timerange, self.backtesting.required_startup)
         self.min_date, self.max_date = get_timerange(processed)
-        return processed
+        return preprocessed
 
     def prepare_hyperopt_data(self) -> None:
         HyperoptStateContainer.set_state(HyperoptState.DATALOAD)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -421,8 +421,9 @@ class Hyperopt:
         preprocessed = self.backtesting.strategy.advise_all_indicators(data)
 
         # Trim startup period from analyzed dataframe to get correct dates for output.
-        processed = trim_dataframes(preprocessed, self.timerange, self.backtesting.required_startup)
-        self.min_date, self.max_date = get_timerange(processed)
+        trimmed = trim_dataframes(preprocessed, self.timerange, self.backtesting.required_startup)
+        self.min_date, self.max_date = get_timerange(trimmed)
+        # Real trimming will happen as part of backtesting.
         return preprocessed
 
     def prepare_hyperopt_data(self) -> None:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #7360

## Quick changelog

- `advise_and_trim` returns `preprocessed` instead of `processed`

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
