### PR TITLE
Add an option drop last shifted labels while backtesting

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -548,6 +548,7 @@ CONF_SCHEMA = {
                 "conv_width": {"type": "integer", "default": 1},
                 "train_period_days": {"type": "integer", "default": 0},
                 "backtest_period_days": {"type": "number", "default": 7},
+                "backtest_drop_shifted_labels": {"type": "boolean", "default": False},
                 "identifier": {"type": "string", "default": "example"},
                 "feature_parameters": {
                     "type": "object",

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -308,6 +308,11 @@ class IFreqaiModel(ABC):
                 dk.append_predictions(append_df)
             else:
                 dataframe_train = dk.slice_dataframe(tr_train, dataframe)
+                if self.freqai_info.get('backtest_drop_shifted_labels', False):
+                    label_period_candles = self.freqai_info.get('feature_parameters', {}) \
+                        .get("label_period_candles", 0)
+                    if label_period_candles > 0:
+                        dataframe_train = dataframe_train.iloc[:-label_period_candles, :]
                 dataframe_backtest = dk.slice_dataframe(tr_backtest, dataframe)
                 if not self.model_exists(dk):
                     dk.find_features(dataframe_train)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Added an option to drop last shifted labels while backtesting. This helps to simulate dry runs better.

- [ ] Update docs  