### PR TITLE
Fix constant PCA

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -206,11 +206,15 @@ class FreqaiDataKitchen:
 
         drop_index = pd.isnull(filtered_df).any(axis=1)  # get the rows that have NaNs,
         drop_index = drop_index.replace(True, 1).replace(False, 0)  # pep8 requirement.
+        ft_params = self.freqai_config["feature_parameters"]
         if (training_filter):
-            const_cols = list((filtered_df.nunique() == 1).loc[lambda x: x].index)
-            if const_cols:
-                filtered_df = filtered_df.filter(filtered_df.columns.difference(const_cols))
-                logger.warning(f"Removed features {const_cols} with constant values.")
+            if not ft_params.get(
+                "principal_component_analysis", False
+            ):
+                const_cols = list((filtered_df.nunique() == 1).loc[lambda x: x].index)
+                if const_cols:
+                    filtered_df = filtered_df.filter(filtered_df.columns.difference(const_cols))
+                    logger.warning(f"Removed features {const_cols} with constant values.")
             # we don't care about total row number (total no. datapoints) in training, we only care
             # about removing any row with NaNs
             # if labels has multiple columns (user wants to train multiple modelEs), we detect here
@@ -241,7 +245,10 @@ class FreqaiDataKitchen:
             self.data["filter_drop_index_training"] = drop_index
 
         else:
-            filtered_df = self.check_pred_labels(filtered_df)
+            if not ft_params.get(
+                "principal_component_analysis", False
+            ):
+                filtered_df = self.check_pred_labels(filtered_df)
             # we are backtesting so we need to preserve row number to send back to strategy,
             # so now we use do_predict to avoid any prediction based on a NaN
             drop_index = pd.isnull(filtered_df).any(axis=1)

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -71,7 +71,6 @@ class FreqaiDataKitchen:
         self.data_path = Path()
         self.label_list: List = []
         self.training_features_list: List = []
-        self.constant_features_list: List = []
         self.model_filename: str = ""
         self.backtesting_results_path = Path()
         self.backtest_predictions_folder: str = "backtesting_predictions"
@@ -211,10 +210,10 @@ class FreqaiDataKitchen:
             const_cols = list((filtered_df.nunique() == 1).loc[lambda x: x].index)
             if const_cols:
                 filtered_df = filtered_df.filter(filtered_df.columns.difference(const_cols))
-                self.constant_features_list = const_cols
+                self.data['constant_features_list'] = const_cols
                 logger.warning(f"Removed features {const_cols} with constant values.")
             else:
-                self.constant_features_list = []
+                self.data['constant_features_list'] = []
             # we don't care about total row number (total no. datapoints) in training, we only care
             # about removing any row with NaNs
             # if labels has multiple columns (user wants to train multiple modelEs), we detect here
@@ -245,7 +244,7 @@ class FreqaiDataKitchen:
             self.data["filter_drop_index_training"] = drop_index
 
         else:
-            if len(self.constant_features_list):
+            if len(self.data['constant_features_list']):
                 filtered_df = self.check_pred_labels(filtered_df)
             # we are backtesting so we need to preserve row number to send back to strategy,
             # so now we use do_predict to avoid any prediction based on a NaN
@@ -472,7 +471,7 @@ class FreqaiDataKitchen:
         :params:
         :df_predictions: incoming predictions
         """
-        constant_labels = self.constant_features_list
+        constant_labels = self.data['constant_features_list']
         df_predictions = df_predictions.filter(
             df_predictions.columns.difference(constant_labels)
         )

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -125,7 +125,8 @@ def test_normalize_data(mocker, freqai_conf):
     freqai = make_data_dictionary(mocker, freqai_conf)
     data_dict = freqai.dk.data_dictionary
     freqai.dk.normalize_data(data_dict)
-    assert len(freqai.dk.data) == 32
+    assert any('_max' in entry for entry in freqai.dk.data.keys())
+    assert any('_min' in entry for entry in freqai.dk.data.keys())
 
 
 def test_filter_features(mocker, freqai_conf):


### PR DESCRIPTION
## Summary

Bug fix for KeyError() trying to remove constant features with PCA enabled.

## Quick changelog

Constant features are removed as they do not contribute to the model. When PCA is enabled, the constant features that were removed no longer matches the df keys and throws an error. This PR disables the removal of constant features if PCA is enabled, as PCA will "remove" them by itself (it only keeps components influencing the variance of the data and a constant feature has little influence). 