### PR TITLE
Combine stop logic

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -42,24 +42,6 @@ class Binance(Exchange):
         (TradingMode.FUTURES, MarginMode.ISOLATED)
     ]
 
-    def stoploss_adjust(self, stop_loss: float, order: Dict, side: str) -> bool:
-        """
-        Verify stop_loss against stoploss-order value (limit or price)
-        Returns True if adjustment is necessary.
-        :param side: "buy" or "sell"
-        """
-        order_types = ('stop_loss_limit', 'stop', 'stop_market')
-
-        return (
-            order.get('stopPrice', None) is None
-            or (
-                order['type'] in order_types
-                and (
-                    (side == "sell" and stop_loss > float(order['stopPrice'])) or
-                    (side == "buy" and stop_loss < float(order['stopPrice']))
-                )
-            ))
-
     def get_tickers(self, symbols: Optional[List[str]] = None, cached: bool = False) -> Tickers:
         tickers = super().get_tickers(symbols=symbols, cached=cached)
         if self.trading_mode == TradingMode.FUTURES:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1076,7 +1076,11 @@ class Exchange:
         Verify stop_loss against stoploss-order value (limit or price)
         Returns True if adjustment is necessary.
         """
-        raise OperationalException(f"stoploss is not implemented for {self.name}.")
+        if not self._ft_has.get('stoploss_on_exchange'):
+            raise OperationalException(f"stoploss is not implemented for {self.name}.")
+
+        return ((side == "sell" and stop_loss > float(order['stopPrice'])) or
+                (side == "buy" and stop_loss < float(order['stopPrice'])))
 
     def _get_stop_order_type(self, user_order_type) -> Tuple[str, str]:
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1079,8 +1079,11 @@ class Exchange:
         if not self._ft_has.get('stoploss_on_exchange'):
             raise OperationalException(f"stoploss is not implemented for {self.name}.")
 
-        return ((side == "sell" and stop_loss > float(order['stopPrice'])) or
+        return (
+            order.get('stopPrice', None) is None
+            or ((side == "sell" and stop_loss > float(order['stopPrice'])) or
                 (side == "buy" and stop_loss < float(order['stopPrice'])))
+        )
 
     def _get_stop_order_type(self, user_order_type) -> Tuple[str, str]:
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1110,7 +1110,7 @@ class Exchange:
                 'In stoploss limit order, stop price should be more than limit price')
         return limit_rate
 
-    def _get_stop_params(self, ordertype: str, stop_price: float) -> Dict:
+    def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> Dict:
         params = self._params.copy()
         # Verify if stopPrice works for your exchange!
         params.update({'stopPrice': stop_price})
@@ -1159,7 +1159,8 @@ class Exchange:
             return dry_order
 
         try:
-            params = self._get_stop_params(ordertype=ordertype, stop_price=stop_price_norm)
+            params = self._get_stop_params(side=side, ordertype=ordertype,
+                                           stop_price=stop_price_norm)
             if self.trading_mode == TradingMode.FUTURES:
                 params['reduceOnly'] = True
 

--- a/freqtrade/exchange/gateio.py
+++ b/freqtrade/exchange/gateio.py
@@ -126,13 +126,3 @@ class Gateio(Exchange):
             pair=pair,
             params={'stop': True}
         )
-
-    def stoploss_adjust(self, stop_loss: float, order: Dict, side: str) -> bool:
-        """
-        Verify stop_loss against stoploss-order value (limit or price)
-        Returns True if adjustment is necessary.
-        """
-        return (order.get('stopPrice', None) is None or (
-            side == "sell" and stop_loss > float(order['stopPrice'])) or
-            (side == "buy" and stop_loss < float(order['stopPrice']))
-            )

--- a/freqtrade/exchange/huobi.py
+++ b/freqtrade/exchange/huobi.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Dict
 
+from freqtrade.constants import BuySell
 from freqtrade.exchange import Exchange
 
 
@@ -35,7 +36,7 @@ class Huobi(Exchange):
             )
         )
 
-    def _get_stop_params(self, ordertype: str, stop_price: float) -> Dict:
+    def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> Dict:
 
         params = self._params.copy()
         params.update({

--- a/freqtrade/exchange/huobi.py
+++ b/freqtrade/exchange/huobi.py
@@ -23,19 +23,6 @@ class Huobi(Exchange):
         "l2_limit_range_required": False,
     }
 
-    def stoploss_adjust(self, stop_loss: float, order: Dict, side: str) -> bool:
-        """
-        Verify stop_loss against stoploss-order value (limit or price)
-        Returns True if adjustment is necessary.
-        """
-        return (
-            order.get('stopPrice', None) is None
-            or (
-                order['type'] == 'stop'
-                and stop_loss > float(order['stopPrice'])
-            )
-        )
-
     def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> Dict:
 
         params = self._params.copy()

--- a/freqtrade/exchange/kucoin.py
+++ b/freqtrade/exchange/kucoin.py
@@ -28,16 +28,6 @@ class Kucoin(Exchange):
         "ohlcv_candle_limit": 1500,
     }
 
-    def stoploss_adjust(self, stop_loss: float, order: Dict, side: str) -> bool:
-        """
-        Verify stop_loss against stoploss-order value (limit or price)
-        Returns True if adjustment is necessary.
-        """
-        return (
-            order.get('stopPrice', None) is None
-            or stop_loss > float(order['stopPrice'])
-        )
-
     def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> Dict:
 
         params = self._params.copy()

--- a/freqtrade/exchange/kucoin.py
+++ b/freqtrade/exchange/kucoin.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Dict
 
+from freqtrade.constants import BuySell
 from freqtrade.exchange import Exchange
 
 
@@ -37,7 +38,7 @@ class Kucoin(Exchange):
             or stop_loss > float(order['stopPrice'])
         )
 
-    def _get_stop_params(self, ordertype: str, stop_price: float) -> Dict:
+    def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> Dict:
 
         params = self._params.copy()
         params.update({

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -162,9 +162,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
     }
     assert exchange.stoploss_adjust(sl1, order, side=side)
     assert not exchange.stoploss_adjust(sl2, order, side=side)
-    # Test with invalid order case
-    order['type'] = 'stop_loss'
-    assert not exchange.stoploss_adjust(sl3, order, side=side)
 
 
 def test_fill_leverage_tiers_binance(default_conf, mocker):

--- a/tests/exchange/test_huobi.py
+++ b/tests/exchange/test_huobi.py
@@ -113,5 +113,4 @@ def test_stoploss_adjust_huobi(mocker, default_conf):
     assert exchange.stoploss_adjust(1501, order, 'sell')
     assert not exchange.stoploss_adjust(1499, order, 'sell')
     # Test with invalid order case
-    order['type'] = 'stop_loss'
-    assert not exchange.stoploss_adjust(1501, order, 'sell')
+    assert exchange.stoploss_adjust(1501, order, 'sell')


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Combine the stop-logic of different exchanges, which is actually almost identical.

## Quick changelog

- use common adjust_stop function instead of one per exchange with identical logic.
