### PR TITLE
Fix inconsistent backtesting results - FreqAI

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1318,7 +1318,7 @@ class FreqaiDataKitchen:
     ) -> bool:
         """
         Check if a backtesting prediction already exists and if the predictions
-        to append has the same sime of backtesting dataframe slice
+        to append has the same size of backtesting dataframe slice
         :param length_backtesting_dataframe: Length of backtesting dataframe slice
         :return:
         :boolean: whether the prediction file is valid.
@@ -1337,7 +1337,7 @@ class FreqaiDataKitchen:
                 return True
             else:
                 logger.info("A new backtesting prediction file is required. "
-                            "(Number of predictions is different of dataframe length).")
+                            "(Number of predictions is different from dataframe length).")
                 return False
         else:
             logger.info(

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1312,14 +1312,16 @@ class FreqaiDataKitchen:
         append_df = pd.read_hdf(self.backtesting_results_path)
         return append_df
 
-    def check_if_backtest_prediction_exists(
-        self
+    def check_if_backtest_prediction_is_valid(
+        self,
+        length_backtesting_dataframe: int
     ) -> bool:
         """
-        Check if a backtesting prediction already exists
-        :param dk: FreqaiDataKitchen
+        Check if a backtesting prediction already exists and if the predictions
+        to append has the same sime of backtesting dataframe slice
+        :param length_backtesting_dataframe: Length of backtesting dataframe slice
         :return:
-        :boolean: whether the prediction file exists or not.
+        :boolean: whether the prediction file is valid.
         """
         path_to_predictionfile = Path(self.full_path /
                                       self.backtest_predictions_folder /
@@ -1327,10 +1329,18 @@ class FreqaiDataKitchen:
         self.backtesting_results_path = path_to_predictionfile
 
         file_exists = path_to_predictionfile.is_file()
+
         if file_exists:
-            logger.info(f"Found backtesting prediction file at {path_to_predictionfile}")
+            append_df = self.get_backtesting_prediction()
+            if len(append_df) == length_backtesting_dataframe:
+                logger.info(f"Found backtesting prediction file at {path_to_predictionfile}")
+                return True
+            else:
+                logger.info("A new backtesting prediction file is required. "
+                            "(Number of predictions is different of dataframe length).")
+                return False
         else:
             logger.info(
                 f"Could not find backtesting prediction file at {path_to_predictionfile}"
             )
-        return file_exists
+            return False

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -275,7 +275,7 @@ class IFreqaiModel(ABC):
 
             dk.set_new_model_names(pair, trained_timestamp)
 
-            if dk.check_if_backtest_prediction_exists():
+            if dk.check_if_backtest_prediction_is_valid(len(dataframe_backtest)):
                 self.dd.load_metadata(dk)
                 dk.find_features(dataframe_train)
                 self.check_if_feature_list_matches_strategy(dk)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This PR fix an issue for backtesting with inconsistent values when the user is using the `backtest_period_days` parameter with a value greater than 1  and when performing backtesting with different timeranges.

Solve the issue: #7666

## What's new?

The first backtesting execution save prediction file based on the training timestamp. When the `backtest_period_days` parameter is greater than 1, or when not specifying it in the configuration file (default: 7), for the next execution with a new timerange the saved file is inconsistent with the new timerange period. This PR adds a new check to verify if the number of predictions is the same length of backtesting slice dataframe for the training period.
