### PR TITLE
Update function in FreqAI interface to record FreqAI config params

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -531,7 +531,7 @@ class IFreqaiModel(ABC):
         Creates and sets the full path for the identifier
         """
         self.full_path = Path(
-            self.config["user_data_dir"] / "models" / f"{self.freqai_info['identifier']}"
+            self.config["user_data_dir"] / "models" / f"{self.identifier}"
         )
         self.full_path.mkdir(parents=True, exist_ok=True)
 

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import threading
 import time
@@ -21,7 +20,7 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_seconds
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
-from freqtrade.freqai.utils import plot_feature_importance
+from freqtrade.freqai.utils import plot_feature_importance, record_params
 from freqtrade.strategy.interface import IStrategy
 
 
@@ -97,7 +96,7 @@ class IFreqaiModel(ABC):
         self._threads: List[threading.Thread] = []
         self._stop_event = threading.Event()
 
-        self.record_params()
+        record_params(config, self.full_path)
 
     def __getstate__(self):
         """
@@ -535,24 +534,6 @@ class IFreqaiModel(ABC):
             self.config["user_data_dir"] / "models" / f"{self.identifier}"
         )
         self.full_path.mkdir(parents=True, exist_ok=True)
-
-    def record_params(self) -> None:
-        """
-        Records run params in the full path for reproducibility
-        """
-        self.params_record_path = self.full_path / "run_params.json"
-
-        run_params = {
-            "freqai": self.config.get('freqai', {}),
-            "timeframe": self.config.get('timeframe'),
-            "stake_amount": self.config.get('stake_amount'),
-            "stake_currency": self.config.get('stake_currency'),
-            "max_open_trades": self.config.get('max_open_trades'),
-            "pairs": self.config.get('exchange', {}).get('pair_whitelist')
-        }
-
-        with open(self.params_record_path, "w") as handle:
-            json.dump(run_params, handle, indent=4)
 
     def extract_data_and_train_model(
         self,

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -211,10 +211,10 @@ def record_params(config: Dict[str, Any], full_path: Path) -> None:
     }
 
     with open(params_record_path, "w") as handle:
-        rapidjson.dump(run_params, handle, indent=4, default=np_encoder,
-                       number_mode=rapidjson.NM_NATIVE)
-
-
-def np_encoder(self, object):
-    if isinstance(object, np.generic):
-        return object.item()
+        rapidjson.dump(
+            run_params,
+            handle,
+            indent=4,
+            default=str,
+            number_mode=rapidjson.NM_NATIVE
+        )

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -1,9 +1,11 @@
 import logging
 from datetime import datetime, timezone
-from typing import Any
+from pathlib import Path
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
+import rapidjson
 
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import Config
@@ -191,3 +193,28 @@ def plot_feature_importance(model: Any, pair: str, dk: FreqaiDataKitchen,
         fig.update_layout(title_text=f"Best and worst features by importance {pair}")
         label = label.replace('&', '').replace('%', '')  # escape two FreqAI specific characters
         store_plot_file(fig, f"{dk.model_filename}-{label}.html", dk.data_path)
+
+
+def record_params(config: Dict[str, Any], full_path: Path) -> None:
+    """
+    Records run params in the full path for reproducibility
+    """
+    params_record_path = full_path / "run_params.json"
+
+    run_params = {
+        "freqai": config.get('freqai', {}),
+        "timeframe": config.get('timeframe'),
+        "stake_amount": config.get('stake_amount'),
+        "stake_currency": config.get('stake_currency'),
+        "max_open_trades": config.get('max_open_trades'),
+        "pairs": config.get('exchange', {}).get('pair_whitelist')
+    }
+
+    with open(params_record_path, "w") as handle:
+        rapidjson.dump(run_params, handle, indent=4, default=np_encoder,
+                       number_mode=rapidjson.NM_NATIVE)
+
+
+def np_encoder(self, object):
+    if isinstance(object, np.generic):
+        return object.item()

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -216,5 +216,5 @@ def record_params(config: Dict[str, Any], full_path: Path) -> None:
             handle,
             indent=4,
             default=str,
-            number_mode=rapidjson.NM_NATIVE
+            number_mode=rapidjson.NM_NATIVE | rapidjson.NM_NAN
         )

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -19,7 +19,7 @@ from tests.freqai.conftest import get_patched_freqai_strategy
 
 def is_arm() -> bool:
     machine = platform.machine()
-    return "arm" in machine or "aarch64" in machine
+    return "arm" in machine or "aarch74" in machine
 
 
 def is_mac() -> bool:
@@ -160,12 +160,12 @@ def test_extract_data_and_train_model_Classifiers(mocker, freqai_conf, model):
 @pytest.mark.parametrize(
     "model, num_files, strat",
     [
-        ("LightGBMRegressor", 6, "freqai_test_strat"),
-        ("XGBoostRegressor", 6, "freqai_test_strat"),
-        ("CatboostRegressor", 6, "freqai_test_strat"),
-        ("XGBoostClassifier", 6, "freqai_test_classifier"),
-        ("LightGBMClassifier", 6, "freqai_test_classifier"),
-        ("CatboostClassifier", 6, "freqai_test_classifier")
+        ("LightGBMRegressor", 7, "freqai_test_strat"),
+        ("XGBoostRegressor", 7, "freqai_test_strat"),
+        ("CatboostRegressor", 7, "freqai_test_strat"),
+        ("XGBoostClassifier", 7, "freqai_test_classifier"),
+        ("LightGBMClassifier", 7, "freqai_test_classifier"),
+        ("CatboostClassifier", 7, "freqai_test_classifier")
     ],
     )
 def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog):
@@ -200,6 +200,7 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog)
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
+    # Changed from 6 to 7 because of the /configs directory
     assert len(model_folders) == num_files
     assert log_has_re(
         "Removed features ",
@@ -234,7 +235,9 @@ def test_start_backtesting_subdaily_backtest_period(mocker, freqai_conf):
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
-    assert len(model_folders) == 9
+
+    # Changed from 9 to 10 because of the /configs dir
+    assert len(model_folders) == 10
 
     shutil.rmtree(Path(freqai.dk.full_path))
 
@@ -260,7 +263,7 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
-    assert len(model_folders) == 6
+    assert len(model_folders) == 7
 
     # without deleting the existing folder structure, re-run
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -19,7 +19,7 @@ from tests.freqai.conftest import get_patched_freqai_strategy
 
 def is_arm() -> bool:
     machine = platform.machine()
-    return "arm" in machine or "aarch74" in machine
+    return "arm" in machine or "aarch64" in machine
 
 
 def is_mac() -> bool:

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -160,12 +160,12 @@ def test_extract_data_and_train_model_Classifiers(mocker, freqai_conf, model):
 @pytest.mark.parametrize(
     "model, num_files, strat",
     [
-        ("LightGBMRegressor", 7, "freqai_test_strat"),
-        ("XGBoostRegressor", 7, "freqai_test_strat"),
-        ("CatboostRegressor", 7, "freqai_test_strat"),
-        ("XGBoostClassifier", 7, "freqai_test_classifier"),
-        ("LightGBMClassifier", 7, "freqai_test_classifier"),
-        ("CatboostClassifier", 7, "freqai_test_classifier")
+        ("LightGBMRegressor", 6, "freqai_test_strat"),
+        ("XGBoostRegressor", 6, "freqai_test_strat"),
+        ("CatboostRegressor", 6, "freqai_test_strat"),
+        ("XGBoostClassifier", 6, "freqai_test_classifier"),
+        ("LightGBMClassifier", 6, "freqai_test_classifier"),
+        ("CatboostClassifier", 6, "freqai_test_classifier")
     ],
     )
 def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog):
@@ -200,7 +200,6 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog)
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
-    # Changed from 6 to 7 because of the /configs directory
     assert len(model_folders) == num_files
     assert log_has_re(
         "Removed features ",
@@ -236,8 +235,7 @@ def test_start_backtesting_subdaily_backtest_period(mocker, freqai_conf):
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
-    # Changed from 9 to 10 because of the /configs dir
-    assert len(model_folders) == 10
+    assert len(model_folders) == 9
 
     shutil.rmtree(Path(freqai.dk.full_path))
 
@@ -263,7 +261,7 @@ def test_start_backtesting_from_existing_folder(mocker, freqai_conf, caplog):
     freqai.start_backtesting(df, metadata, freqai.dk)
     model_folders = [x for x in freqai.dd.full_path.iterdir() if x.is_dir()]
 
-    assert len(model_folders) == 7
+    assert len(model_folders) == 6
 
     # without deleting the existing folder structure, re-run
 


### PR DESCRIPTION
## Summary

~~Supports users with multiple config files being copied to the models directory.~~ 

This now only makes a record of certain config parameters in a `run_params.json` file. The parameters recorded are:
`freqai, timeframe, stake_amount, stake_currency, max_open_trades, pairs`.

## Quick changelog

- ~~Record all configs instead of just the first~~
- ~~Changed from `shutil.copy` to `shutil.copyfile`~~
- Serialize certain config params to a `run_params.json` file

## What's new?

~~Currently, the function `set_full_path` records the configs for reproducibility. However it assumes only one config is used and copies the first one. This PR changes the behavior to include **ALL** configs. Also, when ran in a Docker Swarm setting with the config added to swarm, it is mounted in the container as read only. When copied over with `shutil.copy` it includes permission bits, causing the next run to fail with a permission error. This is fixed by using `shutil.copyfile`.~~

Since we create the file completely ourselves there are no permission issues.
