### PR TITLE
Use default `extra_returns_per_train`

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -629,7 +629,7 @@ class IFreqaiModel(ABC):
             hist_preds_df['DI_values'] = 0
 
         for return_str in dk.data['extra_returns_per_train']:
-            hist_preds_df[return_str] = 0
+            hist_preds_df[return_str] = dk.data['extra_returns_per_train'][return_str]
 
         hist_preds_df['close_price'] = strat_df['close']
         hist_preds_df['date_pred'] = strat_df['date']


### PR DESCRIPTION
The initial build of `extra_returns_per_train` were set to 0. However, users may have default values set in their configs - and therefore we ensure those default values are set during the initial build of `dd.historic_predictions`