### PR TITLE
Implement blocklist for failed leverage #8515

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2374,6 +2374,8 @@ class Exchange:
                 symbols = []
 
                 for symbol, market in markets.items():
+                    if symbol in self._config['exchange'].get('leverage_blocklist', []):
+                        continue                    
                     if (self.market_is_future(market)
                             and market['quote'] == self._config['stake_currency']):
                         symbols.append(symbol)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #8515

## Quick changelog

- Add a check for failed leverage symbols in exchange config

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
In this PR I try to overcome the bug I reported earlier, when running a strategy on OKX futures, which tries to load an incorrect symbol. This fixed the problem for me, but I don't know if it is the best way to do it. If there are any suggestions, I would be happy to apply them in this PR.
