### PR TITLE
allow no / empty minimal_roi

### DIFF
--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -342,15 +342,11 @@ The above configuration would therefore mean:
 
 The calculation does include fees.
 
-To disable ROI completely, set it to an insanely high number:
+To disable ROI completely, set it to an empty dictionary:
 
 ```python
-minimal_roi = {
-    "0": 100
-}
+minimal_roi = {}
 ```
-
-While technically not completely disabled, this would exit once the trade reaches 10000% Profit.
 
 To use times based on candle duration (timeframe), the following snippet can be handy.
 This will allow you to change the timeframe for the strategy, and ROI times will still be set as candles (e.g. after 3 candles ...)

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -148,7 +148,6 @@ CONF_SCHEMA = {
             'patternProperties': {
                 '^[0-9.]+$': {'type': 'number'}
             },
-            'minProperties': 1
         },
         'amount_reserve_percent': {'type': 'number', 'minimum': 0.0, 'maximum': 0.5},
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True, 'minimum': -1},

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -48,7 +48,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
     _ft_params_from_file: Dict
     # associated minimal roi
-    minimal_roi: Dict = {"0": 10.0}
+    minimal_roi: Dict = {}
 
     # associated stoploss
     stoploss: float

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -1265,7 +1265,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :return: minimal ROI entry value or None if none proper ROI entry was found.
         """
         # Get highest entry in ROI dict where key <= trade-duration
-        roi_list = list(filter(lambda x: x <= trade_dur, self.minimal_roi.keys()))
+        roi_list = [x for x in self.minimal_roi.keys() if x <= trade_dur]
         if not roi_list:
             return None, None
         roi_entry = max(roi_list)

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -820,7 +820,7 @@ tc52 = BTContainer(data=[
     [2, 4900, 5250, 4500, 5100, 6172, 0, 0],  # Order readjust
     [3, 5100, 5100, 4650, 4750, 6172, 0, 0],  # stoploss hit?
     [4, 4750, 4950, 4350, 4750, 6172, 0, 0]],
-    stop_loss=-0.03, roi={"0": 0.10}, profit_perc=-0.03,
+    stop_loss=-0.03, roi={}, profit_perc=-0.03,
     use_exit_signal=True, timeout=1000,
     custom_entry_price=4200, adjust_entry_price=5200,
     trades=[BTrade(exit_reason=ExitType.STOP_LOSS, open_tick=1, close_tick=2, is_short=False)]


### PR DESCRIPTION

## Summary

Allow complete disabling of minimal_roi by providing an empty dictionary (which is also the default now).
