### PR TITLE
setup.sh: actually install all dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,10 @@ function updateenv() {
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
         REQUIREMENTS=requirements-dev.txt
+        REQUIREMENTS_PLOT="-r requirements-plot.txt"
+        REQUIREMENTS_HYPEROPT="-r requirements-hyperopt.txt"
+        REQUIREMENTS_FREQAI="-r requirements-freqai.txt"
+        REQUIREMENTS_FREQAI_RL="-r requirements-freqai-rl.txt"
     else
         # requirements-dev.txt includes all the below requirements already, so further questions are pointless.
         read -p "Do you want to install plotting dependencies (plotly) [y/N]? "


### PR DESCRIPTION
I thought if asked to install all dev dependencies, all should actually be installed. or are all requirements from each `requirements-*.txt` duplicated inside `requirenemts-dev.sh`? I don't assume so?