### PR TITLE
Add community showcase

### DIFF
--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -5,6 +5,7 @@ This section will highlight a few projects from members of the community.
 - [Example freqtrade strategies](https://github.com/freqtrade/freqtrade-strategies/)
 - [FrequentHippo - Grafana dashboard with dry/live runs and backtests](http://frequenthippo.ddns.net:3000/) (by hippocritical).
 - [Online pairlist generator](http://pairlist.robot.co.network/) (by Blood4rc).
+- [Freqtrade Backtesting Project](http://bt.robot.co.network/) (by Blood4rc).
 - [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
 - [TUI for freqtrade](https://github.com/froggleston/freqtrade-frogtrade9000) (by Froggleston).
 - [Bot Academy](https://botacademy.ddns.net/) (by stash86) - Blog about crypto bot projects.

--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -7,4 +7,4 @@ This section will highlight a few projects from members of the community.
 - [Online pairlist generator](http://pairlist.robot.co.network/) (by Blood4rc).
 - [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
 - [TUI for freqtrade](https://github.com/froggleston/freqtrade-frogtrade9000) (by Froggleston).
-- [Learn Cryptobot](https://learncryptobot.wordpress.com/) (by stash86) - Blog about crypto projects.
+- [Bot Academy](https://botacademy.ddns.net/) (by stash86) - Blog about crypto bot projects.

--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -1,0 +1,10 @@
+This section will highlight a few projects from members of the community.
+!!! Note
+    The projects below are for the most part not maintained by the freqtrade , therefore use your own caution before using them.
+
+- [Example freqtrade strategies](https://github.com/freqtrade/freqtrade-strategies/)
+- [FrequentHippo - Grafana dashboard with 1000nds of backtests](http://frequenthippo.ddns.net:3000/) (by hippocritical).
+- [Online pairlist generator](http://pairlist.robot.co.network/) (by Blood4rc).
+- [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
+- [TUI for freqtrade](https://github.com/froggleston/freqtrade-frogtrade9000) (by Froggleston).
+- [Learn Cryptobot](https://learncryptobot.wordpress.com/) (by stash86) - Blog about crypto projects.

--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -3,7 +3,7 @@ This section will highlight a few projects from members of the community.
     The projects below are for the most part not maintained by the freqtrade , therefore use your own caution before using them.
 
 - [Example freqtrade strategies](https://github.com/freqtrade/freqtrade-strategies/)
-- [FrequentHippo - Grafana dashboard with 1000nds of backtests](http://frequenthippo.ddns.net:3000/) (by hippocritical).
+- [FrequentHippo - Grafana dashboard with dry/live runs and backtests](http://frequenthippo.ddns.net:3000/) (by hippocritical).
 - [Online pairlist generator](http://pairlist.robot.co.network/) (by Blood4rc).
 - [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
 - [TUI for freqtrade](https://github.com/froggleston/freqtrade-frogtrade9000) (by Froggleston).

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,10 @@ Exchanges confirmed working by the community:
 - [X] [Bitvavo](https://bitvavo.com/)
 - [X] [Kucoin](https://www.kucoin.com/)
 
+## Community showcase
+
+--8<-- "includes/showcase.md"
+
 ## Requirements
 
 ### Hardware requirements


### PR DESCRIPTION
## Summary

Add an initial version of a community showcase, showing great utilities and projects which are developed across freqtrade.

For now, this will be on the front page of the documentation, looking roughly like this:

![image](https://github.com/freqtrade/freqtrade/assets/5024695/00394384-3576-4424-acb5-0a97b2c2f242)
