### PR TITLE
Add backtest notes capability

### DIFF
--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from freqtrade.constants import LAST_BT_RESULT_FN, IntOrInf
 from freqtrade.exceptions import OperationalException
-from freqtrade.misc import json_load
+from freqtrade.misc import file_dump_json, json_load
 from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename
 from freqtrade.persistence import LocalTrade, Trade, init_db
 from freqtrade.types import BacktestHistoryEntryType, BacktestResultType
@@ -217,6 +217,21 @@ def delete_backtest_result(file_abs: Path):
     file_abs_meta = file_abs.with_suffix('.meta.json')
     file_abs.unlink()
     file_abs_meta.unlink()
+
+
+def update_backtest_metadata(filename: Path, strategy: str, content: Dict[str, Any]):
+    """
+    Updates backtest metadata file with new content.
+    :raises: ValueError if metadata file does not exist, or strategy is not in this file.
+    """
+    metadata = load_backtest_metadata(filename)
+    if not metadata:
+        raise ValueError("File does not exist.")
+    if strategy not in metadata:
+        raise ValueError("Strategy not in metadata.")
+    metadata[strategy].update(content)
+    # Write data again.
+    file_dump_json(get_backtest_metadata_filename(filename), metadata)
 
 
 def find_existing_backtest_stats(dirname: Union[Path, str], run_ids: Dict[str, str],

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -175,6 +175,21 @@ def _get_backtest_files(dirname: Path) -> List[Path]:
     return list(reversed(sorted(dirname.glob('backtest-result-*-[0-9][0-9].json'))))
 
 
+def get_backtest_result(filename: Path) -> List[BacktestHistoryEntryType]:
+    """
+    Get backtest result read from metadata file
+    """
+    return [
+        {
+            'filename': filename.stem,
+            'strategy': s,
+            'notes': v.get('notes', ''),
+            'run_id': v['run_id'],
+            'backtest_start_time': v['backtest_start_time'],
+        } for s, v in load_backtest_metadata(filename).items()
+    ]
+
+
 def get_backtest_resultlist(dirname: Path) -> List[BacktestHistoryEntryType]:
     """
     Get list of backtest results read from metadata files
@@ -184,6 +199,7 @@ def get_backtest_resultlist(dirname: Path) -> List[BacktestHistoryEntryType]:
             'filename': filename.stem,
             'strategy': s,
             'run_id': v['run_id'],
+            'notes': v.get('notes', ''),
             'backtest_start_time': v['backtest_start_time'],
         }
         for filename in _get_backtest_files(dirname)

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def store_backtest_stats(
-        recordfilename: Path, stats: BacktestResultType, dtappendix: str) -> None:
+        recordfilename: Path, stats: BacktestResultType, dtappendix: str) -> Path:
     """
     Stores backtest results
     :param recordfilename: Path object, which can either be a filename or a directory.
@@ -40,6 +40,8 @@ def store_backtest_stats(
 
     latest_filename = Path.joinpath(filename.parent, LAST_BT_RESULT_FN)
     file_dump_json(latest_filename, {'latest_backtest': str(filename.name)})
+
+    return filename
 
 
 def _store_backtest_analysis_data(

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -75,10 +75,11 @@ def __run_backtest_bg(btconfig: Config):
         ApiBG.bt['bt'].load_prior_backtest()
 
         ApiBG.bt['bt'].abort = False
+        strategy_name = strat.get_strategy_name()
         if (ApiBG.bt['bt'].results and
-                strat.get_strategy_name() in ApiBG.bt['bt'].results['strategy']):
+                strategy_name in ApiBG.bt['bt'].results['strategy']):
             # When previous result hash matches - reuse that result and skip backtesting.
-            logger.info(f'Reusing result of previous backtest for {strat.get_strategy_name()}')
+            logger.info(f'Reusing result of previous backtest for {strategy_name}')
         else:
             min_date, max_date = ApiBG.bt['bt'].backtest_one_strategy(
                 strat, ApiBG.bt['data'], ApiBG.bt['timerange'])
@@ -88,10 +89,12 @@ def __run_backtest_bg(btconfig: Config):
                 min_date=min_date, max_date=max_date)
 
         if btconfig.get('export', 'none') == 'trades':
-            store_backtest_stats(
+            fn = store_backtest_stats(
                 btconfig['exportfilename'], ApiBG.bt['bt'].results,
                 datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
                 )
+            ApiBG.bt['bt'].results['metadata'][strategy_name]['filename'] = str(fn.name)
+            ApiBG.bt['bt'].results['metadata'][strategy_name]['strategy'] = strategy_name
 
         logger.info("Backtest finished.")
 

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -531,7 +531,7 @@ class BacktestHistoryEntry(BaseModel):
 
 class BacktestMetadataUpdate(BaseModel):
     strategy: str
-    notes: Optional[str]
+    notes: str = ''
 
 
 class SysInfo(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -526,6 +526,7 @@ class BacktestHistoryEntry(BaseModel):
     strategy: str
     run_id: str
     backtest_start_time: int
+    notes: Optional[str] = ''
 
 
 class SysInfo(BaseModel):

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -529,6 +529,11 @@ class BacktestHistoryEntry(BaseModel):
     notes: Optional[str] = ''
 
 
+class BacktestMetadataUpdate(BaseModel):
+    strategy: str
+    notes: Optional[str]
+
+
 class SysInfo(BaseModel):
     cpu_pct: List[float]
     ram_pct: float

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -50,7 +50,8 @@ logger = logging.getLogger(__name__)
 # 2.29: Add /exchanges endpoint
 # 2.30: new /pairlists endpoint
 # 2.31: new /backtest/history/ delete endpoint
-API_VERSION = 2.31
+# 2.32: new /backtest/history/ patch endpoint
+API_VERSION = 2.32
 
 # Public API, requires no auth.
 router_public = APIRouter()

--- a/freqtrade/types/backtest_result_type.py
+++ b/freqtrade/types/backtest_result_type.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from typing_extensions import TypedDict
 
@@ -6,7 +6,6 @@ from typing_extensions import TypedDict
 class BacktestMetadataType(TypedDict):
     run_id: str
     backtest_start_time: int
-    notes: Optional[str]
 
 
 class BacktestResultType(TypedDict):
@@ -26,3 +25,4 @@ def get_BacktestResultType_default() -> BacktestResultType:
 class BacktestHistoryEntryType(BacktestMetadataType):
     filename: str
     strategy: str
+    notes: str

--- a/freqtrade/types/backtest_result_type.py
+++ b/freqtrade/types/backtest_result_type.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from typing_extensions import TypedDict
 
@@ -6,6 +6,7 @@ from typing_extensions import TypedDict
 class BacktestMetadataType(TypedDict):
     run_id: str
     backtest_start_time: int
+    notes: Optional[str]
 
 
 class BacktestResultType(TypedDict):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY, MagicMock, PropertyMock
 
 import pandas as pd
 import pytest
+import rapidjson
 import uvicorn
 from fastapi import FastAPI, WebSocketDisconnect
 from fastapi.exceptions import HTTPException
@@ -79,6 +80,14 @@ def client_post(client: TestClient, url, data={}):
                                 'content-type': 'application/json'
                                 })
 
+def client_patch(client: TestClient, url, data={}):
+
+    return client.patch(url,
+                        json=data,
+                        headers={'Authorization': _basic_auth_str(_TEST_USER, _TEST_PASS),
+                                 'Origin': 'http://example.com',
+                                 'content-type': 'application/json'
+                                 })
 
 def client_get(client: TestClient, url):
     # Add fake Origin to ensure CORS kicks in
@@ -1763,7 +1772,7 @@ def test_api_pairlists_evaluate(botclient, tmpdir, mocker):
     rc = client_get(client, f"{BASE_URI}/pairlists/evaluate/{job_id}")
     assert_response(rc)
     response = rc.json()
-    assert response['result']['whitelist'] == ['ETH/BTC', 'LTC/BTC', 'XRP/BTC', 'NEO/BTC',]
+    assert response['result']['whitelist'] == ['ETH/BTC', 'LTC/BTC', 'XRP/BTC', 'NEO/BTC']
     assert response['result']['length'] == 4
 
     # Restart with additional filter, reducing the list to 2
@@ -2023,7 +2032,7 @@ def test_api_backtest_history(botclient, mocker, testdatadir):
     assert result2['backtest_result']['strategy'][strategy]
 
 
-def test_api_delete_backtest_history_entry(botclient, mocker, tmp_path: Path):
+def test_api_delete_backtest_history_entry(botclient, tmp_path: Path):
     ftbot, client = botclient
 
     # Create a temporary directory and file
@@ -2049,6 +2058,75 @@ def test_api_delete_backtest_history_entry(botclient, mocker, tmp_path: Path):
 
     assert not file_path.exists()
     assert not meta_path.exists()
+
+
+def test_api_patch_backtest_history_entry(botclient, tmp_path: Path):
+    ftbot, client = botclient
+
+    # Create a temporary directory and file
+    bt_results_base = tmp_path / "backtest_results"
+    bt_results_base.mkdir()
+    file_path = bt_results_base / "test.json"
+    file_path.touch()
+    meta_path = file_path.with_suffix('.meta.json')
+    with meta_path.open('w') as metafile:
+        rapidjson.dump({
+            CURRENT_TEST_STRATEGY: {
+                "run_id": "6e542efc8d5e62cef6e5be0ffbc29be81a6e751d",
+                "backtest_start_time": 1690176003}
+            }, metafile)
+
+    def read_metadata():
+        with meta_path.open('r') as metafile:
+            return rapidjson.load(metafile)
+
+    rc = client_patch(client, f"{BASE_URI}/backtest/history/randomFile.json")
+    assert_response(rc, 503)
+
+    ftbot.config['user_data_dir'] = tmp_path
+    ftbot.config['runmode'] = RunMode.WEBSERVER
+
+    rc = client_patch(client, f"{BASE_URI}/backtest/history/randomFile.json", {
+        "strategy": CURRENT_TEST_STRATEGY,
+    })
+    assert rc.status_code == 404
+
+    # Nonexisting strategy
+    rc = client_patch(client, f"{BASE_URI}/backtest/history/{file_path.name}", {
+        "strategy": f"{CURRENT_TEST_STRATEGY}xxx",
+    })
+    assert rc.status_code == 400
+    assert rc.json()['detail'] == 'Strategy not in metadata.'
+
+    # no Notes
+    rc = client_patch(client, f"{BASE_URI}/backtest/history/{file_path.name}", {
+        "strategy": CURRENT_TEST_STRATEGY,
+    })
+    assert rc.status_code == 200
+    res = rc.json()
+    assert isinstance(res, list)
+    assert len(res) == 1
+    assert res[0]['strategy'] == CURRENT_TEST_STRATEGY
+    assert res[0]['notes'] == ''
+
+    fileres = read_metadata()
+    assert fileres[CURRENT_TEST_STRATEGY]['run_id'] == res[0]['run_id']
+    assert fileres[CURRENT_TEST_STRATEGY]['notes'] == ''
+
+    rc = client_patch(client, f"{BASE_URI}/backtest/history/{file_path.name}", {
+        "strategy": CURRENT_TEST_STRATEGY,
+        "notes": "FooBar",
+    })
+    assert rc.status_code == 200
+    res = rc.json()
+    assert isinstance(res, list)
+    assert len(res) == 1
+    assert res[0]['strategy'] == CURRENT_TEST_STRATEGY
+    assert res[0]['notes'] == 'FooBar'
+
+    fileres = read_metadata()
+    assert fileres[CURRENT_TEST_STRATEGY]['run_id'] == res[0]['run_id']
+    assert fileres[CURRENT_TEST_STRATEGY]['notes'] == 'FooBar'
 
 
 def test_health(botclient):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -80,6 +80,7 @@ def client_post(client: TestClient, url, data={}):
                                 'content-type': 'application/json'
                                 })
 
+
 def client_patch(client: TestClient, url, data={}):
 
     return client.patch(url,
@@ -88,6 +89,7 @@ def client_patch(client: TestClient, url, data={}):
                                  'Origin': 'http://example.com',
                                  'content-type': 'application/json'
                                  })
+
 
 def client_get(client: TestClient, url):
     # Add fake Origin to ensure CORS kicks in
@@ -2019,6 +2021,7 @@ def test_api_backtest_history(botclient, mocker, testdatadir):
     assert len(result) == 3
     fn = result[0]['filename']
     assert fn == "backtest-result_multistrat"
+    assert result[0]['notes'] == ''
     strategy = result[0]['strategy']
     rc = client_get(client, f"{BASE_URI}/backtest/history/result?filename={fn}&strategy={strategy}")
     assert_response(rc)


### PR DESCRIPTION
## Summary

Add endpoint to allow the UI to add notes to a backtest result

## Quick changelog

- Add patch endpoint for historic results

Related to: https://github.com/freqtrade/frequi/issues/1353