### PR TITLE
add search share button to website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ theme:
   logo: "images/logo.png"
   favicon: "images/logo.png"
   custom_dir: "docs/overrides"
+  features:
+    - search.share
   palette:
     - scheme: default
       primary: "blue grey"


### PR DESCRIPTION
This adds a "share" symbol in the search bar of the website so users can share exact search queries with one another. 

![image](https://user-images.githubusercontent.com/20807672/189525004-f12e60c4-5d01-4655-85a3-3a85f36032a8.png)
