### PR TITLE
Add a new analysis group to output stats grouped by exit_tag

### DIFF
--- a/docs/advanced-backtesting.md
+++ b/docs/advanced-backtesting.md
@@ -32,7 +32,7 @@ To analyze the entry/exit tags, we now need to use the `freqtrade backtesting-an
 with `--analysis-groups` option provided with space-separated arguments (default `0 1 2`):
 
 ``` bash
-freqtrade backtesting-analysis -c <config.json> --analysis-groups 0 1 2 3 4
+freqtrade backtesting-analysis -c <config.json> --analysis-groups 0 1 2 3 4 5
 ```
 
 This command will read from the last backtesting results. The `--analysis-groups` option is
@@ -43,6 +43,7 @@ ranging from the simplest (0) to the most detailed per pair, per buy and per sel
 * 2: profit summaries grouped by enter_tag and exit_tag
 * 3: profit summaries grouped by pair and enter_tag
 * 4: profit summaries grouped by pair, enter_ and exit_tag (this can get quite large)
+* 5: profit summaries grouped by exit_tag
 
 More options are available by running with the `-h` option.
 

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -632,10 +632,11 @@ AVAILABLE_CLI_OPTIONS = {
               "1: by enter_tag, "
               "2: by enter_tag and exit_tag, "
               "3: by pair and enter_tag, "
-              "4: by pair, enter_ and exit_tag (this can get quite large)"),
+              "4: by pair, enter_ and exit_tag (this can get quite large), "
+              "5: by exit_tag"),
         nargs='+',
         default=['0', '1', '2'],
-        choices=['0', '1', '2', '3', '4'],
+        choices=['0', '1', '2', '3', '4', '5'],
     ),
     "enter_reason_list": Arg(
         "--enter-reason-list",

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -141,6 +141,12 @@ def _do_group_table_output(bigdf, glist):
             # 4: profit summaries grouped by pair, enter_ and exit_tag (this can get quite large)
             if g == "4":
                 group_mask = ['pair', 'enter_reason', 'exit_reason']
+
+            # 5: profit summaries grouped by exit_tag
+            if g == "5":
+                group_mask = ['exit_reason']
+                sortcols = ['exit_reason']
+
             if group_mask:
                 new = bigdf.groupby(group_mask).agg(agg_mask).reset_index()
                 new.columns = group_mask + agg_cols

--- a/tests/data/test_entryexitanalysis.py
+++ b/tests/data/test_entryexitanalysis.py
@@ -190,6 +190,15 @@ def test_backtest_analysis_nomock(default_conf, mocker, caplog, testdatadir, tmp
     assert '1' in captured.out
     assert '2.5' in captured.out
 
+    # test group 5
+    args = get_args(base_args + ['--analysis-groups', "5"])
+    start_analysis_entries_exits(args)
+    captured = capsys.readouterr()
+    assert 'exit_signal' in captured.out
+    assert 'roi' in captured.out
+    assert 'stop_loss' in captured.out
+    assert 'trailing_stop_loss' in captured.out
+
     # test date filtering
     args = get_args(base_args + ['--timerange', "20180129-20180130"])
     start_analysis_entries_exits(args)


### PR DESCRIPTION
## Summary

In backtesting-analysis there was no option to view only exit tag performance. This PR adds analysis group 5 to add this functionality.

## Quick changelog

- Add analysis_group 5
- Update docs and tests

## What's new?

An additional table in the backtesting-analysis output that provides the exit-tag aggregated data.

![image](https://user-images.githubusercontent.com/1872302/212694134-2fcc7e8f-a096-4824-9b73-5928543e4b09.png)

