### PR TITLE
Bug fix `live_retrain_hours`

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -622,9 +622,9 @@ class IFreqaiModel(ABC):
             strategy, corr_dataframes, base_dataframes, pair
         )
 
-        new_trained_timerange = dk.buffer_timerange(new_trained_timerange)
+        buffered_timerange = dk.buffer_timerange(new_trained_timerange)
 
-        unfiltered_dataframe = dk.slice_dataframe(new_trained_timerange, unfiltered_dataframe)
+        unfiltered_dataframe = dk.slice_dataframe(buffered_timerange, unfiltered_dataframe)
 
         # find the features indicated by strategy and store in datakitchen
         dk.find_features(unfiltered_dataframe)

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -622,6 +622,8 @@ class IFreqaiModel(ABC):
             strategy, corr_dataframes, base_dataframes, pair
         )
 
+        trained_timestamp = new_trained_timerange.stopts
+
         buffered_timerange = dk.buffer_timerange(new_trained_timerange)
 
         unfiltered_dataframe = dk.slice_dataframe(buffered_timerange, unfiltered_dataframe)
@@ -632,8 +634,8 @@ class IFreqaiModel(ABC):
 
         model = self.train(unfiltered_dataframe, pair, dk)
 
-        self.dd.pair_dict[pair]["trained_timestamp"] = new_trained_timerange.stopts
-        dk.set_new_model_names(pair, new_trained_timerange.stopts)
+        self.dd.pair_dict[pair]["trained_timestamp"] = trained_timestamp
+        dk.set_new_model_names(pair, trained_timestamp)
         self.dd.save_data(model, pair, dk)
 
         if self.plot_features:


### PR DESCRIPTION
The introduction of `buffer_train_data_candles` truncates the training data timerange. This `timerange.stopts` is used after training to define the training timestamp, which is compared later against the `live_retrain_hours` to decide if a new model should be trained or not. 

If the user buffered the training data, then this `timerange.stopts` was artificially pushed backwards, causing `live_retrain_hours` to improperly think that a new train should be started, even though a model was recently trained within the `live_retrain_hours` period. 

This PR fixes the problem.

Thanks @smarmau and @davedavesen for reporting and investigating.
