### PR TITLE
Fix 4ac update_total_profit

### DIFF
--- a/freqtrade/freqai/RL/Base4ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base4ActionRLEnv.py
@@ -73,8 +73,8 @@ class Base4ActionRLEnv(BaseEnvironment):
                 trade_type = "short"
                 self._last_trade_tick = self._current_tick
             elif action == Actions.Exit.value:
-                self._position = Positions.Neutral
                 self._update_total_profit()
+                self._position = Positions.Neutral
                 trade_type = "neutral"
                 self._last_trade_tick = None
             else:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
_update_total_profit() must be executed before "self._position = Positions.Neutral" because _update_total_profit() calls get_unrealized_profit(), which returns 0 if position is already neutral and total_profit is not updated

