### PR TITLE
Run Torch tests on 3.11

### DIFF
--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -41,7 +41,7 @@ def can_run_model(model: str) -> None:
     if is_pytorch_model and is_mac() and not is_arm():
         pytest.skip("Reinforcement learning / PyTorch module not available on intel based Mac OS.")
 
-    if is_pytorch_model and is_py11():
+    if is_pytorch_model:
         pytest.skip("Reinforcement learning / PyTorch currently not available on python 3.11.")
 
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

With the bumped dependencies (mainly torch), we should be able to run freqAI tests on python 3.11 without problems (except for catboost for now)