### PR TITLE
Update freqai-feature-engineering.md

### DIFF
--- a/docs/freqai-feature-engineering.md
+++ b/docs/freqai-feature-engineering.md
@@ -182,7 +182,7 @@ In total, the number of features the user of the presented example strat has cre
  $= 3 * 3 * 3 * 2 * 2 = 108$.
 
 
- ### Gain finer control over `feature_engineering_*` functions with `metadata`
+### Gain finer control over `feature_engineering_*` functions with `metadata`
 
  All `feature_engineering_*` and `set_freqai_targets()` functions are passed a `metadata` dictionary which contains information about the `pair`, `tf` (timeframe), and `period` that FreqAI is automating for feature building. As such, a user can use `metadata` inside `feature_engineering_*` functions as criteria for blocking/reserving features for certain timeframes, periods, pairs etc.
 

--- a/docs/freqai-feature-engineering.md
+++ b/docs/freqai-feature-engineering.md
@@ -186,7 +186,7 @@ In total, the number of features the user of the presented example strat has cre
 
  All `feature_engineering_*` and `set_freqai_targets()` functions are passed a `metadata` dictionary which contains information about the `pair`, `tf` (timeframe), and `period` that FreqAI is automating for feature building. As such, a user can use `metadata` inside `feature_engineering_*` functions as criteria for blocking/reserving features for certain timeframes, periods, pairs etc.
 
- ```py
+ ```python
 def feature_engineering_expand_all(self, dataframe, period, metadata, **kwargs):
  if metadata["tf"] == "1h":
     dataframe["%-roc-period"] = ta.ROC(dataframe, timeperiod=period)


### PR DESCRIPTION
The `metadata` section of `freqai-feature-engineering.md` had a misplaced whitespace in front of the title. 

This PR removes the whitespace.
