### PR TITLE
make trade_type value more explicit, add profit to trade_history dict

### DIFF
--- a/freqtrade/freqai/RL/Base3ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base3ActionRLEnv.py
@@ -66,7 +66,7 @@ class Base3ActionRLEnv(BaseEnvironment):
             elif action == Actions.Sell.value and not self.can_short:
                 self._update_total_profit()
                 self._position = Positions.Neutral
-                trade_type = "neutral"
+                trade_type = "exit"
                 self._last_trade_tick = None
             else:
                 print("case not defined")
@@ -74,7 +74,7 @@ class Base3ActionRLEnv(BaseEnvironment):
             if trade_type is not None:
                 self.trade_history.append(
                     {'price': self.current_price(), 'index': self._current_tick,
-                     'type': trade_type})
+                     'type': trade_type, 'profit': self.get_unrealized_profit()})
 
         if (self._total_profit < self.max_drawdown or
                 self._total_unrealized_profit < self.max_drawdown):

--- a/freqtrade/freqai/RL/Base4ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base4ActionRLEnv.py
@@ -52,16 +52,6 @@ class Base4ActionRLEnv(BaseEnvironment):
 
         trade_type = None
         if self.is_tradesignal(action):
-            """
-            Action: Neutral, position: Long ->  Close Long
-            Action: Neutral, position: Short -> Close Short
-
-            Action: Long, position: Neutral -> Open Long
-            Action: Long, position: Short -> Close Short and Open Long
-
-            Action: Short, position: Neutral -> Open Short
-            Action: Short, position: Long -> Close Long and Open Short
-            """
 
             if action == Actions.Neutral.value:
                 self._position = Positions.Neutral
@@ -69,16 +59,16 @@ class Base4ActionRLEnv(BaseEnvironment):
                 self._last_trade_tick = None
             elif action == Actions.Long_enter.value:
                 self._position = Positions.Long
-                trade_type = "long"
+                trade_type = "enter_long"
                 self._last_trade_tick = self._current_tick
             elif action == Actions.Short_enter.value:
                 self._position = Positions.Short
-                trade_type = "short"
+                trade_type = "enter_short"
                 self._last_trade_tick = self._current_tick
             elif action == Actions.Exit.value:
                 self._update_total_profit()
                 self._position = Positions.Neutral
-                trade_type = "neutral"
+                trade_type = "exit"
                 self._last_trade_tick = None
             else:
                 print("case not defined")
@@ -86,7 +76,7 @@ class Base4ActionRLEnv(BaseEnvironment):
             if trade_type is not None:
                 self.trade_history.append(
                     {'price': self.current_price(), 'index': self._current_tick,
-                     'type': trade_type})
+                     'type': trade_type, 'profit': self.get_unrealized_profit()})
 
         if (self._total_profit < self.max_drawdown or
                 self._total_unrealized_profit < self.max_drawdown):

--- a/freqtrade/freqai/RL/Base5ActionRLEnv.py
+++ b/freqtrade/freqai/RL/Base5ActionRLEnv.py
@@ -53,16 +53,6 @@ class Base5ActionRLEnv(BaseEnvironment):
 
         trade_type = None
         if self.is_tradesignal(action):
-            """
-            Action: Neutral, position: Long ->  Close Long
-            Action: Neutral, position: Short -> Close Short
-
-            Action: Long, position: Neutral -> Open Long
-            Action: Long, position: Short -> Close Short and Open Long
-
-            Action: Short, position: Neutral -> Open Short
-            Action: Short, position: Long -> Close Long and Open Short
-            """
 
             if action == Actions.Neutral.value:
                 self._position = Positions.Neutral
@@ -70,21 +60,21 @@ class Base5ActionRLEnv(BaseEnvironment):
                 self._last_trade_tick = None
             elif action == Actions.Long_enter.value:
                 self._position = Positions.Long
-                trade_type = "long"
+                trade_type = "enter_long"
                 self._last_trade_tick = self._current_tick
             elif action == Actions.Short_enter.value:
                 self._position = Positions.Short
-                trade_type = "short"
+                trade_type = "enter_short"
                 self._last_trade_tick = self._current_tick
             elif action == Actions.Long_exit.value:
                 self._update_total_profit()
                 self._position = Positions.Neutral
-                trade_type = "neutral"
+                trade_type = "exit_long"
                 self._last_trade_tick = None
             elif action == Actions.Short_exit.value:
                 self._update_total_profit()
                 self._position = Positions.Neutral
-                trade_type = "neutral"
+                trade_type = "exit_short"
                 self._last_trade_tick = None
             else:
                 print("case not defined")
@@ -92,7 +82,7 @@ class Base5ActionRLEnv(BaseEnvironment):
             if trade_type is not None:
                 self.trade_history.append(
                     {'price': self.current_price(), 'index': self._current_tick,
-                     'type': trade_type})
+                     'type': trade_type, 'profit': self.get_unrealized_profit()})
 
         if (self._total_profit < self.max_drawdown or
                 self._total_unrealized_profit < self.max_drawdown):


### PR DESCRIPTION
The goal of this PR is to add useful information to the reinforcement learning environment `self.trade_history` list. This list is refreshed for each episode, so it can be used inside the `calculate_reward()` function to evaluate all the trades that were made during any particular episode. 

We also remove docstrings in favor of people reading code. These kinds of docstrings are outdated quickly (as we saw), and I prefer not to maintain them. 
