### PR TITLE
Add built-in trade fields in indicator list docs

### DIFF
--- a/docs/advanced-backtesting.md
+++ b/docs/advanced-backtesting.md
@@ -103,6 +103,22 @@ The indicators have to be present in your strategy's main DataFrame (either for 
 timeframe or for informative timeframes) otherwise they will simply be ignored in the script
 output.
 
+There are a range of candle and trade-related fields that are included in the analysis so are 
+automatically accessible by including them on the indicator-list, and these include:
+
+- **open_date     :** trade open datetime
+- **close_date    :** trade close datetime
+- **min_rate      :** minimum price seen throughout the position
+- **max_rate      :** maxiumum price seen throughout the position
+- **open          :** signal candle open price
+- **close         :** signal candle close price
+- **high          :** signal candle high price
+- **low           :** signal candle low price
+- **volume        :** signal candle volumne
+- **profit_ratio  :** trade profit ratio
+- **profit_abs    :** absolute profit return of the trade 
+
+
 ### Filtering the trade output by date
 
 To show only trades between dates within your backtested timerange, supply the usual `timerange` option in `YYYYMMDD-[YYYYMMDD]` format:


### PR DESCRIPTION
## Summary

There are some trade- and candle-related fields that are always available to output on the indicator-list so have updated the docs to include the most commonly used ones.

## Quick changelog

- updated advanced-backtesting.md to include commonly-used fields available for indicator-list, e.g. profit_abs, min_rate, max_rate, OHLCV etc
