### PR TITLE
Added 1s timeframe changes and requirements

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -590,9 +590,6 @@ class Exchange:
             raise OperationalException(
                 f"Invalid timeframe '{timeframe}'. This exchange supports: {self.timeframes}")
 
-        if timeframe and timeframe_to_minutes(timeframe) < 1:
-            raise OperationalException("Timeframes < 1m are currently not supported by Freqtrade.")
-
     def validate_ordertypes(self, order_types: Dict) -> None:
         """
         Checks if order-types configured in strategy/config are supported

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.2
 pandas==1.4.4
 pandas-ta==0.3.14b
 
-ccxt==1.93.3
+ccxt==1.93.14
 # Pin cryptography for now due to rust build errors with piwheels
 cryptography==37.0.4
 aiohttp==3.8.1

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -907,12 +907,7 @@ def test_validate_timeframes_failed(default_conf, mocker):
     with pytest.raises(OperationalException,
                        match=r"Invalid timeframe '3m'. This exchange supports.*"):
         Exchange(default_conf)
-    default_conf["timeframe"] = "15s"
-
-    with pytest.raises(OperationalException,
-                       match=r"Timeframes < 1m are currently not supported by Freqtrade."):
-        Exchange(default_conf)
-
+    
 
 def test_validate_timeframes_emulated_ohlcv_1(default_conf, mocker):
     default_conf["timeframe"] = "3m"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

1. From `validate_timeframes` method inside `exchange.py` I think this condition should be erased as there's no possibility of any user input timeframe to be under 1m anymore
```python 
if timeframe and timeframe_to_minutes(timeframe) < 1:
   raise OperationalException("Timeframes < 1m are currently not supported by Freqtrade.")
```

2. Also, the subtest should also be removed from `test_validate_timeframes_failed` inside the `exchange_test.py` due to the same rationale

```python 
default_conf["timeframe"] = "15s"
    with pytest.raises(OperationalException,
                       match=r"Timeframes < 1m are currently not supported by Freqtrade."):
        Exchange(default_conf)
```
3. Requirements should ccxt dependency version 1.93.14 or higher
```python
ccxt==1.93.14
```

## Quick changelog

- Freqtrade now started supporting 1s timeframes on Binance SPOT Exchange (still in testing phase)

## What's new?

Everything discussed in issue #7366 