### PR TITLE
add imposter disclaimer to FreqAI front page

### DIFF
--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -6,7 +6,7 @@
 
 FreqAI is a software designed to automate a variety of tasks associated with training a predictive machine learning model to generate market forecasts given a set of input signals. In general, FreqAI aims to be a sandbox for easily deploying robust machine learning libraries on real-time data ([details](#freqai-position-in-open-source-machine-learning-landscape)).
 
-!!! Note:
+!!! Note
     FreqAI is, and always will be, a not-for-profit, open-source project. FreqAI does *not* have a crypto token, FreqAI does *not* sell signals, and FreqAI does not have a domain besides the present [freqtrade documentation](https://www.freqtrade.io/en/latest/freqai/.
 
 Features include:

--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -6,6 +6,9 @@
 
 FreqAI is a software designed to automate a variety of tasks associated with training a predictive machine learning model to generate market forecasts given a set of input signals. In general, FreqAI aims to be a sandbox for easily deploying robust machine learning libraries on real-time data ([details](#freqai-position-in-open-source-machine-learning-landscape)).
 
+!!! Danger "DISCLAIMER"
+    FreqAI is, and always will be, a not-for-profit, open-source project. FreqAI does *not* have a crypto token, FreqAI does *not* sell signals, and FreqAI does not have a domain besides the present [freqtrade documentation](https://www.freqtrade.io/en/latest/freqai/. Please beware of imposter projects, and help us by reporting them to the official Freqtrade discord server.
+
 Features include:
 
 * **Self-adaptive retraining** - Retrain models during [live deployments](freqai-running.md#live-deployments) to self-adapt to the market in a supervised manner

--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -6,8 +6,8 @@
 
 FreqAI is a software designed to automate a variety of tasks associated with training a predictive machine learning model to generate market forecasts given a set of input signals. In general, FreqAI aims to be a sandbox for easily deploying robust machine learning libraries on real-time data ([details](#freqai-position-in-open-source-machine-learning-landscape)).
 
-!!! Danger "DISCLAIMER"
-    FreqAI is, and always will be, a not-for-profit, open-source project. FreqAI does *not* have a crypto token, FreqAI does *not* sell signals, and FreqAI does not have a domain besides the present [freqtrade documentation](https://www.freqtrade.io/en/latest/freqai/. Please beware of imposter projects, and help us by reporting them to the official Freqtrade discord server.
+!!! Note:
+    FreqAI is, and always will be, a not-for-profit, open-source project. FreqAI does *not* have a crypto token, FreqAI does *not* sell signals, and FreqAI does not have a domain besides the present [freqtrade documentation](https://www.freqtrade.io/en/latest/freqai/.
 
 Features include:
 


### PR DESCRIPTION
In light of recent developments, we want to raise awareness that the Freqtrade/FreqAI projects are not-for-profit and do not have crypto tokens or signal sales. 

I hope this will help people (at least the ones doing standard DD) to understand that we are not affiliated these kinds of imposter projects.