### PR TITLE
Map BUSD to correct coingecko id

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -25,6 +25,7 @@ coingecko_mapping = {
     'bnb': 'binancecoin',
     'sol': 'solana',
     'usdt': 'tether',
+    'busd': 'binance-usd',
 }
 
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Using BUSD as stake currency generates a WARNING because Coingecko returns 2 entries for the same symbol.

## Quick changelog

- added to `coingecko_mapping` the mapping `'busd': 'binance-usd'`

