### PR TITLE
Changing the default OHLCV data from json to hdf5

### DIFF
--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -183,15 +183,15 @@ Freqtrade currently supports 3 data-formats for both OHLCV and trades data:
 * `jsongz` (a gzip-zipped version of json files)
 * `hdf5` (a high performance datastore)
 
-By default, OHLCV data is stored as `json` data, while trades data is stored as `jsongz` data.
+By default, OHLCV data and trades data are stored as `hdf5` data.
 
 This can be changed via the `--data-format-ohlcv` and `--data-format-trades` command line arguments respectively.
 To persist this change, you should also add the following snippet to your configuration, so you don't have to insert the above arguments each time:
 
 ``` jsonc
     // ...
-    "dataformat_ohlcv": "hdf5",
-    "dataformat_trades": "hdf5",
+    "dataformat_ohlcv": "json",
+    "dataformat_trades": "json",
     // ...
 ```
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -424,12 +424,12 @@ CONF_SCHEMA = {
         'dataformat_ohlcv': {
             'type': 'string',
             'enum': AVAILABLE_DATAHANDLERS,
-            'default': 'json'
+            'default': 'hdf5'
         },
         'dataformat_trades': {
             'type': 'string',
             'enum': AVAILABLE_DATAHANDLERS,
-            'default': 'jsongz'
+            'default': 'hdf5'
         },
         'position_adjustment_enable': {'type': 'boolean'},
         'max_entry_position_adjustment': {'type': ['integer', 'number'], 'minimum': -1},


### PR DESCRIPTION
since hdf5 data is faster than json files while processing in backtesting mode, it's better to use as the default data type