### PR TITLE
Fixes gym issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ tables==3.8.0
 blosc==1.11.1
 joblib==1.2.0
 pyarrow==11.0.0; platform_machine != 'armv7l'
+# Fixes issue where gym cannot be installed - https://github.com/pypa/setuptools/issues/3801
+setuptools==65.5.0
 
 # find first, C search in arrays
 py_find_1st==1.1.5


### PR DESCRIPTION
If we set setuptools to version 65.5.0 it solves the gym installation issue.
We can remove this when gym is upgraded.
https://github.com/freqtrade/freqtrade/issues/8078

