### PR TITLE
fix bug in MultiOutput* with conv_width = 1

### DIFF
--- a/config_examples/config_freqai.example.json
+++ b/config_examples/config_freqai.example.json
@@ -80,7 +80,6 @@
             "random_state": 1
         },
         "model_training_parameters": {
-            "n_estimators": 1000
         }
     },
     "bot_name": "",

--- a/freqtrade/freqai/base_models/BaseClassifierModel.py
+++ b/freqtrade/freqai/base_models/BaseClassifierModel.py
@@ -95,6 +95,9 @@ class BaseClassifierModel(IFreqaiModel):
         self.data_cleaning_predict(dk)
 
         predictions = self.model.predict(dk.data_dictionary["prediction_features"])
+        if self.CONV_WIDTH == 1:
+            predictions = np.reshape(predictions, (-1, len(dk.label_list)))
+
         pred_df = DataFrame(predictions, columns=dk.label_list)
 
         predictions_prob = self.model.predict_proba(dk.data_dictionary["prediction_features"])

--- a/freqtrade/freqai/base_models/BaseClassifierModel.py
+++ b/freqtrade/freqai/base_models/BaseClassifierModel.py
@@ -101,6 +101,8 @@ class BaseClassifierModel(IFreqaiModel):
         pred_df = DataFrame(predictions, columns=dk.label_list)
 
         predictions_prob = self.model.predict_proba(dk.data_dictionary["prediction_features"])
+        if self.CONV_WIDTH == 1:
+            predictions_prob = np.reshape(predictions_prob, (-1, len(self.model.classes_)))
         pred_df_prob = DataFrame(predictions_prob, columns=self.model.classes_)
 
         pred_df = pd.concat([pred_df, pred_df_prob], axis=1)

--- a/freqtrade/freqai/base_models/BaseRegressionModel.py
+++ b/freqtrade/freqai/base_models/BaseRegressionModel.py
@@ -95,6 +95,9 @@ class BaseRegressionModel(IFreqaiModel):
         self.data_cleaning_predict(dk)
 
         predictions = self.model.predict(dk.data_dictionary["prediction_features"])
+        if self.CONV_WIDTH == 1:
+            predictions = np.reshape(predictions, (-1, len(dk.label_list)))
+
         pred_df = DataFrame(predictions, columns=dk.label_list)
 
         pred_df = dk.denormalize_labels_from_metadata(pred_df)


### PR DESCRIPTION
MultiOutputClassifier/Regressor was not working with single candle predictions due to the flat shape of 1D np.arrays being incompatible with multi column dataframe creation.

This MR fixes it by reshaping the prediction array if the user is using `conv_width == 1` (the default setting).  
