### PR TITLE
make sure default PCA behavior reduces parameter space size

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -515,7 +515,7 @@ class IFreqaiModel(ABC):
             ]
 
         if ft_params.get("principal_component_analysis", False):
-            pipe_steps.append(('pca', ds.PCA()))
+            pipe_steps.append(('pca', ds.PCA(n_components=0.999)))
             pipe_steps.append(('post-pca-scaler',
                                SKLearnWrapper(MinMaxScaler(feature_range=(-1, 1)))))
 


### PR DESCRIPTION
PCA by default does not reduce the parameter space (i.e. number of features), but  users typically want to use it to reduce the feature count in an effort to improve training/inference computational efficiency.

We set the default behavior to keeping 0.999 explained variance. Power users who want more fine tuned control over the pipeline should still simply build their own by inheriting the `define_data_pipeline()` function. 