### PR TITLE
Normalise distances before Weibull fit

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -780,6 +780,9 @@ class FreqaiDataKitchen:
         into previous timepoints.
         """
 
+        def normalise(dataframe: DataFrame) -> DataFrame:
+            return (dataframe - dataframe.min()) / (dataframe.max() - dataframe.min())
+
         no_prev_pts = self.freqai_config["feature_parameters"]["inlier_metric_window"]
 
         if set_ == 'train':
@@ -824,6 +827,7 @@ class FreqaiDataKitchen:
         inliers = pd.DataFrame(index=distances.index)
         for key in distances.keys():
             current_distances = distances[key].dropna()
+            current_distances = normalise(current_distances)
             fit_params = stats.weibull_min.fit(current_distances)
             quantiles = stats.weibull_min.cdf(current_distances, *fit_params)
 

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -774,14 +774,21 @@ class FreqaiDataKitchen:
 
     def compute_inlier_metric(self, set_='train') -> None:
         """
-
         Compute inlier metric from backwards distance distributions.
         This metric defines how well features from a timepoint fit
         into previous timepoints.
         """
 
-        def normalise(dataframe: DataFrame) -> DataFrame:
-            return (dataframe - dataframe.min()) / (dataframe.max() - dataframe.min())
+        def normalise(dataframe: DataFrame, key: str) -> DataFrame:
+            if set_ == 'train':
+                min_value = dataframe.min()
+                max_value = dataframe.max()
+                self.data[f'{key}_min'] = min_value
+                self.data[f'{key}_max'] = max_value
+            else:
+                min_value = self.data[f'{key}_min']
+                max_value = self.data[f'{key}_max']
+            return (dataframe - min_value) / (max_value - min_value)
 
         no_prev_pts = self.freqai_config["feature_parameters"]["inlier_metric_window"]
 
@@ -827,8 +834,12 @@ class FreqaiDataKitchen:
         inliers = pd.DataFrame(index=distances.index)
         for key in distances.keys():
             current_distances = distances[key].dropna()
-            current_distances = normalise(current_distances)
-            fit_params = stats.weibull_min.fit(current_distances)
+            current_distances = normalise(current_distances, key)
+            if set_ == 'train':
+                fit_params = stats.weibull_min.fit(current_distances)
+                self.data[f'{key}_fit_params'] = fit_params
+            else:
+                fit_params = self.data[f'{key}_fit_params']
             quantiles = stats.weibull_min.cdf(current_distances, *fit_params)
 
             df_inlier = pd.DataFrame(


### PR DESCRIPTION
## Summary

The pairwise distances should be normalised before fitting a Weibull to their distributions for the fit to be correct.

## Quick changelog

The Inlier metric is calculated based on a Weibull function fitted to the distribution of pairwise distances to previous time points. In the current implementation, the distances are not normalised which can sometimes lead to the Weibull fit being incorrect. This PR adds normalisation to the distances before the fitting.  