### PR TITLE
Informative freqai

### DIFF
--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -190,19 +190,6 @@ The FreqAI strategy requires the user to include the following lines of code in 
     # passed to any single indicator)
     startup_candle_count: int = 20
 
-    def informative_pairs(self):
-        whitelist_pairs = self.dp.current_whitelist()
-        corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
-        informative_pairs = []
-        for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
-            for pair in whitelist_pairs:
-                informative_pairs.append((pair, tf))
-            for pair in corr_pairs:
-                if pair in whitelist_pairs:
-                    continue  # avoid duplication
-                informative_pairs.append((pair, tf))
-        return informative_pairs
-
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
         # the model will return all labels created by user in `populate_any_indicators`

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -613,6 +613,22 @@ class IStrategy(ABC, HyperStrategyMixin):
 # END - Intended to be overridden by strategy
 ###
 
+    def __informative_pairs_freqai(self) -> ListPairsWithTimeframes:
+        """
+        Create informative-pairs needed for FreqAI
+        """
+        if self.config.get('freqai', {}).get('enabled', False):
+            whitelist_pairs = self.dp.current_whitelist()
+            candle_type = self.config.get('candle_type_def', CandleType.SPOT)
+            corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
+            informative_pairs = []
+            for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
+                for pair in set(whitelist_pairs + corr_pairs):
+                    informative_pairs.append((pair, tf, candle_type))
+            return informative_pairs
+
+        return []
+
     def gather_informative_pairs(self) -> ListPairsWithTimeframes:
         """
         Internal method which gathers all informative pairs (user or automatically defined).
@@ -637,6 +653,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             else:
                 for pair in self.dp.current_whitelist():
                     informative_pairs.append((pair, inf_data.timeframe, candle_type))
+        informative_pairs.extend(self.__informative_pairs_freqai())
         return list(set(informative_pairs))
 
     def get_strategy_name(self) -> str:

--- a/freqtrade/templates/FreqaiExampleStrategy.py
+++ b/freqtrade/templates/FreqaiExampleStrategy.py
@@ -47,19 +47,6 @@ class FreqaiExampleStrategy(IStrategy):
     std_dev_multiplier_sell = CategoricalParameter(
         [0.1, 0.25, 0.4], space="sell", default=0.2, optimize=True)
 
-    def informative_pairs(self):
-        whitelist_pairs = self.dp.current_whitelist()
-        corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
-        informative_pairs = []
-        for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
-            for pair in whitelist_pairs:
-                informative_pairs.append((pair, tf))
-            for pair in corr_pairs:
-                if pair in whitelist_pairs:
-                    continue  # avoid duplication
-                informative_pairs.append((pair, tf))
-        return informative_pairs
-
     def populate_any_indicators(
         self, pair, df, tf, informative=None, set_generalized_indicators=False
     ):

--- a/freqtrade/templates/FreqaiHybridExampleStrategy.py
+++ b/freqtrade/templates/FreqaiHybridExampleStrategy.py
@@ -95,20 +95,6 @@ class FreqaiExampleHybridStrategy(IStrategy):
     short_rsi = IntParameter(low=51, high=100, default=70, space='sell', optimize=True, load=True)
     exit_short_rsi = IntParameter(low=1, high=50, default=30, space='buy', optimize=True, load=True)
 
-    # FreqAI required function, leave as is or add additional informatives to existing structure.
-    def informative_pairs(self):
-        whitelist_pairs = self.dp.current_whitelist()
-        corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
-        informative_pairs = []
-        for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
-            for pair in whitelist_pairs:
-                informative_pairs.append((pair, tf))
-            for pair in corr_pairs:
-                if pair in whitelist_pairs:
-                    continue  # avoid duplication
-                informative_pairs.append((pair, tf))
-        return informative_pairs
-
     # FreqAI required function, user can add or remove indicators, but general structure
     # must stay the same.
     def populate_any_indicators(

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -320,7 +320,7 @@ def test_principal_component_analysis(mocker, freqai_conf):
 
 @pytest.mark.parametrize('timeframes,corr_pairs', [
     (['5m'], ['ADA/BTC', 'DASH/BTC']),
-    (['5m'], ['ADA/BTC', 'DASH/BTC']),
+    (['5m'], ['ADA/BTC', 'DASH/BTC', 'ETH/USDT']),
     (['5m', '15m'], ['ADA/BTC', 'DASH/BTC', 'ETH/USDT']),
 ])
 def test_freqai_informative_pairs(mocker, freqai_conf, timeframes, corr_pairs):

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -8,6 +8,7 @@ import pytest
 from freqtrade.configuration import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+from freqtrade.plugins.pairlistmanager import PairListManager
 from tests.conftest import get_patched_exchange, log_has_re
 from tests.freqai.conftest import get_patched_freqai_strategy
 
@@ -315,3 +316,27 @@ def test_principal_component_analysis(mocker, freqai_conf):
     assert Path(freqai.dk.data_path / f"{freqai.dk.model_filename}_pca_object.pkl")
 
     shutil.rmtree(Path(freqai.dk.full_path))
+
+
+@pytest.mark.parametrize('timeframes,corr_pairs', [
+    (['5m'], ['ADA/BTC', 'DASH/BTC']),
+    (['5m'], ['ADA/BTC', 'DASH/BTC']),
+    (['5m', '15m'], ['ADA/BTC', 'DASH/BTC', 'ETH/USDT']),
+])
+def test_freqai_informative_pairs(mocker, freqai_conf, timeframes, corr_pairs):
+    freqai_conf['freqai']['feature_parameters'].update({
+        'include_timeframes': timeframes,
+        'include_corr_pairlist': corr_pairs,
+
+    })
+    strategy = get_patched_freqai_strategy(mocker, freqai_conf)
+    exchange = get_patched_exchange(mocker, freqai_conf)
+    pairlists = PairListManager(exchange, freqai_conf)
+    strategy.dp = DataProvider(freqai_conf, exchange, pairlists)
+    pairlist = strategy.dp.current_whitelist()
+
+    pairs_a = strategy.informative_pairs()
+    assert len(pairs_a) == 0
+    pairs_b = strategy.gather_informative_pairs()
+    # we expect unique pairs * timeframes
+    assert len(pairs_b) == len(set(pairlist + corr_pairs)) * len(timeframes)

--- a/tests/strategy/strats/freqai_test_multimodel_strat.py
+++ b/tests/strategy/strats/freqai_test_multimodel_strat.py
@@ -43,19 +43,6 @@ class freqai_test_multimodel_strat(IStrategy):
     )
     max_roi_time_long = IntParameter(0, 800, default=400, space="sell", optimize=False, load=True)
 
-    def informative_pairs(self):
-        whitelist_pairs = self.dp.current_whitelist()
-        corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
-        informative_pairs = []
-        for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
-            for pair in whitelist_pairs:
-                informative_pairs.append((pair, tf))
-            for pair in corr_pairs:
-                if pair in whitelist_pairs:
-                    continue  # avoid duplication
-                informative_pairs.append((pair, tf))
-        return informative_pairs
-
     def populate_any_indicators(
         self, pair, df, tf, informative=None, set_generalized_indicators=False
     ):

--- a/tests/strategy/strats/freqai_test_strat.py
+++ b/tests/strategy/strats/freqai_test_strat.py
@@ -43,19 +43,6 @@ class freqai_test_strat(IStrategy):
     )
     max_roi_time_long = IntParameter(0, 800, default=400, space="sell", optimize=False, load=True)
 
-    def informative_pairs(self):
-        whitelist_pairs = self.dp.current_whitelist()
-        corr_pairs = self.config["freqai"]["feature_parameters"]["include_corr_pairlist"]
-        informative_pairs = []
-        for tf in self.config["freqai"]["feature_parameters"]["include_timeframes"]:
-            for pair in whitelist_pairs:
-                informative_pairs.append((pair, tf))
-            for pair in corr_pairs:
-                if pair in whitelist_pairs:
-                    continue  # avoid duplication
-                informative_pairs.append((pair, tf))
-        return informative_pairs
-
     def populate_any_indicators(
         self, pair, df, tf, informative=None, set_generalized_indicators=False
     ):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

As discussed in https://github.com/freqtrade/freqtrade/pull/7421#discussion_r973207174 - this will remove the need for freqAI users to have `informative_pairs()` implemented with copy/pasted code.
This is 100% predictable - and we can handle this easily.

That said - users can still implement `informative_pairs()` for other informative pairs.
Leaving a current strategy untouched will also work - as we do a "set/list" at the end, removing potential duplicates.

This brings the advantage that we can now fully test this code - and improve it should this be necessary (as well as the reduced dummy-code need in strategies.

## Quick changelog

* Move informative pairs combination for freqAI strategies to freqtrade code, combining `include_corr_pairlist * include_timeframes`.
* Remove freqai `informative_pairs` samples