### PR TITLE
Add links to more FreqAI learning content

### DIFF
--- a/docs/freqai-feature-engineering.md
+++ b/docs/freqai-feature-engineering.md
@@ -180,6 +180,9 @@ You can ask for each of the defined features to be included also for informative
 
 In total, the number of features the user of the presented example strat has created is: length of `include_timeframes` * no. features in `feature_engineering_expand_*()` * length of `include_corr_pairlist` * no. `include_shifted_candles` * length of `indicator_periods_candles`
  $= 3 * 3 * 3 * 2 * 2 = 108$.
+ 
+ !!! note "Learn more about creative feature engineering"
+    Check out our [medium article](https://emergentmethods.medium.com/freqai-from-price-to-prediction-6fadac18b665) geared toward helping users learn how to creatively engineer features.
 
 ### Gain finer control over `feature_engineering_*` functions with `metadata`
 

--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -107,6 +107,13 @@ This is for performance reasons - FreqAI relies on making quick predictions/retr
 it needs to download all the training data at the beginning of a dry/live instance. FreqAI stores and appends
 new candles automatically for future retrains. This means that if new pairs arrive later in the dry run due to a volume pairlist, it will not have the data ready. However, FreqAI does work with the `ShufflePairlist` or a `VolumePairlist` which keeps the total pairlist constant (but reorders the pairs according to volume).
 
+## Additional learning materials
+
+Here we compile some external materials that provide deeper looks into various components of FreqAI:
+
+- [Real-time head-to-head: Adaptive modeling of financial market data using XGBoost and CatBoost](https://emergentmethods.medium.com/real-time-head-to-head-adaptive-modeling-of-financial-market-data-using-xgboost-and-catboost-995a115a7495)
+- [FreqAI - from price to prediction](https://emergentmethods.medium.com/freqai-from-price-to-prediction-6fadac18b665)
+
 ## Credits
 
 FreqAI is developed by a group of individuals who all contribute specific skillsets to the project.


### PR DESCRIPTION
As have written in depth content describing various components of freqai, with pictures, code sample descriptions, strategy files and configs. We would like to make sure FreqAI users can find this content if they are willing to dive deeper into the rabbit hole. Here we add the links. 
