### PR TITLE
Fix outdated systemd related exception text.

### DIFF
--- a/freqtrade/loggers.py
+++ b/freqtrade/loggers.py
@@ -105,7 +105,7 @@ def setup_logging(config: Config) -> None:
             try:
                 from cysystemd.journal import JournaldLogHandler
             except ImportError:
-                raise OperationalException("You need the systemd python package be installed in "
+                raise OperationalException("You need the cysystemd python package be installed in "
                                            "order to use logging to journald.")
             handler_jd = get_existing_handlers(JournaldLogHandler)
             if handler_jd:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -719,7 +719,7 @@ def test_set_loggers_journald_importerror(import_fails):
               'logfile': 'journald',
               }
     with pytest.raises(OperationalException,
-                       match=r'You need the systemd python package.*'):
+                       match=r'You need the cysystemd python package.*'):
         setup_logging(config)
     logger.handlers = orig_handlers
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Complement e9c64c58 that solves the issue: #8187 

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Now the user will prompted by python exception to install `cysystemd` instead `systemd` package.
