### PR TITLE
Allow use of --strategy-list with freqai, with warning

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -430,6 +430,16 @@ class FreqaiDataDrawer:
 
         return
 
+    def load_metadata(self, dk: FreqaiDataKitchen) -> None:
+        """
+        Load only metadata into datakitchen to increase performance during
+        presaved backtesting (prediction file loading).
+        """
+        with open(dk.data_path / f"{dk.model_filename}_metadata.json", "r") as fp:
+            dk.data = json.load(fp)
+            dk.training_features_list = dk.data["training_features_list"]
+            dk.label_list = dk.data["label_list"]
+
     def load_data(self, coin: str, dk: FreqaiDataKitchen) -> Any:
         """
         loads all data required to make a prediction on a sub-train time range

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -260,7 +260,7 @@ class IFreqaiModel(ABC):
                                                 tr_train.stopts,
                                                 tz=timezone.utc).strftime(DATETIME_PRINT_FORMAT)
             logger.info(
-                f"Training {metadata['pair']}, {self.pair_it}/{self.total_pairs} pairs"
+                f"Training {pair}, {self.pair_it}/{self.total_pairs} pairs"
                 f" from {tr_train_startts_str} to {tr_train_stopts_str}, {train_it}/{total_trains} "
                 "trains"
             )
@@ -279,7 +279,7 @@ class IFreqaiModel(ABC):
                 dk.append_predictions(append_df)
             else:
                 if not self.model_exists(
-                    metadata["pair"], dk, trained_timestamp=trained_timestamp_int
+                    pair, dk, trained_timestamp=trained_timestamp_int
                 ):
                     dk.find_features(dataframe_train)
                     self.model = self.train(dataframe_train, pair, dk)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -91,8 +91,8 @@ class Backtesting:
 
         if self.config.get('strategy_list'):
             if self.config.get('freqai', {}).get('enabled', False):
-                raise OperationalException(
-                    "You can't use strategy_list and freqai at the same time.")
+                logger.warning("Using --strategy-list with FreqAI REQUIRES all strategies "
+                               "to have identical populate_any_indicators.")
             for strat in list(self.config['strategy_list']):
                 stratconf = deepcopy(self.config)
                 stratconf['strategy'] = strat

--- a/tests/freqai/test_freqai_backtesting.py
+++ b/tests/freqai/test_freqai_backtesting.py
@@ -3,21 +3,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import PropertyMock
 
-import pytest
-
-from freqtrade.commands.optimize_commands import start_backtesting
-from freqtrade.exceptions import OperationalException
+from freqtrade.commands.optimize_commands import setup_optimize_configuration
+from freqtrade.enums import RunMode
 from freqtrade.optimize.backtesting import Backtesting
 from tests.conftest import (CURRENT_TEST_STRATEGY, get_args, log_has_re, patch_exchange,
                             patched_configuration_load_config_file)
 
 
-def test_freqai_backtest_start_backtest_list(freqai_conf, mocker, testdatadir):
+def test_freqai_backtest_start_backtest_list(freqai_conf, mocker, testdatadir, caplog):
     patch_exchange(mocker)
 
+    now = datetime.now(timezone.utc)
     mocker.patch('freqtrade.plugins.pairlistmanager.PairListManager.whitelist',
                  PropertyMock(return_value=['HULUMULU/USDT', 'XRP/USDT']))
-    # mocker.patch('freqtrade.optimize.backtesting.Backtesting.backtest', backtestmock)
+    mocker.patch('freqtrade.optimize.backtesting.history.load_data')
+    mocker.patch('freqtrade.optimize.backtesting.history.get_timerange', return_value=(now, now))
 
     patched_configuration_load_config_file(mocker, freqai_conf)
 
@@ -30,9 +30,11 @@ def test_freqai_backtest_start_backtest_list(freqai_conf, mocker, testdatadir):
         '--strategy-list', CURRENT_TEST_STRATEGY
     ]
     args = get_args(args)
-    with pytest.raises(OperationalException,
-                       match=r"You can't use strategy_list and freqai at the same time\."):
-        start_backtesting(args)
+    bt_config = setup_optimize_configuration(args, RunMode.BACKTEST)
+    Backtesting(bt_config)
+    assert log_has_re('Using --strategy-list with FreqAI REQUIRES all strategies to have identical '
+                      'populate_any_indicators.', caplog)
+    Backtesting.cleanup()
 
 
 def test_freqai_backtest_load_data(freqai_conf, mocker, caplog):


### PR DESCRIPTION
## Summary

Trying to run backtesting with freqai and multiple strategies via `--strategy-list` currently exits with an `OperationalException`. This PR changes this to allow backtesting multiple strategies in one command, but with a user warning that all strategies must share identical `populate_any_indicators`.

## Quick changelog

- Replace raising `OperationalException` with a user warning.
- Rewrite test.freqai.test_freqai_backtesting.test_freqai_backtest_start_backtest_list to assert the warning is produced.