### PR TITLE
Enable --use-pep517 flag for freqai

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -82,7 +82,7 @@ function updateenv() {
     dev=$REPLY
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-        REQUIREMENTS_FREQAI="-r requirements-freqai.txt"
+        REQUIREMENTS_FREQAI="-r requirements-freqai.txt --use-pep517"
     fi
 
     ${PYTHON} -m pip install --upgrade -r ${REQUIREMENTS} ${REQUIREMENTS_HYPEROPT} ${REQUIREMENTS_PLOT} ${REQUIREMENTS_FREQAI}


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Installing freqtrade with freqai on Apple M1 chip requires some manual installation procedures. The problematic package is currently lightgbm. This flag fixes this problem. 

Solve the issue: #7452 

## What's new?

Enabled --use-pep517 flag for freqai installation.

## References
https://github.com/pypa/pip/issues/8559
