### PR TITLE
protect against unforeseen issues in scanning thread

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -205,9 +205,13 @@ class IFreqaiModel(ABC):
 
             if retrain:
                 self.train_timer('start')
-                self.extract_data_and_train_model(
-                    new_trained_timerange, pair, strategy, dk, data_load_timerange
-                )
+                try:
+                    self.extract_data_and_train_model(
+                        new_trained_timerange, pair, strategy, dk, data_load_timerange
+                    )
+                except Exception as msg:
+                    logger.warning(f'Training {pair} raised exception {msg}, skipping.')
+
                 self.train_timer('stop')
 
                 # only rotate the queue after the first has been trained.


### PR DESCRIPTION
The training thread is vulnerable to unforeseen and rare issues. Such as 

```
catboost/libs/metrics/metric.cpp:5119: All train targets are equal
```
Here we log it as an error and allow the thread to keep going, avoiding a full breakdown of the training thread just because a single pair had an issue. 