### PR TITLE
improve train queue system in FreqAI

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 
 class pair_info(TypedDict):
     model_filename: str
-    first: bool
     trained_timestamp: int
-    priority: int
     data_path: str
     extras: dict
 
@@ -91,7 +89,7 @@ class FreqaiDataDrawer:
         self.old_DBSCAN_eps: Dict[str, float] = {}
         self.empty_pair_dict: pair_info = {
                 "model_filename": "", "trained_timestamp": 0,
-                "priority": 1, "first": True, "data_path": "", "extras": {}}
+                "data_path": "", "extras": {}}
 
     def load_drawer_from_disk(self):
         """
@@ -216,7 +214,6 @@ class FreqaiDataDrawer:
             self.pair_dict[pair] = self.empty_pair_dict.copy()
             model_filename = ""
             trained_timestamp = 0
-            self.pair_dict[pair]["priority"] = len(self.pair_dict)
 
         if not data_path_set and self.follow_mode:
             logger.warning(
@@ -236,17 +233,8 @@ class FreqaiDataDrawer:
             return
         else:
             self.pair_dict[metadata["pair"]] = self.empty_pair_dict.copy()
-            self.pair_dict[metadata["pair"]]["priority"] = len(self.pair_dict)
 
             return
-
-    def pair_to_end_of_training_queue(self, pair: str) -> None:
-        # march all pairs up in the queue
-        with self.pair_dict_lock:
-            for p in self.pair_dict:
-                self.pair_dict[p]["priority"] -= 1
-            # send pair to end of queue
-            self.pair_dict[pair]["priority"] = len(self.pair_dict)
 
     def set_initial_return_values(self, pair: str, pred_df: DataFrame) -> None:
         """

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -707,6 +707,10 @@ class IFreqaiModel(ABC):
         for pair in pair_dict_sorted:
             if pair[0] in current_pairlist:
                 best_queue.appendleft(pair[0])
+        for pair in current_pairlist:
+            if pair not in best_queue:
+                best_queue.appendleft(pair)
+
         logger.info('Set existing queue from trained timestamps.')
         return best_queue
 

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -182,6 +182,7 @@ class IFreqaiModel(ABC):
         :param strategy: IStrategy = The user defined strategy class
         """
         while not self._stop_event.is_set():
+            time.sleep(1)
             pair = self.train_queue[0]
 
             # ensure pair is avaialble in dp

--- a/freqtrade/templates/FreqaiExampleStrategy.py
+++ b/freqtrade/templates/FreqaiExampleStrategy.py
@@ -45,7 +45,7 @@ class FreqaiExampleStrategy(IStrategy):
     std_dev_multiplier_buy = CategoricalParameter(
         [0.75, 1, 1.25, 1.5, 1.75], default=1.25, space="buy", optimize=True)
     std_dev_multiplier_sell = CategoricalParameter(
-        [0.1, 0.25, 0.4], space="sell", default=0.2, optimize=True)
+        [0.75, 1, 1.25, 1.5, 1.75], space="sell", default=1.25, optimize=True)
 
     def informative_pairs(self):
         whitelist_pairs = self.dp.current_whitelist()


### PR DESCRIPTION
The old FreqAI train queue was in-capable of continuing training after reloading from a changed pairlist (while maintaining `identifier` constant). 

This lead to issues where the bot would stop training, and it would simply wait indefinitely without training a pair. 

Current PR switches to a `deque` for the queue and builds queues from existing information to the best of its ability, or if no existing info is available, it builds the queue based on the whitelist.