### PR TITLE
Remotepairlist - fix continous fetching every x bot_loop seconds

### DIFF
--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -142,9 +142,9 @@ class RemotePairList(IPairList):
         """
 
         if self._init_done:
-            if self._pair_cache.get('pairlist') != [None]:
-                pairlist = self._pair_cache.get('pairlist')
-            else:
+            pairlist = self._pair_cache.get('pairlist')
+            if pairlist == [None]:
+                # Valid but empty pairlist.
                 return []
         else:
             pairlist = []
@@ -187,6 +187,7 @@ class RemotePairList(IPairList):
         if pairlist:
             self._pair_cache['pairlist'] = pairlist.copy()
         else:
+            # If pairlist is empty, set a dummy value to avoid fetching again
             self._pair_cache['pairlist'] = [None]
 
         if time_elapsed != 0.0:

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -142,10 +142,10 @@ class RemotePairList(IPairList):
         """
 
         if self._init_done:
-            if self._pair_cache.get('pairlist') == ["Empty"]:
-                return []
-            else:
+            if self._pair_cache.get('pairlist') != [None]:
                 pairlist = self._pair_cache.get('pairlist')
+            else:
+                return []
         else:
             pairlist = []
 
@@ -187,7 +187,7 @@ class RemotePairList(IPairList):
         if pairlist:
             self._pair_cache['pairlist'] = pairlist.copy()
         else:
-            self._pair_cache['pairlist'] = ["Empty"]
+            self._pair_cache['pairlist'] = [None]
 
         if time_elapsed != 0.0:
             self.log_once(f'Pairlist Fetched in {time_elapsed} seconds.', logger.info)

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -142,7 +142,10 @@ class RemotePairList(IPairList):
         """
 
         if self._init_done:
-            pairlist = self._pair_cache.get('pairlist')
+            if self._pair_cache.get('pairlist') == ["Empty"]:
+                return []
+            else:
+                pairlist = self._pair_cache.get('pairlist')
         else:
             pairlist = []
 
@@ -181,7 +184,10 @@ class RemotePairList(IPairList):
         pairlist = self._whitelist_for_active_markets(pairlist)
         pairlist = pairlist[:self._number_pairs]
 
-        self._pair_cache['pairlist'] = pairlist.copy()
+        if pairlist:
+            self._pair_cache['pairlist'] = pairlist.copy()
+        else:
+            self._pair_cache['pairlist'] = ["Empty"]
 
         if time_elapsed != 0.0:
             self.log_once(f'Pairlist Fetched in {time_elapsed} seconds.', logger.info)


### PR DESCRIPTION
## Summary
When an empty pairlist is returned from remote pairlist will fetch the pairlist every bot_loop_seconds due to empty cache.

## What's new?
Store a dummy value in cache, to adhere to the refresh_period