### PR TITLE
feat: Added price_rounding modes in config

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -5,6 +5,8 @@ bot constants
 """
 from typing import Any, Dict, List, Literal, Tuple
 
+from ccxt import ROUND, ROUND_DOWN, ROUND_UP, TRUNCATE
+
 from freqtrade.enums import CandleType, PriceType, RPCMessageType
 
 
@@ -50,6 +52,8 @@ DEFAULT_DATAFRAME_COLUMNS = ['date', 'open', 'high', 'low', 'close', 'volume']
 # it has wide consequences for stored trades files
 DEFAULT_TRADES_COLUMNS = ['timestamp', 'id', 'type', 'side', 'price', 'amount', 'cost']
 TRADING_MODES = ['spot', 'margin', 'futures']
+PRICE_ROUND_MODES = [TRUNCATE, ROUND, ROUND_UP, ROUND_DOWN]
+DEFAULT_PRICE_ROUND_MODE = ROUND_UP
 MARGIN_MODES = ['cross', 'isolated', '']
 
 LAST_BT_RESULT_FN = '.last_result.json'
@@ -476,7 +480,9 @@ CONF_SCHEMA = {
                 'outdated_offset': {'type': 'integer', 'minimum': 1},
                 'markets_refresh_interval': {'type': 'integer'},
                 'ccxt_config': {'type': 'object'},
-                'ccxt_async_config': {'type': 'object'}
+                'ccxt_async_config': {'type': 'object'},
+                'price_rounding_mode': {'type':    'integer', 'enum': PRICE_ROUND_MODES,
+                                        'default': DEFAULT_PRICE_ROUND_MODE}
             },
             'required': ['name']
         },

--- a/freqtrade/exchange/exchange_utils.py
+++ b/freqtrade/exchange/exchange_utils.py
@@ -2,11 +2,12 @@
 Exchange support utils
 """
 from datetime import datetime, timedelta, timezone
-from math import ceil
+from math import ceil, floor
 from typing import Any, Dict, List, Optional, Tuple
 
 import ccxt
-from ccxt import ROUND_DOWN, ROUND_UP, TICK_SIZE, TRUNCATE, decimal_to_precision
+from ccxt import (DECIMAL_PLACES, ROUND, ROUND_DOWN, ROUND_UP, SIGNIFICANT_DIGITS, TICK_SIZE,
+                  TRUNCATE, decimal_to_precision)
 
 from freqtrade.exchange.common import BAD_EXCHANGES, EXCHANGE_HAS_OPTIONAL, EXCHANGE_HAS_REQUIRED
 from freqtrade.util import FtPrecise
@@ -219,35 +220,48 @@ def amount_to_contract_precision(
     return amount
 
 
-def price_to_precision(price: float, price_precision: Optional[float],
-                       precisionMode: Optional[int]) -> float:
+def price_to_precision(
+    price: float,
+    price_precision: Optional[float],
+    precisionMode: Optional[int],
+    rounding_mode: int = ROUND_UP,
+) -> float:
     """
     Returns the price rounded up to the precision the Exchange accepts.
     Partial Re-implementation of ccxt internal method decimal_to_precision(),
     which does not support rounding up
     TODO: If ccxt supports ROUND_UP for decimal_to_precision(), we could remove this and
     align with amount_to_precision().
-    !!! Rounds up
     :param price: price to convert
     :param price_precision: price precision to use. Used from markets[pair]['precision']['price']
     :param precisionMode: precision mode to use. Should be used from precisionMode
                           one of ccxt's DECIMAL_PLACES, SIGNIFICANT_DIGITS, or TICK_SIZE
+    :param rounding_mode: rounding mode to use. Defaults to ROUND_UP
     :return: price rounded up to the precision the Exchange accepts
-
     """
     if price_precision is not None and precisionMode is not None:
-        # price = float(decimal_to_precision(price, rounding_mode=ROUND,
-        #                                    precision=price_precision,
-        #                                    counting_mode=self.precisionMode,
-        #                                    ))
         if precisionMode == TICK_SIZE:
+            if rounding_mode == ROUND:
+                ticks = price / price_precision
+                rounded_ticks = round(ticks)
+                return rounded_ticks * price_precision
             precision = FtPrecise(price_precision)
             price_str = FtPrecise(price)
             missing = price_str % precision
             if not missing == FtPrecise("0"):
-                price = round(float(str(price_str - missing + precision)), 14)
-        else:
-            symbol_prec = price_precision
-            big_price = price * pow(10, symbol_prec)
-            price = ceil(big_price) / pow(10, symbol_prec)
+                return round(float(str(price_str - missing + precision)), 14)
+            return price
+        elif precisionMode in (SIGNIFICANT_DIGITS, DECIMAL_PLACES):
+            ndigits = round(price_precision)
+            if rounding_mode == ROUND:
+                return round(price, ndigits)
+            ticks = price * (10**ndigits)
+            if rounding_mode == ROUND_UP:
+                return ceil(ticks) / (10**ndigits)
+            if rounding_mode == TRUNCATE:
+                return int(ticks) / (10**ndigits)
+            if rounding_mode == ROUND_DOWN:
+                return floor(ticks) / (10**ndigits)
+            raise ValueError(f"Unknown rounding_mode {rounding_mode}")
+        raise ValueError(f"Unknown precisionMode {precisionMode}")
     return price


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
This PR adds new functionality to configure the price rounding mode for new orders.


<!-- Explain in one sentence the goal of this PR -->

<!--Solve the issue: #___ -->

## Quick changelog

- adds `exchange.price_rounding_mode` config option
 
## What's new?
Currently the orders are sent by applying a ROUND_UP rounding to the price, which on some systems might be an issue due to the ways the CPython represents the `float` numbers, leading to wrong price roundings and unexpected behavior. The safest rounding type for built-in Python float numbers is the ccst.ROUND mode, which currently can't be changed without changing the current functionality of freqtrade.
I have added the rounding mode as an option to config, and it can set one of 3 available ccxt rounding modes.

The rounding mode defaults to ccxt.ROUND_UP, and it can be changed by setting `exchange.price_rounding_mode` config parameter to the one of the 3 supported by `ccxt` rounding modes: `TRUNCATE, ROUND, ROUND_UP`.

The feature is also covered by unit-tests.
<!-- Explain in details what this PR solve or improve. You can include visuals. -->
