### PR TITLE
handle data gaps between FreqAI and DP better

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -645,12 +645,20 @@ class FreqaiDataDrawer:
                             + 1
                         )
                     except IndexError:
+                        index = -1
+                        if history_data[pair][tf].iloc[-1]['date'] < df_dp['date'].iloc[0]:
+                            index = 0
+                        else:
+                            index = -1
                         logger.warning(
-                            f"Unable to update pair history for {pair}. "
-                            "If this does not resolve itself after 1 additional candle, "
-                            "please report the error to #freqai discord channel"
+                            f"No common dates in historical data and dataprovider for {pair}. "
+                            f"Appending dataprovider to historical data (full? {not bool(index)})"
+                            "but please be aware that there is likely a gap in the historical "
+                            "data.\n"
+                            f"Historical data ends at {history_data[pair][tf].iloc[-1]['date']} "
+                            f"while dataprovider starts at {df_dp['date'].iloc[0]} and"
+                            f"ends at {df_dp['date'].iloc[0]}."
                         )
-                        return
 
                     history_data[pair][tf] = pd.concat(
                         [

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -661,7 +661,7 @@ class FreqaiDataDrawer:
                                 f"ends at {df_dp['date'].iloc[0]}."
                             )
 
-                    hist_df = pd.concat(
+                    history_data[pair][tf] = pd.concat(
                         [
                             hist_df,
                             df_dp.iloc[index:],

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -645,7 +645,6 @@ class FreqaiDataDrawer:
                             + 1
                         )
                     except IndexError:
-                        index = -1
                         if history_data[pair][tf].iloc[-1]['date'] < df_dp['date'].iloc[0]:
                             index = 0
                         else:


### PR DESCRIPTION
FreqAI was naive in data gap handling by simply skipping data updates if there was no matching date in the dataprovider and the historical FreqAI data. 

This PR ensures that data will always be appended, even if there is no matching date in the historical FreqAI data and the data provider. It logs a warning to the user so that they are aware that a gap in historical data may exist. However, this gap should be isolated to a single incident (if it ever occurs). 

In plain words, if there is no matching date in the historical freqai data and the dataprovider, then it will check to see if this is due to a missing candle or if it is because the bot has missed updates for a full dataprovider length of candles (e.g. 1000 for binance). In the former case, it appends the most recent candle from the dataprovider. In the latter case, it will append the entire dataprovider dataframe. 