### PR TITLE
Convert historic_predictions.pkl to parquet for performance

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -223,7 +223,8 @@ class FreqaiDataDrawer:
             value.to_parquet(filename)
 
         # create a backup
-        shutil.copytree(self.historic_predictions_folder, self.historic_predictions_bkp_folder)
+        shutil.copytree(self.historic_predictions_folder,
+                        self.historic_predictions_bkp_folder, dirs_exist_ok=True)
 
     def save_metric_tracker_to_disk(self):
         """

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -169,11 +169,7 @@ class FreqaiDataDrawer:
 
         if exists:
             try:
-                for file_path in self.historic_predictions_folder.glob("*.parquet"):
-                    key = file_path.stem
-                    key.replace("_", "/")
-                    self.historic_predictions[key] = pd.read_parquet(file_path)
-
+                self.load_historic_predictions_from_folder()
                 logger.info(
                     f"Found existing historic predictions at {self.full_path}, but beware "
                     "that statistics may be inaccurate if the bot has been offline for "
@@ -182,10 +178,7 @@ class FreqaiDataDrawer:
             except EOFError:
                 logger.warning(
                     'Historical prediction files were corrupted. Trying to load backup files.')
-                for file_path in self.historic_predictions_folder.glob("*.parquet"):
-                    key = file_path.stem
-                    key.replace("_", "/")
-                    self.historic_predictions[key] = pd.read_parquet(file_path)
+                self.load_historic_predictions_from_folder()
                 logger.warning('FreqAI successfully loaded the backup '
                                'historical predictions files.')
 
@@ -204,6 +197,18 @@ class FreqaiDataDrawer:
             )
 
         return exists
+
+    def load_historic_predictions_from_folder(self):
+        """
+        Try to build the historic_predictions dictionary from parquet
+        files in the historic_predictions_folder
+        """
+        for file_path in self.historic_predictions_folder.glob("*.parquet"):
+            key = file_path.stem
+            key.replace("_", "/")
+            self.historic_predictions[key] = pd.read_parquet(file_path)
+
+        return
 
     def save_historic_predictions_to_disk(self):
         """

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -75,8 +75,7 @@ class FreqaiDataDrawer:
         self.full_path = full_path
         self.historic_predictions_path = Path(self.full_path / "historic_predictions.pkl")
         self.historic_predictions_folder = Path(self.full_path / "historic_predictions")
-        self.historic_predictions_bkp_folder = Path(
-            self.full_path / "historic_predictions_backup")
+        self.historic_predictions_bkp_folder = Path(self.full_path / "historic_predictions_backup")
         self.pair_dictionary_path = Path(self.full_path / "pair_dictionary.json")
         self.global_metadata_path = Path(self.full_path / "global_metadata.json")
         self.metric_tracker_path = Path(self.full_path / "metric_tracker.json")


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

The goal of this PR is to alleviate saving/loading performance issues for expanding historic_predictions.pkl files on extended FreqAI dry runs. 

As this dataframe is growing indefinitely for the duration of a single `identifier`, it is clear that any active post processing will begin suffering more and more due to pkl loading performance slowdowns. By using Parquet to store this dataframe, we speed up saving time as well, which will reduce computational loads - saving cycles for more important components such as training/inference. 

We already have a large number of users who are running their own dry runs with a valuable `historic_predictions.pkl` growing in size. This PR *also* converts their pkl to a parquet without them having to do any additional work.


