### PR TITLE
add _timeout attribute to discord, otherwise it won't work

### DIFF
--- a/freqtrade/rpc/discord.py
+++ b/freqtrade/rpc/discord.py
@@ -20,6 +20,7 @@ class Discord(Webhook):
         self._format = 'json'
         self._retries = 1
         self._retry_delay = 0.1
+        self._timeout = self._config['discord'].get('timeout', 10)
 
     def cleanup(self) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

You would get this error without the attribute
```
freqtrade.rpc.rpc_manager - ERROR - Exception occurred within RPC module discord
Traceback (most recent call last):
   File "/freqtrade/freqtrade/rpc/rpc_manager.py", line 76, in send_msg
     mod.send_msg(msg)
   File "/freqtrade/freqtrade/rpc/discord.py", line 60, in send_msg
     self._send_msg(payload)
   File "/freqtrade/freqtrade/rpc/webhook.py", line 113, in _send_msg
     response = post(self._url, json=payload, timeout=self._timeout)
                                                      ^^^^^^^^^^^^^
 AttributeError: 'Discord' object has no attribute '_timeout'
 ```

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
