### PR TITLE
generalize model_exists() for RL and Keras

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -563,7 +563,13 @@ class IFreqaiModel(ABC):
         :return:
         :boolean: whether the model file exists or not.
         """
-        path_to_modelfile = Path(dk.data_path / f"{dk.model_filename}_model.joblib")
+        if self.dd.model_type == 'joblib':
+            file_type = ".joblib"
+        elif self.dd.model_type == 'keras':
+            file_type = ".h5"
+        elif 'stable_baselines' in self.dd.model_type or 'sb3_contrib' == self.dd.model_type:
+            file_type = ".zip"
+        path_to_modelfile = Path(dk.data_path / f"{dk.model_filename}_model.{file_type}")
         file_exists = path_to_modelfile.is_file()
         if file_exists:
             logger.info("Found model at %s", dk.data_path / dk.model_filename)


### PR DESCRIPTION
Supercedes #8181 with an aim of generalizing model_exists for all supported model file types.
