### PR TITLE
bring back market side setting in get_state_info

### DIFF
--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -193,6 +193,10 @@ class BaseReinforcementLearningModel(IFreqaiModel):
                 now = datetime.now(timezone.utc).timestamp()
                 trade_duration = int((now - trade.open_date_utc.timestamp()) / self.base_tf_seconds)
                 current_profit = trade.calc_profit_ratio(current_rate)
+                if trade.is_short:
+                    market_side = 0
+                else:
+                    market_side = 1
 
         return market_side, current_profit, int(trade_duration)
 


### PR DESCRIPTION
Market side was missing from the `get_state_info()` in RL. This MR brings it back. 