### PR TITLE
Remove constant labels from prediction

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -460,6 +460,18 @@ class FreqaiDataKitchen:
 
         return df
 
+    def check_pred_labels(self, df_predictions: DataFrame) -> None:
+        """
+        Check that prediction feature labels match training feature labels.
+        :params:
+        :df_predictions: incoming predictions
+        """
+        train_labels = self.data_dictionary["train_features"].columns
+        pred_labels = df_predictions.columns
+        if len(train_labels.difference(pred_labels)) != 0:
+            self.data_dictionary["prediction_features"] = df_predictions[train_labels]
+        return
+
     def principal_component_analysis(self) -> None:
         """
         Performs Principal Component Analysis on the data for dimensionality reduction

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -241,6 +241,7 @@ class FreqaiDataKitchen:
             self.data["filter_drop_index_training"] = drop_index
 
         else:
+            filtered_df = self.check_pred_labels(filtered_df)
             # we are backtesting so we need to preserve row number to send back to strategy,
             # so now we use do_predict to avoid any prediction based on a NaN
             drop_index = pd.isnull(filtered_df).any(axis=1)
@@ -460,7 +461,7 @@ class FreqaiDataKitchen:
 
         return df
 
-    def check_pred_labels(self, df_predictions: DataFrame) -> None:
+    def check_pred_labels(self, df_predictions: DataFrame) -> DataFrame:
         """
         Check that prediction feature labels match training feature labels.
         :params:
@@ -468,9 +469,15 @@ class FreqaiDataKitchen:
         """
         train_labels = self.data_dictionary["train_features"].columns
         pred_labels = df_predictions.columns
-        if len(train_labels.difference(pred_labels)) != 0:
-            self.data_dictionary["prediction_features"] = df_predictions[train_labels]
-        return
+        num_diffs = len(pred_labels.difference(train_labels))
+        if num_diffs != 0:
+            df_predictions = df_predictions[train_labels]
+            logger.warning(
+                f"Removed {num_diffs} features from prediction features, "
+                f"these were likely considered constant values during most recent training."
+            )
+
+        return df_predictions
 
     def principal_component_analysis(self) -> None:
         """

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -492,8 +492,6 @@ class IFreqaiModel(ABC):
         # ensure user is feeding the correct indicators to the model
         self.check_if_feature_list_matches_strategy(dk)
 
-        dk.check_pred_labels(dk.data_dictionary['prediction_features'])
-
         if ft_params.get('inlier_metric_window', 0):
             dk.compute_inlier_metric(set_='predict')
 

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -492,6 +492,8 @@ class IFreqaiModel(ABC):
         # ensure user is feeding the correct indicators to the model
         self.check_if_feature_list_matches_strategy(dk)
 
+        dk.check_pred_labels(dk.data_dictionary['prediction_features'])
+
         if ft_params.get('inlier_metric_window', 0):
             dk.compute_inlier_metric(set_='predict')
 

--- a/tests/freqai/conftest.py
+++ b/tests/freqai/conftest.py
@@ -107,6 +107,8 @@ def make_unfiltered_dataframe(mocker, freqai_conf):
     unfiltered_dataframe = freqai.dk.use_strategy_to_populate_indicators(
                 strategy, corr_dataframes, base_dataframes, freqai.dk.pair
             )
+    for i in range(5):
+        unfiltered_dataframe[f'constant_{i}'] = i
 
     unfiltered_dataframe = freqai.dk.slice_dataframe(new_timerange, unfiltered_dataframe)
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -181,6 +181,8 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
+    for i in range(5):
+        df[f'constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
@@ -208,6 +210,8 @@ def test_start_backtesting_subdaily_backtest_period(mocker, freqai_conf):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
+    for i in range(5):
+        df[f'constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
@@ -233,6 +237,8 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
+    for i in range(5):
+        df[f'constant_{i}'] = i
 
     metadata = {"pair": "ADA/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
@@ -256,6 +262,8 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
+    for i in range(5):
+        df[f'constant_{i}'] = i
     freqai.start_backtesting(df, metadata, freqai.dk)
 
     assert log_has_re(
@@ -312,6 +320,8 @@ def test_follow_mode(mocker, freqai_conf):
     freqai.dd.load_all_pair_histories(timerange, freqai.dk)
 
     df = strategy.dp.get_pair_dataframe('ADA/BTC', '5m')
+    for i in range(5):
+        df[f'constant_{i}'] = i
     freqai.start_live(df, metadata, strategy, freqai.dk)
 
     assert len(freqai.dk.return_dataframe.index) == 5702

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -157,7 +157,7 @@ def test_extract_data_and_train_model_Classifiers(mocker, freqai_conf, model):
         ("CatboostClassifier", 6, "freqai_test_classifier")
     ],
     )
-def test_start_backtesting(mocker, freqai_conf, model, num_files, strat):
+def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog):
     freqai_conf.get("freqai", {}).update({"save_backtest_models": True})
     freqai_conf['runmode'] = RunMode.BACKTEST
     Trade.use_db = False
@@ -182,13 +182,21 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat):
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
     for i in range(5):
-        df[f'constant_{i}'] = i
+        df.loc[:, f'%-constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
     assert len(model_folders) == num_files
+    assert log_has_re(
+        "Removed features ",
+        caplog,
+    )
+    assert log_has_re(
+        "Removed 5 features from prediction features, ",
+        caplog,
+    )
     Backtesting.cleanup()
     shutil.rmtree(Path(freqai.dk.full_path))
 
@@ -210,8 +218,6 @@ def test_start_backtesting_subdaily_backtest_period(mocker, freqai_conf):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
-    for i in range(5):
-        df[f'constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
@@ -237,8 +243,6 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
-    for i in range(5):
-        df[f'constant_{i}'] = i
 
     metadata = {"pair": "ADA/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
@@ -262,8 +266,7 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
-    for i in range(5):
-        df[f'constant_{i}'] = i
+
     freqai.start_backtesting(df, metadata, freqai.dk)
 
     assert log_has_re(
@@ -320,8 +323,7 @@ def test_follow_mode(mocker, freqai_conf):
     freqai.dd.load_all_pair_histories(timerange, freqai.dk)
 
     df = strategy.dp.get_pair_dataframe('ADA/BTC', '5m')
-    for i in range(5):
-        df[f'constant_{i}'] = i
+
     freqai.start_live(df, metadata, strategy, freqai.dk)
 
     assert len(freqai.dk.return_dataframe.index) == 5702

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -182,7 +182,8 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog)
 
     df = freqai.dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "LTC/BTC")
     for i in range(5):
-        df.loc[:, f'%-constant_{i}'] = i
+        df[f'%-constant_{i}'] = i
+        # df.loc[:, f'%-constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)


### PR DESCRIPTION
## Summary

Match prediction labels to training labels if constant features were removed from training data.
https://github.com/freqtrade/freqtrade/issues/7542#issue-1399878192

## Quick changelog

Constant features bring no information to the ML model and are therefore removed. This PR ensures that constant features are removed from prediction data so that the labels match the training data.
