### PR TITLE
docs: use helper function `stoploss_from_absolute` in strategy callba…

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -352,7 +352,7 @@ class AwesomeStrategy(IStrategy):
 
         # Convert absolute price to percentage relative to current_rate
         if stoploss_price < current_rate:
-            return (stoploss_price / current_rate) - 1
+            return stoploss_from_absolute(stoploss_price, current_rate, is_short=trade.is_short))
 
         # return maximum stoploss value, keeping current stoploss price unchanged
         return 1

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -352,7 +352,7 @@ class AwesomeStrategy(IStrategy):
 
         # Convert absolute price to percentage relative to current_rate
         if stoploss_price < current_rate:
-            return stoploss_from_absolute(stoploss_price, current_rate, is_short=trade.is_short))
+            return stoploss_from_absolute(stoploss_price, current_rate, is_short=trade.is_short)
 
         # return maximum stoploss value, keeping current stoploss price unchanged
         return 1

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -318,11 +318,11 @@ class AwesomeStrategy(IStrategy):
 
         # evaluate highest to lowest, so that highest possible stop is used
         if current_profit > 0.40:
-            return stoploss_from_open(0.25, current_profit, is_short=trade.is_short, leverage=trade.leverage)
+            return stoploss_from_open(0.25, current_profit, is_short=trade.is_short)
         elif current_profit > 0.25:
-            return stoploss_from_open(0.15, current_profit, is_short=trade.is_short, leverage=trade.leverage)
+            return stoploss_from_open(0.15, current_profit, is_short=trade.is_short)
         elif current_profit > 0.20:
-            return stoploss_from_open(0.07, current_profit, is_short=trade.is_short, leverage=trade.leverage)
+            return stoploss_from_open(0.07, current_profit, is_short=trade.is_short)
 
         # return maximum stoploss value, keeping current stoploss price unchanged
         return 1

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -318,11 +318,11 @@ class AwesomeStrategy(IStrategy):
 
         # evaluate highest to lowest, so that highest possible stop is used
         if current_profit > 0.40:
-            return stoploss_from_open(0.25, current_profit, is_short=trade.is_short)
+            return stoploss_from_open(0.25, current_profit, is_short=trade.is_short, leverage=trade.leverage)
         elif current_profit > 0.25:
-            return stoploss_from_open(0.15, current_profit, is_short=trade.is_short)
+            return stoploss_from_open(0.15, current_profit, is_short=trade.is_short, leverage=trade.leverage)
         elif current_profit > 0.20:
-            return stoploss_from_open(0.07, current_profit, is_short=trade.is_short)
+            return stoploss_from_open(0.07, current_profit, is_short=trade.is_short, leverage=trade.leverage)
 
         # return maximum stoploss value, keeping current stoploss price unchanged
         return 1


### PR DESCRIPTION
…cks "absolute" example
  ## Summary

Use "official" helper function instead of "own" formula so if something changes example have higher changes to still work by using the maintained method via `stoploss_from_absolute` helper function.

`def stoploss_from_absolute()` also has a `is_short` argument, which I incorporated.

But docs say, it doesn't matter if return value is positive or negative:
>The absolute value of the return value is used (the sign is ignored), so returning 0.05 or -0.05 have the same result, a stoploss 5% below the current price.

and all that `is_short` does is this:
```py
    if is_short:
        stoploss = -stoploss
```
so maybe it's not even needed.
