### PR TITLE
Remove dependency workarounds in place for gym

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Installation - *nix
       if: runner.os == 'Linux'
       run: |
-        python -m pip install --upgrade pip==23.0.1 wheel==0.38.4
+        python -m pip install --upgrade pip wheel
         export LD_LIBRARY_PATH=${HOME}/dependencies/lib:$LD_LIBRARY_PATH
         export TA_LIBRARY_PATH=${HOME}/dependencies/lib
         export TA_INCLUDE_PATH=${HOME}/dependencies/include
@@ -163,7 +163,7 @@ jobs:
         rm /usr/local/bin/python3.11-config || true
 
         brew install hdf5 c-blosc
-        python -m pip install --upgrade pip==23.0.1 wheel==0.38.4
+        python -m pip install --upgrade pip wheel
         export LD_LIBRARY_PATH=${HOME}/dependencies/lib:$LD_LIBRARY_PATH
         export TA_LIBRARY_PATH=${HOME}/dependencies/lib
         export TA_INCLUDE_PATH=${HOME}/dependencies/include
@@ -352,7 +352,7 @@ jobs:
     - name: Installation - *nix
       if: runner.os == 'Linux'
       run: |
-        python -m pip install --upgrade pip==23.0.1 wheel==0.38.4
+        python -m pip install --upgrade pip wheel
         export LD_LIBRARY_PATH=${HOME}/dependencies/lib:$LD_LIBRARY_PATH
         export TA_LIBRARY_PATH=${HOME}/dependencies/lib
         export TA_INCLUDE_PATH=${HOME}/dependencies/include

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM base as python-deps
 RUN  apt-get update \
   && apt-get -y install build-essential libssl-dev git libffi-dev libgfortran5 pkg-config cmake gcc \
   && apt-get clean \
-  && pip install --upgrade pip==23.0.1 wheel==0.38.4
+  && pip install --upgrade pip wheel
 
 # Install TA-lib
 COPY build_helpers/* /tmp/

--- a/build_helpers/install_windows.ps1
+++ b/build_helpers/install_windows.ps1
@@ -1,7 +1,7 @@
 # Downloads don't work automatically, since the URL is regenerated via javascript.
 # Downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#ta-lib
 
-python -m pip install --upgrade pip==23.0.1 wheel==0.38.4
+python -m pip install --upgrade pip wheel
 
 $pyv = python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,12 +30,6 @@ The easiest way to install and run Freqtrade is to clone the bot Github reposito
 !!! Warning "Up-to-date clock"
     The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.
 
-!!! Error "Running setup.py install for gym did not run successfully."
-    If you get an error related with gym we suggest you to downgrade setuptools it to version 65.5.0 you can do it with the following command:
-    ```bash
-    pip install setuptools==65.5.0
-    ```
-
 ------
 
 ## Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 46.4.0", "wheel"]
+requires = ["setuptools >= 64.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements-freqai-rl.txt
+++ b/requirements-freqai-rl.txt
@@ -7,7 +7,5 @@ torch==1.13.1; python_version < '3.11'
 gymnasium==0.28.1
 stable_baselines3==2.0.0a5
 sb3_contrib>=2.0.0a4
-# Gym is forced to this version by stable-baselines3.
-setuptools==65.5.1 # Should be removed when gym is fixed.
 # Progress bar for stable-baselines3 and sb3-contrib
 tqdm==4.65.0

--- a/setup.sh
+++ b/setup.sh
@@ -49,8 +49,7 @@ function updateenv() {
     source .env/bin/activate
     SYS_ARCH=$(uname -m)
     echo "pip install in-progress. Please wait..."
-    # Setuptools 65.5.0 is the last version that can install gym==0.21.0
-    ${PYTHON} -m pip install --upgrade pip==23.0.1 wheel==0.38.4 setuptools==65.5.1
+    ${PYTHON} -m pip install --upgrade pip wheel setuptools
     REQUIREMENTS_HYPEROPT=""
     REQUIREMENTS_PLOT=""
     REQUIREMENTS_FREQAI=""


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Remove workarounds we had to put in place to support the outdated gym dependency.

with #8336 merged, these should no longer be necessary (ci will tell for certain).