### PR TITLE
Fix counting available trade slots in backtesting.

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1123,6 +1123,7 @@ class Backtesting:
                     if self.manage_open_orders(t, current_time, row):
                         # Close trade
                         open_trade_count -= 1
+                        open_trade_count_start -= 1
                         open_trades[pair].remove(t)
                         LocalTrade.trades_open.remove(t)
                         self.wallets.update()

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1457,6 +1457,7 @@ def test_api_strategies(botclient, tmpdir):
         'InformativeDecoratorTest',
         'StrategyTestV2',
         'StrategyTestV3',
+        'StrategyTestV3CustomEntryPrice',
         'StrategyTestV3Futures',
         'freqai_test_classifier',
         'freqai_test_multimodel_strat',

--- a/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
+++ b/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
@@ -1,0 +1,37 @@
+# pragma pylint: disable=missing-docstring, invalid-name, pointless-string-statement
+
+from datetime import datetime
+from typing import Optional
+
+from pandas import DataFrame
+from strategy_test_v3 import StrategyTestV3
+
+
+class StrategyTestV3CustomEntryPrice(StrategyTestV3):
+    """
+    Strategy used by tests freqtrade bot.
+    Please do not modify this strategy, it's  intended for internal use only.
+    Please look at the SampleStrategy in the user_data/strategy directory
+    or strategy repository https://github.com/freqtrade/freqtrade-strategies
+    for samples and inspiration.
+    """
+    new_entry_price: float = 0.001
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            dataframe['volume'] > 0,
+            'enter_long'] = 1
+
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return dataframe
+
+    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+                           entry_tag: Optional[str], side: str, **kwargs) -> float:
+
+        return self.new_entry_price

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -34,7 +34,7 @@ def test_search_all_strategies_no_failed():
     directory = Path(__file__).parent / "strats"
     strategies = StrategyResolver._search_all_objects(directory, enum_failed=False)
     assert isinstance(strategies, list)
-    assert len(strategies) == 9
+    assert len(strategies) == 10
     assert isinstance(strategies[0], dict)
 
 
@@ -42,10 +42,11 @@ def test_search_all_strategies_with_failed():
     directory = Path(__file__).parent / "strats"
     strategies = StrategyResolver._search_all_objects(directory, enum_failed=True)
     assert isinstance(strategies, list)
-    assert len(strategies) == 10
+    assert len(strategies) == 11
     # with enum_failed=True search_all_objects() shall find 2 good strategies
     # and 1 which fails to load
-    assert len([x for x in strategies if x['class'] is not None]) == 9
+    assert len([x for x in strategies if x['class'] is not None]) == 10
+
     assert len([x for x in strategies if x['class'] is None]) == 1
 
     directory = Path(__file__).parent / "strats_nonexistingdir"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

When the backtest cancels an order, it should decrement the open_trade_count_start value, which is later used to check for available trading slots.

Solve the issue: #7592

## Quick changelog

- decrement the `open_trade_count_start` when canceling an order
- add a new test strategy with a custom entry price
- add a test for the issue
