### PR TITLE
Fix disrepancy in freqai doc code example

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -43,10 +43,10 @@ The FreqAI strategy requires including the following lines of code in the standa
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
-        # the model will return all labels created by user in `set_freqai_labels()`
+        # the model will return all labels created by user in `feature_engineering_*`
         # (& appended targets), an indication of whether or not the prediction should be accepted,
         # the target mean/std values for each of the labels created by user in
-        # `feature_engineering_*` for each training period.
+        # `set_freqai_targets()` for each training period.
 
         dataframe = self.freqai.start(dataframe, metadata, self)
 

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -43,7 +43,7 @@ The FreqAI strategy requires including the following lines of code in the standa
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
-        # the model will return all labels created by user in `feature_engineering_*`
+        # the model will return all labels created by user in `set_freqai_targets()`
         # (& appended targets), an indication of whether or not the prediction should be accepted,
         # the target mean/std values for each of the labels created by user in
         # `set_freqai_targets()` for each training period.

--- a/freqtrade/templates/FreqaiExampleStrategy.py
+++ b/freqtrade/templates/FreqaiExampleStrategy.py
@@ -229,7 +229,7 @@ class FreqaiExampleStrategy(IStrategy):
 
         # All indicators must be populated by feature_engineering_*() functions
 
-        # the model will return all labels created by user in `feature_engineering_*`
+        # the model will return all labels created by user in `set_freqai_targets()`
         # (& appended targets), an indication of whether or not the prediction should be accepted,
         # the target mean/std values for each of the labels created by user in
         # `set_freqai_targets()` for each training period.


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Now the `populate_indicators()` documentation in freqai-configuration.md is identical with FreqaiExampleStrategy.py. I don't find the `set_freqai_labels()` anywhere.