### PR TITLE
Ensure train ordering after restart

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -702,8 +702,8 @@ class IFreqaiModel(ABC):
         """
         current_pairlist = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.dd.pair_dict:
-            logger.info('Set fresh train queue from whitelist.')
-            logger.info(f'Queue: {current_pairlist}')
+            logger.info('Set fresh train queue from whitelist. '
+                        f'Queue: {current_pairlist}')
             return deque(current_pairlist)
 
         best_queue = deque()
@@ -717,8 +717,8 @@ class IFreqaiModel(ABC):
             if pair not in best_queue:
                 best_queue.appendleft(pair)
 
-        logger.info('Set existing queue from trained timestamps.')
-        logger.info(f'Best approximation queue: {best_queue}')
+        logger.info('Set existing queue from trained timestamps. '
+                    f'Best approximation queue: {best_queue}')
         return best_queue
 
     # Following methods which are overridden by user made prediction models.

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -703,6 +703,7 @@ class IFreqaiModel(ABC):
         current_pairlist = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.dd.pair_dict:
             logger.info('Set fresh train queue from whitelist.')
+            logger.info(f'Queue: {current_pairlist}')
             return deque(current_pairlist)
 
         best_queue = deque()
@@ -717,6 +718,7 @@ class IFreqaiModel(ABC):
                 best_queue.appendleft(pair)
 
         logger.info('Set existing queue from trained timestamps.')
+        logger.info(f'Best approximation queue: {best_queue}')
         return best_queue
 
     # Following methods which are overridden by user made prediction models.

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -712,7 +712,7 @@ class IFreqaiModel(ABC):
                                   key=lambda k: k[1]['trained_timestamp'])
         for pair in pair_dict_sorted:
             if pair[0] in current_pairlist:
-                best_queue.appendright(pair[0])
+                best_queue.append(pair[0])
         for pair in current_pairlist:
             if pair not in best_queue:
                 best_queue.appendleft(pair)

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -711,7 +711,7 @@ class IFreqaiModel(ABC):
                                   key=lambda k: k[1]['trained_timestamp'])
         for pair in pair_dict_sorted:
             if pair[0] in current_pairlist:
-                best_queue.appendleft(pair[0])
+                best_queue.appendright(pair[0])
         for pair in current_pairlist:
             if pair not in best_queue:
                 best_queue.appendleft(pair)


### PR DESCRIPTION
Ensure lowest timestamps get trained first after restart.

The dict is sorted from lowest timestamp to highest timestamp - this means that we want to appendright() so that lower timestamps get trained before higher timestamps. 