### PR TITLE
update calmar, sharpe, and sortino hyperopt losses to use latest formula

### DIFF
--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_calmar.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 from pandas import DataFrame
 
 from freqtrade.constants import Config
-from freqtrade.data.metrics import calculate_max_drawdown
+from freqtrade.data.metrics import calculate_calmar
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
@@ -23,42 +23,15 @@ class CalmarHyperOptLoss(IHyperOptLoss):
     """
 
     @staticmethod
-    def hyperopt_loss_function(
-        results: DataFrame,
-        trade_count: int,
-        min_date: datetime,
-        max_date: datetime,
-        config: Config,
-        processed: Dict[str, DataFrame],
-        backtest_stats: Dict[str, Any],
-        *args,
-        **kwargs
-    ) -> float:
+    def hyperopt_loss_function(results: DataFrame, trade_count: int,
+                               min_date: datetime, max_date: datetime,
+                               config: Config, *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for more optimal results.
 
         Uses Calmar Ratio calculation.
         """
-        total_profit = backtest_stats["profit_total"]
-        days_period = (max_date - min_date).days
-
-        # adding slippage of 0.1% per trade
-        total_profit = total_profit - 0.0005
-        expected_returns_mean = total_profit.sum() / days_period * 100
-
-        # calculate max drawdown
-        try:
-            _, _, _, _, _, max_drawdown = calculate_max_drawdown(
-                results, value_col="profit_abs"
-            )
-        except ValueError:
-            max_drawdown = 0
-
-        if max_drawdown != 0:
-            calmar_ratio = expected_returns_mean / max_drawdown * msqrt(365)
-        else:
-            # Define high (negative) calmar ratio to be clear that this is NOT optimal.
-            calmar_ratio = -20.0
-
+        starting_balance = config['dry_run_wallet']
+        calmar_ratio = calculate_calmar(results, min_date, max_date, starting_balance)
         # print(expected_returns_mean, max_drawdown, calmar_ratio)
         return -calmar_ratio

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_calmar.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_calmar.py
@@ -5,8 +5,6 @@ This module defines the alternative HyperOptLoss class which can be used for
 Hyperoptimization.
 """
 from datetime import datetime
-from math import sqrt as msqrt
-from typing import Any, Dict
 
 from pandas import DataFrame
 

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
@@ -10,7 +10,8 @@ import numpy as np
 from pandas import DataFrame
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
-
+from freqtrade.constants import Config
+from freqtrade.data.metrics import calculate_sharpe
 
 class SharpeHyperOptLoss(IHyperOptLoss):
     """

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
@@ -22,25 +22,13 @@ class SharpeHyperOptLoss(IHyperOptLoss):
     @staticmethod
     def hyperopt_loss_function(results: DataFrame, trade_count: int,
                                min_date: datetime, max_date: datetime,
-                               *args, **kwargs) -> float:
+                               config: Config, *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for more optimal results.
 
         Uses Sharpe Ratio calculation.
         """
-        total_profit = results["profit_ratio"]
-        days_period = (max_date - min_date).days
-
-        # adding slippage of 0.1% per trade
-        total_profit = total_profit - 0.0005
-        expected_returns_mean = total_profit.sum() / days_period
-        up_stdev = np.std(total_profit)
-
-        if up_stdev != 0:
-            sharp_ratio = expected_returns_mean / up_stdev * np.sqrt(365)
-        else:
-            # Define high (negative) sharpe ratio to be clear that this is NOT optimal.
-            sharp_ratio = -20.
-
+        starting_balance = config['dry_run_wallet']
+        sharp_ratio = calculate_sharpe(results, min_date, max_date, starting_balance)
         # print(expected_returns_mean, up_stdev, sharp_ratio)
         return -sharp_ratio

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
@@ -6,12 +6,12 @@ Hyperoptimization.
 """
 from datetime import datetime
 
-import numpy as np
 from pandas import DataFrame
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 from freqtrade.constants import Config
 from freqtrade.data.metrics import calculate_sharpe
+
 
 class SharpeHyperOptLoss(IHyperOptLoss):
     """

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sharpe.py
@@ -8,9 +8,9 @@ from datetime import datetime
 
 from pandas import DataFrame
 
-from freqtrade.optimize.hyperopt import IHyperOptLoss
 from freqtrade.constants import Config
 from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
 class SharpeHyperOptLoss(IHyperOptLoss):

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
@@ -8,9 +8,9 @@ from datetime import datetime
 
 from pandas import DataFrame
 
-from freqtrade.optimize.hyperopt import IHyperOptLoss
 from freqtrade.constants import Config
 from freqtrade.data.metrics import calculate_sortino
+from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
 class SortinoHyperOptLoss(IHyperOptLoss):

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
@@ -10,7 +10,8 @@ import numpy as np
 from pandas import DataFrame
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
-
+from freqtrade.constants import Config
+from freqtrade.data.metrics import calculate_sortino
 
 class SortinoHyperOptLoss(IHyperOptLoss):
     """
@@ -22,28 +23,13 @@ class SortinoHyperOptLoss(IHyperOptLoss):
     @staticmethod
     def hyperopt_loss_function(results: DataFrame, trade_count: int,
                                min_date: datetime, max_date: datetime,
-                               *args, **kwargs) -> float:
+                               config: Config, *args, **kwargs) -> float:
         """
         Objective function, returns smaller number for more optimal results.
 
         Uses Sortino Ratio calculation.
         """
-        total_profit = results["profit_ratio"]
-        days_period = (max_date - min_date).days
-
-        # adding slippage of 0.1% per trade
-        total_profit = total_profit - 0.0005
-        expected_returns_mean = total_profit.sum() / days_period
-
-        results['downside_returns'] = 0
-        results.loc[total_profit < 0, 'downside_returns'] = results['profit_ratio']
-        down_stdev = np.std(results['downside_returns'])
-
-        if down_stdev != 0:
-            sortino_ratio = expected_returns_mean / down_stdev * np.sqrt(365)
-        else:
-            # Define high (negative) sortino ratio to be clear that this is NOT optimal.
-            sortino_ratio = -20.
-
+        starting_balance = config['dry_run_wallet']
+        sortino_ratio = calculate_sortino(results, min_date, max_date, starting_balance)
         # print(expected_returns_mean, down_stdev, sortino_ratio)
         return -sortino_ratio

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_sortino.py
@@ -6,12 +6,12 @@ Hyperoptimization.
 """
 from datetime import datetime
 
-import numpy as np
 from pandas import DataFrame
 
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 from freqtrade.constants import Config
 from freqtrade.data.metrics import calculate_sortino
+
 
 class SortinoHyperOptLoss(IHyperOptLoss):
     """

--- a/tests/optimize/conftest.py
+++ b/tests/optimize/conftest.py
@@ -48,8 +48,8 @@ def hyperopt_results():
     return pd.DataFrame(
         {
             'pair': ['ETH/USDT', 'ETH/USDT', 'ETH/USDT', 'ETH/USDT'],
-            'profit_ratio': [-0.1, 0.2, -0.1, 0.3],
-            'profit_abs': [-0.2, 0.4, -0.2, 0.6],
+            'profit_ratio': [-0.1, 0.2, -0.12, 0.3],
+            'profit_abs': [-0.2, 0.4, -0.21, 0.6],
             'trade_duration': [10, 30, 10, 10],
             'amount': [0.1, 0.1, 0.1, 0.1],
             'exit_reason': [ExitType.STOP_LOSS, ExitType.ROI, ExitType.STOP_LOSS, ExitType.ROI],


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

update calmar, sharpe, and sortino hyperopt losses to use latest formula

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
