### PR TITLE
Fix add state info bt

### DIFF
--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -83,6 +83,7 @@ class BaseEnvironment(gym.Env):
         if dp:
             self.live = dp.runmode in (RunMode.DRY_RUN, RunMode.LIVE)
         if not self.live and self.add_state_info:
+            self.add_state_info = False
             logger.warning("add_state_info is not available in backtesting. Deactivating.")
 
     def reset_env(self, df: DataFrame, prices: DataFrame, window_size: int,

--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -12,6 +12,7 @@ from gym.utils import seeding
 from pandas import DataFrame
 
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.enums import RunMode
 
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,11 @@ class BaseEnvironment(gym.Env):
         # set here to default 5Ac, but all children envs can override this
         self.actions: Type[Enum] = BaseActions
         self.custom_info: dict = {}
+        self.live: bool = False
+        if dp:
+            self.live = dp.runmode in (RunMode.DRY_RUN, RunMode.LIVE)
+        if not self.live and self.add_state_info:
+            logger.warning("add_state_info is not available in backtesting. Deactivating.")
 
     def reset_env(self, df: DataFrame, prices: DataFrame, window_size: int,
                   reward_kwargs: dict, starting_point=True):
@@ -188,7 +194,7 @@ class BaseEnvironment(gym.Env):
         """
         features_window = self.signal_features[(
             self._current_tick - self.window_size):self._current_tick]
-        if self.add_state_info:
+        if self.add_state_info and self.live:
             features_and_state = DataFrame(np.zeros((len(features_window), 3)),
                                            columns=['current_profit_pct',
                                                     'position',


### PR DESCRIPTION
`add_state_info` was not properly deactivated during backtesting. This PR checks the dataprovider during initialization of the RL environment to ensure that `add_state_info` will only be active during dry/live runs. 