### PR TITLE
Remove deepcopy protection, replace it with a warning message

### DIFF
--- a/freqtrade/strategy/strategy_wrapper.py
+++ b/freqtrade/strategy/strategy_wrapper.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, TypeVar, cast
 from freqtrade.exceptions import StrategyError
 from freqtrade.persistence import Trade
 
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary

The `trade` parameter is copied with `deepcopy` to protect the user from unexpected behavior. This: 

- produces a large drawback in performance, especially on strategies with a lot of DCA orders.
- prevents advanced strategies that require mutating `trade`.

This PR removes the deep copy and replaces it with a warning message that is displayed during `dry_run` and `live` modes. The mechanism to check for mutation of `trade` is done by using the `sqlalchemy` engine by checking if `trade` has been flagged as dirty, indicating a mutation.

## Quick changelog

- remove deepcopy, add a warning message if trade have mutated.

## What's new?

The following benchmark shows a speedup of 150%.
<details>
  <summary>Config:</summary>

```json
{
  "max_open_trades": 1,
  "stake_currency": "USDT",
  "stake_amount": 100,
  "tradable_balance_ratio": 0.99,
  "fiat_display_currency": "USD",
  "timeframe": "5m",
  "dry_run": true,
  "dry_run_wallet": 1000000,
  "position_adjustment_enable": true,
  "cancel_open_orders_on_exit": false,
  "trading_mode": "futures",
  "margin_mode": "isolated",
  "unfilledtimeout": {
    "entry": 10,
    "exit": 10,
    "exit_timeout_count": 0,
    "unit": "minutes"
  },
  "entry_pricing": {
    "price_side": "same",
    "use_order_book": true,
    "order_book_top": 1,
    "price_last_balance": 0.0,
    "check_depth_of_market": {
      "enabled": false,
      "bids_to_ask_delta": 1
    }
  },
  "exit_pricing": {
    "price_side": "same",
    "use_order_book": true,
    "order_book_top": 1
  },
  "exchange": {
    "name": "okx",
    "key": "",
    "secret": "",
    "ccxt_config": {},
    "ccxt_async_config": {},
    "pair_whitelist": [
      "LTC/USDT:USDT"
    ],
    "pair_blacklist": [
    ]
  },
  "pairlists": [
    {
      "method": "StaticPairList"
    }
  ],
  "bot_name": "freqtrade",
  "initial_state": "running",
  "force_entry_enable": false,
  "internals": {
    "process_throttle_secs": 5
  }
}

```

</details>

<details>
  <summary>Strategy:</summary>

``` python
from typing import Optional

import numpy as np  # noqa
import pandas as pd  # noqa
from pandas import DataFrame

from freqtrade.strategy import (IStrategy)

class SampleStrategy(IStrategy):
    INTERFACE_VERSION = 3

    can_short: bool = False
    minimal_roi = {
        "600000": -1
    }
    stoploss = -1.0
    # Trailing stoploss
    trailing_stop = False
    timeframe = '5m'
    # Run "populate_indicators()" only for new candle.
    process_only_new_candles = True

    # These values can be overridden in the config.
    use_exit_signal = True
    exit_profit_only = False
    ignore_roi_if_entry_signal = False

    # Number of candles the strategy requires before producing valid signals
    startup_candle_count: int = 30

    # Optional order type mapping.
    order_types = {
        'entry': 'limit',
        'exit': 'limit',
        'stoploss': 'market',
        'stoploss_on_exchange': False
    }

    # Optional order time in force.
    order_time_in_force = {
        'entry': 'GTC',
        'exit': 'GTC'
    }

    def informative_pairs(self):
        return []

    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        return dataframe

    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        dataframe.loc[
            :,
            'enter_long'] = 1

        dataframe.loc[
            :,
            'enter_short'] = 0

        return dataframe

    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        dataframe.loc[
            :,

            'exit_long'] = 0

        dataframe.loc[
            :,
            'exit_short'] = 1

        return dataframe

    def adjust_trade_position(self, trade, current_time,
                              current_rate: float, current_profit: float,
                              min_stake: Optional[float], max_stake: float,
                              current_entry_rate: float,
                              current_exit_rate: float,
                              current_entry_profit: float,
                              current_exit_profit: float, **kwargs) -> Optional[
      float]:
      return 100
```
</details>

Run:

`freqtrade backtesting --config user_data/config.json --strategy-path user_data/strategies --strategy SampleStrategy --timeframe 5m --cache none --timerange=20230205-20230210`

Previously took 2 minutes, now takes 45 seconds.
