### PR TITLE
`order.amount` -> `order.safe_amount`

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1628,7 +1628,7 @@ class FreqtradeBot(LoggingMixin):
 
         # second condition is for mypy only; order will always be passed during sub trade
         if sub_trade and order is not None:
-            amount = order.safe_filled if fill else order.amount
+            amount = order.safe_filled if fill else order.safe_amount
             order_rate: float = order.safe_price
 
             profit = trade.calc_profit(rate=order_rate, amount=amount, open_rate=trade.open_rate)


### PR DESCRIPTION
## Summary

Fixes the following error:
```bash
2023-02-02 14:43:12,493 - freqtrade.rpc.rpc_manager - INFO - Sending rpc message: {'type': exit, 'trade_id': 1, 'exchange': 'Okx', 'pair': LTC/USDT:USDT, 'leverage': 1.0, 'direction': 'Long', 'gain': 'loss', 'limit': 99.73, 'order_rate': 99.73, 'order_type': 'limit', 'amount': None, 'open_rate': 99.92050297721806, 'close_rate': 99.73, 'current_rate': 99.73, 'profit_amount': *, 'profit_ratio': -0.00226579, 'sell_reason': 'partial_exit', 'exit_reason': 'partial_exit', 'open_date': datetime.datetime(2023, 2, 2, 5, 54, 10, 131812), 'close_date': datetime.datetime(2023, 2, 2, 14, 43, 12, 493749), 'stake_amount': *, 'stake_currency': 'USDT', 'fiat_currency': 'USD', 'sub_trade': True, 'cumulative_profit': *}
2023-02-02 14:43:12,494 - freqtrade.rpc.rpc_manager - ERROR - Exception occurred within RPC module telegram
Traceback (most recent call last):
  File "*/freqtrade/rpc/rpc_manager.py", line 79, in send_msg
    mod.send_msg(msg)
  File "*/freqtrade/rpc/telegram.py", line 446, in send_msg
    message = self.compose_message(deepcopy(msg), msg_type)
  File "*/freqtrade/rpc/telegram.py", line 386, in compose_message
    message = self._format_exit_msg(msg)
  File "*/freqtrade/rpc/telegram.py", line 303, in _format_exit_msg
    msg['amount'] = round(msg['amount'], 8)
TypeError: type NoneType doesn't define __round__ method
```

Solve the issue: #___


## What's new?

When an exit order is created on the exchange, it's amount is not yet specified and order.amount is None, we need to fallback on ft_amount for the exit notify message.
