### PR TITLE
Fix last_process related bug in RPC.health (BUG-#8231)

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -127,7 +127,7 @@ class FreqtradeBot(LoggingMixin):
                 for minutes in [0, 15, 30, 45]:
                     t = str(time(time_slot, minutes, 2))
                     self._schedule.every().day.at(t).do(update)
-        self.last_process = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        self.last_process: Optional[datetime] = None
 
         self.strategy.ft_bot_start()
         # Initialize protections AFTER bot start - otherwise parameters are not loaded.

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -456,5 +456,5 @@ class SysInfo(BaseModel):
 
 
 class Health(BaseModel):
-    last_process: datetime
-    last_process_ts: int
+    last_process: Optional[datetime]
+    last_process_ts: Optional[int]

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -346,4 +346,4 @@ def sysinfo():
 
 @router.get('/health', response_model=Health, tags=['info'])
 def health(rpc: RPC = Depends(get_rpc)):
-    return rpc._health()
+    return rpc.health()

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -89,7 +89,7 @@ class RPC:
     # Bind _fiat_converter if needed
     _fiat_converter: Optional[CryptoToFiatConverter] = None
 
-    def __init__(self, freqtrade: "FreqtradeBot") -> None:
+    def __init__(self, freqtrade) -> None:
         """
         Initializes all enabled rpc modules
         :param freqtrade: Instance of a freqtrade bot

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -89,7 +89,7 @@ class RPC:
     # Bind _fiat_converter if needed
     _fiat_converter: Optional[CryptoToFiatConverter] = None
 
-    def __init__(self, freqtrade) -> None:
+    def __init__(self, freqtrade: "FreqtradeBot") -> None:
         """
         Initializes all enabled rpc modules
         :param freqtrade: Instance of a freqtrade bot
@@ -1198,10 +1198,17 @@ class RPC:
             "ram_pct": psutil.virtual_memory().percent
         }
 
-    def _health(self) -> Dict[str, Union[str, int]]:
+    def health(self) -> Dict[str, Optional[Union[str, int]]]:
         last_p = self._freqtrade.last_process
+        if last_p is None:
+            return {
+                "last_process": None,
+                "last_process_loc": None,
+                "last_process_ts": None,
+            }
+
         return {
-            'last_process': str(last_p),
-            'last_process_loc': last_p.astimezone(tzlocal()).strftime(DATETIME_PRINT_FORMAT),
-            'last_process_ts': int(last_p.timestamp()),
+            "last_process": str(last_p),
+            "last_process_loc": last_p.astimezone(tzlocal()).strftime(DATETIME_PRINT_FORMAT),
+            "last_process_ts": int(last_p.timestamp()),
         }

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1527,7 +1527,7 @@ class Telegram(RPCHandler):
         Handler for /health
         Shows the last process timestamp
         """
-        health = self._rpc._health()
+        health = self._rpc.health()
         message = f"Last process: `{health['last_process_loc']}`"
         self._send_msg(message)
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -1252,6 +1252,6 @@ def test_rpc_health(mocker, default_conf) -> None:
 
     freqtradebot = get_patched_freqtradebot(mocker, default_conf)
     rpc = RPC(freqtradebot)
-    result = rpc._health()
-    assert result['last_process'] == '1970-01-01 00:00:00+00:00'
-    assert result['last_process_ts'] == 0
+    result = rpc.health()
+    assert result['last_process'] is None
+    assert result['last_process_ts'] is None

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1801,8 +1801,8 @@ def test_health(botclient):
 
     assert_response(rc)
     ret = rc.json()
-    assert ret['last_process_ts'] == 0
-    assert ret['last_process'] == '1970-01-01T00:00:00+00:00'
+    assert ret["last_process_ts"] is None
+    assert ret["last_process"] is None
 
 
 def test_api_ws_subscribe(botclient, mocker):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Fixes bug in RPC.health related to the TimeZone that was reproducing only on Windows and on UTC-pozitive timezones.

Solve the issue: #8231 

#### Note: 
The main concern with this fix is the contract of the `/health` endpoint which should be able to handle `null`s in the json response.
As the alternative solution with less-risk impact is to change the default timestamp of `last_process` return to `1970-01-02 00:00:00`, that would fix the problem for all time zones, but that wouldn't be semantically correct since the last_process actually is undefined, so to maintain a logical consistency - using a null/None value would be a better choice.

Please let me know if the clients of the `/health` endpoint aren't able to handle the `null`s, and I'll change back the contract to datetime strings.

## Quick changelog

- `FreqtradeBot.last_process` by default is None now
- `RPC._health` method named changed to `health()` since this is public method, used by external clients.
- `Health` api schema updated to match the semantics of the returned data.
- tests fixed to pass

## What's new?

The `/health` endpoint now will return `null` for last_process timestamps if the bot hasn't been started yet.
