### PR TITLE
Fix dependencies & tests to run on Windows

### DIFF
--- a/requirements-freqai-rl.txt
+++ b/requirements-freqai-rl.txt
@@ -3,8 +3,8 @@
 
 # Required for freqai-rl
 torch==1.13.1
-stable-baselines3==1.7.0
+stable-baselines3==1.7.0; sys_platform != "win32"
 sb3-contrib==1.7.0
 # Gym is forced to this version by stable-baselines3.
 setuptools==65.5.1 # Should be removed when gym is fixed.
-gym==0.21
+gym==0.21; sys_platform != "win32"

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -1,5 +1,6 @@
 import platform
 import shutil
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -16,6 +17,9 @@ from freqtrade.plugins.pairlistmanager import PairListManager
 from tests.conftest import create_mock_trades, get_patched_exchange, log_has_re
 from tests.freqai.conftest import get_patched_freqai_strategy, make_rl_config
 
+if sys.platform.startswith("win"):
+    pytest.skip("Skipping these tests as it depends on stable-baselines3==1.7.0 which doesn't support Windows",
+                allow_module_level=True)
 
 def is_arm() -> bool:
     machine = platform.machine()

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -1,6 +1,6 @@
 # pragma pylint: disable=missing-docstring, C0103
 # pragma pylint: disable=invalid-sequence-index, invalid-name, too-many-arguments
-
+import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from unittest.mock import ANY, MagicMock, PropertyMock
@@ -1247,6 +1247,7 @@ def test_rpc_edge_enabled(mocker, edge_conf) -> None:
     assert ret[0]['Stoploss'] == -0.02
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Throws OSError on Windows")
 def test_rpc_health(mocker, default_conf) -> None:
     mocker.patch('freqtrade.rpc.telegram.Telegram', MagicMock())
 

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -2,6 +2,7 @@
 Unit test file for rpc/api_server.py
 """
 import logging
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1794,6 +1795,7 @@ def test_api_backtest_history(botclient, mocker, testdatadir):
     assert result2['backtest_result']['strategy'][strategy]
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Throws OSError on Windows")
 def test_health(botclient):
     ftbot, client = botclient
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Fix dependencies and tests to run on Windows.

Currently some of the dependencies are incompatible with Windows, as well as some tests fail to run on Windows and this PR fixes to make all tests pass by ignoring those incompatible, and not installing incompatible packages on Windows.

<!-- Explain in one sentence the goal of this PR -->

<!--Solve the issue: #___ -->

## Quick changelog

- fix `requirements-freqai-rl.txt` to not install on Win platform incompatible packages;
- fix tests to skip running incompatible tests on Win platform;

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
No new features/functionalities.