### PR TITLE
Better secure the user's exchange keys during runtime

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -690,4 +690,6 @@ BidAsk = Literal['bid', 'ask']
 OBLiteral = Literal['asks', 'bids']
 
 Config = Dict[str, Any]
+# Exchange part of the configuration.
+ExchangeConfig = Dict[str, Any]
 IntOrInf = float

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa: F401
 # isort: off
-from freqtrade.exchange.common import remove_credentials, MAP_EXCHANGE_CHILDCLASS
+from freqtrade.exchange.common import remove_exchange_credentials, MAP_EXCHANGE_CHILDCLASS
 from freqtrade.exchange.exchange import Exchange
 # isort: on
 from freqtrade.exchange.binance import Binance

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -4,7 +4,7 @@ import time
 from functools import wraps
 from typing import Any, Callable, Optional, TypeVar, cast, overload
 
-from freqtrade.constants import Config
+from freqtrade.constants import ExchangeConfig
 from freqtrade.exceptions import DDosProtection, RetryableOrderError, TemporaryError
 from freqtrade.mixins import LoggingMixin
 
@@ -89,18 +89,18 @@ EXCHANGE_HAS_OPTIONAL = [
 ]
 
 
-def remove_credentials(config: Config) -> None:
+def remove_exchange_credentials(exchange_config: ExchangeConfig, dry_run: bool) -> None:
     """
     Removes exchange keys from the configuration and specifies dry-run
     Used for backtesting / hyperopt / edge and utils.
     Modifies the input dict!
     """
-    if config.get('dry_run', False):
-        config['exchange']['key'] = ''
-        config['exchange']['apiKey'] = ''
-        config['exchange']['secret'] = ''
-        config['exchange']['password'] = ''
-        config['exchange']['uid'] = ''
+    if dry_run:
+        exchange_config['key'] = ''
+        exchange_config['apiKey'] = ''
+        exchange_config['secret'] = ''
+        exchange_config['password'] = ''
+        exchange_config['uid'] = ''
 
 
 def calculate_backoff(retrycount, max_retries):

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -23,6 +23,7 @@ from freqtrade.exceptions import (DependencyException, ExchangeError, Insufficie
                                   InvalidOrderException, PricingError)
 from freqtrade.exchange import (ROUND_DOWN, ROUND_UP, timeframe_to_minutes, timeframe_to_next_date,
                                 timeframe_to_seconds)
+from freqtrade.exchange.common import remove_exchange_credentials
 from freqtrade.misc import safe_value_fallback, safe_value_fallback2
 from freqtrade.mixins import LoggingMixin
 from freqtrade.persistence import Order, PairLocks, Trade, init_db
@@ -64,6 +65,8 @@ class FreqtradeBot(LoggingMixin):
         # Init objects
         self.config = config
         exchange_config = deepcopy(config['exchange'])
+        # Remove credentials from original exchange config to avoid accidental credentail exposure
+        remove_exchange_credentials(config['exchange'], True)
 
         self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -63,6 +63,7 @@ class FreqtradeBot(LoggingMixin):
 
         # Init objects
         self.config = config
+        exchange_config = deepcopy(config['exchange'])
 
         self.strategy: IStrategy = StrategyResolver.load_strategy(self.config)
 
@@ -70,7 +71,7 @@ class FreqtradeBot(LoggingMixin):
         validate_config_consistency(config)
 
         self.exchange = ExchangeResolver.load_exchange(
-            self.config, load_leverage_tiers=True)
+            self.config, exchange_config=exchange_config, load_leverage_tiers=True)
 
         init_db(self.config['db_url'])
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -13,7 +13,7 @@ from schedule import Scheduler
 
 from freqtrade import constants
 from freqtrade.configuration import validate_config_consistency
-from freqtrade.constants import BuySell, Config, LongShort
+from freqtrade.constants import BuySell, Config, ExchangeConfig, LongShort
 from freqtrade.data.converter import order_book_to_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.edge import Edge
@@ -64,7 +64,7 @@ class FreqtradeBot(LoggingMixin):
 
         # Init objects
         self.config = config
-        exchange_config = deepcopy(config['exchange'])
+        exchange_config: ExchangeConfig = deepcopy(config['exchange'])
         # Remove credentials from original exchange config to avoid accidental credentail exposure
         remove_exchange_credentials(config['exchange'], True)
 

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -19,7 +19,7 @@ class ExchangeResolver(IResolver):
     object_type = Exchange
 
     @staticmethod
-    def load_exchange(config: Config, validate: bool = True,
+    def load_exchange(config: Config, *, validate: bool = True,
                       load_leverage_tiers: bool = False) -> Exchange:
         """
         Load the custom class from config parameter

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -2,6 +2,7 @@
 This module loads custom exchanges
 """
 import logging
+from typing import Any, Dict, Optional
 
 import freqtrade.exchange as exchanges
 from freqtrade.constants import Config
@@ -19,8 +20,8 @@ class ExchangeResolver(IResolver):
     object_type = Exchange
 
     @staticmethod
-    def load_exchange(config: Config, *, validate: bool = True,
-                      load_leverage_tiers: bool = False) -> Exchange:
+    def load_exchange(config: Config, *, exchange_config: Optional[Dict[str, Any]] = None,
+                      validate: bool = True, load_leverage_tiers: bool = False) -> Exchange:
         """
         Load the custom class from config parameter
         :param exchange_name: name of the Exchange to load
@@ -37,13 +38,14 @@ class ExchangeResolver(IResolver):
                 kwargs={
                     'config': config,
                     'validate': validate,
+                    'exchange_config': exchange_config,
                     'load_leverage_tiers': load_leverage_tiers}
             )
         except ImportError:
             logger.info(
                 f"No {exchange_name} specific subclass found. Using the generic class instead.")
         if not exchange:
-            exchange = Exchange(config, validate=validate)
+            exchange = Exchange(config, validate=validate, exchange_config=exchange_config,)
         return exchange
 
     @staticmethod

--- a/freqtrade/resolvers/exchange_resolver.py
+++ b/freqtrade/resolvers/exchange_resolver.py
@@ -2,10 +2,10 @@
 This module loads custom exchanges
 """
 import logging
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import freqtrade.exchange as exchanges
-from freqtrade.constants import Config
+from freqtrade.constants import Config, ExchangeConfig
 from freqtrade.exchange import MAP_EXCHANGE_CHILDCLASS, Exchange
 from freqtrade.resolvers import IResolver
 
@@ -20,7 +20,7 @@ class ExchangeResolver(IResolver):
     object_type = Exchange
 
     @staticmethod
-    def load_exchange(config: Config, *, exchange_config: Optional[Dict[str, Any]] = None,
+    def load_exchange(config: Config, *, exchange_config: Optional[ExchangeConfig] = None,
                       validate: bool = True, load_leverage_tiers: bool = False) -> Exchange:
         """
         Load the custom class from config parameter

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -11,6 +11,7 @@ from freqtrade.configuration.config_validation import validate_config_consistenc
 from freqtrade.data.btanalysis import get_backtest_resultlist, load_and_merge_backtest_result
 from freqtrade.enums import BacktestState
 from freqtrade.exceptions import DependencyException, OperationalException
+from freqtrade.exchange.common import remove_exchange_credentials
 from freqtrade.misc import deep_merge_dicts
 from freqtrade.rpc.api_server.api_schemas import (BacktestHistoryEntry, BacktestRequest,
                                                   BacktestResponse)
@@ -38,6 +39,7 @@ async def api_start_backtest(  # noqa: C901
         raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")
 
     btconfig = deepcopy(config)
+    remove_exchange_credentials(btconfig['exchange'], True)
     settings = dict(bt_settings)
     if settings.get('freqai', None) is not None:
         settings['freqai'] = dict(settings['freqai'])

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -20,7 +20,7 @@ from freqtrade.exchange import (Binance, Bittrex, Exchange, Kraken, amount_to_pr
                                 timeframe_to_minutes, timeframe_to_msecs, timeframe_to_next_date,
                                 timeframe_to_prev_date, timeframe_to_seconds)
 from freqtrade.exchange.common import (API_FETCH_ORDER_RETRY_COUNT, API_RETRY_COUNT,
-                                       calculate_backoff, remove_credentials)
+                                       calculate_backoff, remove_exchange_credentials)
 from freqtrade.exchange.exchange import amount_to_contract_precision
 from freqtrade.resolvers.exchange_resolver import ExchangeResolver
 from tests.conftest import (EXMS, generate_test_data_raw, get_mock_coro, get_patched_exchange,
@@ -137,16 +137,14 @@ def test_init(default_conf, mocker, caplog):
     assert log_has('Instance is running with dry_run enabled', caplog)
 
 
-def test_remove_credentials(default_conf, caplog) -> None:
+def test_remove_exchange_credentials(default_conf) -> None:
     conf = deepcopy(default_conf)
-    conf['dry_run'] = False
-    remove_credentials(conf)
+    remove_exchange_credentials(conf['exchange'], False)
 
     assert conf['exchange']['key'] != ''
     assert conf['exchange']['secret'] != ''
 
-    conf['dry_run'] = True
-    remove_credentials(conf)
+    remove_exchange_credentials(conf['exchange'], True)
     assert conf['exchange']['key'] == ''
     assert conf['exchange']['secret'] == ''
     assert conf['exchange']['password'] == ''

--- a/tests/test_freqtradebot.py
+++ b/tests/test_freqtradebot.py
@@ -121,7 +121,7 @@ def test_order_dict(default_conf_usdt, mocker, runmode, caplog) -> None:
 
     freqtrade = FreqtradeBot(conf)
     if runmode == RunMode.LIVE:
-        assert not log_has_re(".*stoploss_on_exchange .* dry-run", caplog)
+        assert not log_has_re(r".*stoploss_on_exchange .* dry-run", caplog)
     assert freqtrade.strategy.order_types['stoploss_on_exchange']
 
     caplog.clear()
@@ -136,7 +136,7 @@ def test_order_dict(default_conf_usdt, mocker, runmode, caplog) -> None:
     }
     freqtrade = FreqtradeBot(conf)
     assert not freqtrade.strategy.order_types['stoploss_on_exchange']
-    assert not log_has_re(".*stoploss_on_exchange .* dry-run", caplog)
+    assert not log_has_re(r".*stoploss_on_exchange .* dry-run", caplog)
 
 
 def test_get_trade_stake_amount(default_conf_usdt, mocker) -> None:


### PR DESCRIPTION
## Summary

As freqtrade becomes more popular, it's userbase has been shifting from being strategy developers, to often users who simply reuse other people's strategies they find on the internet without properly vetting these strategies.

This represents a risk to the user's exchange keys, which are currently exposed to the strategy as part of the configuration - which is an unnecessary risk, as it's an information the strategy does not need.

This PR will fix this by removing the keys from the configuration before passing it to the strategy - and will result in the keys being available only to the exchange, but no longer to other parts of freqtrade (which don't need them, anyway).

Implicitly, this will also reduce the amount of times the keys are in memory, as they're no longer in the (always existing) config dictionary.

## Quick changelog

- remove keys before pushing config to the strategy
