### PR TITLE
docs: fix broken link to quickstart

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Per default, the bot loads the configuration from the `config.json` file, locate
 
 You can specify a different configuration file used by the bot with the `-c/--config` command-line option.
 
-If you used the [Quick start](docker_quickstart/#docker-quick-start) method for installing
+If you used the [Quick start](docker_quickstart.md#docker-quick-start) method for installing
 the bot, the installation script should have already created the default configuration file (`config.json`) for you.
 
 If the default configuration file is not created we recommend to use `freqtrade new-config --config config.json` to generate a basic configuration file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Per default, the bot loads the configuration from the `config.json` file, locate
 
 You can specify a different configuration file used by the bot with the `-c/--config` command-line option.
 
-If you used the [Quick start](installation.md/#quick-start) method for installing
+If you used the [Quick start](docker_quickstart/#docker-quick-start) method for installing
 the bot, the installation script should have already created the default configuration file (`config.json`) for you.
 
 If the default configuration file is not created we recommend to use `freqtrade new-config --config config.json` to generate a basic configuration file.


### PR DESCRIPTION
## Summary

Link "Quick Start" on https://www.freqtrade.io/en/latest/configuration/ was broken. The section quick start doesn't exist anymore on `installation.md` but the section in the docker quickstart seems to be the semantically the same.