### PR TITLE
(WIP) - FreqAI Backtesting - fix call to populate_any_indicators

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1184,6 +1184,7 @@ class FreqaiDataKitchen:
         pair: str = "",
         prediction_dataframe: DataFrame = pd.DataFrame(),
         do_corr_pairs: bool = True,
+        set_only_targets: bool = False
     ) -> DataFrame:
         """
         Use the user defined strategy for populating indicators during retrain
@@ -1222,7 +1223,8 @@ class FreqaiDataKitchen:
                 dataframe.copy(),
                 tf,
                 informative=base_dataframes[tf],
-                set_generalized_indicators=sgi
+                set_generalized_indicators=sgi,
+                set_only_targets=set_only_targets
             )
 
         # ensure corr pairs are always last
@@ -1235,7 +1237,8 @@ class FreqaiDataKitchen:
                         corr_pair,
                         dataframe.copy(),
                         tf,
-                        informative=corr_dataframes[corr_pair][tf]
+                        informative=corr_dataframes[corr_pair][tf],
+                        set_only_targets=set_only_targets
                     )
 
         self.get_unique_classes_from_labels(dataframe)

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -596,7 +596,8 @@ class IStrategy(ABC, HyperStrategyMixin):
 
     def populate_any_indicators(self, pair: str, df: DataFrame, tf: str,
                                 informative: DataFrame = None,
-                                set_generalized_indicators: bool = False) -> DataFrame:
+                                set_generalized_indicators: bool = False,
+                                set_only_targets: bool = False) -> DataFrame:
         """
         Function designed to automatically generate, name and merge features
         from user indicated timeframes in the configuration file. User can add
@@ -607,6 +608,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param df: strategy dataframe which will receive merges from informatives
         :param tf: timeframe of the dataframe which will modify the feature names
         :param informative: the dataframe associated with the informative pair
+        :param set_only_targets: if True, only the target features will be set
         """
         return df
 


### PR DESCRIPTION
## Summary

Currently in the FreqAI backtest, the `populate_any_indicators` function is called only once for the entire dataframe. This PR aims to change the behavior so that the labels are calculated according to the sliced dataframe, simulating more closely the behavior in dry/run live.

- [x] Create draft solution
- [ ] Discuss the proposed solution
- [ ] Test different scenarios
- [ ] Fix tests
- [ ] Documentation