### PR TITLE
Docker compose now in docker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Please do not use bug reports to request new features.
   * Operating system: ____
   * Python Version: _____ (`python -V`)
   * CCXT version: _____ (`pip freeze | grep ccxt`)
-  * Freqtrade Version: ____ (`freqtrade -V` or `docker-compose run --rm freqtrade -V` for Freqtrade running in docker)
+  * Freqtrade Version: ____ (`freqtrade -V` or `docker compose run --rm freqtrade -V` for Freqtrade running in docker)
   
 Note: All issues other than enhancement requests will be closed without further comment if the above template is deleted or not filled out.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ Have you search for this feature before requesting it? It's highly likely that a
   * Operating system: ____
   * Python Version: _____ (`python -V`)
   * CCXT version: _____ (`pip freeze | grep ccxt`)
-  * Freqtrade Version: ____ (`freqtrade -V` or `docker-compose run --rm freqtrade -V` for Freqtrade running in docker)
+  * Freqtrade Version: ____ (`freqtrade -V` or `docker compose run --rm freqtrade -V` for Freqtrade running in docker)
 
 
 ## Describe the enhancement

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -18,7 +18,7 @@ Please do not use the question template to report bugs or to request new feature
   * Operating system: ____
   * Python Version: _____ (`python -V`)
   * CCXT version: _____ (`pip freeze | grep ccxt`)
-  * Freqtrade Version: ____ (`freqtrade -V` or `docker-compose run --rm freqtrade -V` for Freqtrade running in docker)
+  * Freqtrade Version: ____ (`freqtrade -V` or `docker compose run --rm freqtrade -V` for Freqtrade running in docker)
   
 ## Your question
 

--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -5,7 +5,7 @@ You can analyze the results of backtests and trading history easily using Jupyte
 ## Quick start with docker
 
 Freqtrade provides a docker-compose file which starts up a jupyter lab server.
-You can run this server using the following command: `docker-compose -f docker/docker-compose-jupyter.yml up`
+You can run this server using the following command: `docker compose -f docker/docker-compose-jupyter.yml up`
 
 This will create a dockercontainer running jupyter lab, which will be accessible using `https://127.0.0.1:8888/lab`.
 Please use the link that's printed in the console after startup for simplified login.

--- a/docs/docker_quickstart.md
+++ b/docs/docker_quickstart.md
@@ -10,14 +10,14 @@ Start by downloading and installing Docker CE for your platform:
 * [Windows](https://docs.docker.com/docker-for-windows/install/)
 * [Linux](https://docs.docker.com/install/)
 
-To simplify running freqtrade, [`docker-compose`](https://docs.docker.com/compose/install/) should be installed and available to follow the below [docker quick start guide](#docker-quick-start).
+To simplify running freqtrade, [`docker compose`](https://docs.docker.com/compose/install/) should be installed and available to follow the below [docker quick start guide](#docker-quick-start).
 
-## Freqtrade with docker-compose
+## Freqtrade with docker
 
-Freqtrade provides an official Docker image on [Dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/), as well as a [docker-compose file](https://github.com/freqtrade/freqtrade/blob/stable/docker-compose.yml) ready for usage.
+Freqtrade provides an official Docker image on [Dockerhub](https://hub.docker.com/r/freqtradeorg/freqtrade/), as well as a [docker compose file](https://github.com/freqtrade/freqtrade/blob/stable/docker-compose.yml) ready for usage.
 
 !!! Note
-    - The following section assumes that `docker` and `docker-compose` are installed and available to the logged in user.
+    - The following section assumes that `docker` is installed and available to the logged in user.
     - All below commands use relative directories and will have to be executed from the directory containing the `docker-compose.yml` file.
 
 ### Docker quick start
@@ -31,13 +31,13 @@ cd ft_userdata/
 curl https://raw.githubusercontent.com/freqtrade/freqtrade/stable/docker-compose.yml -o docker-compose.yml
 
 # Pull the freqtrade image
-docker-compose pull
+docker compose pull
 
 # Create user directory structure
-docker-compose run --rm freqtrade create-userdir --userdir user_data
+docker compose run --rm freqtrade create-userdir --userdir user_data
 
 # Create configuration - Requires answering interactive questions
-docker-compose run --rm freqtrade new-config --config user_data/config.json
+docker compose run --rm freqtrade new-config --config user_data/config.json
 ```
 
 The above snippet creates a new directory called `ft_userdata`, downloads the latest compose file and pulls the freqtrade image.
@@ -64,7 +64,7 @@ The `SampleStrategy` is run by default.
 Once this is done, you're ready to launch the bot in trading mode (Dry-run or Live-trading, depending on your answer to the corresponding question you made above).
 
 ``` bash
-docker-compose up -d
+docker compose up -d
 ```
 
 !!! Warning "Default configuration"
@@ -84,27 +84,27 @@ You can now access the UI by typing localhost:8080 in your browser.
 
 #### Monitoring the bot
 
-You can check for running instances with `docker-compose ps`.
+You can check for running instances with `docker compose ps`.
 This should list the service `freqtrade` as `running`. If that's not the case, best check the logs (see next point).
 
-#### Docker-compose logs
+#### Docker compose logs
 
 Logs will be written to: `user_data/logs/freqtrade.log`.  
-You can also check the latest log with the command `docker-compose logs -f`.
+You can also check the latest log with the command `docker compose logs -f`.
 
 #### Database
 
 The database will be located at: `user_data/tradesv3.sqlite`
 
-#### Updating freqtrade with docker-compose
+#### Updating freqtrade with docker
 
-Updating freqtrade when using `docker-compose` is as simple as running the following 2 commands:
+Updating freqtrade when using `docker` is as simple as running the following 2 commands:
 
 ``` bash
 # Download the latest image
-docker-compose pull
+docker compose pull
 # Restart the image
-docker-compose up -d
+docker compose up -d
 ```
 
 This will first pull the latest image, and will then restart the container with the just pulled version.
@@ -116,43 +116,43 @@ This will first pull the latest image, and will then restart the container with 
 
 Advanced users may edit the docker-compose file further to include all possible options or arguments.
 
-All freqtrade arguments will be available by running `docker-compose run --rm freqtrade <command> <optional arguments>`.
+All freqtrade arguments will be available by running `docker compose run --rm freqtrade <command> <optional arguments>`.
 
-!!! Warning "`docker-compose` for trade commands"
-    Trade commands (`freqtrade trade <...>`) should not be ran via `docker-compose run` - but should use `docker-compose up -d` instead.
+!!! Warning "`docker compose` for trade commands"
+    Trade commands (`freqtrade trade <...>`) should not be ran via `docker compose run` - but should use `docker compose up -d` instead.
     This makes sure that the container is properly started (including port forwardings) and will make sure that the container will restart after a system reboot.
     If you intend to use freqUI, please also ensure to adjust the [configuration accordingly](rest-api.md#configuration-with-docker), otherwise the UI will not be available.
 
-!!! Note "`docker-compose run --rm`"
+!!! Note "`docker compose run --rm`"
     Including `--rm` will remove the container after completion, and is highly recommended for all modes except trading mode (running with `freqtrade trade` command).
 
-??? Note "Using docker without docker-compose"
-    "`docker-compose run --rm`" will require a compose file to be provided.
+??? Note "Using docker without docker"
+    "`docker compose run --rm`" will require a compose file to be provided.
     Some freqtrade commands that don't require authentication such as `list-pairs` can be run with "`docker run --rm`" instead.  
     For example `docker run --rm freqtradeorg/freqtrade:stable list-pairs --exchange binance --quote BTC --print-json`.  
     This can be useful for fetching exchange information to add to your `config.json` without affecting your running containers.
 
-#### Example: Download data with docker-compose
+#### Example: Download data with docker
 
 Download backtesting data for 5 days for the pair ETH/BTC and 1h timeframe from Binance. The data will be stored in the directory `user_data/data/` on the host.
 
 ``` bash
-docker-compose run --rm freqtrade download-data --pairs ETH/BTC --exchange binance --days 5 -t 1h
+docker compose run --rm freqtrade download-data --pairs ETH/BTC --exchange binance --days 5 -t 1h
 ```
 
 Head over to the [Data Downloading Documentation](data-download.md) for more details on downloading data.
 
-#### Example: Backtest with docker-compose
+#### Example: Backtest with docker
 
 Run backtesting in docker-containers for SampleStrategy and specified timerange of historical data, on 5m timeframe:
 
 ``` bash
-docker-compose run --rm freqtrade backtesting --config user_data/config.json --strategy SampleStrategy --timerange 20190801-20191001 -i 5m
+docker compose run --rm freqtrade backtesting --config user_data/config.json --strategy SampleStrategy --timerange 20190801-20191001 -i 5m
 ```
 
 Head over to the [Backtesting Documentation](backtesting.md) to learn more.
 
-### Additional dependencies with docker-compose
+### Additional dependencies with docker
 
 If your strategy requires dependencies not included in the default image - it will be necessary to build the image on your host.
 For this, please create a Dockerfile containing installation steps for the additional dependencies (have a look at [docker/Dockerfile.custom](https://github.com/freqtrade/freqtrade/blob/develop/docker/Dockerfile.custom) for an example).
@@ -166,15 +166,15 @@ You'll then also need to modify the `docker-compose.yml` file and uncomment the 
       dockerfile: "./Dockerfile.<yourextension>"
 ```
 
-You can then run `docker-compose build --pull` to build the docker image, and run it using the commands described above.
+You can then run `docker compose build --pull` to build the docker image, and run it using the commands described above.
 
-### Plotting with docker-compose
+### Plotting with docker
 
 Commands `freqtrade plot-profit` and `freqtrade plot-dataframe` ([Documentation](plotting.md)) are available by changing the image to `*_plot` in your docker-compose.yml file.
 You can then use these commands as follows:
 
 ``` bash
-docker-compose run --rm freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH --timerange=20180801-20180805
+docker compose run --rm freqtrade plot-dataframe --strategy AwesomeStrategy -p BTC/ETH --timerange=20180801-20180805
 ```
 
 The output will be stored in the `user_data/plot` directory, and can be opened with any modern browser.
@@ -185,7 +185,7 @@ Freqtrade provides a docker-compose file which starts up a jupyter lab server.
 You can run this server using the following command:
 
 ``` bash
-docker-compose -f docker/docker-compose-jupyter.yml up
+docker compose -f docker/docker-compose-jupyter.yml up
 ```
 
 This will create a docker-container running jupyter lab, which will be accessible using `https://127.0.0.1:8888/lab`.
@@ -194,7 +194,7 @@ Please use the link that's printed in the console after startup for simplified l
 Since part of this image is built on your machine, it is recommended to rebuild the image from time to time to keep freqtrade (and dependencies) up-to-date.
 
 ``` bash
-docker-compose -f docker/docker-compose-jupyter.yml build --no-cache
+docker compose -f docker/docker-compose-jupyter.yml build --no-cache
 ```
 
 ## Troubleshooting

--- a/docs/docker_quickstart.md
+++ b/docs/docker_quickstart.md
@@ -4,13 +4,15 @@ This page explains how to run the bot with Docker. It is not meant to work out o
 
 ## Install Docker
 
-Start by downloading and installing Docker CE for your platform:
+Start by downloading and installing Docker / Docker Desktop for your platform:
 
 * [Mac](https://docs.docker.com/docker-for-mac/install/)
 * [Windows](https://docs.docker.com/docker-for-windows/install/)
 * [Linux](https://docs.docker.com/install/)
 
-To simplify running freqtrade, [`docker compose`](https://docs.docker.com/compose/install/) should be installed and available to follow the below [docker quick start guide](#docker-quick-start).
+!!! Info "Docker compose install"
+    Freqtrade documentation assumes the use of Docker desktop (or the docker compose plugin).  
+    While the docker-compose standalone installation still works, it will require changing all `docker compose` commands from `docker compose` to `docker-compose` to work (e.g. `docker compose up -d` will become `docker-compose up -d`).
 
 ## Freqtrade with docker
 

--- a/docs/sql_cheatsheet.md
+++ b/docs/sql_cheatsheet.md
@@ -13,12 +13,12 @@ Feel free to use a visual Database editor like SqliteBrowser if you feel more co
 sudo apt-get install sqlite3
 ```
 
-### Using sqlite3 via docker-compose
+### Using sqlite3 via docker
 
 The freqtrade docker image does contain sqlite3, so you can edit the database without having to install anything on the host system.
 
 ``` bash
-docker-compose exec freqtrade /bin/bash
+docker compose exec freqtrade /bin/bash
 sqlite3 <database-file>.sqlite
 ```
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -6,14 +6,14 @@ To update your freqtrade installation, please use one of the below methods, corr
     Breaking changes / changed behavior will be documented in the changelog that is posted alongside every release.
     For the develop branch, please follow PR's to avoid being surprised by changes.
 
-## docker-compose
+## docker
 
 !!! Note "Legacy installations using the `master` image"
     We're switching from master to stable for the release Images - please adjust your docker-file and replace `freqtradeorg/freqtrade:master` with `freqtradeorg/freqtrade:stable`
 
 ``` bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 ## Installation via setup script

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -654,7 +654,7 @@ Common arguments:
 
 You can also use webserver mode via docker.
 Starting a one-off container requires the configuration of the port explicitly, as ports are not exposed by default.
-You can use `docker-compose run --rm -p 127.0.0.1:8080:8080 freqtrade webserver` to start a one-off container that'll be removed once you stop it. This assumes that port 8080 is still available and no other bot is running on that port.
+You can use `docker compose run --rm -p 127.0.0.1:8080:8080 freqtrade webserver` to start a one-off container that'll be removed once you stop it. This assumes that port 8080 is still available and no other bot is running on that port.
 
 Alternatively, you can reconfigure the docker-compose file to have the command updated:
 
@@ -664,7 +664,7 @@ Alternatively, you can reconfigure the docker-compose file to have the command u
       --config /freqtrade/user_data/config.json
 ```
 
-You can now use `docker-compose up` to start the webserver.
+You can now use `docker compose up` to start the webserver.
 This assumes that the configuration has a webserver enabled and configured for docker (listening port = `0.0.0.0`).
 
 !!! Tip


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Docker compose is now part of docker.

```
docker-compose 
```
does not work anymore.

## Quick changelog

just removed all the problematic *-*