### PR TITLE
Remove old version pin for catboost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        check-latest: true
 
     - name: Cache_dependencies
       uses: actions/cache@v3

--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -5,8 +5,7 @@
 # Required for freqai
 scikit-learn==1.1.3
 joblib==1.2.0
-catboost==1.1.1; sys_platform == 'darwin' and python_version < '3.9'
-catboost==1.2; 'arm' not in platform_machine and (sys_platform != 'darwin' or python_version >= '3.9')
+catboost==1.2; 'arm' not in platform_machine
 lightgbm==3.3.5
 xgboost==1.7.5
 tensorboard==2.13.0


### PR DESCRIPTION

## Summary
Update catboost to 1.2.0 completely - as the macos CI issue is gone now.