### PR TITLE
Add check for None prices in forceenter REST API script

### DIFF
--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -281,7 +281,7 @@ class FtRestClient():
                 "side": side,
                 }
         if price:
-            params['price'] = price
+            data['price'] = price
         return self._post("forceenter", data=data)
 
     def forceexit(self, tradeid, ordertype=None, amount=None):

--- a/scripts/rest_client.py
+++ b/scripts/rest_client.py
@@ -279,8 +279,9 @@ class FtRestClient():
         """
         data = {"pair": pair,
                 "side": side,
-                "price": price,
                 }
+        if price:
+            params['price'] = price
         return self._post("forceenter", data=data)
 
     def forceexit(self, tradeid, ordertype=None, amount=None):


### PR DESCRIPTION
Add fix for forceenter to avoid passing None prices back to the API

## Summary

To fix the problem raised in https://github.com/freqtrade/freqtrade/issues/8621

## Quick changelog

- Add check to avoid passing `price: None` to API backend
