### PR TITLE
Support for python 3.11 via setup.sh script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ function check_installed_python() {
         exit 2
     fi
 
-    for v in 10 9 8
+    for v in 11 10 9 8
     do
         PYTHON="python3.${v}"
         which $PYTHON


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Use freqtrade with latest python 3.11

## What's new?

Support for __python 3.11__

<!-- Explain in details what this PR solve or improve. You can include visuals. -->

Now it's possible to use python 3.11 when run `./setup.sh` 
