### PR TITLE
Bump catboost to 1.2, disable some constraints

### DIFF
--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -5,8 +5,8 @@
 # Required for freqai
 scikit-learn==1.1.3
 joblib==1.2.0
-catboost==1.1.1; platform_machine == 'darwin' and python_version < '3.9'
-catboost==1.2; 'arm' not in platform_machine and (platform_machine != 'darwin' or python_version >= '3.9')
+catboost==1.1.1; sys_platform == 'darwin' and python_version < '3.9'
+catboost==1.2; 'arm' not in platform_machine and (sys_platform != 'darwin' or python_version >= '3.9')
 lightgbm==3.3.5
 xgboost==1.7.5
 tensorboard==2.13.0

--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -6,7 +6,7 @@
 scikit-learn==1.1.3
 joblib==1.2.0
 catboost==1.1.1; platform_machine == 'darwin' and python_version < '3.9'
-catboost==1.2; 'arm' not in platform_machine
+catboost==1.2; 'arm' not in platform_machine and (platform_machine != 'darwin' or python_version >= '3.9')
 lightgbm==3.3.5
 xgboost==1.7.5
 tensorboard==2.13.0

--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -5,7 +5,7 @@
 # Required for freqai
 scikit-learn==1.1.3
 joblib==1.2.0
-catboost==1.1.1; platform_machine != 'aarch64' and 'arm' not in platform_machine and python_version < '3.11'
+catboost==1.2; 'arm' not in platform_machine
 lightgbm==3.3.5
 xgboost==1.7.5
 tensorboard==2.13.0

--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -5,6 +5,7 @@
 # Required for freqai
 scikit-learn==1.1.3
 joblib==1.2.0
+catboost==1.1.1; platform_machine == 'darwin' and python_version < '3.9'
 catboost==1.2; 'arm' not in platform_machine
 lightgbm==3.3.5
 xgboost==1.7.5

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -34,7 +34,7 @@ def is_mac() -> bool:
 
 
 def can_run_model(model: str) -> None:
-    if (is_arm() or is_py11()) and "Catboost" in model:
+    if is_arm() and "Catboost" in model:
         pytest.skip("CatBoost is not supported on ARM.")
 
     is_pytorch_model = 'Reinforcement' in model or 'PyTorch' in model


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

[Catboost 1.2](https://github.com/catboost/catboost/releases/tag/v1.2) supports python 3.11 - and provides wheels for aarch64.

Further tests will be necessary - but CI should pass now with a more complete CI picture.


Currently blocked by https://github.com/catboost/catboost/issues/2371