### PR TITLE
Fix FreaqAI backtesting - startup_candle_count bug

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -468,8 +468,14 @@ class FreqaiDataKitchen:
         Function which takes the backtesting time range and
         remove training data from dataframe
         """
+        startup_candle_count = self.config.get('startup_candle_count', 0)
+        tf = self.config['timeframe']
         tr = self.config["timerange"]
+
         backtesting_timerange = TimeRange.parse_timerange(tr)
+        if startup_candle_count > 0 and backtesting_timerange:
+            backtesting_timerange.subtract_start(timeframe_to_seconds(tf) * startup_candle_count)
+
         start = datetime.fromtimestamp(backtesting_timerange.startts, tz=timezone.utc)
         df = self.return_dataframe
         df = df.loc[df["date"] >= start, :]

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -461,6 +461,20 @@ class FreqaiDataKitchen:
 
         return df
 
+    def remove_training_from_backtesting(
+        self
+    ) -> DataFrame:
+        """
+        Function which takes the backtesting time range and
+        remove training data from dataframe
+        """
+        tr = self.config["timerange"]
+        backtesting_timerange = TimeRange.parse_timerange(tr)
+        start = datetime.fromtimestamp(backtesting_timerange.startts, tz=timezone.utc)
+        df = self.return_dataframe
+        df = df.loc[df["date"] >= start, :]
+        return df
+
     def principal_component_analysis(self) -> None:
         """
         Performs Principal Component Analysis on the data for dimensionality reduction
@@ -954,6 +968,7 @@ class FreqaiDataKitchen:
         to_keep = [col for col in dataframe.columns if not col.startswith("&")]
         self.return_dataframe = pd.concat([dataframe[to_keep], self.full_df], axis=1)
 
+        self.return_dataframe = self.remove_training_from_backtesting()
         self.full_df = DataFrame()
 
         return

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -466,7 +466,8 @@ class FreqaiDataKitchen:
     ) -> DataFrame:
         """
         Function which takes the backtesting time range and
-        remove training data from dataframe
+        remove training data from dataframe, keeping only the
+        startup_candle_count candles
         """
         startup_candle_count = self.config.get('startup_candle_count', 0)
         tf = self.config['timeframe']


### PR DESCRIPTION
## Summary

Freqai also needs to send the candles related to startup_candle_count for the FT backtesting module to work properly. 
