### PR TITLE
Remove loop of normalization from metadata

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -354,11 +354,12 @@ class FreqaiDataKitchen:
         :param df: Dataframe to be standardized
         """
 
-        train_max = []
-        train_min = []
-        for item in df.keys():
-            train_max.append(self.data[item + "_max"])
-            train_min.append(self.data[item + "_min"])
+        train_max = [None] * len(df.keys())
+        train_min = [None] * len(df.keys())
+
+        for i, item in enumerate(df.keys()):
+            train_max[i] = self.data[f"{item}_max"]
+            train_min[i] = self.data[f"{item}_min"]
 
         train_max_series = pd.Series(train_max, index=df.keys())
         train_min_series = pd.Series(train_min, index=df.keys())

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -354,13 +354,18 @@ class FreqaiDataKitchen:
         :param df: Dataframe to be standardized
         """
 
+        train_max = []
+        train_min = []
         for item in df.keys():
-            df[item] = (
-                2
-                * (df[item] - self.data[f"{item}_min"])
-                / (self.data[f"{item}_max"] - self.data[f"{item}_min"])
-                - 1
-            )
+            train_max.append(self.data[item + "_max"])
+            train_min.append(self.data[item + "_min"])
+
+        train_max_series = pd.Series(train_max, index=df.keys())
+        train_min_series = pd.Series(train_min, index=df.keys())
+
+        df = (
+            2 * (df - train_min_series) / (train_max_series - train_min_series) - 1
+        )
 
         return df
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Normalization from metadata was way slow if the features count was high since it was looping through whole dataframe columns. Moved calculation to pandas to make it faster. 

