### PR TITLE
freqai RL agent info during training

### DIFF
--- a/freqtrade/freqai/RL/Base4ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base4ActionRLEnv.py
@@ -20,6 +20,9 @@ class Base4ActionRLEnv(BaseEnvironment):
     """
     Base class for a 4 action environment
     """
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.actions = Actions
 
     def set_action_space(self):
         self.action_space = spaces.Discrete(len(Actions))
@@ -92,9 +95,12 @@ class Base4ActionRLEnv(BaseEnvironment):
 
         info = dict(
             tick=self._current_tick,
+            action=action,
             total_reward=self.total_reward,
             total_profit=self._total_profit,
-            position=self._position.value
+            position=self._position.value,
+            trade_duration=self.get_trade_duration(),
+            current_profit_pct=self.get_unrealized_profit()
         )
 
         observation = self._get_observation()

--- a/freqtrade/freqai/RL/Base4ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base4ActionRLEnv.py
@@ -20,8 +20,8 @@ class Base4ActionRLEnv(BaseEnvironment):
     """
     Base class for a 4 action environment
     """
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.actions = Actions
 
     def set_action_space(self):

--- a/freqtrade/freqai/RL/Base5ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base5ActionRLEnv.py
@@ -21,6 +21,9 @@ class Base5ActionRLEnv(BaseEnvironment):
     """
     Base class for a 5 action environment
     """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.actions = Actions
 
     def set_action_space(self):
         self.action_space = spaces.Discrete(len(Actions))
@@ -98,9 +101,12 @@ class Base5ActionRLEnv(BaseEnvironment):
 
         info = dict(
             tick=self._current_tick,
+            action=action,
             total_reward=self.total_reward,
             total_profit=self._total_profit,
-            position=self._position.value
+            position=self._position.value,
+            trade_duration=self.get_trade_duration(),
+            current_profit_pct=self.get_unrealized_profit()
         )
 
         observation = self._get_observation()

--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -77,6 +77,7 @@ class BaseEnvironment(gym.Env):
 
         # set here to default 5Ac, but all children envs can overwrite this
         self.actions: Type[Enum] = BaseActions
+        self.custom_info: dict = {}
 
     def reset_env(self, df: DataFrame, prices: DataFrame, window_size: int,
                   reward_kwargs: dict, starting_point=True):

--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -75,7 +75,7 @@ class BaseEnvironment(gym.Env):
         else:
             self.fee = 0.0015
 
-        # set here to default 5Ac, but all children envs can overwrite this
+        # set here to default 5Ac, but all children envs can override this
         self.actions: Type[Enum] = BaseActions
         self.custom_info: dict = {}
 
@@ -121,7 +121,6 @@ class BaseEnvironment(gym.Env):
         self._total_unrealized_profit: float = 1
         self.history: dict = {}
         self.trade_history: list = []
-        self.custom_info: dict = {}
 
     @abstractmethod
     def set_action_space(self):

--- a/freqtrade/freqai/RL/TensorboardCallback.py
+++ b/freqtrade/freqai/RL/TensorboardCallback.py
@@ -1,0 +1,61 @@
+from enum import Enum
+from typing import Any, Dict, Type, Union
+
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.logger import HParam
+
+from freqtrade.freqai.RL.BaseEnvironment import BaseActions
+
+
+class TensorboardCallback(BaseCallback):
+    """
+    Custom callback for plotting additional values in tensorboard and
+    episodic summary reports.
+    """
+    def __init__(self, verbose=1, actions: Type[Enum] = BaseActions):
+        super(TensorboardCallback, self).__init__(verbose)
+        self.model: Any = None
+        # An alias for self.model.get_env(), the environment used for training
+        self.logger = None  # type: Any
+        # self.training_env = None  # type: Union[gym.Env, VecEnv]
+        self.actions: Type[Enum] = actions
+
+    def _on_training_start(self) -> None:
+        hparam_dict = {
+            "algorithm": self.model.__class__.__name__,
+            "learning_rate": self.model.learning_rate,
+            # "gamma": self.model.gamma,
+            # "gae_lambda": self.model.gae_lambda,
+            # "batch_size": self.model.batch_size,
+            # "n_steps": self.model.n_steps,
+        }
+        metric_dict: Dict[str, Union[float, int]] = {
+            "eval/mean_reward": 0,
+            "rollout/ep_rew_mean": 0,
+            "rollout/ep_len_mean": 0,
+            "train/value_loss": 0,
+            "train/explained_variance": 0,
+        }
+        self.logger.record(
+            "hparams",
+            HParam(hparam_dict, metric_dict),
+            exclude=("stdout", "log", "json", "csv"),
+        )
+
+    def _on_step(self) -> bool:
+        custom_info = self.training_env.get_attr("custom_info")[0]  # type: ignore
+        self.logger.record("_state/position", self.locals["infos"][0]["position"])
+        self.logger.record("_state/trade_duration", self.locals["infos"][0]["trade_duration"])
+        self.logger.record("_state/current_profit_pct", self.locals["infos"]
+                           [0]["current_profit_pct"])
+        self.logger.record("_reward/total_profit", self.locals["infos"][0]["total_profit"])
+        self.logger.record("_reward/total_reward", self.locals["infos"][0]["total_reward"])
+        self.logger.record_mean("_reward/mean_trade_duration", self.locals["infos"]
+                                [0]["trade_duration"])
+        self.logger.record("_actions/action", self.locals["infos"][0]["action"])
+        self.logger.record("_actions/_Invalid", custom_info["Invalid"])
+        self.logger.record("_actions/_Unknown", custom_info["Unknown"])
+        self.logger.record("_actions/Hold", custom_info["Hold"])
+        for action in self.actions:
+            self.logger.record(f"_actions/{action.name}", custom_info[action.name])
+        return True

--- a/freqtrade/freqai/RL/TensorboardCallback.py
+++ b/freqtrade/freqai/RL/TensorboardCallback.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Type, Union
 from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.logger import HParam
 
-from freqtrade.freqai.RL.BaseEnvironment import BaseActions
+from freqtrade.freqai.RL.BaseEnvironment import BaseActions, BaseEnvironment
 
 
 class TensorboardCallback(BaseCallback):
@@ -15,9 +15,8 @@ class TensorboardCallback(BaseCallback):
     def __init__(self, verbose=1, actions: Type[Enum] = BaseActions):
         super(TensorboardCallback, self).__init__(verbose)
         self.model: Any = None
-        # An alias for self.model.get_env(), the environment used for training
         self.logger = None  # type: Any
-        # self.training_env = None  # type: Union[gym.Env, VecEnv]
+        self.training_env: BaseEnvironment = None  # type: ignore
         self.actions: Type[Enum] = actions
 
     def _on_training_start(self) -> None:
@@ -43,7 +42,7 @@ class TensorboardCallback(BaseCallback):
         )
 
     def _on_step(self) -> bool:
-        custom_info = self.training_env.get_attr("custom_info")[0]  # type: ignore
+        custom_info = self.training_env.custom_info
         self.logger.record("_state/position", self.locals["infos"][0]["position"])
         self.logger.record("_state/trade_duration", self.locals["infos"][0]["trade_duration"])
         self.logger.record("_state/current_profit_pct", self.locals["infos"]

--- a/freqtrade/freqai/RL/TensorboardCallback.py
+++ b/freqtrade/freqai/RL/TensorboardCallback.py
@@ -42,7 +42,7 @@ class TensorboardCallback(BaseCallback):
         )
 
     def _on_step(self) -> bool:
-        custom_info = self.training_env.custom_info
+        custom_info = self.training_env.get_attr("custom_info")[0]
         self.logger.record("_state/position", self.locals["infos"][0]["position"])
         self.logger.record("_state/trade_duration", self.locals["infos"][0]["trade_duration"])
         self.logger.record("_state/current_profit_pct", self.locals["infos"]

--- a/freqtrade/freqai/prediction_models/ReinforcementLearner.py
+++ b/freqtrade/freqai/prediction_models/ReinforcementLearner.py
@@ -88,33 +88,6 @@ class ReinforcementLearner(BaseReinforcementLearningModel):
         User can override any function in BaseRLEnv and gym.Env. Here the user
         sets a custom reward based on profit and trade duration.
         """
-        def reset(self):
-
-            # Reset custom info
-            self.custom_info = {}
-            self.custom_info["Invalid"] = 0
-            self.custom_info["Hold"] = 0
-            self.custom_info["Unknown"] = 0
-            self.custom_info["pnl_factor"] = 0
-            self.custom_info["duration_factor"] = 0
-            self.custom_info["reward_exit"] = 0
-            self.custom_info["reward_hold"] = 0
-            for action in Actions:
-                self.custom_info[f"{action.name}"] = 0
-            return super().reset()
-
-        def step(self, action: int):
-            observation, step_reward, done, info = super().step(action)
-            info = dict(
-                tick=self._current_tick,
-                action=action,
-                total_reward=self.total_reward,
-                total_profit=self._total_profit,
-                position=self._position.value,
-                trade_duration=self.get_trade_duration(),
-                current_profit_pct=self.get_unrealized_profit()
-            )
-            return observation, step_reward, done, info
 
         def calculate_reward(self, action: int) -> float:
             """

--- a/freqtrade/freqai/prediction_models/ReinforcementLearner.py
+++ b/freqtrade/freqai/prediction_models/ReinforcementLearner.py
@@ -102,7 +102,7 @@ class ReinforcementLearner(BaseReinforcementLearningModel):
             for action in Actions:
                 self.custom_info[f"{action.name}"] = 0
             return super().reset()
-        
+
         def step(self, action: int):
             observation, step_reward, done, info = super().step(action)
             info = dict(
@@ -134,7 +134,7 @@ class ReinforcementLearner(BaseReinforcementLearningModel):
             factor = 100.
 
             # reward agent for entering trades
-            if (action ==Actions.Long_enter.value
+            if (action == Actions.Long_enter.value
                     and self._position == Positions.Neutral):
                 self.custom_info[f"{Actions.Long_enter.name}"] += 1
                 return 25
@@ -174,6 +174,6 @@ class ReinforcementLearner(BaseReinforcementLearningModel):
                     factor *= self.rl_config['model_reward_parameters'].get('win_reward_factor', 2)
                 self.custom_info[f"{Actions.Short_exit.name}"] += 1
                 return float(pnl * factor)
-            
+
             self.custom_info["Unknown"] += 1
             return 0.

--- a/freqtrade/freqai/prediction_models/ReinforcementLearner_multiproc.py
+++ b/freqtrade/freqai/prediction_models/ReinforcementLearner_multiproc.py
@@ -1,14 +1,14 @@
 import logging
-from typing import Any, Dict  # , Tuple
+from typing import Any, Dict
 
-# import numpy.typing as npt
 from pandas import DataFrame
 from stable_baselines3.common.callbacks import EvalCallback
 from stable_baselines3.common.vec_env import SubprocVecEnv
 
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.prediction_models.ReinforcementLearner import ReinforcementLearner
-from freqtrade.freqai.RL.BaseReinforcementLearningModel import TensorboardCallback, make_env
+from freqtrade.freqai.RL.BaseReinforcementLearningModel import make_env
+from freqtrade.freqai.RL.TensorboardCallback import TensorboardCallback
 
 
 logger = logging.getLogger(__name__)
@@ -50,4 +50,5 @@ class ReinforcementLearner_multiproc(ReinforcementLearner):
                                           render=False, eval_freq=len(train_df),
                                           best_model_save_path=str(dk.data_path))
 
-        self.tensorboard_callback = TensorboardCallback()
+        actions = self.train_env.env_method("get_actions")[0]
+        self.tensorboard_callback = TensorboardCallback(verbose=1, actions=actions)

--- a/freqtrade/freqai/prediction_models/ReinforcementLearner_multiproc.py
+++ b/freqtrade/freqai/prediction_models/ReinforcementLearner_multiproc.py
@@ -8,7 +8,7 @@ from stable_baselines3.common.vec_env import SubprocVecEnv
 
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.prediction_models.ReinforcementLearner import ReinforcementLearner
-from freqtrade.freqai.RL.BaseReinforcementLearningModel import make_env
+from freqtrade.freqai.RL.BaseReinforcementLearningModel import TensorboardCallback, make_env
 
 
 logger = logging.getLogger(__name__)
@@ -49,3 +49,5 @@ class ReinforcementLearner_multiproc(ReinforcementLearner):
         self.eval_callback = EvalCallback(self.eval_env, deterministic=True,
                                           render=False, eval_freq=len(train_df),
                                           best_model_save_path=str(dk.data_path))
+
+        self.tensorboard_callback = TensorboardCallback()

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -237,7 +237,6 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog)
     df = freqai.cache_corr_pairlist_dfs(df, freqai.dk)
     for i in range(5):
         df[f'%-constant_{i}'] = i
-        # df.loc[:, f'%-constant_{i}'] = i
 
     metadata = {"pair": "LTC/BTC"}
     freqai.start_backtesting(df, metadata, freqai.dk)


### PR DESCRIPTION
## Summary

Adds metrics to RL training within freqai to the console during callbacks

Original author of code @stm on discord 

Example:

```-----------------------------------------
| _actions/               |             |
|    Hold                 | 4           |
|    Long_enter           | 10          |
|    Long_exit            | 9           |
|    Neutral              | 2           |
|    Short_enter          | 13          |
|    Short_exit           | 13          |
|    _Invalid             | 71          |
|    _Unknown             | 36          |
|    action               | 1           |
| _reward/                |             |
|    mean_trade_duration  | 2.55        |
|    total_profit         | 0.988       |
|    total_reward         | 427         |
| _state/                 |             |
|    current_profit_pct   | 5.59e-05    |
|    position             | 1           |
|    trade_duration       | 8           |
| rollout/                |             |
|    ep_len_mean          | 1.51e+03    |
|    ep_rew_mean          | 3.83e+03    |
| time/                   |             |
|    fps                  | 61          |
|    iterations           | 13          |
|    time_elapsed         | 27          |
|    total_timesteps      | 1664        |
| train/                  |             |
|    approx_kl            | 0.006526591 |
|    clip_fraction        | 0.0102      |
|    clip_range           | 0.2         |
|    entropy_loss         | -1.54       |
|    explained_variance   | 0.116       |
|    learning_rate        | 0.00025     |
|    loss                 | 94.3        |
|    n_updates            | 120         |
|    policy_gradient_loss | -0.00613    |
|    value_loss           | 208         |
-----------------------------------------