### PR TITLE
Update base_tensorboard.py

### DIFF
--- a/freqtrade/freqai/tensorboard/base_tensorboard.py
+++ b/freqtrade/freqai/tensorboard/base_tensorboard.py
@@ -10,8 +10,7 @@ logger = logging.getLogger(__name__)
 
 class BaseTensorboardLogger:
     def __init__(self, logdir: Path, activate: bool = True):
-        logger.warning("Tensorboard is not installed, no logs will be written."
-                       "Ensure torch is installed, or use the torch/RL docker images")
+        pass
 
     def log_scalar(self, tag: str, scalar_value: Any, step: int):
         return
@@ -23,8 +22,7 @@ class BaseTensorboardLogger:
 class BaseTensorBoardCallback(TrainingCallback):
 
     def __init__(self, logdir: Path, activate: bool = True):
-        logger.warning("Tensorboard is not installed, no logs will be written."
-                       "Ensure torch is installed, or use the torch/RL docker images")
+        pass
 
     def after_iteration(
         self, model, epoch: int, evals_log: TrainingCallback.EvalsLog


### PR DESCRIPTION
The warning messages in `base_tensorboard.py` were not correct - there are many situations where FreqAI will default to empty TensorboardLogger objects in the `get_tb_logger()` function, while still having and using Tensorboard.

The examples are the two callback examples, XGBoost and RL. They initialize their tb_loggers separately from our `get_tb_logger()`, so in these cases our `get_tb_logger()` just returns an empty object. 

In fact, the only time the `get_tb_logger()` returns a TensorboardLogger is when the user is deploying a PyTorch variant. 