### PR TITLE
Revert "Bump scikit-learn from 1.1.3 to 1.2.0"

### DIFF
--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -3,7 +3,7 @@
 -r requirements-plot.txt
 
 # Required for freqai
-scikit-learn==1.2.0
+scikit-learn==1.1.3
 joblib==1.2.0
 catboost==1.1.1; platform_machine != 'aarch64'
 lightgbm==3.3.3

--- a/requirements-hyperopt.txt
+++ b/requirements-hyperopt.txt
@@ -3,7 +3,7 @@
 
 # Required for hyperopt
 scipy==1.9.3
-scikit-learn==1.2.0
+scikit-learn==1.1.3
 scikit-optimize==0.9.0
 filelock==3.8.2
 progressbar2==4.2.0


### PR DESCRIPTION
Reverts freqtrade/freqtrade#7884 due to https://github.com/scikit-optimize/scikit-optimize/issues/1137.

closes #7896