### PR TITLE
FreqAI: Reorder data cleaning

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -496,6 +496,10 @@ class FreqaiDataDrawer:
             save_path / f"{dk.model_filename}_trained_df.pkl"
         )
 
+        dk.data_dictionary["train_features_no_transf"].to_pickle(
+            save_path / f"{dk.model_filename}_trained_df_no_transf.pkl"
+        )
+
         dk.data_dictionary["train_dates"].to_pickle(
             save_path / f"{dk.model_filename}_trained_dates_df.pkl"
         )
@@ -513,6 +517,8 @@ class FreqaiDataDrawer:
         if coin not in self.meta_data_dictionary:
             self.meta_data_dictionary[coin] = {}
         self.meta_data_dictionary[coin]["train_df"] = dk.data_dictionary["train_features"]
+        self.meta_data_dictionary[coin]["train_df_no_transf"] = \
+            dk.data_dictionary["train_features_no_transf"]
         self.meta_data_dictionary[coin]["meta_data"] = dk.data
         self.save_drawer_to_disk()
 
@@ -553,6 +559,8 @@ class FreqaiDataDrawer:
         if coin in self.meta_data_dictionary:
             dk.data = self.meta_data_dictionary[coin]["meta_data"]
             dk.data_dictionary["train_features"] = self.meta_data_dictionary[coin]["train_df"]
+            dk.data_dictionary["train_features_no_transf"] = \
+                self.meta_data_dictionary[coin]["train_df_no_transf"]
         else:
             with open(dk.data_path / f"{dk.model_filename}_metadata.json", "r") as fp:
                 dk.data = rapidjson.load(fp, number_mode=rapidjson.NM_NATIVE)

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -465,16 +465,8 @@ class IFreqaiModel(ABC):
             if self.freqai_info["data_split_parameters"]["test_size"] > 0:
                 dk.compute_inlier_metric(set_='test')
 
-        if ft_params.get(
-            "principal_component_analysis", False
-        ):
-            dk.principal_component_analysis()
-
         if ft_params.get("use_SVM_to_remove_outliers", False):
             dk.use_SVM_to_remove_outliers(predict=False)
-
-        if ft_params.get("DI_threshold", 0):
-            dk.data["avg_mean_dist"] = dk.compute_distances()
 
         if ft_params.get("use_DBSCAN_to_remove_outliers", False):
             if dk.pair in self.dd.old_DBSCAN_eps:
@@ -483,6 +475,14 @@ class IFreqaiModel(ABC):
                 eps = None
             dk.use_DBSCAN_to_remove_outliers(predict=False, eps=eps)
             self.dd.old_DBSCAN_eps[dk.pair] = dk.data['DBSCAN_eps']
+
+        if ft_params.get("DI_threshold", 0):
+            dk.data["avg_mean_dist"] = dk.compute_distances()
+
+        if ft_params.get(
+            "principal_component_analysis", False
+        ):
+            dk.principal_component_analysis()
 
         if self.freqai_info["feature_parameters"].get('noise_standard_deviation', 0):
             dk.add_noise_to_training_features()
@@ -500,19 +500,19 @@ class IFreqaiModel(ABC):
         if ft_params.get('inlier_metric_window', 0):
             dk.compute_inlier_metric(set_='predict')
 
-        if ft_params.get(
-            "principal_component_analysis", False
-        ):
-            dk.pca_transform(dk.data_dictionary['prediction_features'])
-
         if ft_params.get("use_SVM_to_remove_outliers", False):
             dk.use_SVM_to_remove_outliers(predict=True)
+
+        if ft_params.get("use_DBSCAN_to_remove_outliers", False):
+            dk.use_DBSCAN_to_remove_outliers(predict=True)
 
         if ft_params.get("DI_threshold", 0):
             dk.check_if_pred_in_training_spaces()
 
-        if ft_params.get("use_DBSCAN_to_remove_outliers", False):
-            dk.use_DBSCAN_to_remove_outliers(predict=True)
+        if ft_params.get(
+            "principal_component_analysis", False
+        ):
+            dk.pca_transform(dk.data_dictionary['prediction_features'])
 
     def model_exists(self, dk: FreqaiDataKitchen) -> bool:
         """

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -157,5 +157,5 @@ def test_make_train_test_datasets(mocker, freqai_conf):
     data_dictionary = freqai.dk.make_train_test_datasets(features_filtered, labels_filtered)
 
     assert data_dictionary
-    assert len(data_dictionary) == 7
+    assert len(data_dictionary) == 9
     assert len(data_dictionary['train_features'].index) == 1916

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -338,7 +338,11 @@ def test_follow_mode(mocker, freqai_conf):
     freqai.dd.load_all_pair_histories(timerange, freqai.dk)
 
     df = strategy.dp.get_pair_dataframe('ADA/BTC', '5m')
-
+    # import pytest
+    # pytest.set_trace()
+    freqai.dk.build_data_dictionary(
+                [], [], [], [], [], []
+                )
     freqai.start_live(df, metadata, strategy, freqai.dk)
 
     assert len(freqai.dk.return_dataframe.index) == 5702


### PR DESCRIPTION
## Summary

Change the order of data manipulation in `data_cleaning_train()` and `data_cleaning_predict()` in `data_kitchen` so that outlier identification and removal is done before calculation of dissimilarity index (`DI`), and `PCA` transformation.

## Quick changelog

The input data is manipulated, according to user input, before being used for training/testing/predicting. This PR changes the order of such data manipulation so that all outlier detection/removal is done prior to calculation of the dissimilarity index (`DI`), and so that `PCA` transformation is done as the last step. This reordering increases consistency as all currently available outlier detection/removal is now done prior to the calculation of the `DI`, and the `PCA` transformation. This reordering also means that outliers no longer have an influence on the `DI` or `PCA`.
This required some refactoring of the code, and changes to some tests, to ensure that un-transformed (no `PCA`) data remains available for outlier detection/removal using `DBSCAN` (if enabled by the user). 
