### PR TITLE
Fixed a bug that prevents clearing old models

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -355,7 +355,7 @@ class FreqaiDataDrawer:
         for dir in model_folders:
             result = pattern.match(str(dir.name))
             if result is None:
-                break
+                continue
             coin = result.group(1)
             timestamp = result.group(2)
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->
Fix the issue of purging old models when the "user_data/models/unique-id" directory contains sub-directories with names that do not match a regular expression "sub-train-(\w+)_(\d{10})".
For example, "user_data/models/unique-id/tensorboard".

Solve the issue: #___

## Quick changelog

- Old models are purged correctly if the model dir contains dirs with names that do not match the regex
