### PR TITLE
Enable plotconfig wsmode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         # stages: [push]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.942"
+    rev: "v0.991"
     hooks:
       - id: mypy
         exclude: build_helpers

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 # 2.20: Add websocket endpoints
 # 2.21: Add new_candle messagetype
 # 2.22: Add FreqAI to backtesting
-API_VERSION = 2.22
+# 2.23: Allow plot config request in webserver mode
+API_VERSION = 2.23
 
 # Public API, requires no auth.
 router_public = APIRouter()

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -248,8 +248,18 @@ def pair_history(pair: str, timeframe: str, timerange: str, strategy: str,
 
 
 @router.get('/plot_config', response_model=PlotConfig, tags=['candle data'])
-def plot_config(rpc: RPC = Depends(get_rpc)):
-    return PlotConfig.parse_obj(rpc._rpc_plot_config())
+def plot_config(strategy: Optional[str] = None, config=Depends(get_config),
+                rpc: Optional[RPC] = Depends(get_rpc_optional)):
+    if not strategy:
+        if not rpc:
+            raise RPCException("Strategy is mandatory in webserver mode.")
+        return PlotConfig.parse_obj(rpc._rpc_plot_config())
+    else:
+        config1 = deepcopy(config)
+        config1.update({
+            'strategy': strategy
+        })
+        return PlotConfig.parse_obj(RPC._rpc_plot_config_with_strategy(config1))
 
 
 @router.get('/strategies', response_model=StrategyListResponse, tags=['strategy'])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1127,12 +1127,12 @@ class RPC:
         return self._freqtrade.active_pair_whitelist
 
     @staticmethod
-    def _rpc_analysed_history_full(config, pair: str, timeframe: str,
+    def _rpc_analysed_history_full(config: Config, pair: str, timeframe: str,
                                    timerange: str, exchange) -> Dict[str, Any]:
         timerange_parsed = TimeRange.parse_timerange(timerange)
 
         _data = load_data(
-            datadir=config.get("datadir"),
+            datadir=config["datadir"],
             pairs=[pair],
             timeframe=timeframe,
             timerange=timerange_parsed,

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1158,6 +1158,16 @@ class RPC:
         return self._freqtrade.strategy.plot_config
 
     @staticmethod
+    def _rpc_plot_config_with_strategy(config: Config) -> Dict[str, Any]:
+
+        from freqtrade.resolvers.strategy_resolver import StrategyResolver
+        strategy = StrategyResolver.load_strategy(config)
+
+        if (strategy.plot_config and 'subplots' not in strategy.plot_config):
+            strategy.plot_config['subplots'] = {}
+        return strategy.plot_config
+
+    @staticmethod
     def _rpc_sysinfo() -> Dict[str, Any]:
         return {
             "cpu_pct": psutil.cpu_percent(interval=1, percpu=True),

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1417,7 +1417,7 @@ def test_api_pair_history(botclient, ohlcv_history):
                                   "No data for UNITTEST/BTC, 5m in 20200111-20200112 found.")
 
 
-def test_api_plot_config(botclient):
+def test_api_plot_config(botclient, mocker):
     ftbot, client = botclient
 
     rc = client_get(client, f"{BASE_URI}/plot_config")
@@ -1440,6 +1440,21 @@ def test_api_plot_config(botclient):
 
     assert isinstance(rc.json()['main_plot'], dict)
     assert isinstance(rc.json()['subplots'], dict)
+
+    rc = client_get(client, f"{BASE_URI}/plot_config?strategy=freqai_test_classifier")
+    assert_response(rc)
+    res = rc.json()
+    assert 'target_roi' in res['subplots']
+    assert 'do_predict' in res['subplots']
+
+    rc = client_get(client, f"{BASE_URI}/plot_config?strategy=HyperoptableStrategy")
+    assert_response(rc)
+    assert rc.json()['subplots'] == {}
+
+    mocker.patch('freqtrade.rpc.api_server.api_v1.get_rpc_optional', return_value=None)
+
+    rc = client_get(client, f"{BASE_URI}/plot_config")
+    assert_response(rc)
 
 
 def test_api_strategies(botclient, tmpdir):

--- a/tests/strategy/strats/hyperoptable_strategy.py
+++ b/tests/strategy/strats/hyperoptable_strategy.py
@@ -34,6 +34,11 @@ class HyperoptableStrategy(StrategyTestV3):
     protection_enabled = BooleanParameter(default=True)
     protection_cooldown_lookback = IntParameter([0, 50], default=30)
 
+    # Invalid plot config ...
+    plot_config = {
+        "main_plot": {},
+    }
+
     @property
     def protections(self):
         prot = []


### PR DESCRIPTION
## Summary
Enable plot-config retrieval in webserver mode - better supporting backtesting scenarios.

## Quick changelog

- Add optional strategy argument to plot_config mode