### PR TITLE
Set model_type in base RL model

### DIFF
--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -64,6 +64,7 @@ class BaseReinforcementLearningModel(IFreqaiModel):
         self.policy_type = self.freqai_info['rl_config']['policy_type']
         self.unset_outlier_removal()
         self.net_arch = self.rl_config.get('net_arch', [128, 128])
+        self.dd.model_type = "stable_baselines"
 
     def unset_outlier_removal(self):
         """

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -99,12 +99,7 @@ class FreqaiDataDrawer:
         self.empty_pair_dict: pair_info = {
                 "model_filename": "", "trained_timestamp": 0,
                 "data_path": "", "extras": {}}
-        if 'Reinforcement' in self.config['freqaimodel']:
-            self.model_type = 'stable_baselines'
-            logger.warning('User passed a ReinforcementLearner model, FreqAI will '
-                           'now use stable_baselines3 to save models.')
-        else:
-            self.model_type = self.freqai_info.get('model_save_type', 'joblib')
+        self.model_type = self.freqai_info.get('model_save_type', 'joblib')
 
     def update_metric_tracker(self, metric: str, value: float, pair: str) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This PR aims to fix an error when user tries to use a custom model saved in freqaimodels folder. Currently it is assumed that custom model file name includes "Reinforcement". But if the user chooses to use "MyCoolRLModel", as instructed on docs, model saving and loading will not work.