### PR TITLE
Allow FreqAI to send back individual columns in backtesting (`spice_rack` need)

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -90,8 +90,12 @@ class DataProvider:
         if saved_pair not in self.__cached_pairs_backtesting:
             timerange = TimeRange.parse_timerange(None if self._config.get(
                 'timerange') is None else str(self._config.get('timerange')))
+
+            # In backtesting, the training data was already add
+            add_train_candles = self.runmode in (RunMode.DRY_RUN, RunMode.LIVE)
+            startup_candles = self.get_required_startup(str(timeframe), add_train_candles)
+
             # Move informative start time respecting startup_candle_count
-            startup_candles = self.get_required_startup(str(timeframe))
             tf_seconds = timeframe_to_seconds(str(timeframe))
             timerange.subtract_start(tf_seconds * startup_candles)
             self.__cached_pairs_backtesting[saved_pair] = load_pair_history(
@@ -105,7 +109,7 @@ class DataProvider:
             )
         return self.__cached_pairs_backtesting[saved_pair].copy()
 
-    def get_required_startup(self, timeframe: str) -> int:
+    def get_required_startup(self, timeframe: str, add_train_candles: bool = True) -> int:
         freqai_config = self._config.get('freqai', {})
         if not freqai_config.get('enabled', False):
             return self._config.get('startup_candle_count', 0)
@@ -115,7 +119,9 @@ class DataProvider:
             # make sure the startupcandles is at least the set maximum indicator periods
             self._config['startup_candle_count'] = max(startup_candles, max(indicator_periods))
             tf_seconds = timeframe_to_seconds(timeframe)
-            train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
+            train_candles = 0
+            if add_train_candles:
+                train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
             total_candles = int(self._config['startup_candle_count'] + train_candles)
             logger.info(f'Increasing startup_candle_count for freqai to {total_candles}')
             return total_candles

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -143,10 +143,14 @@ class Backtesting:
 
         # Get maximum required startup period
         self.required_startup = max([strat.startup_candle_count for strat in self.strategylist])
-        # Add maximum startup candle count to configuration for informative pairs support
-        self.config['startup_candle_count'] = self.required_startup
         self.exchange.validate_required_startup_candles(self.required_startup, self.timeframe)
 
+        if self.config.get('freqai', {}).get('enabled', False):
+            # For FreqAI, increase the required_startup to includes the training data
+            self.required_startup = self.dataprovider.get_required_startup(self.timeframe)
+
+        # Add maximum startup candle count to configuration for informative pairs support
+        self.config['startup_candle_count'] = self.required_startup
         self.trading_mode: TradingMode = config.get('trading_mode', TradingMode.SPOT)
         # strategies which define "can_short=True" will fail to load in Spot mode.
         self._can_short = self.trading_mode != TradingMode.SPOT
@@ -221,7 +225,7 @@ class Backtesting:
             pairs=self.pairlists.whitelist,
             timeframe=self.timeframe,
             timerange=self.timerange,
-            startup_candles=self.dataprovider.get_required_startup(self.timeframe),
+            startup_candles=self.config['startup_candle_count'],
             fail_without_data=True,
             data_format=self.config.get('dataformat_ohlcv', 'json'),
             candle_type=self.config.get('candle_type_def', CandleType.SPOT)


### PR DESCRIPTION
## Summary

Try to let FT trim the backtesting data instead of FreqAI by modifying startup_candle in backtesting module.

FreqAI is designed to replace the entire dataframe in backtesting.

spice_rack simply adds a column to an existing dataframe.

The dataframes are not equal in length because FreqAI is trimming off training data candles at the end of the backtesting calculations so that backtesting statistics would be correct.

Now we need the dataframe in FreqAI to match the length of the dataframe in the backtest, which includes the training data candles. So the trimming needs to happen later, to maintain backtesting statistics accuracy.

Please read the [conversation on discord](https://discord.com/channels/700048804539400213/983285489299779645/1021150889811120158) for background.

Please also review [this PR](https://github.com/freqtrade/freqtrade/pull/7391) to understand why the training data was interfering with backtesting statistics, and needed to be removed.