### PR TITLE
Feature market direction

### DIFF
--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -179,7 +179,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/count` | Displays number of trades used and available
 | `/locks` | Show currently locked pairs.
 | `/unlock <pair or lock_id>` | Remove the lock for this pair (or for this lock id).
-| `/marketdir [long | short | even | none]` | Updates the user managed variable that represents the current market direction.
+| `/marketdir [long | short | even | none]` | Updates the user managed variable that represents the current market direction. If no direction is provided, the currently set direction will be displayed.
 | **Modify Trade states** |
 | `/forceexit <trade_id> | /fx <tradeid>` | Instantly exits the given trade  (Ignoring `minimum_roi`).
 | `/forceexit all | /fx all` | Instantly exits all open trades (Ignoring `minimum_roi`).
@@ -420,6 +420,12 @@ ARDR/ETH   0.366667      0.143059       -0.01
 
 ### /marketdir
 
-Updates the user managed variable that represents the current market direction. This variable is not set
-to any valid market direction on bot startup and must be set by the user. As an example `/marketdir long`
-would set the variable to be `long`.
+If a market direction is provided the command updates the user managed variable that represents the current market direction.
+This variable is not set to any valid market direction on bot startup and must be set by the user. The example below is for `/marketdir long`:
+```
+Successfully updated marketdirection from none to long.
+```
+If no market direction is provided the command outputs the currently set market directions. The example below is for `/marketdir`:
+```
+Currently set marketdirection: even
+```

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -421,5 +421,5 @@ ARDR/ETH   0.366667      0.143059       -0.01
 ### /marketdir
 
 Updates the user managed variable that represents the current market direction. This variable is not set
-to any market direction on bot startup and must be set by the user. For example `/marketdir long`
+to any valid market direction on bot startup and must be set by the user. As an example `/marketdir long`
 would set the variable to be `long`.

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -422,10 +422,18 @@ ARDR/ETH   0.366667      0.143059       -0.01
 
 If a market direction is provided the command updates the user managed variable that represents the current market direction.
 This variable is not set to any valid market direction on bot startup and must be set by the user. The example below is for `/marketdir long`:
+
 ```
 Successfully updated marketdirection from none to long.
 ```
+
 If no market direction is provided the command outputs the currently set market directions. The example below is for `/marketdir`:
+
 ```
 Currently set marketdirection: even
 ```
+
+You can use the market direction in your strategy via `self.market_direction`.
+
+!!! Warning "Bot restarts"
+    Please note that the market direction is not persisted, and will be reset after a bot restart/reload.

--- a/docs/telegram-usage.md
+++ b/docs/telegram-usage.md
@@ -152,7 +152,7 @@ You can create your own keyboard in `config.json`:
 !!! Note "Supported Commands"
     Only the following commands are allowed. Command arguments are not supported!
 
-    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopentry`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`
+    `/start`, `/stop`, `/status`, `/status table`, `/trades`, `/profit`, `/performance`, `/daily`, `/stats`, `/count`, `/locks`, `/balance`, `/stopentry`, `/reload_config`, `/show_config`, `/logs`, `/whitelist`, `/blacklist`, `/edge`, `/help`, `/version`, `/marketdir`
 
 ## Telegram commands
 
@@ -179,6 +179,7 @@ official commands. You can ask at any moment for help with `/help`.
 | `/count` | Displays number of trades used and available
 | `/locks` | Show currently locked pairs.
 | `/unlock <pair or lock_id>` | Remove the lock for this pair (or for this lock id).
+| `/marketdir [long | short | even | none]` | Updates the user managed variable that represents the current market direction.
 | **Modify Trade states** |
 | `/forceexit <trade_id> | /fx <tradeid>` | Instantly exits the given trade  (Ignoring `minimum_roi`).
 | `/forceexit all | /fx all` | Instantly exits all open trades (Ignoring `minimum_roi`).
@@ -416,3 +417,9 @@ ARDR/ETH   0.366667      0.143059       -0.01
 ### /version
 
 > **Version:** `0.14.3`
+
+### /marketdir
+
+Updates the user managed variable that represents the current market direction. This variable is not set
+to any market direction on bot startup and must be set by the user. For example `/marketdir long`
+would set the variable to be `long`.

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -5,6 +5,7 @@ from freqtrade.enums.exitchecktuple import ExitCheckTuple
 from freqtrade.enums.exittype import ExitType
 from freqtrade.enums.hyperoptstate import HyperoptState
 from freqtrade.enums.marginmode import MarginMode
+from freqtrade.enums.marketstatetype import MarketDirection
 from freqtrade.enums.ordertypevalue import OrderTypeValues
 from freqtrade.enums.pricetype import PriceType
 from freqtrade.enums.rpcmessagetype import NO_ECHO_MESSAGES, RPCMessageType, RPCRequestType
@@ -12,4 +13,3 @@ from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODE
 from freqtrade.enums.signaltype import SignalDirection, SignalTagType, SignalType
 from freqtrade.enums.state import State
 from freqtrade.enums.tradingmode import TradingMode
-from freqtrade.enums.marketstatetype import MarketDirection

--- a/freqtrade/enums/__init__.py
+++ b/freqtrade/enums/__init__.py
@@ -12,3 +12,4 @@ from freqtrade.enums.runmode import NON_UTIL_MODES, OPTIMIZE_MODES, TRADING_MODE
 from freqtrade.enums.signaltype import SignalDirection, SignalTagType, SignalType
 from freqtrade.enums.state import State
 from freqtrade.enums.tradingmode import TradingMode
+from freqtrade.enums.marketstatetype import MarketDirection

--- a/freqtrade/enums/marketstatetype.py
+++ b/freqtrade/enums/marketstatetype.py
@@ -8,4 +8,8 @@ class MarketDirection(Enum):
     LONG = "long"
     SHORT = "short"
     EVEN = "even"
-    NONE = ''
+    NONE = "none"
+
+    def __str__(self):
+        # convert to string
+        return self.value

--- a/freqtrade/enums/marketstatetype.py
+++ b/freqtrade/enums/marketstatetype.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class MarketDirection(Enum):
+    """
+    Enum for various market directions.
+    """
+    LONG = "long"
+    SHORT = "short"
+    EVEN = "even"
+    NONE = ''
+
+    @staticmethod
+    def string_to_enum(label : str) -> str:
+        match label:
+            case "long":
+                return MarketDirection.LONG
+            case "short":
+                return MarketDirection.SHORT
+            case "even":
+                return MarketDirection.EVEN
+            case 'none':
+                return MarketDirection.NONE
+            case _:
+                return None
+

--- a/freqtrade/enums/marketstatetype.py
+++ b/freqtrade/enums/marketstatetype.py
@@ -9,18 +9,3 @@ class MarketDirection(Enum):
     SHORT = "short"
     EVEN = "even"
     NONE = ''
-
-    @staticmethod
-    def string_to_enum(label : str) -> str:
-        match label:
-            case "long":
-                return MarketDirection.LONG
-            case "short":
-                return MarketDirection.SHORT
-            case "even":
-                return MarketDirection.EVEN
-            case 'none':
-                return MarketDirection.NONE
-            case _:
-                return None
-

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1206,5 +1206,8 @@ class RPC:
             'last_process_ts': int(last_p.timestamp()),
         }
 
-    def _update_market_direction(self, direction: MarketDirection):
+    def _update_market_direction(self, direction: MarketDirection) -> None:
         self._freqtrade.strategy.market_direction = direction
+
+    def _get_market_direction(self) -> MarketDirection:
+        return self._freqtrade.strategy.market_direction

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -19,8 +19,8 @@ from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CANCEL_REASON, DATETIME_PRINT_FORMAT, Config
 from freqtrade.data.history import load_data
 from freqtrade.data.metrics import calculate_max_drawdown
-from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, SignalDirection, State,
-                             TradingMode, MarketDirection)
+from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirection, SignalDirection,
+                             State, TradingMode)
 from freqtrade.exceptions import ExchangeError, PricingError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_msecs
 from freqtrade.loggers import bufferHandler

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -20,7 +20,7 @@ from freqtrade.constants import CANCEL_REASON, DATETIME_PRINT_FORMAT, Config
 from freqtrade.data.history import load_data
 from freqtrade.data.metrics import calculate_max_drawdown
 from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, SignalDirection, State,
-                             TradingMode)
+                             TradingMode, MarketDirection)
 from freqtrade.exceptions import ExchangeError, PricingError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_msecs
 from freqtrade.loggers import bufferHandler
@@ -1205,3 +1205,6 @@ class RPC:
             'last_process_loc': last_p.astimezone(tzlocal()).strftime(DATETIME_PRINT_FORMAT),
             'last_process_ts': int(last_p.timestamp()),
         }
+
+    def _update_market_direction(self, direction: MarketDirection):
+        self._freqtrade.strategy.market_direction = direction

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -129,7 +129,7 @@ class Telegram(RPCHandler):
             r'/weekly$', r'/weekly \d+$', r'/monthly$', r'/monthly \d+$',
             r'/forcebuy$', r'/forcelong$', r'/forceshort$',
             r'/forcesell$', r'/forceexit$',
-            r'/edge$', r'/health$', r'/help$', r'/version$', r'/marketdir$'
+            r'/edge$', r'/health$', r'/help$', r'/version$', r'/marketdir \d+$'
         ]
         # Create keys for generation
         valid_keys_print = [k.replace('$', '') for k in valid_keys]
@@ -1690,14 +1690,15 @@ class Telegram(RPCHandler):
         """
         if context.args and len(context.args) == 1:
             new_market_dir = context.args[0]
-            match new_market_dir:
-                case "long":
-                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.LONG
-                case "short":
-                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.SHORT
-                case "even":
-                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.EVEN
-                case "none":
-                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.NONE
-                case _:
-                    raise RPCException("Invalid market direction provided")
+            if new_market_dir == "long":
+                self._rpc._update_market_direction(MarketDirection.LONG)
+            elif new_market_dir == "short":
+                self._rpc._update_market_direction(MarketDirection.SHORT)
+            elif new_market_dir == "even":
+                self._rpc._update_market_direction(MarketDirection.EVEN)
+            elif new_market_dir == "none":
+                self._rpc._update_market_direction(MarketDirection.NONE)
+            else:
+                raise RPCException("Invalid market direction provided")
+        else:
+            raise RPCException("Invalid usage of command /marketdir.")

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1689,7 +1689,15 @@ class Telegram(RPCHandler):
         :return: None
         """
         if context.args and len(context.args) == 1:
-            market_dir = MarketDirection.string_to_enum(context.args[0])
-            if market_dir:
-                self._rpc._freqtrade.strategy.market_direction = market_dir
-
+            new_market_dir = context.args[0]
+            match new_market_dir:
+                case "long":
+                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.LONG
+                case "short":
+                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.SHORT
+                case "even":
+                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.EVEN
+                case "none":
+                    self._rpc._freqtrade.strategy.market_direction = MarketDirection.NONE
+                case _:
+                    raise RPCException("Invalid market direction provided")

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -129,7 +129,7 @@ class Telegram(RPCHandler):
             r'/weekly$', r'/weekly \d+$', r'/monthly$', r'/monthly \d+$',
             r'/forcebuy$', r'/forcelong$', r'/forceshort$',
             r'/forcesell$', r'/forceexit$',
-            r'/edge$', r'/health$', r'/help$', r'/version$', r'/marketdir \d+$'
+            r'/edge$', r'/health$', r'/help$', r'/version$', r'/marketdir (long|short|even|none)$'
         ]
         # Create keys for generation
         valid_keys_print = [k.replace('$', '') for k in valid_keys]
@@ -1495,6 +1495,8 @@ class Telegram(RPCHandler):
             "*/count:* `Show number of active trades compared to allowed number of trades`\n"
             "*/edge:* `Shows validated pairs by Edge if it is enabled` \n"
             "*/health* `Show latest process timestamp - defaults to 1970-01-01 00:00:00` \n"
+            "*/marketdir [long | short | even | none]:* `Updates the user managed variable"
+            " that represents the current market direction` \n"
 
             "_Statistics_\n"
             "------------\n"

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -12,7 +12,7 @@ from pandas import DataFrame
 
 from freqtrade.constants import Config, IntOrInf, ListPairsWithTimeframes
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, RunMode, SignalDirection,
+from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirection,  RunMode, SignalDirection,
                              SignalTagType, SignalType, TradingMode)
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date, timeframe_to_seconds
@@ -121,6 +121,9 @@ class IStrategy(ABC, HyperStrategyMixin):
 
     # Definition of plot_config. See plotting documentation for more details.
     plot_config: Dict = {}
+
+    # A self set parameter that represents the market direction. filled from configuration
+    market_direction: MarketDirection = MarketDirection.NONE
 
     def __init__(self, config: Config) -> None:
         self.config = config

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -12,8 +12,8 @@ from pandas import DataFrame
 
 from freqtrade.constants import Config, IntOrInf, ListPairsWithTimeframes
 from freqtrade.data.dataprovider import DataProvider
-from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirection,  RunMode, SignalDirection,
-                             SignalTagType, SignalType, TradingMode)
+from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirection, RunMode,
+                             SignalDirection, SignalTagType, SignalType, TradingMode)
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date, timeframe_to_seconds
 from freqtrade.misc import remove_entry_exit_signals

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -20,7 +20,8 @@ from telegram.error import BadRequest, NetworkError, TelegramError
 from freqtrade import __version__
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.edge import PairInfo
-from freqtrade.enums import ExitType, MarketDirection, RPCMessageType, RunMode, SignalDirection, State
+from freqtrade.enums import (ExitType, MarketDirection, RPCMessageType, RunMode, SignalDirection,
+                             State)
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.loggers import setup_logging

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -20,7 +20,7 @@ from telegram.error import BadRequest, NetworkError, TelegramError
 from freqtrade import __version__
 from freqtrade.constants import CANCEL_REASON
 from freqtrade.edge import PairInfo
-from freqtrade.enums import ExitType, RPCMessageType, RunMode, SignalDirection, State
+from freqtrade.enums import ExitType, MarketDirection, RPCMessageType, RunMode, SignalDirection, State
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.loggers import setup_logging
@@ -2394,3 +2394,15 @@ def test__send_msg_keyboard(default_conf, mocker, caplog) -> None:
     assert log_has("using custom keyboard from config.json: "
                    "[['/daily', '/stats', '/balance', '/profit', '/profit 5'], ['/count', "
                    "'/start', '/reload_config', '/help']]", caplog)
+
+
+def test_change_market_direction(default_conf, mocker, update) -> None:
+    telegram, _, msg_mock = get_telegram_testobject(mocker, default_conf)
+    assert telegram._rpc._freqtrade.strategy.market_direction == MarketDirection.NONE
+    context = MagicMock()
+    context.args = ["long"]
+    telegram._changemarketdir(update, context)
+    assert telegram._rpc._freqtrade.strategy.market_direction == MarketDirection.LONG
+    context = MagicMock()
+    context.args = ["invalid"]
+    assert telegram._rpc._freqtrade.strategy.market_direction == MarketDirection.LONG

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -106,7 +106,7 @@ def test_telegram_init(default_conf, mocker, caplog) -> None:
                    "['reload_config', 'reload_conf'], ['show_config', 'show_conf'], "
                    "['stopbuy', 'stopentry'], ['whitelist'], ['blacklist'], "
                    "['blacklist_delete', 'bl_delete'], "
-                   "['logs'], ['edge'], ['health'], ['help'], ['version']"
+                   "['logs'], ['edge'], ['health'], ['help'], ['version'], ['marketdir']"
                    "]")
 
     assert log_has(message_str, caplog)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Adds new user set optional field which represents market direction, as well as a telegram command allowing users to change this field.

Solve the issue: #8011 

## Quick changelog

- Added new command ` \marketdir <param>` to change the marketdir variable

## What's new?
- Added new field `market_direction `to the `IStrategy `class 
- Added a new enum `MarketDirection`
- Added new command ` \marketdir <param>` to change the marketdir variable
- Added a test to check if the functionality works as intended

The goal of this PR is to allow users to have an internal variable they can control to signify what they think the market conditions are. The default value for this if not set by the user is `MarketDirection.NONE` meaning if a user has not chosen to set up this value, it will not hold any meaning or influence anything else.

