### PR TITLE
Fix feature list match for PCA

### DIFF
--- a/freqtrade/freqai/base_models/BaseClassifierModel.py
+++ b/freqtrade/freqai/base_models/BaseClassifierModel.py
@@ -92,7 +92,7 @@ class BaseClassifierModel(IFreqaiModel):
         filtered_df = dk.normalize_data_from_metadata(filtered_df)
         dk.data_dictionary["prediction_features"] = filtered_df
 
-        self.data_cleaning_predict(dk, filtered_df)
+        self.data_cleaning_predict(dk)
 
         predictions = self.model.predict(dk.data_dictionary["prediction_features"])
         pred_df = DataFrame(predictions, columns=dk.label_list)

--- a/freqtrade/freqai/base_models/BaseRegressionModel.py
+++ b/freqtrade/freqai/base_models/BaseRegressionModel.py
@@ -92,7 +92,7 @@ class BaseRegressionModel(IFreqaiModel):
         dk.data_dictionary["prediction_features"] = filtered_df
 
         # optional additional data cleaning/analysis
-        self.data_cleaning_predict(dk, filtered_df)
+        self.data_cleaning_predict(dk)
 
         predictions = self.model.predict(dk.data_dictionary["prediction_features"])
         pred_df = DataFrame(predictions, columns=dk.label_list)

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -423,7 +423,7 @@ class FreqaiDataDrawer:
 
         dk.data["data_path"] = str(dk.data_path)
         dk.data["model_filename"] = str(dk.model_filename)
-        dk.data["training_features_list"] = list(dk.data_dictionary["train_features"].columns)
+        dk.data["training_features_list"] = dk.training_features_list
         dk.data["label_list"] = dk.label_list
         # store the metadata
         with open(save_path / f"{dk.model_filename}_metadata.json", "w") as fp:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -844,12 +844,10 @@ class FreqaiDataKitchen:
             self.remove_beginning_points_from_data_dict(set_, no_prev_pts)
             self.data_dictionary[f'{set_}_features'] = pd.concat(
                 [compute_df, inlier_metric], axis=1)
-            # self.find_features(self.data_dictionary[f'{set_}_features'])
         else:
             self.data_dictionary['prediction_features'] = pd.concat(
                 [compute_df, inlier_metric], axis=1)
             self.data_dictionary['prediction_features'].fillna(0, inplace=True)
-            # self.find_features(self.data_dictionary['prediction_features'])
 
         logger.info('Inlier metric computed and added to features.')
 

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -844,10 +844,12 @@ class FreqaiDataKitchen:
             self.remove_beginning_points_from_data_dict(set_, no_prev_pts)
             self.data_dictionary[f'{set_}_features'] = pd.concat(
                 [compute_df, inlier_metric], axis=1)
+            # self.find_features(self.data_dictionary[f'{set_}_features'])
         else:
             self.data_dictionary['prediction_features'] = pd.concat(
                 [compute_df, inlier_metric], axis=1)
             self.data_dictionary['prediction_features'].fillna(0, inplace=True)
+            # self.find_features(self.data_dictionary['prediction_features'])
 
         logger.info('Inlier metric computed and added to features.')
 

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import re
 import shutil
 from datetime import datetime, timezone
 from math import cos, sin
@@ -882,9 +881,6 @@ class FreqaiDataKitchen:
         """
         column_names = dataframe.columns
         features = [c for c in column_names if "%" in c]
-        pca_features = [c for c in column_names if re.search(r"^PC\d+$", c)]
-        if not features and pca_features:
-            features = pca_features
 
         if not features:
             raise OperationalException("Could not find any features!")

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import re
 import shutil
 from datetime import datetime, timezone
 from math import cos, sin
@@ -881,6 +882,10 @@ class FreqaiDataKitchen:
         """
         column_names = dataframe.columns
         features = [c for c in column_names if "%" in c]
+        pca_features = [c for c in column_names if re.search(r"^PC\d+$", c)]
+        if not features and pca_features:
+            features = pca_features
+
         if not features:
             raise OperationalException("Could not find any features!")
 

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -434,6 +434,10 @@ class IFreqaiModel(ABC):
             feature_list = dk.data["training_features_list_raw"]
         else:
             feature_list = dk.data['training_features_list']
+
+        if self.ft_params.get('principal_component_analysis', False):
+            feature_list = dk.data['training_features_list']
+
         if dk.training_features_list != feature_list:
             raise OperationalException(
                 "Trying to access pretrained model with `identifier` "

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -275,7 +275,8 @@ class IFreqaiModel(ABC):
 
             if dk.check_if_backtest_prediction_exists():
                 self.dd.load_metadata(dk)
-                self.check_if_feature_list_matches_strategy(dataframe_train, dk)
+                dk.find_features(dataframe_train)
+                self.check_if_feature_list_matches_strategy(dk)
                 append_df = dk.get_backtesting_prediction()
                 dk.append_predictions(append_df)
             else:
@@ -296,7 +297,6 @@ class IFreqaiModel(ABC):
                 else:
                     self.model = self.dd.load_data(pair, dk)
 
-                # self.check_if_feature_list_matches_strategy(dataframe_train, dk)
                 pred_df, do_preds = self.predict(dataframe_backtest, dk)
                 append_df = dk.get_predictions_to_append(pred_df, do_preds)
                 dk.append_predictions(append_df)
@@ -420,7 +420,7 @@ class IFreqaiModel(ABC):
         return
 
     def check_if_feature_list_matches_strategy(
-        self, dataframe: DataFrame, dk: FreqaiDataKitchen
+        self, dk: FreqaiDataKitchen
     ) -> None:
         """
         Ensure user is passing the proper feature set if they are reusing an `identifier` pointing
@@ -429,13 +429,10 @@ class IFreqaiModel(ABC):
         :param dk: FreqaiDataKitchen = non-persistent data container/analyzer for
                    current coin/bot loop
         """
-        dk.find_features(dataframe)
+
         if "training_features_list_raw" in dk.data:
             feature_list = dk.data["training_features_list_raw"]
         else:
-            feature_list = dk.data['training_features_list']
-
-        if self.ft_params.get('principal_component_analysis', False):
             feature_list = dk.data['training_features_list']
 
         if dk.training_features_list != feature_list:
@@ -510,7 +507,7 @@ class IFreqaiModel(ABC):
             dk.use_DBSCAN_to_remove_outliers(predict=True)
 
         # ensure user is feeding the correct indicators to the model
-        self.check_if_feature_list_matches_strategy(dk.data_dictionary['prediction_features'], dk)
+        self.check_if_feature_list_matches_strategy(dk)
 
     def model_exists(self, dk: FreqaiDataKitchen) -> bool:
         """

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -482,12 +482,15 @@ class IFreqaiModel(ABC):
         if self.freqai_info["feature_parameters"].get('noise_standard_deviation', 0):
             dk.add_noise_to_training_features()
 
-    def data_cleaning_predict(self, dk: FreqaiDataKitchen, dataframe: DataFrame) -> None:
+    def data_cleaning_predict(self, dk: FreqaiDataKitchen) -> None:
         """
         Base data cleaning method for predict.
         Functions here are complementary to the functions of data_cleaning_train.
         """
         ft_params = self.freqai_info["feature_parameters"]
+
+        # ensure user is feeding the correct indicators to the model
+        self.check_if_feature_list_matches_strategy(dk)
 
         if ft_params.get('inlier_metric_window', 0):
             dk.compute_inlier_metric(set_='predict')
@@ -505,9 +508,6 @@ class IFreqaiModel(ABC):
 
         if ft_params.get("use_DBSCAN_to_remove_outliers", False):
             dk.use_DBSCAN_to_remove_outliers(predict=True)
-
-        # ensure user is feeding the correct indicators to the model
-        self.check_if_feature_list_matches_strategy(dk)
 
     def model_exists(self, dk: FreqaiDataKitchen) -> bool:
         """


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Currently pca transformation is not working correctly because feature list doesn't match with training features. 
This is an attempt to solve the following error messages we get now if we enable PCA:

```
File "/home/ubuntu/Temp/freqtrade/freqtrade/freqai/freqai_interface.py", line 432, in check_if_feature_list_matches_strategy
    dk.find_features(dataframe)
File "/home/ubuntu/Temp/freqtrade/freqtrade/freqai/data_kitchen.py", line 885, in find_features
    raise OperationalException("Could not find any features!")
freqtrade.exceptions.OperationalException: Could not find any features!
2022-09-30 06:24:17,563 - freqtrade.strategy.interface - WARNING - Unable to analyze candle (OHLCV) data for pair EOS/USDT: Could not find any features!
```