### PR TITLE
Increase bybit ohlcv_candle_limit to 1000

### DIFF
--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -27,7 +27,7 @@ class Bybit(Exchange):
     """
 
     _ft_has: Dict = {
-        "ohlcv_candle_limit": 200,
+        "ohlcv_candle_limit": 1000,
         "ohlcv_has_history": True,
     }
     _ft_has_futures: Dict = {

--- a/tests/exchange/test_bybit.py
+++ b/tests/exchange/test_bybit.py
@@ -26,7 +26,7 @@ async def test_bybit_fetch_funding_rate(default_conf, mocker):
     api_mock = MagicMock()
     api_mock.fetch_funding_rate_history = get_mock_coro(return_value=[])
     exchange = get_patched_exchange(mocker, default_conf, id='bybit', api_mock=api_mock)
-    limit = 200
+    limit = 1000
     # Test fetch_funding_rate_history (current data)
     await exchange._fetch_funding_rate_history(
         pair='BTC/USDT:USDT',


### PR DESCRIPTION
Bybit supports fetching up to 1000 candles in a single request.

bybit API docs:
https://bybit-exchange.github.io/docs/v5/market/kline
 <html>
<body>
<!--StartFragment-->

limit | false | integer | Limit for data size per page. [1, 1000]. Default: 200
-- | -- | -- | --


<!--EndFragment-->
</body>
</html>

CCXT : 
https://github.com/ccxt/ccxt/blob/a4d71c478ce7905a82f73bf82dff1349d1bec166/ts/src/bybit.ts#L2348

Following test snippet returns 1000 candles:
```
#!/usr/bin/python
import pandas as pd
import ccxt
from datetime import datetime

exchange = ccxt.bybit()

for timeframe in ['1m']:
    df = pd.DataFrame(
        exchange.fetch_ohlcv(
            symbol='BTC/USDT',
            timeframe=timeframe,
            since=exchange.milliseconds() - (1*365*24*3600*1000),
            limit=1000
        ),
        columns = ['Time', 'Open', 'High', 'Low', 'Close', 'Volume']
    )

    df['Time'] = [datetime.fromtimestamp(float(time)/1000) for time in df['Time']]
    df.set_index('Time', inplace=True)
    print(df)
```