### PR TITLE
Add additional data normalization methods to freqai module, including…

### DIFF
--- a/config_examples/config_freqai.example.json
+++ b/config_examples/config_freqai.example.json
@@ -73,7 +73,8 @@
                 10,
                 20
             ],
-            "plot_feature_importances": 0
+            "plot_feature_importances": 0,
+            "data_normalization": "legacy"
         },
         "data_split_parameters": {
             "test_size": 0.33,

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -112,7 +112,7 @@ class FreqaiDataKitchen:
         self.unique_class_list: list = []
         self.backtest_live_models_data: Dict[str, Any] = {}
         self.normalizer: Normalization = normalization_factory(config, self.data, self.pkl_data,
-                                                self.unique_class_list)
+                                                               self.unique_class_list)
 
     def set_paths(
         self,

--- a/freqtrade/freqai/normalization.py
+++ b/freqtrade/freqai/normalization.py
@@ -1,0 +1,272 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, TypeVar
+
+import pandas as pd
+from pandas import DataFrame
+from sklearn.preprocessing import MinMaxScaler, QuantileTransformer, StandardScaler
+
+from freqtrade.constants import Config
+from freqtrade.exceptions import OperationalException
+
+
+TransformerType = TypeVar('TransformerType', MinMaxScaler, StandardScaler, QuantileTransformer)
+
+
+def normalization_factory(
+            config: Config,
+            meta_data: Dict[str, Any],
+            pickle_meta_data: Dict[str, Any],
+            unique_class_list: list
+    ):
+        freqai_config: Dict[str, Any] = config["freqai"]
+        norm_config_id = freqai_config["feature_parameters"].get("data_normalization", "legacy")
+        if norm_config_id.lower() == "legacy":
+            return LegacyNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+        elif norm_config_id.lower() == "standard":
+            return StandardNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+        elif norm_config_id.lower() == "minmax":
+            return MinMaxNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+        elif norm_config_id.lower() == "quantile":
+            return QuantileNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+        else:
+            raise OperationalException(f"Invalid data normalization identifier '{norm_config_id}'")
+
+
+class Normalization(ABC):
+    def __init__(
+        self,
+            config: Config,
+            meta_data: Dict[str, Any],
+            pickle_meta_data: Dict[str, Any],
+            unique_class_list: list
+    ):
+        self.freqai_config: Dict[str, Any] = config["freqai"]
+        self.data: Dict[str, Any] = meta_data
+        self.pkl_data: Dict[str, Any] = pickle_meta_data
+        self.unique_class_list: list = unique_class_list
+
+    @abstractmethod
+    def normalize_data(self, data_dictionary: Dict) -> Dict[Any, Any]:
+        """"""
+
+    @abstractmethod
+    def normalize_single_dataframe(self, df: DataFrame) -> DataFrame:
+        """"""
+
+    @abstractmethod
+    def normalize_data_from_metadata(self, df: DataFrame) -> DataFrame:
+        """"""
+
+    @abstractmethod
+    def denormalize_labels_from_metadata(self, df: DataFrame) -> DataFrame:
+        """"""
+
+
+class LegacyNormalization(Normalization):
+    def normalize_data(self, data_dictionary: Dict) -> Dict[Any, Any]:
+        """
+        Normalize all data in the data_dictionary according to the training dataset
+        :param data_dictionary: dictionary containing the cleaned and
+                                split training/test data/labels
+        :returns:
+        :data_dictionary: updated dictionary with standardized values.
+        """
+
+        # standardize the data by training stats
+        train_max = data_dictionary["train_features"].max()
+        train_min = data_dictionary["train_features"].min()
+        data_dictionary["train_features"] = (
+            2 * (data_dictionary["train_features"] - train_min) / (train_max - train_min) - 1
+        )
+        data_dictionary["test_features"] = (
+            2 * (data_dictionary["test_features"] - train_min) / (train_max - train_min) - 1
+        )
+
+        for item in train_max.keys():
+            self.data[item + "_max"] = train_max[item]
+            self.data[item + "_min"] = train_min[item]
+
+        for item in data_dictionary["train_labels"].keys():
+            if data_dictionary["train_labels"][item].dtype == object:
+                continue
+            train_labels_max = data_dictionary["train_labels"][item].max()
+            train_labels_min = data_dictionary["train_labels"][item].min()
+            data_dictionary["train_labels"][item] = (
+                2
+                * (data_dictionary["train_labels"][item] - train_labels_min)
+                / (train_labels_max - train_labels_min)
+                - 1
+            )
+            if self.freqai_config.get('data_split_parameters', {}).get('test_size', 0.1) != 0:
+                data_dictionary["test_labels"][item] = (
+                    2
+                    * (data_dictionary["test_labels"][item] - train_labels_min)
+                    / (train_labels_max - train_labels_min)
+                    - 1
+                )
+
+            self.data[f"{item}_max"] = train_labels_max
+            self.data[f"{item}_min"] = train_labels_min
+        return data_dictionary
+
+    def normalize_single_dataframe(self, df: DataFrame) -> DataFrame:
+
+        train_max = df.max()
+        train_min = df.min()
+        df = (
+            2 * (df - train_min) / (train_max - train_min) - 1
+        )
+
+        for item in train_max.keys():
+            self.data[item + "_max"] = train_max[item]
+            self.data[item + "_min"] = train_min[item]
+
+        return df
+
+    def normalize_data_from_metadata(self, df: DataFrame) -> DataFrame:
+        """
+        Normalize a set of data using the mean and standard deviation from
+        the associated training data.
+        :param df: Dataframe to be standardized
+        """
+
+        train_max = [None] * len(df.keys())
+        train_min = [None] * len(df.keys())
+
+        for i, item in enumerate(df.keys()):
+            train_max[i] = self.data[f"{item}_max"]
+            train_min[i] = self.data[f"{item}_min"]
+
+        train_max_series = pd.Series(train_max, index=df.keys())
+        train_min_series = pd.Series(train_min, index=df.keys())
+
+        df = (
+            2 * (df - train_min_series) / (train_max_series - train_min_series) - 1
+        )
+
+        return df
+
+    def denormalize_labels_from_metadata(self, df: DataFrame) -> DataFrame:
+        """
+        Denormalize a set of data using the mean and standard deviation from
+        the associated training data.
+        :param df: Dataframe of predictions to be denormalized
+        """
+
+        for label in df.columns:
+            if df[label].dtype == object or label in self.unique_class_list:
+                continue
+            df[label] = (
+                (df[label] + 1)
+                * (self.data[f"{label}_max"] - self.data[f"{label}_min"])
+                / 2
+            ) + self.data[f"{label}_min"]
+
+        return df
+
+
+class SKLearnNormalization(Normalization):
+    def __init__(self,
+                 config: Config,
+                 meta_data: Dict[str, Any],
+                 pickle_meta_data: Dict[str, Any],
+                 unique_class_list: list,
+                 transformer: TransformerType):
+        super().__init__(config, meta_data, pickle_meta_data, unique_class_list)
+        self.transformer = transformer
+
+    def normalize_data(self, data_dictionary: Dict) -> Dict[Any, Any]:
+        """
+        Normalize all data in the data_dictionary according to the training dataset
+        :param data_dictionary: dictionary containing the cleaned and
+                                split training/test data/labels
+        :returns:
+        :data_dictionary: updated dictionary with standardized values.
+        """
+
+        # standardize the data by training stats
+        for column in data_dictionary["train_features"].columns:
+            scaler = self.transformer()
+            data_dictionary["train_features"][column] = \
+                scaler.fit_transform(data_dictionary["train_features"][[column]])
+            data_dictionary["test_features"][column] = \
+                scaler.transform(data_dictionary["test_features"][[column]])
+            self.pkl_data[column + "_scaler"] = scaler
+
+        for column in data_dictionary["train_labels"].columns:
+            if data_dictionary["train_labels"][column].dtype == object:
+                continue
+            scaler = self.transformer()
+            data_dictionary["train_labels"][column] = \
+                scaler.fit_transform(data_dictionary["train_labels"][[column]])
+
+            if self.freqai_config.get('data_split_parameters', {}).get('test_size', 0.1) != 0:
+                data_dictionary["test_labels"][column] = \
+                    scaler.transform(data_dictionary["test_labels"][[column]])
+
+            self.pkl_data[column + "_scaler"] = scaler
+        return data_dictionary
+
+    def normalize_single_dataframe(self, df: DataFrame) -> DataFrame:
+        for column in df.columns:
+            scaler = self.transformer()
+            df[column] = scaler.fit_transform(df[[column]])
+            self.pkl_data[column + "_scaler"] = scaler
+
+        return df
+
+    def normalize_data_from_metadata(self, df: DataFrame) -> DataFrame:
+        """
+        Normalize a set of data using the mean and standard deviation from
+        the associated training data.
+        :param df: Dataframe to be standardized
+        """
+
+        for column in df.columns:
+            df[column] = self.pkl_data[column + "_scaler"].transform(df[[column]])
+
+        return df
+
+    def denormalize_labels_from_metadata(self, df: DataFrame) -> DataFrame:
+        """
+        Denormalize a set of data using the mean and standard deviation from
+        the associated training data.
+        :param df: Dataframe of predictions to be denormalized
+        """
+
+        for column in df.columns:
+            if df[column].dtype == object or column in self.unique_class_list:
+                continue
+            df[column] = self.pkl_data[column + "_scaler"].inverse_transform(df[[column]])
+
+        return df
+
+
+class StandardNormalization(SKLearnNormalization):
+    def __init__(self,
+                 config: Config,
+                 meta_data: Dict[str, Any],
+                 pickle_meta_data: Dict[str, Any],
+                 unique_class_list: list):
+        super().__init__(config, meta_data, pickle_meta_data, unique_class_list, StandardScaler)
+
+
+class MinMaxNormalization(SKLearnNormalization):
+    def __init__(self,
+                 config: Config,
+                 meta_data: Dict[str, Any],
+                 pickle_meta_data: Dict[str, Any],
+                 unique_class_list: list):
+        super().__init__(config, meta_data, pickle_meta_data, unique_class_list, MinMaxScaler)
+
+
+class QuantileNormalization(SKLearnNormalization):
+    def __init__(self,
+                 config: Config,
+                 meta_data: Dict[str, Any],
+                 pickle_meta_data: Dict[str, Any],
+                 unique_class_list: list):
+        super().__init__(config, meta_data, pickle_meta_data, unique_class_list,
+                         QuantileTransformer)
+
+

--- a/freqtrade/freqai/normalization.py
+++ b/freqtrade/freqai/normalization.py
@@ -16,20 +16,19 @@ def normalization_factory(
             config: Config,
             meta_data: Dict[str, Any],
             pickle_meta_data: Dict[str, Any],
-            unique_class_list: list
-    ):
-        freqai_config: Dict[str, Any] = config["freqai"]
-        norm_config_id = freqai_config["feature_parameters"].get("data_normalization", "legacy")
-        if norm_config_id.lower() == "legacy":
-            return LegacyNormalization(config, meta_data, pickle_meta_data, unique_class_list)
-        elif norm_config_id.lower() == "standard":
-            return StandardNormalization(config, meta_data, pickle_meta_data, unique_class_list)
-        elif norm_config_id.lower() == "minmax":
-            return MinMaxNormalization(config, meta_data, pickle_meta_data, unique_class_list)
-        elif norm_config_id.lower() == "quantile":
-            return QuantileNormalization(config, meta_data, pickle_meta_data, unique_class_list)
-        else:
-            raise OperationalException(f"Invalid data normalization identifier '{norm_config_id}'")
+            unique_class_list: list):
+    freqai_config: Dict[str, Any] = config["freqai"]
+    norm_config_id = freqai_config["feature_parameters"].get("data_normalization", "legacy")
+    if norm_config_id.lower() == "legacy":
+        return LegacyNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+    elif norm_config_id.lower() == "standard":
+        return StandardNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+    elif norm_config_id.lower() == "minmax":
+        return MinMaxNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+    elif norm_config_id.lower() == "quantile":
+        return QuantileNormalization(config, meta_data, pickle_meta_data, unique_class_list)
+    else:
+        raise OperationalException(f"Invalid data normalization identifier '{norm_config_id}'")
 
 
 class Normalization(ABC):
@@ -268,5 +267,3 @@ class QuantileNormalization(SKLearnNormalization):
                  unique_class_list: list):
         super().__init__(config, meta_data, pickle_meta_data, unique_class_list,
                          QuantileTransformer)
-
-

--- a/tests/freqai/conftest.py
+++ b/tests/freqai/conftest.py
@@ -142,7 +142,7 @@ def make_unfiltered_dataframe(mocker, freqai_conf):
     return freqai, unfiltered_dataframe
 
 
-def make_data_dictionary(mocker, freqai_conf):
+def make_data_dictionary(mocker, freqai_conf, normalized=True):
     freqai_conf.update({"timerange": "20180110-20180130"})
 
     strategy = get_patched_freqai_strategy(mocker, freqai_conf)
@@ -181,7 +181,8 @@ def make_data_dictionary(mocker, freqai_conf):
 
     data_dictionary = freqai.dk.make_train_test_datasets(features_filtered, labels_filtered)
 
-    data_dictionary = freqai.dk.normalize_data(data_dictionary)
+    if normalized:
+        data_dictionary = freqai.dk.normalize_data(data_dictionary)
 
     return freqai
 

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -125,14 +125,6 @@ def test_principal_component_analysis(mocker, freqai_conf, caplog):
     )
 
 
-def test_normalize_data(mocker, freqai_conf):
-    freqai = make_data_dictionary(mocker, freqai_conf)
-    data_dict = freqai.dk.data_dictionary
-    freqai.dk.normalize_data(data_dict)
-    assert any('_max' in entry for entry in freqai.dk.data.keys())
-    assert any('_min' in entry for entry in freqai.dk.data.keys())
-
-
 def test_filter_features(mocker, freqai_conf):
     freqai, unfiltered_dataframe = make_unfiltered_dataframe(mocker, freqai_conf)
     freqai.dk.find_features(unfiltered_dataframe)

--- a/tests/freqai/test_normalization.py
+++ b/tests/freqai/test_normalization.py
@@ -1,0 +1,107 @@
+import pytest
+
+from freqtrade.exceptions import OperationalException
+from freqtrade.freqai.normalization import (LegacyNormalization, MinMaxNormalization,
+                                            QuantileNormalization, StandardNormalization)
+from tests.freqai.conftest import make_data_dictionary
+
+
+def test_default_normalization_is_legacy(mocker, freqai_conf):
+    freqai_1st = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict_1st = freqai_1st.dk.data_dictionary
+    freqai_1st.dk.normalize_data(data_dict_1st)
+
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "legacy"
+    freqai_2nd = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict_2nd = freqai_2nd.dk.data_dictionary
+
+    assert not freqai_1st.dk.data_dictionary['train_features'].equals(
+        freqai_2nd.dk.data_dictionary['train_features']), "raw data is equal to normalized data"
+
+    freqai_2nd.dk.normalize_data(data_dict_2nd)
+
+    assert freqai_1st.dk.data_dictionary['train_features'].equals(
+        freqai_2nd.dk.data_dictionary['train_features']), \
+        "explicit\\implicit legacy normalization mismatch"
+
+
+def test_legacy_normalization_add_max_min_columns(mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "legacy"
+    freqai = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict = freqai.dk.data_dictionary
+    freqai.dk.normalize_data(data_dict)
+
+    assert any('_max' in entry for entry in freqai.dk.data.keys())
+    assert any('_min' in entry for entry in freqai.dk.data.keys())
+
+
+def test_standard_normalization_dont_add_max_min_columns(mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "standard"
+    freqai = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict = freqai.dk.data_dictionary
+    freqai.dk.normalize_data(data_dict)
+    assert all(not entry.endswith('_max') for entry in freqai.dk.data.keys())
+    assert all(not entry.endswith('_min') for entry in freqai.dk.data.keys())
+
+
+def test_legacy_and_standard_normalization_difference(mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "legacy"
+    freqai_1st = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict_1st = freqai_1st.dk.data_dictionary
+    freqai_1st.dk.normalize_data(data_dict_1st)
+
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "standard"
+    freqai_2nd = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict_2nd = freqai_2nd.dk.data_dictionary
+    freqai_2nd.dk.normalize_data(data_dict_2nd)
+
+    assert not freqai_1st.dk.data_dictionary['train_features'].equals(
+        freqai_2nd.dk.data_dictionary['train_features']), \
+        "legacy and standard normalization produce same features"
+
+
+@pytest.mark.parametrize(
+    "config_id, norm_class",
+    [
+        ("legacy", LegacyNormalization),
+        ("standard", StandardNormalization),
+        ("minmax", MinMaxNormalization),
+        ("quantile", QuantileNormalization),
+    ],
+)
+def test_normalization_class(config_id, norm_class, mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = config_id
+    freqai = make_data_dictionary(mocker, freqai_conf)
+    assert type(freqai.dk.normalizer) == norm_class
+
+
+def test_assertion_invalid_normalization_id(mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = "not_a_norm_id"
+    try:
+        make_data_dictionary(mocker, freqai_conf)
+        assert False, "missing expected normalization factory exception"
+    except OperationalException as e_info:
+        assert str(e_info).startswith("Invalid data normalization identifier"), \
+            "unexpected exception string"
+
+@pytest.mark.parametrize(
+    "config_id",
+    [
+        "legacy",
+        "standard",
+        "minmax",
+        "quantile",
+    ],
+)
+def test_denormalization(config_id, mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_parameters"]["data_normalization"] = config_id
+    freqai_1st = make_data_dictionary(mocker, freqai_conf)
+    data_dict_1st = freqai_1st.dk.data_dictionary
+
+    freqai_2nd = make_data_dictionary(mocker, freqai_conf, normalized=False)
+    data_dict_2nd = freqai_2nd.dk.data_dictionary
+
+    denorm_labels = freqai_1st.dk.denormalize_labels_from_metadata(
+        data_dict_1st["train_labels"]).round(9)
+    assert denorm_labels.equals(data_dict_2nd['train_labels'].round(9)), \
+        "raw labels data isn't the same as denormalized labels"

--- a/tests/freqai/test_normalization.py
+++ b/tests/freqai/test_normalization.py
@@ -84,6 +84,7 @@ def test_assertion_invalid_normalization_id(mocker, freqai_conf):
         assert str(e_info).startswith("Invalid data normalization identifier"), \
             "unexpected exception string"
 
+
 @pytest.mark.parametrize(
     "config_id",
     [

--- a/tests/freqai/test_normalization.py
+++ b/tests/freqai/test_normalization.py
@@ -33,6 +33,7 @@ def test_legacy_normalization_add_max_min_columns(mocker, freqai_conf):
 
     assert any('_max' in entry for entry in freqai.dk.data.keys())
     assert any('_min' in entry for entry in freqai.dk.data.keys())
+    assert all(not entry.endswith('_scaler') for entry in freqai.dk.pkl_data.keys())
 
 
 def test_standard_normalization_dont_add_max_min_columns(mocker, freqai_conf):
@@ -42,6 +43,7 @@ def test_standard_normalization_dont_add_max_min_columns(mocker, freqai_conf):
     freqai.dk.normalize_data(data_dict)
     assert all(not entry.endswith('_max') for entry in freqai.dk.data.keys())
     assert all(not entry.endswith('_min') for entry in freqai.dk.data.keys())
+    assert any(entry.endswith('_scaler') for entry in freqai.dk.pkl_data.keys())
 
 
 def test_legacy_and_standard_normalization_difference(mocker, freqai_conf):


### PR DESCRIPTION
… StandardScaler, MinMaxScaler, and QuantileTransformer. Add support for pickle metadata, normalization_factory, and unit tests.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This pull request adds additional data normalization methods to the freqai module in the freqtrade project. Specifically, it adds a "data_normalization" configuration option with a default value of "legacy" representing the current normalization method. It also adds three additional normalization methods based on the sklearn library: "standard" using the StandardScaler, "minmax" using the MinMaxScaler, and "quantile" using the QuantileTransformer. Support for pickle metadata has also been added for using sklearn native objects that do not currently support json.dump. Lastly, a normalization_factory has been added to produce the normalization object used by the data_kitchen for all relevant normalization operations, and the new normalization config and logic has been unit tested.


## What's new?

- Added "data_normalization" configuration option with default value of "legacy".
- Added three additional normalization methods: "standard" using StandardScaler, "minmax" using MinMaxScaler, and "quantile" using QuantileTransformer.
- Added support for pickle metadata in addition to the json metadata currently used.
- Added normalization_factory to produce the normalization object used by the data_kitchen for all relevant normalization operations.
- Unit tested the new normalization config and logic.
