### PR TITLE
Dry-run open balance should include realized profit

### DIFF
--- a/freqtrade/wallets.py
+++ b/freqtrade/wallets.py
@@ -84,6 +84,7 @@ class Wallets:
             tot_profit = Trade.get_total_closed_profit()
         else:
             tot_profit = LocalTrade.total_profit
+        tot_profit += sum(trade.realized_profit for trade in open_trades)
         tot_in_trades = sum(trade.stake_amount for trade in open_trades)
         used_stake = 0.0
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -493,6 +493,8 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
         get_funding_fees=MagicMock(return_value=0),
     )
     mocker.patch(f"{EXMS}.get_max_leverage", return_value=10)
+    starting_amount = freqtrade.wallets.get_total('USDT')
+    assert starting_amount == 1000
 
     patch_get_signal(freqtrade)
     freqtrade.strategy.leverage = MagicMock(return_value=leverage)
@@ -505,6 +507,11 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
     assert trade.leverage == leverage
     assert pytest.approx(trade.amount) == 30.0 * leverage
     assert trade.open_rate == 2.0
+    assert pytest.approx(freqtrade.wallets.get_free('USDT')) == starting_amount - 60
+    if spot:
+        assert pytest.approx(freqtrade.wallets.get_total('USDT')) == starting_amount - 60
+    else:
+        assert freqtrade.wallets.get_total('USDT') == starting_amount
 
     # Too small size
     freqtrade.strategy.adjust_trade_position = MagicMock(return_value=-59)
@@ -527,6 +534,14 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
     assert trade.open_rate == 2.0
     assert trade.is_open
     assert trade.realized_profit > 0.098 * leverage
+    expected_profit = starting_amount - 40.1980
+    assert pytest.approx(freqtrade.wallets.get_free('USDT')) == expected_profit
+
+    if spot:
+        assert pytest.approx(freqtrade.wallets.get_total('USDT')) == expected_profit
+    else:
+        # total won't change in futures mode, only free / used will.
+        assert freqtrade.wallets.get_total('USDT') == starting_amount
     caplog.clear()
 
     # Sell more than what we got (we got ~20 coins left)
@@ -551,3 +566,10 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
     assert pytest.approx(trade.stake_amount) == 40.198
     assert trade.is_open
     assert log_has_re('Amount to exit is 0.0 due to exchange limits - not exiting.', caplog)
+    expected_profit = starting_amount - 40.1980
+    assert pytest.approx(freqtrade.wallets.get_free('USDT')) == expected_profit
+    if spot:
+        assert pytest.approx(freqtrade.wallets.get_total('USDT')) == expected_profit
+    else:
+        # total won't change in futures mode, only free / used will.
+        assert freqtrade.wallets.get_total('USDT') == starting_amount

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -534,14 +534,14 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
     assert trade.open_rate == 2.0
     assert trade.is_open
     assert trade.realized_profit > 0.098 * leverage
-    expected_profit = starting_amount - 40.1980
+    expected_profit = starting_amount - 40.1980 + trade.realized_profit
     assert pytest.approx(freqtrade.wallets.get_free('USDT')) == expected_profit
 
     if spot:
         assert pytest.approx(freqtrade.wallets.get_total('USDT')) == expected_profit
     else:
         # total won't change in futures mode, only free / used will.
-        assert freqtrade.wallets.get_total('USDT') == starting_amount
+        assert freqtrade.wallets.get_total('USDT') == starting_amount + trade.realized_profit
     caplog.clear()
 
     # Sell more than what we got (we got ~20 coins left)
@@ -566,10 +566,10 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
     assert pytest.approx(trade.stake_amount) == 40.198
     assert trade.is_open
     assert log_has_re('Amount to exit is 0.0 due to exchange limits - not exiting.', caplog)
-    expected_profit = starting_amount - 40.1980
+    expected_profit = starting_amount - 40.1980 + trade.realized_profit
     assert pytest.approx(freqtrade.wallets.get_free('USDT')) == expected_profit
     if spot:
         assert pytest.approx(freqtrade.wallets.get_total('USDT')) == expected_profit
     else:
         # total won't change in futures mode, only free / used will.
-        assert freqtrade.wallets.get_total('USDT') == starting_amount
+        assert freqtrade.wallets.get_total('USDT') == starting_amount + trade.realized_profit


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Open balance should include realized profit. Not doing so will over/understate available balance (it's no longer in a trade, but also potentially not available).


Closes #8877

## Quick changelog

- Add test covering this scenario
- Fix bug