### PR TITLE
allow user to drop ohlc from features in RL

### DIFF
--- a/docs/freqai-parameter-table.md
+++ b/docs/freqai-parameter-table.md
@@ -84,6 +84,7 @@ Mandatory parameters are marked as **Required** and have to be set in one of the
 | `add_state_info` | Tell FreqAI to include state information in the feature set for training and inferencing. The current state variables include trade duration, current profit, trade position. This is only available in dry/live runs, and is automatically switched to false for backtesting. <br> **Datatype:** bool. <br> Default: `False`.
 | `net_arch` | Network architecture which is well described in [`stable_baselines3` doc](https://stable-baselines3.readthedocs.io/en/master/guide/custom_policy.html#examples). In summary: `[<shared layers>, dict(vf=[<non-shared value network layers>], pi=[<non-shared policy network layers>])]`. By default this is set to `[128, 128]`, which defines 2 shared hidden layers with 128 units each.
 | `randomize_starting_position` | Randomize the starting point of each episode to avoid overfitting. <br> **Datatype:** bool. <br> Default: `False`.
+| `drop_ohlc_from_features` | Do not include the normalized ohlc data in the feature set passed to the agent during training (ohlc will still be used for driving the environment in all cases) <br> **Datatype:** Boolean. <br> **Default:** `False`
 
 ### Additional parameters
 

--- a/docs/freqai-reinforcement-learning.md
+++ b/docs/freqai-reinforcement-learning.md
@@ -176,9 +176,11 @@ As you begin to modify the strategy and the prediction model, you will quickly r
 
                 factor = 100
 
+                pair = self.pair.replace(':', '')
+
                 # you can use feature values from dataframe
                 # Assumes the shifted RSI indicator has been generated in the strategy.
-                rsi_now = self.raw_features[f"%-rsi-period-10_shift-1_{self.pair}_"
+                rsi_now = self.raw_features[f"%-rsi-period-10_shift-1_{pair}_"
                                 f"{self.config['timeframe']}"].iloc[self._current_tick]
 
                 # reward agent for entering trades

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -588,6 +588,7 @@ CONF_SCHEMA = {
                 "rl_config": {
                     "type": "object",
                     "properties": {
+                        "drop_ohlc_from_features": {"type": "boolean", "default": False},
                         "train_cycles": {"type": "integer"},
                         "max_trade_duration_candles": {"type": "integer"},
                         "add_state_info": {"type": "boolean", "default": False},

--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -330,6 +330,8 @@ class BaseReinforcementLearningModel(IFreqaiModel):
 
         if self.rl_config["drop_ohlc_from_features"]:
             df.drop(drop_list, axis=1, inplace=True)
+            feature_list = dk.training_features_list
+            dk.training_features_list = [e for e in feature_list if e not in drop_list]
 
         return df
 

--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -330,8 +330,6 @@ class BaseReinforcementLearningModel(IFreqaiModel):
 
         if self.rl_config["drop_ohlc_from_features"]:
             df.drop(drop_list, axis=1, inplace=True)
-            feature_list = dk.training_features_list
-            feature_list = [e for e in feature_list if e not in drop_list]
 
         return df
 

--- a/tests/freqai/conftest.py
+++ b/tests/freqai/conftest.py
@@ -78,7 +78,9 @@ def make_rl_config(conf):
             "rr": 1,
             "profit_aim": 0.02,
             "win_reward_factor": 2
-        }}
+        },
+        "drop_ohlc_from_features": False
+        }
 
     return conf
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -75,15 +75,9 @@ def test_extract_data_and_train_model_Standard(mocker, freqai_conf, model, pca,
         freqai_conf['freqai']['feature_parameters'].update({"use_SVM_to_remove_outliers": True})
         freqai_conf['freqai']['data_split_parameters'].update({'shuffle': True})
 
-    if 'ReinforcementLearner' in model:
-        model_save_ext = 'zip'
-        freqai_conf = make_rl_config(freqai_conf)
-        # test the RL guardrails
-        freqai_conf['freqai']['feature_parameters'].update({"use_SVM_to_remove_outliers": True})
-        freqai_conf['freqai']['data_split_parameters'].update({'shuffle': True})
-
     if 'test_3ac' in model or 'test_4ac' in model:
         freqai_conf["freqaimodel_path"] = str(Path(__file__).parents[1] / "freqai" / "test_models")
+        freqai_conf["freqai"]["rl_config"]["drop_ohlc_from_features"] = True
 
     strategy = get_patched_freqai_strategy(mocker, freqai_conf)
     exchange = get_patched_exchange(mocker, freqai_conf)


### PR DESCRIPTION
A user quite astutely pointed out that we are forcing users to include normalized OHLC data in the reinforcement learning module. While this is not necessarily a bad thing, it is a good point that some users may prefer not to have normalized OHLC in their training features.

Note that this does *not* affect the use of OHLC data in the training environment, it only removes them as features from the agent's neural network input. 
