### PR TITLE
Online test trade history

### DIFF
--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -354,7 +354,7 @@ def _download_trades_history(exchange: Exchange,
             trades = []
 
         if not since:
-            since = int((datetime.now() - timedelta(days=-new_pairs_days)).timestamp()) * 1000
+            since = int((datetime.now() - timedelta(days=new_pairs_days)).timestamp()) * 1000
 
         from_id = trades[-1][1] if trades else None
         if trades and since < trades[-1][0]:

--- a/tests/exchange/test_ccxt_compat.py
+++ b/tests/exchange/test_ccxt_compat.py
@@ -43,6 +43,7 @@ EXCHANGES = {
         'hasQuoteVolumeFutures': True,
         'leverage_tiers_public': False,
         'leverage_in_spot_market': False,
+        'trades_lookback_hours': 4,
         'private_methods': [
             'fapiPrivateGetPositionSideDual',
             'fapiPrivateGetMultiAssetsMargin'
@@ -98,6 +99,7 @@ EXCHANGES = {
         'timeframe': '1h',
         'leverage_tiers_public': False,
         'leverage_in_spot_market': True,
+        'trades_lookback_hours': 12,
     },
     'kucoin': {
         'pair': 'XRP/USDT',
@@ -640,7 +642,21 @@ class TestCCXTExchange:
         assert isinstance(funding_fee, float)
         # assert funding_fee > 0
 
-    # TODO: tests fetch_trades (?)
+    def test_ccxt__async_get_trade_history(self, exchange: EXCHANGE_FIXTURE_TYPE):
+        exch, exchangename = exchange
+        if not (lookback := EXCHANGES[exchangename].get('trades_lookback_hours')):
+            pytest.skip('test_fetch_trades not enabled for this exchange')
+        pair = EXCHANGES[exchangename]['pair']
+        since = int((datetime.now(timezone.utc) - timedelta(hours=lookback)).timestamp() * 1000)
+        res = exch.loop.run_until_complete(
+            exch._async_get_trade_history(pair, since, None, None)
+        )
+        assert len(res) == 2
+        res_pair, res_trades = res
+        assert res_pair == pair
+        assert isinstance(res_trades, list)
+        assert res_trades[0][0] >= since
+        assert len(res_trades) > 1200
 
     def test_ccxt_get_fee(self, exchange: EXCHANGE_FIXTURE_TYPE):
         exch, exchangename = exchange


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Add explicit test for datadownload, fix bug in `--dl-trades` mode.

closes #8860 

## Quick changelog

- Explicit test for trades download
- Fix bug for initial trades download (`download-data --dl-trades`).