### PR TITLE
Update gateio terminology to Gate

### DIFF
--- a/docs/stoploss.md
+++ b/docs/stoploss.md
@@ -24,7 +24,7 @@ These modes can be configured with these values:
 ```
 
 !!! Note
-    Stoploss on exchange is only supported for Binance (stop-loss-limit), Huobi (stop-limit), Kraken (stop-loss-market, stop-loss-limit), Gateio (stop-limit), and Kucoin (stop-limit and stop-market) as of now.  
+    Stoploss on exchange is only supported for Binance (stop-loss-limit), Huobi (stop-limit), Kraken (stop-loss-market, stop-loss-limit), Gate (stop-limit), and Kucoin (stop-limit and stop-market) as of now.  
     <ins>Do not set too low/tight stoploss value if using stop loss on exchange!</ins>  
     If set to low/tight then you have greater risk of missing fill on the order and stoploss will not work.
 

--- a/freqtrade/commands/build_config_commands.py
+++ b/freqtrade/commands/build_config_commands.py
@@ -108,7 +108,7 @@ def ask_user_config() -> Dict[str, Any]:
                 "binance",
                 "binanceus",
                 "bittrex",
-                "gateio",
+                "gate",
                 "huobi",
                 "kraken",
                 "kucoin",
@@ -123,7 +123,7 @@ def ask_user_config() -> Dict[str, Any]:
             "message": "Do you want to trade Perpetual Swaps (perpetual futures)?",
             "default": False,
             "filter": lambda val: 'futures' if val else 'spot',
-            "when": lambda x: x["exchange_name"] in ['binance', 'gateio', 'okx'],
+            "when": lambda x: x["exchange_name"] in ['binance', 'gate', 'okx'],
         },
         {
             "type": "autocomplete",

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -17,7 +17,7 @@ from freqtrade.exchange.exchange_utils import (amount_to_contract_precision, amo
                                                timeframe_to_next_date, timeframe_to_prev_date,
                                                timeframe_to_seconds, validate_exchange,
                                                validate_exchanges)
-from freqtrade.exchange.gateio import Gateio
+from freqtrade.exchange.gate import Gate
 from freqtrade.exchange.hitbtc import Hitbtc
 from freqtrade.exchange.huobi import Huobi
 from freqtrade.exchange.kraken import Kraken

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -46,13 +46,13 @@ MAP_EXCHANGE_CHILDCLASS = {
     'binanceje': 'binance',
     'binanceusdm': 'binance',
     'okex': 'okx',
-    'gate': 'gateio',
+    'gateio': 'gate',
 }
 
 SUPPORTED_EXCHANGES = [
     'binance',
     'bittrex',
-    'gateio',
+    'gate',
     'huobi',
     'kraken',
     'okx',

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2780,7 +2780,7 @@ class Exchange:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
         PERPETUAL:
-         gateio: https://www.gate.io/help/futures/futures/27724/liquidation-price-bankruptcy-price
+         gate: https://www.gate.io/help/futures/futures/27724/liquidation-price-bankruptcy-price
          > Liquidation Price = (Entry Price ± Margin / Contract Multiplier / Size) /
                                 [ 1 ± (Maintenance Margin Ratio + Taker Rate)]
             Wherein, "+" or "-" depends on whether the contract goes long or short:
@@ -2801,7 +2801,7 @@ class Exchange:
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
 
-        # * Not required by Gateio or OKX
+        # * Not required by Gate or OKX
         :param mm_ex_1:
         :param upnl_ex_1:
         """

--- a/freqtrade/exchange/gate.py
+++ b/freqtrade/exchange/gate.py
@@ -13,7 +13,7 @@ from freqtrade.misc import safe_value_fallback2
 logger = logging.getLogger(__name__)
 
 
-class Gateio(Exchange):
+class Gate(Exchange):
     """
     Gate.io exchange class. Contains adjustments needed for Freqtrade to work
     with this exchange.
@@ -85,7 +85,7 @@ class Gateio(Exchange):
 
         if self.trading_mode == TradingMode.FUTURES:
             # Futures usually don't contain fees in the response.
-            # As such, futures orders on gateio will not contain a fee, which causes
+            # As such, futures orders on gate will not contain a fee, which causes
             # a repeated "update fee" cycle and wrong calculations.
             # Therefore we patch the response with fees if it's not available.
             # An alternative also contianing fees would be

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -137,7 +137,7 @@ EXCHANGES = {
                 'tradeType': 'TRADE'
             }],
     },
-    'gateio': {
+    'gate': {
         'pair': 'BTC/USDT',
         'stake_currency': 'USDT',
         'hasQuoteVolume': True,
@@ -357,8 +357,8 @@ class TestCCXTExchange():
             'stoploss': 'limit',
             })
 
-        if exchangename == 'gateio':
-            # gateio doesn't have market orders on spot
+        if exchangename == 'gate':
+            # gate doesn't have market orders on spot
             return
         exch.validate_ordertypes({
             'entry': 'market',
@@ -421,7 +421,7 @@ class TestCCXTExchange():
 
     def test_ccxt_fetch_tickers_futures(self, exchange_futures: EXCHANGE_FIXTURE_TYPE):
         exch, exchangename = exchange_futures
-        if not exch or exchangename in ('gateio'):
+        if not exch or exchangename in ('gate'):
             # exchange_futures only returns values for supported exchanges
             return
 
@@ -461,8 +461,8 @@ class TestCCXTExchange():
         assert len(l2['bids']) >= 1
         l2_limit_range = exch._ft_has['l2_limit_range']
         l2_limit_range_required = exch._ft_has['l2_limit_range_required']
-        if exchangename == 'gateio':
-            # TODO: Gateio is unstable here at the moment, ignoring the limit partially.
+        if exchangename == 'gate':
+            # TODO: Gate is unstable here at the moment, ignoring the limit partially.
             return
         for val in [1, 2, 5, 25, 100]:
             l2 = exch.fetch_l2_order_book(pair, val)

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -27,7 +27,7 @@ from tests.conftest import (generate_test_data_raw, get_mock_coro, get_patched_e
 
 
 # Make sure to always keep one exchange here which is NOT subclassed!!
-EXCHANGES = ['bittrex', 'binance', 'kraken', 'gateio']
+EXCHANGES = ['bittrex', 'binance', 'kraken', 'gate']
 
 get_entry_rate_data = [
     ('other', 20, 19, 10, 0.0, 20),  # Full ask side
@@ -1783,7 +1783,7 @@ def test_fetch_trading_fees(default_conf, mocker):
             'maker': 0.0,
             'taker': 0.0005}
     }
-    exchange_name = 'gateio'
+    exchange_name = 'gate'
     default_conf['dry_run'] = False
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
@@ -3147,24 +3147,24 @@ def test_cancel_stoploss_order(default_conf, mocker, exchange_name):
 def test_cancel_stoploss_order_with_result(default_conf, mocker, exchange_name):
     default_conf['dry_run'] = False
     mocker.patch('freqtrade.exchange.Exchange.fetch_stoploss_order', return_value={'for': 123})
-    mocker.patch('freqtrade.exchange.Gateio.fetch_stoploss_order', return_value={'for': 123})
+    mocker.patch('freqtrade.exchange.Gate.fetch_stoploss_order', return_value={'for': 123})
     exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
 
     res = {'fee': {}, 'status': 'canceled', 'amount': 1234}
     mocker.patch('freqtrade.exchange.Exchange.cancel_stoploss_order', return_value=res)
-    mocker.patch('freqtrade.exchange.Gateio.cancel_stoploss_order', return_value=res)
+    mocker.patch('freqtrade.exchange.Gate.cancel_stoploss_order', return_value=res)
     co = exchange.cancel_stoploss_order_with_result(order_id='_', pair='TKN/BTC', amount=555)
     assert co == res
 
     mocker.patch('freqtrade.exchange.Exchange.cancel_stoploss_order', return_value='canceled')
-    mocker.patch('freqtrade.exchange.Gateio.cancel_stoploss_order', return_value='canceled')
+    mocker.patch('freqtrade.exchange.Gate.cancel_stoploss_order', return_value='canceled')
     # Fall back to fetch_stoploss_order
     co = exchange.cancel_stoploss_order_with_result(order_id='_', pair='TKN/BTC', amount=555)
     assert co == {'for': 123}
 
     exc = InvalidOrderException("")
     mocker.patch('freqtrade.exchange.Exchange.fetch_stoploss_order', side_effect=exc)
-    mocker.patch('freqtrade.exchange.Gateio.fetch_stoploss_order', side_effect=exc)
+    mocker.patch('freqtrade.exchange.Gate.fetch_stoploss_order', side_effect=exc)
     co = exchange.cancel_stoploss_order_with_result(order_id='_', pair='TKN/BTC', amount=555)
     assert co['amount'] == 555
     assert co == {'fee': {}, 'status': 'canceled', 'amount': 555, 'info': {}}
@@ -3172,7 +3172,7 @@ def test_cancel_stoploss_order_with_result(default_conf, mocker, exchange_name):
     with pytest.raises(InvalidOrderException):
         exc = InvalidOrderException("Did not find order")
         mocker.patch('freqtrade.exchange.Exchange.cancel_stoploss_order', side_effect=exc)
-        mocker.patch('freqtrade.exchange.Gateio.cancel_stoploss_order', side_effect=exc)
+        mocker.patch('freqtrade.exchange.Gate.cancel_stoploss_order', side_effect=exc)
         exchange = get_patched_exchange(mocker, default_conf, id=exchange_name)
         exchange.cancel_stoploss_order_with_result(order_id='_', pair='TKN/BTC', amount=123)
 
@@ -3952,14 +3952,14 @@ def test_set_margin_mode(mocker, default_conf, margin_mode):
     ("bittrex", TradingMode.MARGIN, MarginMode.ISOLATED, True),
     ("bittrex", TradingMode.FUTURES, MarginMode.CROSS, True),
     ("bittrex", TradingMode.FUTURES, MarginMode.ISOLATED, True),
-    ("gateio", TradingMode.MARGIN, MarginMode.ISOLATED, True),
+    ("gate", TradingMode.MARGIN, MarginMode.ISOLATED, True),
     ("okx", TradingMode.SPOT, None, False),
     ("okx", TradingMode.MARGIN, MarginMode.CROSS, True),
     ("okx", TradingMode.MARGIN, MarginMode.ISOLATED, True),
     ("okx", TradingMode.FUTURES, MarginMode.CROSS, True),
 
     ("binance", TradingMode.FUTURES, MarginMode.ISOLATED, False),
-    ("gateio", TradingMode.FUTURES, MarginMode.ISOLATED, False),
+    ("gate", TradingMode.FUTURES, MarginMode.ISOLATED, False),
     ("okx", TradingMode.FUTURES, MarginMode.ISOLATED, False),
 
     # * Remove once implemented
@@ -3967,16 +3967,16 @@ def test_set_margin_mode(mocker, default_conf, margin_mode):
     ("binance", TradingMode.FUTURES, MarginMode.CROSS, True),
     ("kraken", TradingMode.MARGIN, MarginMode.CROSS, True),
     ("kraken", TradingMode.FUTURES, MarginMode.CROSS, True),
-    ("gateio", TradingMode.MARGIN, MarginMode.CROSS, True),
-    ("gateio", TradingMode.FUTURES, MarginMode.CROSS, True),
+    ("gate", TradingMode.MARGIN, MarginMode.CROSS, True),
+    ("gate", TradingMode.FUTURES, MarginMode.CROSS, True),
 
     # * Uncomment once implemented
     # ("binance", TradingMode.MARGIN, MarginMode.CROSS, False),
     # ("binance", TradingMode.FUTURES, MarginMode.CROSS, False),
     # ("kraken", TradingMode.MARGIN, MarginMode.CROSS, False),
     # ("kraken", TradingMode.FUTURES, MarginMode.CROSS, False),
-    # ("gateio", TradingMode.MARGIN, MarginMode.CROSS, False),
-    # ("gateio", TradingMode.FUTURES, MarginMode.CROSS, False),
+    # ("gate", TradingMode.MARGIN, MarginMode.CROSS, False),
+    # ("gate", TradingMode.FUTURES, MarginMode.CROSS, False),
 ])
 def test_validate_trading_mode_and_margin_mode(
     default_conf,
@@ -4001,7 +4001,7 @@ def test_validate_trading_mode_and_margin_mode(
     ("binance", "futures", {"options": {"defaultType": "swap"}}),
     ("bybit", "spot", {"options": {"defaultType": "spot"}}),
     ("bybit", "futures", {"options": {"defaultType": "swap"}}),
-    ("gateio", "futures", {"options": {"defaultType": "swap"}}),
+    ("gate", "futures", {"options": {"defaultType": "swap"}}),
     ("hitbtc", "futures", {"options": {"defaultType": "swap"}}),
     ("kraken", "futures", {"options": {"defaultType": "swap"}}),
     ("kucoin", "futures", {"options": {"defaultType": "swap"}}),
@@ -4032,7 +4032,7 @@ def test_get_max_leverage_from_margin(default_conf, mocker, pair, nominal_value,
     default_conf['margin_mode'] = 'isolated'
     api_mock = MagicMock()
     type(api_mock).has = PropertyMock(return_value={'fetchLeverageTiers': False})
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="gateio")
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="gate")
     assert exchange.get_max_leverage(pair, nominal_value) == max_lev
 
 
@@ -4177,10 +4177,10 @@ def test_combine_funding_and_mark(
     # ('kraken', "2021-09-01 00:00:00", "2021-09-01 07:59:59",  30.0, -0.0012443999999999999),
     # ('kraken', "2021-09-01 00:00:00", "2021-09-01 12:00:00", 30.0,  0.0045759),
     # ('kraken', "2021-09-01 00:00:01", "2021-09-01 08:00:00",  30.0, -0.0008289),
-    ('gateio', 0, 2, "2021-09-01 00:10:00", "2021-09-01 04:00:00",  30.0, 0.0),
-    ('gateio', 0, 2, "2021-09-01 00:00:00", "2021-09-01 08:00:00",  30.0, -0.0009140999),
-    ('gateio', 0, 2, "2021-09-01 00:00:00", "2021-09-01 12:00:00",  30.0, -0.0009140999),
-    ('gateio', 1, 2, "2021-09-01 00:00:01", "2021-09-01 08:00:00",  30.0, -0.0002493),
+    ('gate', 0, 2, "2021-09-01 00:10:00", "2021-09-01 04:00:00",  30.0, 0.0),
+    ('gate', 0, 2, "2021-09-01 00:00:00", "2021-09-01 08:00:00",  30.0, -0.0009140999),
+    ('gate', 0, 2, "2021-09-01 00:00:00", "2021-09-01 12:00:00",  30.0, -0.0009140999),
+    ('gate', 1, 2, "2021-09-01 00:00:01", "2021-09-01 08:00:00",  30.0, -0.0002493),
     ('binance', 0,  2, "2021-09-01 00:00:00", "2021-09-01 08:00:00",  50.0, -0.0015235),
     # TODO: Uncoment once _calculate_funding_fees can pas time_in_ratio to exchange._get_funding_fee
     # ('kraken', "2021-09-01 00:00:00", "2021-09-01 08:00:00",  50.0, -0.0024895),
@@ -4238,7 +4238,7 @@ def test__fetch_and_calculate_funding_fees(
     d2 = datetime.strptime(f"{d2} +0000", '%Y-%m-%d %H:%M:%S %z')
     funding_rate_history = {
         'binance': funding_rate_history_octohourly,
-        'gateio': funding_rate_history_octohourly,
+        'gate': funding_rate_history_octohourly,
     }[exchange][rate_start:rate_end]
     api_mock = MagicMock()
     api_mock.fetch_funding_rate_history = get_mock_coro(return_value=funding_rate_history)
@@ -4267,7 +4267,7 @@ def test__fetch_and_calculate_funding_fees(
 
 @pytest.mark.parametrize('exchange,expected_fees', [
     ('binance', -0.0009140999999999999),
-    ('gateio', -0.0009140999999999999),
+    ('gate', -0.0009140999999999999),
 ])
 def test__fetch_and_calculate_funding_fees_datetime_called(
     mocker,
@@ -4408,7 +4408,7 @@ def test__order_contracts_to_amount(
             'info': {},
         },
         {
-            # Realistic stoploss order on gateio.
+            # Realistic stoploss order on gate.
             'id': '123456380',
             'clientOrderId': '12345638203',
             'timestamp': None,
@@ -5006,7 +5006,7 @@ def test_get_max_leverage_futures(default_conf, mocker, leverage_tiers):
         exchange.get_max_leverage("BTC/USDT:USDT", 1000000000.01)
 
 
-@pytest.mark.parametrize("exchange_name", ['bittrex', 'binance', 'kraken', 'gateio', 'okx'])
+@pytest.mark.parametrize("exchange_name", ['bittrex', 'binance', 'kraken', 'gate', 'okx'])
 def test__get_params(mocker, default_conf, exchange_name):
     api_mock = MagicMock()
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
@@ -5161,8 +5161,8 @@ def test_get_liquidation_price1(mocker, default_conf):
     "is_short,trading_mode,exchange_name,margin_mode,leverage,open_rate,amount,expected_liq", [
         (False, 'spot', 'binance', '', 5.0,  10.0, 1.0, None),
         (True, 'spot', 'binance', '', 5.0,  10.0, 1.0, None),
-        (False, 'spot', 'gateio', '', 5.0,  10.0, 1.0, None),
-        (True, 'spot', 'gateio', '', 5.0,  10.0, 1.0, None),
+        (False, 'spot', 'gate', '', 5.0,  10.0, 1.0, None),
+        (True, 'spot', 'gate', '', 5.0,  10.0, 1.0, None),
         (False, 'spot', 'okx', '', 5.0,  10.0, 1.0, None),
         (True, 'spot', 'okx', '', 5.0,  10.0, 1.0, None),
         # Binance, short
@@ -5175,15 +5175,15 @@ def test_get_liquidation_price1(mocker, default_conf):
         (False, 'futures', 'binance', 'isolated', 5, 8, 1.0, 6.454545454545454),
         (False, 'futures', 'binance', 'isolated', 3, 10, 1.0, 6.723905723905723),
         (False, 'futures', 'binance', 'isolated', 5, 10, 0.6, 8.063973063973064),
-        # Gateio/okx, short
-        (True, 'futures', 'gateio', 'isolated', 5, 10, 1.0, 11.87413417771621),
-        (True, 'futures', 'gateio', 'isolated', 5, 10, 2.0, 11.87413417771621),
-        (True, 'futures', 'gateio', 'isolated', 3, 10, 1.0, 13.193482419684678),
-        (True, 'futures', 'gateio', 'isolated', 5, 8, 1.0, 9.499307342172967),
+        # Gate/okx, short
+        (True, 'futures', 'gate', 'isolated', 5, 10, 1.0, 11.87413417771621),
+        (True, 'futures', 'gate', 'isolated', 5, 10, 2.0, 11.87413417771621),
+        (True, 'futures', 'gate', 'isolated', 3, 10, 1.0, 13.193482419684678),
+        (True, 'futures', 'gate', 'isolated', 5, 8, 1.0, 9.499307342172967),
         (True, 'futures', 'okx', 'isolated', 3, 10, 1.0, 13.193482419684678),
-        # Gateio/okx, long
-        (False, 'futures', 'gateio', 'isolated', 5.0, 10.0, 1.0, 8.085708510208207),
-        (False, 'futures', 'gateio', 'isolated', 3.0, 10.0, 1.0, 6.738090425173506),
+        # Gate/okx, long
+        (False, 'futures', 'gate', 'isolated', 5.0, 10.0, 1.0, 8.085708510208207),
+        (False, 'futures', 'gate', 'isolated', 3.0, 10.0, 1.0, 6.738090425173506),
         (False, 'futures', 'okx', 'isolated', 3.0, 10.0, 1.0, 6.738090425173506),
         # bybit, long
         (False, 'futures', 'bybit', 'isolated', 1.0, 10.0, 1.0, 0.1),
@@ -5240,7 +5240,7 @@ def test_get_liquidation_price(
     leverage = 5, open_rate = 10, amount = 0.6
         ((1.6 + 0.01) - (1 * 0.6 * 10)) / ((0.6 * 0.01) - (1 * 0.6)) = 7.39057239057239
 
-    Gateio/Okx, Short
+    Gate/Okx, Short
     leverage = 5, open_rate = 10, amount = 1.0
         (open_rate + (wallet_balance / position)) / (1 + (mm_ratio + taker_fee_rate))
         (10 + (2 / 1.0)) / (1 + (0.01 + 0.0006)) = 11.87413417771621
@@ -5251,7 +5251,7 @@ def test_get_liquidation_price(
     leverage = 5, open_rate = 8, amount = 1.0
         (8 + (1.6 / 1.0)) / (1 + (0.01 + 0.0006)) = 9.499307342172967
 
-    Gateio/Okx, Long
+    Gate/Okx, Long
     leverage = 5, open_rate = 10, amount = 1.0
         (open_rate - (wallet_balance / position)) / (1 - (mm_ratio + taker_fee_rate))
         (10 - (2 / 1)) / (1 - (0.01 + 0.0006)) = 8.085708510208207
@@ -5266,7 +5266,7 @@ def test_get_liquidation_price(
     default_conf_usdt['trading_mode'] = trading_mode
     default_conf_usdt['exchange']['name'] = exchange_name
     default_conf_usdt['margin_mode'] = margin_mode
-    mocker.patch('freqtrade.exchange.Gateio.validate_ordertypes')
+    mocker.patch('freqtrade.exchange.Gate.validate_ordertypes')
     exchange = get_patched_exchange(mocker, default_conf_usdt, id=exchange_name)
 
     exchange.get_maintenance_ratio_and_amt = MagicMock(return_value=(0.01, 0.01))

--- a/tests/exchange/test_gate.py
+++ b/tests/exchange/test_gate.py
@@ -5,13 +5,13 @@ import pytest
 
 from freqtrade.enums import MarginMode, TradingMode
 from freqtrade.exceptions import OperationalException
-from freqtrade.exchange import Gateio
+from freqtrade.exchange import Gate
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import get_patched_exchange
 
 
-def test_validate_order_types_gateio(default_conf, mocker):
-    default_conf['exchange']['name'] = 'gateio'
+def test_validate_order_types_gate(default_conf, mocker):
+    default_conf['exchange']['name'] = 'gate'
     mocker.patch('freqtrade.exchange.Exchange._init_ccxt')
     mocker.patch('freqtrade.exchange.Exchange._load_markets', return_value={})
     mocker.patch('freqtrade.exchange.Exchange.validate_pairs')
@@ -20,7 +20,7 @@ def test_validate_order_types_gateio(default_conf, mocker):
     mocker.patch('freqtrade.exchange.Exchange.validate_pricing')
     mocker.patch('freqtrade.exchange.Exchange.name', 'Gate')
     exch = ExchangeResolver.load_exchange('gate', default_conf, True)
-    assert isinstance(exch, Gateio)
+    assert isinstance(exch, Gate)
 
     default_conf['order_types'] = {
         'entry': 'market',
@@ -31,18 +31,18 @@ def test_validate_order_types_gateio(default_conf, mocker):
 
     with pytest.raises(OperationalException,
                        match=r'Exchange .* does not support market orders.'):
-        ExchangeResolver.load_exchange('gateio', default_conf, True)
+        ExchangeResolver.load_exchange('gate', default_conf, True)
 
     # market-orders supported on futures markets.
     default_conf['trading_mode'] = 'futures'
     default_conf['margin_mode'] = 'isolated'
-    ex = ExchangeResolver.load_exchange('gateio', default_conf, True)
+    ex = ExchangeResolver.load_exchange('gate', default_conf, True)
     assert ex
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test_fetch_stoploss_order_gateio(default_conf, mocker):
-    exchange = get_patched_exchange(mocker, default_conf, id='gateio')
+def test_fetch_stoploss_order_gate(default_conf, mocker):
+    exchange = get_patched_exchange(mocker, default_conf, id='gate')
 
     fetch_order_mock = MagicMock()
     exchange.fetch_order = fetch_order_mock
@@ -56,7 +56,7 @@ def test_fetch_stoploss_order_gateio(default_conf, mocker):
     default_conf['trading_mode'] = 'futures'
     default_conf['margin_mode'] = 'isolated'
 
-    exchange = get_patched_exchange(mocker, default_conf, id='gateio')
+    exchange = get_patched_exchange(mocker, default_conf, id='gate')
 
     exchange.fetch_order = MagicMock(return_value={
         'status': 'closed',
@@ -73,8 +73,8 @@ def test_fetch_stoploss_order_gateio(default_conf, mocker):
     assert exchange.fetch_order.call_args_list[1][1]['order_id'] == '222555'
 
 
-def test_cancel_stoploss_order_gateio(default_conf, mocker):
-    exchange = get_patched_exchange(mocker, default_conf, id='gateio')
+def test_cancel_stoploss_order_gate(default_conf, mocker):
+    exchange = get_patched_exchange(mocker, default_conf, id='gate')
 
     cancel_order_mock = MagicMock()
     exchange.cancel_order = cancel_order_mock
@@ -90,8 +90,8 @@ def test_cancel_stoploss_order_gateio(default_conf, mocker):
     (1501, 1499, 1501, "sell"),
     (1499, 1501, 1499, "buy")
 ])
-def test_stoploss_adjust_gateio(mocker, default_conf, sl1, sl2, sl3, side):
-    exchange = get_patched_exchange(mocker, default_conf, id='gateio')
+def test_stoploss_adjust_gate(mocker, default_conf, sl1, sl2, sl3, side):
+    exchange = get_patched_exchange(mocker, default_conf, id='gate')
     order = {
         'price': 1500,
         'stopPrice': 1500,
@@ -104,7 +104,7 @@ def test_stoploss_adjust_gateio(mocker, default_conf, sl1, sl2, sl3, side):
     ('taker', 0.0005, 0.0001554325),
     ('maker', 0.0, 0.0),
 ])
-def test_fetch_my_trades_gateio(mocker, default_conf, takerormaker, rate, cost):
+def test_fetch_my_trades_gate(mocker, default_conf, takerormaker, rate, cost):
     mocker.patch('freqtrade.exchange.Exchange.exchange_has', return_value=True)
     tick = {'ETH/USDT:USDT': {
         'info': {'user_id': '',
@@ -134,7 +134,7 @@ def test_fetch_my_trades_gateio(mocker, default_conf, takerormaker, rate, cost):
         'takerOrMaker': takerormaker,
         'amount': 1,  # 1 contract
     }])
-    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id='gateio')
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id='gate')
     exchange._trading_fees = tick
     trades = exchange.get_trades_for_order('22255', 'ETH/USDT:USDT', datetime.now(timezone.utc))
     trade = trades[0]

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -737,18 +737,18 @@ def test_process_informative_pairs_added(default_conf_usdt, ticker_usdt, mocker)
 @pytest.mark.parametrize("is_short,trading_mode,exchange_name,margin_mode,liq_buffer,liq_price", [
     (False, 'spot', 'binance', None, 0.0, None),
     (True, 'spot', 'binance', None, 0.0, None),
-    (False, 'spot', 'gateio', None, 0.0, None),
-    (True, 'spot', 'gateio', None, 0.0, None),
+    (False, 'spot', 'gate', None, 0.0, None),
+    (True, 'spot', 'gate', None, 0.0, None),
     (False, 'spot', 'okx', None, 0.0, None),
     (True, 'spot', 'okx', None, 0.0, None),
     (True, 'futures', 'binance', 'isolated', 0.0, 11.88151815181518),
     (False, 'futures', 'binance', 'isolated', 0.0, 8.080471380471382),
-    (True, 'futures', 'gateio', 'isolated', 0.0, 11.87413417771621),
-    (False, 'futures', 'gateio', 'isolated', 0.0, 8.085708510208207),
+    (True, 'futures', 'gate', 'isolated', 0.0, 11.87413417771621),
+    (False, 'futures', 'gate', 'isolated', 0.0, 8.085708510208207),
     (True, 'futures', 'binance', 'isolated', 0.05, 11.7874422442244),
     (False, 'futures', 'binance', 'isolated', 0.05, 8.17644781144781),
-    (True, 'futures', 'gateio', 'isolated', 0.05, 11.7804274688304),
-    (False, 'futures', 'gateio', 'isolated', 0.05, 8.181423084697796),
+    (True, 'futures', 'gate', 'isolated', 0.05, 11.7804274688304),
+    (False, 'futures', 'gate', 'isolated', 0.05, 8.181423084697796),
     (True, 'futures', 'okx', 'isolated', 0.0, 11.87413417771621),
     (False, 'futures', 'okx', 'isolated', 0.0, 8.085708510208207),
     (True, 'futures', 'bybit', 'isolated', 0.0, 11.9),
@@ -768,11 +768,11 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_order,
         ((wb + cum_b) - (side_1 * position * ep1)) / ((position * mmr_b) - (side_1 * position))
         ((2 + 0.01) - (1 * 1 * 10)) / ((1 * 0.01) - (1 * 1)) = 8.070707070707071
 
-    exchange_name = gateio/okx, is_short = true
+    exchange_name = gate/okx, is_short = true
         (open_rate + (wallet_balance / position)) / (1 + (mm_ratio + taker_fee_rate))
         (10 + (2 / 1)) / (1 + (0.01 + 0.0006)) = 11.87413417771621
 
-    exchange_name = gateio/okx, is_short = false
+    exchange_name = gate/okx, is_short = false
         (open_rate - (wallet_balance / position)) / (1 - (mm_ratio + taker_fee_rate))
         (10 - (2 / 1)) / (1 - (0.01 + 0.0006)) = 8.085708510208207
     """
@@ -785,7 +785,7 @@ def test_execute_entry(mocker, default_conf_usdt, fee, limit_order,
     default_conf_usdt['exchange']['name'] = exchange_name
     if margin_mode:
         default_conf_usdt['margin_mode'] = margin_mode
-    mocker.patch('freqtrade.exchange.Gateio.validate_ordertypes')
+    mocker.patch('freqtrade.exchange.Gate.validate_ordertypes')
     patch_RPCManager(mocker)
     patch_exchange(mocker, id=exchange_name)
     freqtrade = FreqtradeBot(default_conf_usdt)


### PR DESCRIPTION

## Summary

Gate.io rebranded to "gate" a while ago.
We should follow suite - obviously the "gateio" alias will still remain functional.