### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,11 @@ freqai = [
 
 freqai_rl = [
     'torch',
+    'gymnasium',
     'stable-baselines3',
-    'gym==0.21',
-    'sb3-contrib'
+    'sb3-contrib',
+    'setuptools',
+    'tqdm'
 ]
 
 hdf5 = [

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,20 @@ hdf5 = [
 develop = [
     'coveralls',
     'mypy',
+    'ruff',
+    'pre-commit',
     'pytest',
     'pytest-asyncio',
     'pytest-cov',
     'pytest-mock',
     'pytest-random-order',
+    'isort',
+    'time-machine',
+    'types-cachetools',
+    'types-filelock',
+    'types-requests',
+    'types-tabulate',
+    'types-python-dateutil'
 ]
 
 jupyter = [

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,15 @@ setup(
         'aiofiles',
         'schedule',
         'websockets',
-        'janus'
+        'janus',
+        'ast-comments',
+        'aiohttp',
+        'blosc',
+        'cryptography',
+        'httpx',
+        'python-dateutil',
+        'tables'
+
     ],
     extras_require={
         'dev': all_extra,

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ hyperopt = [
 
 freqai = [
     'scikit-learn',
+    'joblib',
     'catboost; platform_machine != "aarch64"',
     'lightgbm',
-    'xgboost'
+    'xgboost',
+    'tensorboard'
 ]
 
 freqai_rl = [


### PR DESCRIPTION
## Summary

Discrepancy between `requirements.txt` and `setup.py` broke pypi package (2023.4 at least), `pip install -e .`, `poetry add`, etc

Solve the issue: None

## Quick changelog

- Added missing dependencies from `requirements*.txt` files to `setup.py`

## What's new?

`pip install -e .` works like a charm, presumably pypi package works as well.

Hi!

I'm quite new to this project and haven't managed to fully wrap my mind around it yet so was uncertain about any constraints required for those packages and took the most straightforward approach just to add missing packages as is. 

`pip install packaging` and `pip install ast-comments` was enough to get a help message from the cli but I'm not sure if that's truly enough.

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/45842462/235599862-13fe8eb6-29e3-45aa-8155-f479f3b03524.png">

