### PR TITLE
Add optional `suffix` parameter to `merge_informative_pair`

### DIFF
--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -31,6 +31,8 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
     :param ffill: Forwardfill missing values - optional but usually required
     :param append_timeframe: Rename columns by appending timeframe.
     :param date_column: A custom date column name.
+    :param suffix: A string suffix to add at the end of the informative columns. If specified,
+                   append_timeframe must be false.
     :return: Merged dataframe
     :raise: ValueError if the secondary timeframe is shorter than the dataframe timeframe
     """
@@ -57,7 +59,7 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
         date_merge = f'date_merge_{timeframe_inf}'
         informative.columns = [f"{col}_{timeframe_inf}" for col in informative.columns]
 
-    elif suffix:
+    elif suffix and not append_timeframe:
         date_merge = f'date_merge_{suffix}'
         informative.columns = [f"{col}_{suffix}" for col in informative.columns]
 

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -55,16 +55,15 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
 
     # Rename columns to be unique
     date_merge = 'date_merge'
-    if append_timeframe and not suffix:
+    if suffix and append_timeframe:
+        raise ValueError("You can not specify `append_timeframe` as True and a `suffix`.")
+    elif append_timeframe:
         date_merge = f'date_merge_{timeframe_inf}'
         informative.columns = [f"{col}_{timeframe_inf}" for col in informative.columns]
 
-    elif suffix and not append_timeframe:
+    elif suffix:
         date_merge = f'date_merge_{suffix}'
         informative.columns = [f"{col}_{suffix}" for col in informative.columns]
-
-    elif suffix and append_timeframe:
-        raise ValueError("You can not specify `append_timeframe` as True and a `suffix`.")
 
     # Combine the 2 dataframes
     # all indicators on the informative sample MUST be calculated before this point

--- a/freqtrade/strategy/strategy_helper.py
+++ b/freqtrade/strategy/strategy_helper.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pandas as pd
 
 from freqtrade.exchange import timeframe_to_minutes
@@ -6,7 +8,8 @@ from freqtrade.exchange import timeframe_to_minutes
 def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
                            timeframe: str, timeframe_inf: str, ffill: bool = True,
                            append_timeframe: bool = True,
-                           date_column: str = 'date') -> pd.DataFrame:
+                           date_column: str = 'date',
+                           suffix: Optional[str] = None) -> pd.DataFrame:
     """
     Correctly merge informative samples to the original dataframe, avoiding lookahead bias.
 
@@ -50,9 +53,16 @@ def merge_informative_pair(dataframe: pd.DataFrame, informative: pd.DataFrame,
 
     # Rename columns to be unique
     date_merge = 'date_merge'
-    if append_timeframe:
+    if append_timeframe and not suffix:
         date_merge = f'date_merge_{timeframe_inf}'
         informative.columns = [f"{col}_{timeframe_inf}" for col in informative.columns]
+
+    elif suffix:
+        date_merge = f'date_merge_{suffix}'
+        informative.columns = [f"{col}_{suffix}" for col in informative.columns]
+
+    elif suffix and append_timeframe:
+        raise ValueError("You can not specify `append_timeframe` as True and a `suffix`.")
 
     # Combine the 2 dataframes
     # all indicators on the informative sample MUST be calculated before this point

--- a/tests/strategy/test_strategy_helpers.py
+++ b/tests/strategy/test_strategy_helpers.py
@@ -117,6 +117,29 @@ def test_merge_informative_pair_lower():
         merge_informative_pair(data, informative, '1h', '15m', ffill=True)
 
 
+def test_merge_informative_pair_suffix():
+    data = generate_test_data('15m', 20)
+    informative = generate_test_data('1h', 20)
+
+    result = merge_informative_pair(data, informative, '15m', '1h',
+                                    append_timeframe=False, suffix="suf")
+
+    assert 'date' in result.columns
+    assert result['date'].equals(data['date'])
+    assert 'date_suf' in result.columns
+
+    assert 'open_suf' in result.columns
+    assert 'open_1h' not in result.columns
+
+
+def test_merge_informative_pair_suffix_append_timeframe():
+    data = generate_test_data('15m', 20)
+    informative = generate_test_data('1h', 20)
+
+    with pytest.raises(ValueError, match=r"You can not specify `append_timeframe` .*"):
+        merge_informative_pair(data, informative, '15m', '1h', suffix="suf")
+
+
 def test_stoploss_from_open():
     open_price_ranges = [
         [0.01, 1.00, 30],


### PR DESCRIPTION
## Summary

Add an optional `suffix` parameter to `merge_informative_pair` to specify the informative columns suffix instead of just the timeframe.