### PR TITLE
Add JOSS citation to freqai doc

### DIFF
--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -72,10 +72,24 @@ pip install -r requirements-freqai.txt
 
 If you are using docker, a dedicated tag with FreqAI dependencies is available as `:freqai`. As such - you can replace the image line in your docker-compose file with `image: freqtradeorg/freqtrade:develop_freqai`. This image contains the regular FreqAI dependencies. Similar to native installs, Catboost will not be available on ARM based devices.
 
-
 ### FreqAI position in open-source machine learning landscape
 
 Forecasting chaotic time-series based systems, such as equity/cryptocurrency markets, requires a broad set of tools geared toward testing a wide range of hypotheses. Fortunately, a recent maturation of robust machine learning libraries (e.g. `scikit-learn`) has opened up a wide range of research possibilities. Scientists from a diverse range of fields can now easily prototype their studies on an abundance of established machine learning algorithms. Similarly, these user-friendly libraries enable "citzen scientists" to use their basic Python skills for data-exploration. However, leveraging these machine learning libraries on historical and live chaotic data sources can be logistically difficult and expensive. Additionally, robust data-collection, storage, and handling presents a disparate challenge. [`FreqAI`](#freqai) aims to provide a generalized and extensible open-sourced framework geared toward live deployments of adaptive modeling for market forecasting. The `FreqAI` framework is effectively a sandbox for the rich world of open-source machine learning libraries. Inside the `FreqAI` sandbox, users find they can combine a wide variety of third-party libraries to test creative hypotheses on a free live 24/7 chaotic data source - cryptocurrency exchange data. 
+
+### Citing FreqAI
+
+FreqAI is published in the Journal of Open Source Software [link](https://joss.theoj.org/papers/10.21105/joss.04864). If you find FreqAI useful in your research, please use the following citation:
+
+```bibtex
+@article{Caulk2022, 
+    doi = {10.21105/joss.04864},
+    url = {https://doi.org/10.21105/joss.04864},
+    year = {2022}, publisher = {The Open Journal},
+    volume = {7}, number = {80}, pages = {4864},
+    author = {Robert A. Caulk and Elin Törnquist and Matthias Voppichler and Andrew R. Lawless and Ryan McMullan and Wagner Costa Santos and Timothy C. Pogue and Johan van der Vlugt and Stefan P. Gehring and Pascal Schmidt},
+    title = {FreqAI: generalizing adaptive modeling for chaotic time-series market forecasts},
+    journal = {Journal of Open Source Software} } 
+```
 
 ## Common pitfalls
 
@@ -99,6 +113,8 @@ Code review and software architecture brainstorming:
 
 Software development:
 Wagner Costa @wagnercosta
+Emre Suzen @aemr3
+Timothy Pogue @wizrds
 
 Beta testing and bug reporting:
-Stefan Gehring @bloodhunter4rc, @longyu, Andrew Lawless @paranoidandy, Pascal Schmidt @smidelis, Ryan McMullan @smarmau, Juha Nykänen @suikula, Johan van der Vlugt @jooopiert, Richárd Józsa @richardjosza, Timothy Pogue @wizrds
+Stefan Gehring @bloodhunter4rc, @longyu, Andrew Lawless @paranoidandy, Pascal Schmidt @smidelis, Ryan McMullan @smarmau, Juha Nykänen @suikula, Johan van der Vlugt @jooopiert, Richárd Józsa @richardjosza

--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -78,7 +78,7 @@ Forecasting chaotic time-series based systems, such as equity/cryptocurrency mar
 
 ### Citing FreqAI
 
-FreqAI is published in the Journal of Open Source Software [link](https://joss.theoj.org/papers/10.21105/joss.04864). If you find FreqAI useful in your research, please use the following citation:
+FreqAI is [published in the Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.04864). If you find FreqAI useful in your research, please use the following citation:
 
 ```bibtex
 @article{Caulk2022, 


### PR DESCRIPTION
Now that FreqAI is published in JOSS, we would like to add a link to the article as well as an indication of how to cite the software for researchers. 