### PR TITLE
fix "--version": needs to change working directory

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -3,11 +3,13 @@ __version__ = '2023.1.dev'
 
 if 'dev' in __version__:
     try:
+        import os
         import subprocess
+        freqtrade_basedir = os.path.dirname(os.path.abspath(__file__))
 
         __version__ = __version__ + '-' + subprocess.check_output(
             ['git', 'log', '--format="%h"', '-n 1'],
-            stderr=subprocess.DEVNULL).decode("utf-8").rstrip().strip('"')
+            stderr=subprocess.DEVNULL, cwd=freqtrade_basedir).decode("utf-8").rstrip().strip('"')
 
     except Exception:  # pragma: no cover
         # git not available, ignore

--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -2,10 +2,10 @@
 __version__ = '2023.1.dev'
 
 if 'dev' in __version__:
+    from pathlib import Path
     try:
-        import os
         import subprocess
-        freqtrade_basedir = os.path.dirname(os.path.abspath(__file__))
+        freqtrade_basedir = Path(__file__).parent
 
         __version__ = __version__ + '-' + subprocess.check_output(
             ['git', 'log', '--format="%h"', '-n 1'],
@@ -15,7 +15,6 @@ if 'dev' in __version__:
         # git not available, ignore
         try:
             # Try Fallback to freqtrade_commit file (created by CI while building docker image)
-            from pathlib import Path
             versionfile = Path('./freqtrade_commit')
             if versionfile.is_file():
                 __version__ = f"docker-{__version__}-{versionfile.read_text()[:8]}"


### PR DESCRIPTION
before calling `git`. otherwise it would display git commit id from the
directory where you are calling `freqtrade` from instead of freqtrade's
current commit id

## Summary

    `--version:` needs to change working directory before calling `git`. otherwise it would display git commit id from the
    directory where you are calling `freqtrade` from instead of freqtrade's
    current commit id

## Reproduce
    - into a git repo other then freqtrade: `cd my-strategies`
    - (optional) `pip install -e ../freqtrade`
    - call `freqtrade --version`: note hash after "dev-"
    - check `git log -n 1` => will be above hash
    - double-check: go to your `freqtrade/` and check `git log -n 1` there, will be different

