### PR TITLE
Fix None limit on pair_candles RPC call

### DIFF
--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -347,7 +347,7 @@ class FtRestClient():
         if limit:
             params['limit'] = limit
         return self._get("pair_candles", params=params)
-    
+
     def pair_history(self, pair, timeframe, strategy, timerange=None):
         """Return historic, analyzed dataframe
 

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -340,12 +340,14 @@ class FtRestClient():
         :param limit: Limit result to the last n candles.
         :return: json object
         """
-        return self._get("pair_candles", params={
+        params = {
             "pair": pair,
             "timeframe": timeframe,
-            "limit": limit,
-        })
-
+        }
+        if limit:
+            params['limit'] = limit
+        return self._get("pair_candles", params=params)
+    
     def pair_history(self, pair, timeframe, strategy, timerange=None):
         """Return historic, analyzed dataframe
 


### PR DESCRIPTION
## Summary

Solve the issue: [#8309](https://github.com/freqtrade/freqtrade/issues/8309)

## Quick changelog

Add limit check to pair_candles RPC call in rest_client.py
