### PR TITLE
Make extra_returns_per_train data available during backtest

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -958,7 +958,7 @@ class FreqaiDataKitchen:
             append_df[f"{label}_std"] = self.data["labels_std"][label]
 
         for extra_col in self.data["extra_returns_per_train"]:
-            append_df[f"{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
+            append_df["{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
 
         append_df["do_predict"] = do_predict
         if self.freqai_config["feature_parameters"].get("DI_threshold", 0) > 0:

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -957,6 +957,9 @@ class FreqaiDataKitchen:
             append_df[f"{label}_mean"] = self.data["labels_mean"][label]
             append_df[f"{label}_std"] = self.data["labels_std"][label]
 
+        for extra_col in self.data["extra_returns_per_train"]:
+            append_df[f"{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
+
         append_df["do_predict"] = do_predict
         if self.freqai_config["feature_parameters"].get("DI_threshold", 0) > 0:
             append_df["DI_values"] = self.DI_values


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Make the data within `extra_returns_per_train` available to the strategy when backtesting.

## Quick changelog

- make change to data_kitchen.py #L960

## What's new?

The values that the user populates within `extra_returns_per_train` can now be accessed by the strategy during backtest. 

As an example: if the user might define the following in their config:
```
"extra_returns_per_train": {
            "entry_threshold_high_precision": 0,
            "exit_threshold_high_recall": 0
}
```

And they might populate these values while training their model:
```
dk.data["extra_returns_per_train"]["entry_threshold_high_precision"] = entry_threshold_high_precision
dk.data["extra_returns_per_train"]["exit_threshold_high_recall"] = exit_threshold_high_recall
```

These fields would then be available within `populate_indicators()`. As example, they could be used to set entry/exit thresholds:
```
dataframe["long_entry_target"] = dataframe["entry_threshold_high_precision"].rolling(smoothing_win).mean()
dataframe["long_exit_target"] = dataframe["exit_threshold_high_recall"].rolling(smoothing_win).mean()
```

### Tasks

- [x] Make changes to data_kitchen
- [x] Validate working with backtest when `extra_returns_per_train` is populated
- [x] Validate working with `extra_returns_per_train` is NOT populated
- [ ] Unit tests updated (don't see any unit tests for `test_get_predictions_to_append`)
- [x] Run pytest and ensure no regressions

@drafty: Does this cover all the bases for what we discussed? LMK if any issues/gaps you see. I've confirmed this is working for my strategy that uses `extra_returns_per_train` data in a backtest.

Thanks
