### PR TITLE
bybit provides up to 2years of historic ohlcv data on any timefame.

### DIFF
--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -28,7 +28,7 @@ class Bybit(Exchange):
 
     _ft_has: Dict = {
         "ohlcv_candle_limit": 200,
-        "ohlcv_has_history": False,
+        "ohlcv_has_history": True,
     }
     _ft_has_futures: Dict = {
         "ohlcv_has_history": True,


### PR DESCRIPTION
bybit provides up to 2years of historic ohlcv data on any timefame.
Confirmed with below ccxt call.


```
#!/usr/bin/python
import pandas as pd
import ccxt
from datetime import datetime

exchange = ccxt.bybit()

for timeframe in ['1m','5m','30m','1d','1w']:
    df = pd.DataFrame(
        exchange.fetch_ohlcv(
            symbol='BTC/USDT',
            timeframe=timeframe,
            since=exchange.milliseconds() - (2*365*24*3600*1000),
            limit=2
        ),
        columns = ['Time', 'Open', 'High', 'Low', 'Close', 'Volume']
    )

    df['Time'] = [datetime.fromtimestamp(float(time)/1000) for time in df['Time']]
    df.set_index('Time', inplace=True)
    print(df)

```

Cc @xmatthias 