### PR TITLE
Telegram. Fixed the blacklist removal message

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1413,12 +1413,12 @@ class Telegram(RPCHandler):
         Handler for /blacklist
         Shows the currently active blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args))
+        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args), ['adding', 'to'])
 
-    def send_blacklist_msg(self, blacklist: Dict):
+    def send_blacklist_msg(self, blacklist: Dict, action):
         errmsgs = []
         for pair, error in blacklist['errors'].items():
-            errmsgs.append(f"Error adding `{pair}` to blacklist: `{error['error_msg']}`")
+            errmsgs.append(f"Error {action[0]} `{pair}` {action[1]} blacklist: `{error['error_msg']}`")
         if errmsgs:
             self._send_msg('\n'.join(errmsgs))
 
@@ -1434,7 +1434,7 @@ class Telegram(RPCHandler):
         Handler for /bl_delete
         Deletes pair(s) from current blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []))
+        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []), ['deleting', 'from'])
 
     @authorized_only
     def _logs(self, update: Update, context: CallbackContext) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1413,12 +1413,13 @@ class Telegram(RPCHandler):
         Handler for /blacklist
         Shows the currently active blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args), ['adding', 'to'])
+        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args), 1)
 
-    def send_blacklist_msg(self, blacklist: Dict, action):
+    def send_blacklist_msg(self, blacklist: Dict, des):
         errmsgs = []
+        act = ['adding', 'to'] if des == 1 else ['deleting', 'from']
         for pair, error in blacklist['errors'].items():
-            errmsgs.append(f"Error {action[0]} `{pair}` {action[1]} blacklist: `{error['error_msg']}`")
+            errmsgs.append(f"Error {act[0]} `{pair}` {act[1]} blacklist: `{error['error_msg']}`")
         if errmsgs:
             self._send_msg('\n'.join(errmsgs))
 
@@ -1434,7 +1435,7 @@ class Telegram(RPCHandler):
         Handler for /bl_delete
         Deletes pair(s) from current blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []), ['deleting', 'from'])
+        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []), 0)
 
     @authorized_only
     def _logs(self, update: Update, context: CallbackContext) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1413,13 +1413,12 @@ class Telegram(RPCHandler):
         Handler for /blacklist
         Shows the currently active blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args), 1)
+        self.send_blacklist_msg(self._rpc._rpc_blacklist(context.args))
 
-    def send_blacklist_msg(self, blacklist: Dict, des):
+    def send_blacklist_msg(self, blacklist: Dict):
         errmsgs = []
-        act = ['adding', 'to'] if des == 1 else ['deleting', 'from']
         for pair, error in blacklist['errors'].items():
-            errmsgs.append(f"Error {act[0]} `{pair}` {act[1]} blacklist: `{error['error_msg']}`")
+            errmsgs.append(f"Error: {error['error_msg']}")
         if errmsgs:
             self._send_msg('\n'.join(errmsgs))
 
@@ -1435,7 +1434,7 @@ class Telegram(RPCHandler):
         Handler for /bl_delete
         Deletes pair(s) from current blacklist
         """
-        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []), 0)
+        self.send_blacklist_msg(self._rpc._rpc_blacklist_delete(context.args or []))
 
     @authorized_only
     def _logs(self, update: Update, context: CallbackContext) -> None:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->
There is an issue with an error message when removing a pair from the blacklist that is not on the blacklist. Example below:

```
/bl_delete BTC/*

Error adding BTC/* to blacklist: Pair BTC/* is not in the current blacklist.

Blacklist contains 1 pairs
BTC/USDT

```

## Quick changelog

- `action` argument added to the `send_blacklist_msg()` function

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->

The necessary strings have been added to get the correct answer in the telegram. Now answer looks like:
`Error deleting BTC/* from blacklist: Pair BTC/* is not in the current blacklist.`
