### PR TITLE
Add eval set to CatboostClassifier

### DIFF
--- a/freqtrade/freqai/prediction_models/CatboostClassifier.py
+++ b/freqtrade/freqai/prediction_models/CatboostClassifier.py
@@ -30,6 +30,14 @@ class CatboostClassifier(BaseClassifierModel):
             label=data_dictionary["train_labels"],
             weight=data_dictionary["train_weights"],
         )
+        if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) == 0:
+            test_data = None
+        else:
+            test_data = Pool(
+                data=data_dictionary["test_features"],
+                label=data_dictionary["test_labels"],
+                weight=data_dictionary["test_weights"],
+            )
 
         cbr = CatBoostClassifier(
             allow_writing_files=True,
@@ -40,6 +48,6 @@ class CatboostClassifier(BaseClassifierModel):
 
         init_model = self.get_init_model(dk.pair)
 
-        cbr.fit(train_data, init_model=init_model)
+        cbr.fit(X=train_data, eval_set=test_data, init_model=init_model)
 
         return cbr


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Added missing eval_set parameter to CatboostClassifier. 
