### PR TITLE
add close price and date to `historic_predictions.pkl`

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -294,6 +294,12 @@ class FreqaiDataDrawer:
             for return_str in rets:
                 df[return_str].iloc[-1] = rets[return_str]
 
+        # this logic carries users between version without needing to 
+        # change their identifier
+        if 'close_price' not in df.columns:
+            df['close_price'] = 0
+            df['date_pred'] = 0
+
         df['close_price'].iloc[-1] = strat_df['close'].iloc[-1]
         df['date_pred'].iloc[-1] = strat_df['date'].iloc[-1]
 

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -257,7 +257,7 @@ class FreqaiDataDrawer:
 
     def append_model_predictions(self, pair: str, predictions: DataFrame,
                                  do_preds: NDArray[np.int_],
-                                 dk: FreqaiDataKitchen, len_df: int) -> None:
+                                 dk: FreqaiDataKitchen, strat_df: DataFrame) -> None:
         """
         Append model predictions to historic predictions dataframe, then set the
         strategy return dataframe to the tail of the historic predictions. The length of
@@ -266,6 +266,7 @@ class FreqaiDataDrawer:
         historic predictions.
         """
 
+        len_df = len(strat_df)
         index = self.historic_predictions[pair].index[-1:]
         columns = self.historic_predictions[pair].columns
 
@@ -292,6 +293,9 @@ class FreqaiDataDrawer:
             rets = dk.data['extra_returns_per_train']
             for return_str in rets:
                 df[return_str].iloc[-1] = rets[return_str]
+
+        df['close_price'].iloc[-1] = strat_df['close'].iloc[-1]
+        df['date_pred'].iloc[-1] = strat_df['date'].iloc[-1]
 
         self.model_return_values[pair] = df.tail(len_df).reset_index(drop=True)
 

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -294,7 +294,7 @@ class FreqaiDataDrawer:
             for return_str in rets:
                 df[return_str].iloc[-1] = rets[return_str]
 
-        # this logic carries users between version without needing to 
+        # this logic carries users between version without needing to
         # change their identifier
         if 'close_price' not in df.columns:
             df['close_price'] = np.nan

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -297,8 +297,8 @@ class FreqaiDataDrawer:
         # this logic carries users between version without needing to 
         # change their identifier
         if 'close_price' not in df.columns:
-            df['close_price'] = 0
-            df['date_pred'] = 0
+            df['close_price'] = np.nan
+            df['date_pred'] = np.nan
 
         df['close_price'].iloc[-1] = strat_df['close'].iloc[-1]
         df['date_pred'].iloc[-1] = strat_df['date'].iloc[-1]

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -393,7 +393,7 @@ class IFreqaiModel(ABC):
             # allows FreqUI to show full return values.
             pred_df, do_preds = self.predict(dataframe, dk)
             if pair not in self.dd.historic_predictions:
-                self.set_initial_historic_predictions(pred_df, dk, pair)
+                self.set_initial_historic_predictions(pred_df, dk, pair, dataframe)
             self.dd.set_initial_return_values(pair, pred_df)
 
             dk.return_dataframe = self.dd.attach_return_values_to_return_dataframe(pair, dataframe)
@@ -414,7 +414,7 @@ class IFreqaiModel(ABC):
 
         if self.freqai_info.get('fit_live_predictions_candles', 0) and self.live:
             self.fit_live_predictions(dk, pair)
-        self.dd.append_model_predictions(pair, pred_df, do_preds, dk, len(dataframe))
+        self.dd.append_model_predictions(pair, pred_df, do_preds, dk, dataframe)
         dk.return_dataframe = self.dd.attach_return_values_to_return_dataframe(pair, dataframe)
 
         return
@@ -583,7 +583,7 @@ class IFreqaiModel(ABC):
             self.dd.purge_old_models()
 
     def set_initial_historic_predictions(
-        self, pred_df: DataFrame, dk: FreqaiDataKitchen, pair: str
+        self, pred_df: DataFrame, dk: FreqaiDataKitchen, pair: str, strat_df: DataFrame
     ) -> None:
         """
         This function is called only if the datadrawer failed to load an
@@ -625,6 +625,9 @@ class IFreqaiModel(ABC):
 
         for return_str in dk.data['extra_returns_per_train']:
             hist_preds_df[return_str] = 0
+
+        hist_preds_df['close_price'] = strat_df['close']
+        hist_preds_df['date_pred'] = strat_df['date']
 
         # # for keras type models, the conv_window needs to be prepended so
         # # viewing is correct in frequi


### PR DESCRIPTION
Add close price and date at each prediction data point in the persistent `historic_predictions.pkl` to enable performance tracking and deeper post processing options. 