### PR TITLE
Temporarily downgrade blosc for arm64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ tabulate==0.9.0
 pycoingecko==3.1.0
 jinja2==3.1.2
 tables==3.7.0
-blosc==1.11.0
+blosc==1.10.6; platform_machine == 'arm64'
+blosc==1.11.0; platform_machine != 'arm64'
 joblib==1.2.0
 pyarrow==10.0.1; platform_machine != 'armv7l'
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Updated blosc module cannot be installed on apple M1 machines. This PR temporarily downgrades blosc for arm64 machines.

```
Collecting blosc==1.11.0
  Using cached blosc-1.11.0.tar.gz (1.2 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "/Temp/freqtrade/.env/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
          main()
        File "/Temp/freqtrade/.env/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Temp/freqtrade/.env/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/0k/k8hy18dd4yl7r66y6yg35z8r0000gn/T/pip-build-env-mhcf9k7l/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/private/var/folders/0k/k8hy18dd4yl7r66y6yg35z8r0000gn/T/pip-build-env-mhcf9k7l/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/0k/k8hy18dd4yl7r66y6yg35z8r0000gn/T/pip-build-env-mhcf9k7l/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 484, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/private/var/folders/0k/k8hy18dd4yl7r66y6yg35z8r0000gn/T/pip-build-env-mhcf9k7l/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 84, in <module>
      KeyError: 'flags'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

