### PR TITLE
Improved WebSocketChannel API

### DIFF
--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -75,7 +75,7 @@ async def _process_consumer_request(
         # Format response
         response = WSWhitelistMessage(data=whitelist)
         # Send it back
-        await channel_manager.send_direct(channel, response)
+        await channel_manager.send_direct(channel, response.dict(exclude_none=True))
 
     elif type == RPCRequestType.ANALYZED_DF:
         limit = None
@@ -90,7 +90,7 @@ async def _process_consumer_request(
         # For every dataframe, send as a separate message
         for _, message in analyzed_df.items():
             response = WSAnalyzedDFMessage(data=message)
-            await channel_manager.send_direct(channel, response)
+        await channel_manager.send_direct(channel, response.dict(exclude_none=True))
 
 
 @router.websocket("/message/ws")

--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -90,7 +90,7 @@ async def _process_consumer_request(
         # For every dataframe, send as a separate message
         for _, message in analyzed_df.items():
             response = WSAnalyzedDFMessage(data=message)
-        await channel_manager.send_direct(channel, response.dict(exclude_none=True))
+            await channel_manager.send_direct(channel, response.dict(exclude_none=True))
 
 
 @router.websocket("/message/ws")

--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Any, Dict
 
@@ -11,6 +10,7 @@ from freqtrade.enums import RPCMessageType, RPCRequestType
 from freqtrade.rpc.api_server.api_auth import validate_ws_token
 from freqtrade.rpc.api_server.deps import get_channel_manager, get_rpc
 from freqtrade.rpc.api_server.ws import WebSocketChannel
+from freqtrade.rpc.api_server.ws.channel import ChannelManager
 from freqtrade.rpc.api_server.ws_schemas import (WSAnalyzedDFMessage, WSMessageSchema,
                                                  WSRequestSchema, WSWhitelistMessage)
 from freqtrade.rpc.rpc import RPC
@@ -37,7 +37,8 @@ async def is_websocket_alive(ws: WebSocket) -> bool:
 async def _process_consumer_request(
     request: Dict[str, Any],
     channel: WebSocketChannel,
-    rpc: RPC
+    rpc: RPC,
+    channel_manager: ChannelManager
 ):
     """
     Validate and handle a request from a websocket consumer
@@ -72,9 +73,9 @@ async def _process_consumer_request(
         whitelist = rpc._ws_request_whitelist()
 
         # Format response
-        response = WSWhitelistMessage(data=whitelist)
+        response = WSWhitelistMessage(data=whitelist).dict(exclude_none=True)
         # Send it back
-        await channel.send(response.dict(exclude_none=True))
+        await channel_manager.send_direct(channel, response)
 
     elif type == RPCRequestType.ANALYZED_DF:
         limit = None
@@ -88,10 +89,8 @@ async def _process_consumer_request(
 
         # For every dataframe, send as a separate message
         for _, message in analyzed_df.items():
-            response = WSAnalyzedDFMessage(data=message)
-            await channel.send(response.dict(exclude_none=True))
-            # Throttle the messages to 50/s
-            await asyncio.sleep(0.02)
+            response = WSAnalyzedDFMessage(data=message).dict(exclude_none=True)
+            await channel_manager.send_direct(channel, response)
 
 
 @router.websocket("/message/ws")
@@ -116,7 +115,7 @@ async def message_endpoint(
                     request = await channel.recv()
 
                     # Process the request here
-                    await _process_consumer_request(request, channel, rpc)
+                    await _process_consumer_request(request, channel, rpc, channel_manager)
 
             except (WebSocketDisconnect, WebSocketException):
                 # Handle client disconnects

--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -73,7 +73,7 @@ async def _process_consumer_request(
         whitelist = rpc._ws_request_whitelist()
 
         # Format response
-        response = WSWhitelistMessage(data=whitelist).dict(exclude_none=True)
+        response = WSWhitelistMessage(data=whitelist)
         # Send it back
         await channel_manager.send_direct(channel, response)
 
@@ -89,7 +89,7 @@ async def _process_consumer_request(
 
         # For every dataframe, send as a separate message
         for _, message in analyzed_df.items():
-            response = WSAnalyzedDFMessage(data=message).dict(exclude_none=True)
+            response = WSAnalyzedDFMessage(data=message)
             await channel_manager.send_direct(channel, response)
 
 

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -198,10 +198,6 @@ class ApiServer(RPCHandler):
                 logger.debug(f"Found message of type: {message.get('type')}")
                 # Broadcast it
                 await self._ws_channel_manager.broadcast(message)
-                # Limit messages per sec.
-                # Could cause problems with queue size if too low, and
-                # problems with network traffik if too high.
-                await asyncio.sleep(0.001)
         except asyncio.CancelledError:
             pass
 

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -16,7 +16,7 @@ from freqtrade.constants import Config
 from freqtrade.exceptions import OperationalException
 from freqtrade.rpc.api_server.uvicorn_threaded import UvicornServer
 from freqtrade.rpc.api_server.ws import ChannelManager
-from freqtrade.rpc.api_server.ws_schemas import WSMessageSchema
+from freqtrade.rpc.api_server.ws_schemas import WSMessageSchemaType
 from freqtrade.rpc.rpc import RPC, RPCException, RPCHandler
 
 
@@ -131,7 +131,7 @@ class ApiServer(RPCHandler):
     def send_msg(self, msg: Dict[str, Any]) -> None:
         if self._ws_queue:
             sync_q = self._ws_queue.sync_q
-            sync_q.put(WSMessageSchema(**msg))
+            sync_q.put(msg)
 
     def handle_rpc_exception(self, request, exc):
         logger.exception(f"API Error calling: {exc}")
@@ -195,8 +195,8 @@ class ApiServer(RPCHandler):
             while True:
                 logger.debug("Getting queue messages...")
                 # Get data from queue
-                message: WSMessageSchema = await async_queue.get()
-                logger.debug(f"Found message of type: {message.type}")
+                message: WSMessageSchemaType = await async_queue.get()
+                logger.debug(f"Found message of type: {message.get('type')}")
                 # Broadcast it
                 await self._ws_channel_manager.broadcast(message)
         except asyncio.CancelledError:

--- a/freqtrade/rpc/api_server/ws/channel.py
+++ b/freqtrade/rpc/api_server/ws/channel.py
@@ -40,6 +40,7 @@ class WebSocketChannel:
         self.throttle = throttle
 
         self._subscriptions: List[str] = []
+        # 32 is the size of the receiving queue in websockets package
         self.queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=32)
         self._relay_task = asyncio.create_task(self.relay())
 

--- a/freqtrade/rpc/api_server/ws/proxy.py
+++ b/freqtrade/rpc/api_server/ws/proxy.py
@@ -16,6 +16,10 @@ class WebSocketProxy:
         self._websocket: Union[FastAPIWebSocket, WebSocket] = websocket
 
     @property
+    def raw(self):
+        return self._websocket
+
+    @property
     def remote_addr(self) -> Tuple[Any, ...]:
         if isinstance(self._websocket, WebSocket):
             return self._websocket.remote_address

--- a/freqtrade/rpc/api_server/ws/proxy.py
+++ b/freqtrade/rpc/api_server/ws/proxy.py
@@ -16,7 +16,7 @@ class WebSocketProxy:
         self._websocket: Union[FastAPIWebSocket, WebSocket] = websocket
 
     @property
-    def raw(self):
+    def raw_websocket(self):
         return self._websocket
 
     @property

--- a/freqtrade/rpc/api_server/ws_schemas.py
+++ b/freqtrade/rpc/api_server/ws_schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 
 from pandas import DataFrame
 from pydantic import BaseModel
@@ -16,6 +16,12 @@ class BaseArbitraryModel(BaseModel):
 class WSRequestSchema(BaseArbitraryModel):
     type: RPCRequestType
     data: Optional[Any] = None
+
+
+class WSMessageSchemaType(TypedDict):
+    # Type for typing to avoid doing pydantic typechecks.
+    type: RPCMessageType
+    data: Optional[Dict[str, Any]]
 
 
 class WSMessageSchema(BaseArbitraryModel):

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -270,6 +270,11 @@ class ExternalMessageConsumer:
                     logger.debug(f"Connection to {channel} still alive...")
 
                     continue
+                except (websockets.exceptions.ConnectionClosed):
+                    # Just eat the error and continue reconnecting
+                    logger.warning(f"Disconnection in {channel} - retrying in {self.sleep_time}s")
+                    await asyncio.sleep(self.sleep_time)
+                    break
                 except Exception as e:
                     logger.warning(f"Ping error {channel} - retrying in {self.sleep_time}s")
                     logger.debug(e, exc_info=e)


### PR DESCRIPTION
## Summary

Improved WebSocketChannel API with a more unified approach without needing throttling outside of the mechanism.

## Quick changelog

- Update sending via the WebSocketChannel and ChannelManager to manage throttling

## What's new?

This change allows a more readable and sensible solution to sending messages via a WebSocketChannel. Right now, we must add sleep calls throughout the code to throttle how fast we send messages via a channel. With this PR, the channel has better management of large pairlists by waiting a certain amount of time for the relay function to drain it's outgoing messages, effectively throttling how fast it sends messages in one place.
