### PR TITLE
Docs : Correct user namespace from `cust_` to `custom_`

### DIFF
--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -1,15 +1,15 @@
 # Advanced Strategies
 
 This page explains some advanced concepts available for strategies.
-If you're just getting started, please be familiar with the methods described in the [Strategy Customization](strategy-customization.md) documentation and with the [Freqtrade basics](bot-basics.md) first.
+If you're just getting started, please familiarize yourself with the [Freqtrade basics](bot-basics.md) and methods described in [Strategy Customization](strategy-customization.md) first.
 
-[Freqtrade basics](bot-basics.md) describes in which sequence each method described below is called, which can be helpful to understand which method to use for your custom needs.
+The call sequence of the methods described here is covered under [bot execution logic](bot-basics.md#bot-execution-logic). Those docs are also helpful in deciding which method is most suitable for your customisation needs.
 
 !!! Note
-    All callback methods described below should only be implemented in a strategy if they are actually used.
+    Callback methods should *only* be implemented if a strategy uses them.
 
 !!! Tip
-    You can get a strategy template containing all below methods by running `freqtrade new-strategy --strategy MyAwesomeStrategy --template advanced`
+    Start off with a strategy template containing all available callback methods by running `freqtrade new-strategy --strategy MyAwesomeStrategy --template advanced`
 
 ## Storing information
 

--- a/docs/strategy-advanced.md
+++ b/docs/strategy-advanced.md
@@ -15,7 +15,7 @@ If you're just getting started, please be familiar with the methods described in
 
 Storing information can be accomplished by creating a new dictionary within the strategy class.
 
-The name of the variable can be chosen at will, but should be prefixed with `cust_` to avoid naming collisions with predefined strategy variables.
+The name of the variable can be chosen at will, but should be prefixed with `custom_` to avoid naming collisions with predefined strategy variables.
 
 ```python
 class AwesomeStrategy(IStrategy):

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -43,7 +43,7 @@ class AwesomeStrategy(IStrategy):
         if self.config['runmode'].value in ('live', 'dry_run'):
             # Assign this to the class by using self.*
             # can then be used by populate_* methods
-            self.cust_remote_data = requests.get('https://some_remote_source.example.com')
+            self.custom_remote_data = requests.get('https://some_remote_source.example.com')
 
 ```
 


### PR DESCRIPTION
## Summary

Resolved small inconsistencies in the docs.

## Quick changelog

- [Correct user namespace from cust_ to custom_](https://github.com/freqtrade/freqtrade/commit/b545fc5590f03d84ba7aa5eaadba8b9aca896a70)
- [Edit Advanced Strategies intro for clarify and brevity](https://github.com/freqtrade/freqtrade/pull/8525/commits/818da02f6ca8c81a8b476d9065dba65390611603)