### PR TITLE
Better Message WebSocket performance

### DIFF
--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -134,13 +134,13 @@ async def message_endpoint(
 
             except (
                 WebSocketDisconnect,
-                websockets.exceptions.ConnectionClosed
+                websockets.exceptions.WebSocketException
             ):
                 # Handle client disconnects
                 logger.info(f"Consumer disconnected - {channel}")
             except Exception as e:
                 logger.info(f"Consumer connection failed - {channel}")
-                logger.exception(e)
+                logger.debug(e, exc_info=e)
                 # Handle cases like -
                 # RuntimeError('Cannot call "send" once a closed message has been sent')
             finally:

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -245,6 +245,7 @@ class ApiServer(RPCHandler):
                                   use_colors=False,
                                   log_config=None,
                                   access_log=True if verbosity != 'error' else False,
+                                  ws_ping_interval=None
                                   )
         try:
             self._server = UvicornServer(uvconfig)

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -62,7 +62,7 @@ class ExternalMessageConsumer:
         self.enabled = self._emc_config.get('enabled', False)
         self.producers: List[Producer] = self._emc_config.get('producers', [])
 
-        self.wait_timeout = self._emc_config.get('wait_timeout', 300)  # in seconds
+        self.wait_timeout = self._emc_config.get('wait_timeout', 30)  # in seconds
         self.ping_timeout = self._emc_config.get('ping_timeout', 10)  # in seconds
         self.sleep_time = self._emc_config.get('sleep_time', 10)  # in seconds
 
@@ -182,7 +182,11 @@ class ExternalMessageConsumer:
                 ws_url = f"ws://{host}:{port}/api/v1/message/ws?token={token}"
 
                 # This will raise InvalidURI if the url is bad
-                async with websockets.connect(ws_url, max_size=self.message_size_limit) as ws:
+                async with websockets.connect(
+                    ws_url,
+                    max_size=self.message_size_limit,
+                    ping_interval=None
+                ) as ws:
                     channel = WebSocketChannel(ws, channel_id=name)
 
                     logger.info(f"Producer connection success - {channel}")
@@ -325,7 +329,7 @@ class ExternalMessageConsumer:
             df = remove_entry_exit_signals(df)
 
         # Add the dataframe to the dataprovider
-        self._dp._add_external_df(pair, df,
+        self._dp._add_producer_df(pair, df,
                                   last_analyzed=la,
                                   timeframe=timeframe,
                                   candle_type=candle_type,

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -177,7 +177,7 @@ def test_get_producer_df(mocker, default_conf, ohlcv_history):
     assert la == empty_la
 
     # the data is added, should return that added dataframe
-    dataprovider._add_external_df(pair, ohlcv_history, now, timeframe, candle_type)
+    dataprovider._add_producer_df(pair, ohlcv_history, now, timeframe, candle_type)
     dataframe, la = dataprovider.get_producer_df(pair, timeframe, candle_type)
     assert len(dataframe) > 0
     assert la > empty_la


### PR DESCRIPTION
## Summary

This PR aims to improve the overall performance of the Message Websocket. First, we move away from a naive broadcasting method to a queue-per-client method which should help latency between messages by not waiting on slow connections to send other messages. Next, the broadcasted dataframes have been changed from the full dataframe to the most recent candle. The initial request still requests the full dataframe to begin with, but then any subsequent dataframe messages are appended to the data already there instead of overwriting it. This should guarantee that dataframe messages (besides the initial messages) to be incredibly small.