### PR TITLE
Change to broadcasting single candles in Producer/Consumer

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -61,6 +61,7 @@ USERPATH_FREQAIMODELS = 'freqaimodels'
 
 TELEGRAM_SETTING_OPTIONS = ['on', 'off', 'silent']
 WEBHOOK_FORMAT_OPTIONS = ['form', 'json', 'raw']
+FULL_DATAFRAME_THRESHOLD = 100
 
 ENV_VAR_PREFIX = 'FREQTRADE__'
 

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -7,7 +7,7 @@ Common Interface for bot and strategy to access data.
 import logging
 from collections import deque
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from pandas import DataFrame, concat
 
@@ -165,7 +165,7 @@ class DataProvider:
         timeframe: str,
         candle_type: CandleType,
         producer_name: str = "default"
-    ) -> Union[bool, int]:
+    ) -> Tuple[bool, int]:
         """
         Append a candle to the existing external dataframe
 
@@ -179,22 +179,22 @@ class DataProvider:
         if producer_name not in self.__producer_pairs_df:
             # We don't have data from this producer yet,
             # so we can't append a candle
-            return False
+            return (False, 0)
 
         if pair_key not in self.__producer_pairs_df[producer_name]:
             # We don't have data for this pair_key,
             # so we can't append a candle
-            return False
+            return (False, 0)
 
         # CHECK FOR MISSING CANDLES
-        # return int
+        # return (False, int > 0)
 
         existing_df, _ = self.__producer_pairs_df[producer_name][pair_key]
         appended_df = self._append_candle_to_dataframe(existing_df, dataframe)
 
         # Everything is good, we appended
         self.__producer_pairs_df[producer_name][pair_key] = appended_df, last_analyzed
-        return True
+        return (True, 0)
 
     def _append_candle_to_dataframe(self, existing: DataFrame, new: DataFrame) -> DataFrame:
         """

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -186,7 +186,7 @@ class DataProvider:
         if len(dataframe) >= FULL_DATAFRAME_THRESHOLD:
             # This is likely a full dataframe
             # Add the dataframe to the dataprovider
-            self._add_external_df(
+            self._replace_external_df(
                 pair,
                 dataframe,
                 last_analyzed=last_analyzed,
@@ -228,7 +228,7 @@ class DataProvider:
             appended_df = append_candles_to_dataframe(existing_df1, dataframe)
 
         # Everything is good, we appended
-        self._add_external_df(
+        self._replace_external_df(
                     pair,
                     appended_df,
                     last_analyzed=last_analyzed,

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -179,15 +179,19 @@ class DataProvider:
         if producer_name not in self.__producer_pairs_df:
             # We don't have data from this producer yet,
             # so we can't append a candle
-            return (False, 0)
+            return (False, 999)
 
         if pair_key not in self.__producer_pairs_df[producer_name]:
             # We don't have data for this pair_key,
             # so we can't append a candle
-            return (False, 0)
+            return (False, 999)
 
         # CHECK FOR MISSING CANDLES
-        # return (False, int > 0)
+        # Calculate difference between last candle in local dataframe
+        # and first candle in incoming dataframe. Take difference and divide
+        # by timeframe to find out how many candles we still need. If 1
+        # then the incoming candle is the right candle. If more than 1,
+        # return (False, missing candles - 1)
 
         existing_df, _ = self.__producer_pairs_df[producer_name][pair_key]
         appended_df = self._append_candle_to_dataframe(existing_df, dataframe)
@@ -207,8 +211,8 @@ class DataProvider:
         if existing.iloc[-1]['date'] != new.iloc[-1]['date']:
             existing = concat([existing, new])
 
-        # Only keep the last 1000 candles in memory
-        existing = existing[-1000:] if len(existing) > 1000 else existing
+        # Only keep the last 1500 candles in memory
+        existing = existing[-1500:] if len(existing) > 1000 else existing
 
         return existing
 

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -194,7 +194,9 @@ class DataProvider:
         # and return True, 0
         if local_last == incoming_first:
             existing_df.iloc[-1] = dataframe.iloc[0]
-            existing_df = existing_df.reset_index(drop=True)
+            existing_data = (existing_df.reset_index(drop=True), _)
+
+            self.__producer_pairs_df[producer_name][pair_key] = existing_data
             return (True, 0)
 
         candle_difference = (incoming_first - local_last) / timeframe_delta

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -189,7 +189,7 @@ class DataProvider:
             # return False and 1000 for the full df
             return (False, 1000)
 
-        existing_df, la = self.__producer_pairs_df[producer_name][pair_key]
+        existing_df, _ = self.__producer_pairs_df[producer_name][pair_key]
 
         # Handle overlapping candles
         old_candles = existing_df[

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -179,7 +179,7 @@ class DataProvider:
         if (producer_name not in self.__producer_pairs_df) \
            or (pair_key not in self.__producer_pairs_df[producer_name]):
             # We don't have data from this producer yet,
-            # sor we don't have data for this pair_key
+            # or we don't have data for this pair_key
             # return False and 1000 for the full df
             return (False, 1000)
 
@@ -189,6 +189,13 @@ class DataProvider:
         timeframe_delta = to_timedelta(timeframe)  # Convert the timeframe to a timedelta for pandas
         local_last = existing_df.iloc[-1]['date']  # We want the last date from our copy of data
         incoming_first = dataframe.iloc[0]['date']  # We want the first date from the incoming data
+
+        # We have received this candle before, update our copy
+        # and return True, 0
+        if local_last == incoming_first:
+            existing_df.iloc[-1] = dataframe.iloc[0]
+            existing_df = existing_df.reset_index(drop=True)
+            return (True, 0)
 
         candle_difference = (incoming_first - local_last) / timeframe_delta
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -301,3 +301,21 @@ def remove_entry_exit_signals(dataframe: pd.DataFrame):
     dataframe[SignalTagType.EXIT_TAG.value] = None
 
     return dataframe
+
+
+def append_candles_to_dataframe(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
+    """
+    Append the `right` dataframe to the `left` dataframe
+
+    :param left: The full dataframe you want appended to
+    :param right: The new dataframe containing the data you want appended
+    :returns: The dataframe with the right data in it
+    """
+    if left.iloc[-1]['date'] != right.iloc[-1]['date']:
+        left = pd.concat([left, right])
+
+    # Only keep the last 1500 candles in memory
+    left = left[-1500:] if len(left) > 1500 else left
+    left.reset_index(drop=True, inplace=True)
+
+    return left

--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -91,9 +91,10 @@ async def _process_consumer_request(
     elif type == RPCRequestType.ANALYZED_DF:
         # Limit the amount of candles per dataframe to 'limit' or 1500
         limit = min(data.get('limit', 1500), 1500) if data else None
+        pair = data.get('pair', None) if data else None
 
         # For every pair in the generator, send a separate message
-        for message in rpc._ws_request_analyzed_df(limit):
+        for message in rpc._ws_request_analyzed_df(limit, pair):
             # Format response
             response = WSAnalyzedDFMessage(data=message)
             await channel.send(response.dict(exclude_none=True))

--- a/freqtrade/rpc/api_server/ws_schemas.py
+++ b/freqtrade/rpc/api_server/ws_schemas.py
@@ -47,7 +47,7 @@ class WSWhitelistRequest(WSRequestSchema):
 
 class WSAnalyzedDFRequest(WSRequestSchema):
     type: RPCRequestType = RPCRequestType.ANALYZED_DF
-    data: Dict[str, Any] = {"limit": 1500}
+    data: Dict[str, Any] = {"limit": 1500, "pair": None}
 
 
 # ------------------------------ MESSAGE SCHEMAS ----------------------------

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -411,8 +411,7 @@ class ExternalMessageConsumer:
                 # Set to None for all candles if we missed a full df's worth of candles
                 n_missing = n_missing if n_missing < FULL_DATAFRAME_THRESHOLD else 1500
 
-                logger.warning("Holes in data or no existing df, "
-                               f"requesting {n_missing} candles "
+                logger.warning("Holes in data or no existing df, requesting {n_missing} candles "
                                f"for {key} from `{producer_name}`")
 
                 self.send_producer_request(

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -253,7 +253,7 @@ class ExternalMessageConsumer:
         # Now send any subsequent requests published to
         # this channel's stream
         async for request, _ in channel_stream:
-            logger.info(f"Sending request to channel - {channel} - {request}")
+            logger.debug(f"Sending request to channel - {channel} - {request}")
             await channel.send(request)
 
     async def _receive_messages(
@@ -377,14 +377,14 @@ class ExternalMessageConsumer:
         pair, timeframe, candle_type = key
 
         if df.empty:
-            logger.info(f"Received Empty Dataframe for {key}")
+            logger.debug(f"Received Empty Dataframe for {key}")
             return
 
         # If set, remove the Entry and Exit signals from the Producer
         if self._emc_config.get('remove_entry_exit_signals', False):
             df = remove_entry_exit_signals(df)
 
-        logger.info(f"Received {len(df)} candle(s) for {key}")
+        logger.debug(f"Received {len(df)} candle(s) for {key}")
 
         if len(df) >= 999:
             # This is a full dataframe
@@ -413,9 +413,9 @@ class ExternalMessageConsumer:
             )
 
             if not did_append:
-                logger.info("Holes in data or no existing df, "
-                            f"requesting {n_missing} candles "
-                            f"for {key} from `{producer_name}`")
+                logger.debug("Holes in data or no existing df, "
+                             f"requesting {n_missing} candles "
+                             f"for {key} from `{producer_name}`")
 
                 self.send_producer_request(
                     producer_name,
@@ -428,6 +428,6 @@ class ExternalMessageConsumer:
                 )
                 return
 
-        logger.info(
+        logger.debug(
             f"Consumed message from `{producer_name}` "
             f"of type `RPCMessageType.ANALYZED_DF` for {key}")

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -293,18 +293,11 @@ class ExternalMessageConsumer:
                     logger.info(f"Connection to {channel} still alive, latency: {latency}ms")
                     continue
 
-                except (websockets.exceptions.ConnectionClosed):
-                    # Just eat the error and continue reconnecting
-                    logger.warning(f"Disconnection in {channel} - retrying in {self.sleep_time}s")
-                    await asyncio.sleep(self.sleep_time)
-                    break
-
                 except Exception as e:
                     # Just eat the error and continue reconnecting
                     logger.warning(f"Ping error {channel} - {e} - retrying in {self.sleep_time}s")
                     logger.debug(e, exc_info=e)
-                    await asyncio.sleep(self.sleep_time)
-                    break
+                    raise
 
     def send_producer_request(
         self,

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -388,8 +388,8 @@ class ExternalMessageConsumer:
                 producer_name=producer_name
             )
 
-        elif len(df) == 1:
-            # This is just a single candle
+        elif len(df) < 999:
+            # This is n single candles
             # Have dataprovider append it to
             # the full datafame. If it can't,
             # request the missing candles

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -202,7 +202,11 @@ class ExternalMessageConsumer:
                     max_size=self.message_size_limit,
                     ping_interval=None
                 ) as ws:
-                    async with create_channel(ws, channel_id=name) as channel:
+                    async with create_channel(
+                        ws,
+                        channel_id=name,
+                        send_throttle=0.5
+                    ) as channel:
 
                         # Create the message stream for this channel
                         self._channel_streams[name] = MessageStream()

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -224,20 +224,21 @@ class ExternalMessageConsumer:
                 websockets.exceptions.InvalidMessage
             ) as e:
                 logger.error(f"Connection Refused - {e} retrying in {self.sleep_time}s")
+                await asyncio.sleep(self.sleep_time)
+                continue
 
             except (
                 websockets.exceptions.ConnectionClosedError,
                 websockets.exceptions.ConnectionClosedOK
             ):
                 # Just keep trying to connect again indefinitely
-                pass
+                await asyncio.sleep(self.sleep_time)
+                continue
 
             except Exception as e:
                 # An unforseen error has occurred, log and continue
                 logger.error("Unexpected error has occurred:")
                 logger.exception(e)
-
-            finally:
                 await asyncio.sleep(self.sleep_time)
                 continue
 

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -393,14 +393,16 @@ class ExternalMessageConsumer:
             # Have dataprovider append it to
             # the full datafame. If it can't,
             # request the missing candles
-            if not self._dp._add_external_candle(
+            did_append, n_missing = self._dp._add_external_candle(
                 pair,
                 df,
                 last_analyzed=la,
                 timeframe=timeframe,
                 candle_type=candle_type,
                 producer_name=producer_name
-            ):
+            )
+
+            if not did_append:
                 logger.info("Holes in data or no existing df, "
                             f"requesting data for {key} from `{producer_name}`")
 
@@ -408,7 +410,7 @@ class ExternalMessageConsumer:
                     producer_name,
                     WSAnalyzedDFRequest(
                         data={
-                            "limit": 1000,
+                            "limit": n_missing if n_missing > 0 else 1000,
                             "pair": pair
                         }
                     )

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -43,10 +43,6 @@ def schema_to_dict(schema: Union[WSMessageSchema, WSRequestSchema]):
     return schema.dict(exclude_none=True)
 
 
-# def parse_message(message: Dict[str, Any], message_schema: Type[WSMessageSchema]):
-#     return message_schema.parse_obj(message)
-
-
 class ExternalMessageConsumer:
     """
     The main controller class for consuming external messages from

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1062,31 +1062,28 @@ class RPC:
         self,
         pair: str,
         timeframe: str,
-        limit: Optional[Union[int, List[str]]] = None
+        limit: Optional[int] = None
     ) -> Tuple[DataFrame, datetime]:
         """
         Get the dataframe and last analyze from the dataprovider
 
         :param pair: The pair to get
         :param timeframe: The timeframe of data to get
-        :param limit: If an integer, limits the size of dataframe
-                      If a list of string date times, only returns those candles
+        :param limit: The amount of candles in the dataframe
         """
         _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(
             pair, timeframe)
         _data = _data.copy()
 
-        if limit and isinstance(limit, int):
+        if limit:
             _data = _data.iloc[-limit:]
-        elif limit and isinstance(limit, str):
-            _data = _data.iloc[_data['date'].isin(limit)]
 
         return _data, last_analyzed
 
     def _ws_all_analysed_dataframes(
         self,
         pairlist: List[str],
-        limit: Optional[Union[int, List[str]]] = None
+        limit: Optional[int] = None
     ) -> Generator[Dict[str, Any], None, None]:
         """
         Get the analysed dataframes of each pair in the pairlist.
@@ -1113,7 +1110,7 @@ class RPC:
     def _ws_request_analyzed_df(
         self,
         pair: Optional[str],
-        limit: Optional[Union[int, List[str]]] = None,
+        limit: Optional[int] = None,
     ):
         """ Historical Analyzed Dataframes for WebSocket """
         pairlist = [pair] if pair else self._freqtrade.active_pair_whitelist

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1062,7 +1062,7 @@ class RPC:
         self,
         pair: str,
         timeframe: str,
-        limit: Optional[int] = None
+        limit: Optional[int]
     ) -> Tuple[DataFrame, datetime]:
         """
         Get the dataframe and last analyze from the dataprovider
@@ -1083,7 +1083,7 @@ class RPC:
     def _ws_all_analysed_dataframes(
         self,
         pairlist: List[str],
-        limit: Optional[int] = None
+        limit: Optional[int]
     ) -> Generator[Dict[str, Any], None, None]:
         """
         Get the analysed dataframes of each pair in the pairlist.

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1109,8 +1109,8 @@ class RPC:
 
     def _ws_request_analyzed_df(
         self,
-        pair: Optional[str],
         limit: Optional[int] = None,
+        pair: Optional[str] = None
     ):
         """ Historical Analyzed Dataframes for WebSocket """
         pairlist = [pair] if pair else self._freqtrade.active_pair_whitelist

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1087,8 +1087,8 @@ class RPC:
     ) -> Generator[Dict[str, Any], None, None]:
         """
         Get the analysed dataframes of each pair in the pairlist.
-        Limit size of dataframe if specified.
-        If candles, only return the candles specified.
+        If specified, only return the most recent `limit` candles for
+        each dataframe.
 
         :param pairlist: A list of pairs to get
         :param limit: If an integer, limits the size of dataframe

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1058,23 +1058,46 @@ class RPC:
         return self._convert_dataframe_to_dict(self._freqtrade.config['strategy'],
                                                pair, timeframe, _data, last_analyzed)
 
-    def __rpc_analysed_dataframe_raw(self, pair: str, timeframe: str,
-                                     limit: Optional[int]) -> Tuple[DataFrame, datetime]:
-        """ Get the dataframe and last analyze from the dataprovider """
+    def __rpc_analysed_dataframe_raw(
+        self,
+        pair: str,
+        timeframe: str,
+        limit: Optional[Union[int, List[str]]] = None
+    ) -> Tuple[DataFrame, datetime]:
+        """
+        Get the dataframe and last analyze from the dataprovider
+
+        :param pair: The pair to get
+        :param timeframe: The timeframe of data to get
+        :param limit: If an integer, limits the size of dataframe
+                      If a list of string date times, only returns those candles
+        """
         _data, last_analyzed = self._freqtrade.dataprovider.get_analyzed_dataframe(
             pair, timeframe)
         _data = _data.copy()
 
-        if limit:
+        if limit and isinstance(limit, int):
             _data = _data.iloc[-limit:]
+        elif limit and isinstance(limit, str):
+            _data = _data.iloc[_data['date'].isin(limit)]
+
         return _data, last_analyzed
 
     def _ws_all_analysed_dataframes(
         self,
         pairlist: List[str],
-        limit: Optional[int]
+        limit: Optional[Union[int, List[str]]] = None
     ) -> Generator[Dict[str, Any], None, None]:
-        """ Get the analysed dataframes of each pair in the pairlist """
+        """
+        Get the analysed dataframes of each pair in the pairlist.
+        Limit size of dataframe if specified.
+        If candles, only return the candles specified.
+
+        :param pairlist: A list of pairs to get
+        :param limit: If an integer, limits the size of dataframe
+                      If a list of string date times, only returns those candles
+        :returns: A generator of dictionaries with the key, dataframe, and last analyzed timestamp
+        """
         timeframe = self._freqtrade.config['timeframe']
         candle_type = self._freqtrade.config.get('candle_type_def', CandleType.SPOT)
 
@@ -1087,10 +1110,15 @@ class RPC:
                 "la": last_analyzed
             }
 
-    def _ws_request_analyzed_df(self, limit: Optional[int]):
+    def _ws_request_analyzed_df(
+        self,
+        pair: Optional[str],
+        limit: Optional[Union[int, List[str]]] = None,
+    ):
         """ Historical Analyzed Dataframes for WebSocket """
-        whitelist = self._freqtrade.active_pair_whitelist
-        return self._ws_all_analysed_dataframes(whitelist, limit)
+        pairlist = [pair] if pair else self._freqtrade.active_pair_whitelist
+
+        return self._ws_all_analysed_dataframes(pairlist, limit)
 
     def _ws_request_whitelist(self):
         """ Whitelist data for WebSocket """

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -2,13 +2,13 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from pandas import DataFrame
+from pandas import DataFrame, Timestamp
 
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import CandleType, RunMode
 from freqtrade.exceptions import ExchangeError, OperationalException
 from freqtrade.plugins.pairlistmanager import PairListManager
-from tests.conftest import get_patched_exchange
+from tests.conftest import generate_test_data, get_patched_exchange
 
 
 @pytest.mark.parametrize('candle_type', [
@@ -412,3 +412,67 @@ def test_dp_send_msg(default_conf):
     dp = DataProvider(default_conf, None)
     dp.send_msg(msg, always_send=True)
     assert msg not in dp._msg_queue
+
+
+def test_dp__add_external_candle(default_conf_usdt):
+    timeframe = '1h'
+    default_conf_usdt["timeframe"] = timeframe
+    dp = DataProvider(default_conf_usdt, None)
+    df = generate_test_data(timeframe, 24, '2022-01-01 00:00:00+00:00')
+    last_analyzed = datetime.now(timezone.utc)
+
+    res = dp._add_external_candle('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is False
+    # Why 1000 ??
+    assert res[1] == 1000
+
+    dp._add_external_df('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    # BTC is not stored yet
+    res = dp._add_external_candle('BTC/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is False
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    assert len(df) == 24
+
+    # Add the same dataframe again - dataframe size shall not change.
+    res = dp._add_external_candle('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is True
+    assert res[1] == 0
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    assert len(df) == 24
+
+    # Add a new day.
+    df2 = generate_test_data(timeframe, 24, '2022-01-02 00:00:00+00:00')
+
+    res = dp._add_external_candle('ETH/USDT', df2, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is True
+    assert res[1] == 0
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    assert len(df) == 48
+
+    # Add a dataframe with a 12 hour offset - so 12 candles are overlapping, and 12 valid.
+    df3 = generate_test_data(timeframe, 24, '2022-01-02 12:00:00+00:00')
+
+    res = dp._add_external_candle('ETH/USDT', df3, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is True
+    assert res[1] == 0
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    # New length = 48 + 12 (since we have a 12 hour offset).
+    assert len(df) == 60
+    assert df.iloc[-1]['date'] == df3.iloc[-1]['date']
+    assert df.iloc[-1]['date'] == Timestamp('2022-01-03 11:00:00+00:00')
+
+    # Generate 1 new candle
+    df4 = generate_test_data(timeframe, 1, '2022-01-03 12:00:00+00:00')
+    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    # assert res[0] is True
+    # assert res[1] == 0
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    # New length = 61 + 1
+    assert len(df) == 61
+
+    # Gap in the data ...
+    df4 = generate_test_data(timeframe, 1, '2022-01-05 00:00:00+00:00')
+    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is False
+    # 36 hours - from 2022-01-03 12:00:00+00:00 to 2022-01-05 00:00:00+00:00
+    assert res[1] == 36

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -161,9 +161,9 @@ def test_producer_pairs(mocker, default_conf, ohlcv_history):
     assert dataprovider.get_producer_pairs("bad") == []
 
 
-def test_get_producer_df(mocker, default_conf, ohlcv_history):
+def test_get_producer_df(mocker, default_conf):
     dataprovider = DataProvider(default_conf, None)
-
+    ohlcv_history = generate_test_data('5m', 150)
     pair = 'BTC/USDT'
     timeframe = default_conf['timeframe']
     candle_type = CandleType.SPOT
@@ -414,27 +414,28 @@ def test_dp_send_msg(default_conf):
     assert msg not in dp._msg_queue
 
 
-def test_dp__add_external_candle(default_conf_usdt):
+def test_dp__add_external_df(default_conf_usdt):
     timeframe = '1h'
     default_conf_usdt["timeframe"] = timeframe
     dp = DataProvider(default_conf_usdt, None)
     df = generate_test_data(timeframe, 24, '2022-01-01 00:00:00+00:00')
     last_analyzed = datetime.now(timezone.utc)
 
-    res = dp._add_external_candle('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is False
     # Why 1000 ??
     assert res[1] == 1000
 
-    dp._add_external_df('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    # Hard add dataframe
+    dp._replace_external_df('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
     # BTC is not stored yet
-    res = dp._add_external_candle('BTC/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('BTC/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is False
-    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
-    assert len(df) == 24
+    df_res, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    assert len(df_res) == 24
 
     # Add the same dataframe again - dataframe size shall not change.
-    res = dp._add_external_candle('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is True
     assert res[1] == 0
     df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
@@ -443,7 +444,7 @@ def test_dp__add_external_candle(default_conf_usdt):
     # Add a new day.
     df2 = generate_test_data(timeframe, 24, '2022-01-02 00:00:00+00:00')
 
-    res = dp._add_external_candle('ETH/USDT', df2, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df2, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is True
     assert res[1] == 0
     df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
@@ -452,7 +453,7 @@ def test_dp__add_external_candle(default_conf_usdt):
     # Add a dataframe with a 12 hour offset - so 12 candles are overlapping, and 12 valid.
     df3 = generate_test_data(timeframe, 24, '2022-01-02 12:00:00+00:00')
 
-    res = dp._add_external_candle('ETH/USDT', df3, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df3, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is True
     assert res[1] == 0
     df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
@@ -463,7 +464,7 @@ def test_dp__add_external_candle(default_conf_usdt):
 
     # Generate 1 new candle
     df4 = generate_test_data(timeframe, 1, '2022-01-03 12:00:00+00:00')
-    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
     # assert res[0] is True
     # assert res[1] == 0
     df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
@@ -474,7 +475,7 @@ def test_dp__add_external_candle(default_conf_usdt):
 
     # Gap in the data ...
     df4 = generate_test_data(timeframe, 1, '2022-01-05 00:00:00+00:00')
-    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is False
     # 36 hours - from 2022-01-03 12:00:00+00:00 to 2022-01-05 00:00:00+00:00
     assert res[1] == 36
@@ -484,7 +485,7 @@ def test_dp__add_external_candle(default_conf_usdt):
 
     # Empty dataframe
     df4 = generate_test_data(timeframe, 0, '2022-01-05 00:00:00+00:00')
-    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    res = dp._add_external_df('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
     assert res[0] is False
     # 36 hours - from 2022-01-03 12:00:00+00:00 to 2022-01-05 00:00:00+00:00
     assert res[1] == 0

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -469,6 +469,8 @@ def test_dp__add_external_candle(default_conf_usdt):
     df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
     # New length = 61 + 1
     assert len(df) == 61
+    assert df.iloc[-2]['date'] == Timestamp('2022-01-03 11:00:00+00:00')
+    assert df.iloc[-1]['date'] == Timestamp('2022-01-03 12:00:00+00:00')
 
     # Gap in the data ...
     df4 = generate_test_data(timeframe, 1, '2022-01-05 00:00:00+00:00')
@@ -476,3 +478,13 @@ def test_dp__add_external_candle(default_conf_usdt):
     assert res[0] is False
     # 36 hours - from 2022-01-03 12:00:00+00:00 to 2022-01-05 00:00:00+00:00
     assert res[1] == 36
+    df, _ = dp.get_producer_df('ETH/USDT', timeframe, CandleType.SPOT)
+    # New length = 61 + 1
+    assert len(df) == 61
+
+    # Empty dataframe
+    df4 = generate_test_data(timeframe, 0, '2022-01-05 00:00:00+00:00')
+    res = dp._add_external_candle('ETH/USDT', df4, last_analyzed, timeframe, CandleType.SPOT)
+    assert res[0] is False
+    # 36 hours - from 2022-01-03 12:00:00+00:00 to 2022-01-05 00:00:00+00:00
+    assert res[1] == 0


### PR DESCRIPTION
## Summary

This PR re-implements the logic required for changing the Producer to only broadcast the most recent candle when calculated as opposed to the entire Dataframe. This reduces the message sizes significantly and helps increase network performance, all while keeping the same resource usage on the Consumer.

## Quick changelog

- Re-implement EMC using new WebSocketChannel API's
- Add methods to DataProvider for appending candles to Producer data
- Update `analyzed_df` request on Producer side to allow specifying the pair
- Add mechanism for EMC to request data from Producers when needed
