### PR TITLE
Make test for `None` explicit

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2731,7 +2731,7 @@ class Exchange:
                 pos = positions[0]
                 isolated_liq = pos['liquidationPrice']
 
-        if isolated_liq:
+        if isolated_liq is not None:
             buffer_amount = abs(open_rate - isolated_liq) * self.liquidation_buffer
             isolated_liq = (
                 isolated_liq - buffer_amount


### PR DESCRIPTION
## Summary

Solve the issue: #8090


## What's new?

Prevent liquidation prices of 0.0 to be set to 'None'.
