### PR TITLE
Update setup.sh script to use `.venv`

### DIFF
--- a/build_helpers/install_ta-lib.sh
+++ b/build_helpers/install_ta-lib.sh
@@ -8,8 +8,9 @@ if [ -n "$2" ] || [ ! -f "${INSTALL_LOC}/lib/libta_lib.a" ]; then
   tar zxvf ta-lib-0.4.0-src.tar.gz
   cd ta-lib \
   && sed -i.bak "s|0.00000001|0.000000000000000001 |g" src/ta_func/ta_utility.h \
-  && curl 'https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess' -o config.guess \
-  && curl 'https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub' -o config.sub \
+  && echo "Downloading gcc config.guess and config.sub" \
+  && curl -s 'https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess' -o config.guess \
+  && curl -s 'https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub' -o config.sub \
   && ./configure --prefix=${INSTALL_LOC}/ \
   && make
   if [ $? -ne 0 ]; then

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -3,7 +3,7 @@
 This page explains the different parameters of the bot and how to run it.
 
 !!! Note
-    If you've used `setup.sh`, don't forget to activate your virtual environment (`source .env/bin/activate`) before running freqtrade commands.
+    If you've used `setup.sh`, don't forget to activate your virtual environment (`source .venv/bin/activate`) before running freqtrade commands.
 
 !!! Warning "Up-to-date clock"
     The clock on the system running the bot must be accurate, synchronized to a NTP server frequently enough to avoid problems with communication to the exchanges.

--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -27,7 +27,7 @@ For this to work, first activate your virtual environment and run the following 
 
 ``` bash
 # Activate virtual environment
-source .env/bin/activate
+source .venv/bin/activate
 
 pip install ipykernel
 ipython kernel install --user --name=freqtrade

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ Running the bot with `freqtrade trade --config config.json` shows the output `fr
 This could be caused by the following reasons:
 
 * The virtual environment is not active.
-  * Run `source .env/bin/activate` to activate the virtual environment.
+  * Run `source .venv/bin/activate` to activate the virtual environment.
 * The installation did not complete successfully.
   * Please check the [Installation documentation](installation.md).
 

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -31,7 +31,7 @@ The docker-image includes hyperopt dependencies, no further action needed.
 ### Easy installation script (setup.sh) / Manual installation
 
 ```bash
-source .env/bin/activate
+source .venv/bin/activate
 pip install -r requirements-hyperopt.txt
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,11 +143,11 @@ If you are on Debian, Ubuntu or MacOS, freqtrade provides the script to install 
 
 ### Activate your virtual environment
 
-Each time you open a new terminal, you must run `source .env/bin/activate` to activate your virtual environment.
+Each time you open a new terminal, you must run `source .venv/bin/activate` to activate your virtual environment.
 
 ```bash
-# then activate your .env
-source ./.env/bin/activate
+# activate virtual environment
+source ./.venv/bin/activate
 ```
 
 ### Congratulations
@@ -172,7 +172,7 @@ With this option, the script will install the bot and most dependencies:
 You will need to have git and python3.8+ installed beforehand for this to work.
 
 * Mandatory software as: `ta-lib`
-* Setup your virtualenv under `.env/`
+* Setup your virtualenv under `.venv/`
 
 This option is a combination of installation tasks and `--reset`
 
@@ -225,11 +225,11 @@ rm -rf ./ta-lib*
 You will run freqtrade in separated `virtual environment`
 
 ```bash
-# create virtualenv in directory /freqtrade/.env
-python3 -m venv .env
+# create virtualenv in directory /freqtrade/.venv
+python3 -m venv .venv
 
 # run virtualenv
-source .env/bin/activate
+source .venv/bin/activate
 ```
 
 #### Install python dependencies
@@ -411,8 +411,8 @@ If you used (1)`Script` or (2)`Manual` installation, you need to run the bot in 
 # if:
 bash: freqtrade: command not found
 
-# then activate your .env
-source ./.env/bin/activate
+# then activate your virtual environment
+source ./.venv/bin/activate
 ```
 
 ### MacOS installation error

--- a/docs/windows_installation.md
+++ b/docs/windows_installation.md
@@ -31,8 +31,8 @@ Other versions must be downloaded from the above link.
 
 ``` powershell
 cd \path\freqtrade
-python -m venv .env
-.env\Scripts\activate.ps1
+python -m venv .venv
+.venv\Scripts\activate.ps1
 # optionally install ta-lib from wheel
 # Eventually adjust the below filename to match the downloaded wheel
 pip install --find-links build_helpers\ TA-Lib -U

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ ignore = ["freqtrade/vendor/**"]
 
 [tool.ruff]
 line-length = 100
-extend-exclude = [".env"]
+extend-exclude = [".env", ".venv"]
 target-version = "py38"
 extend-select = [
   "C90",    # mccabe

--- a/setup.sh
+++ b/setup.sh
@@ -41,12 +41,12 @@ function check_installed_python() {
 }
 
 function updateenv() {
-    echo_block "Updating your virtual env"
-    if [ ! -f .env/bin/activate ]; then
+    echo_block "Updating your virtual environment"
+    if [ ! -f .venv/bin/activate ]; then
         echo "Something went wrong, no virtual environment found."
         exit 1
     fi
-    source .env/bin/activate
+    source .venv/bin/activate
     SYS_ARCH=$(uname -m)
     echo "pip install in-progress. Please wait..."
     ${PYTHON} -m pip install --upgrade pip wheel setuptools
@@ -186,7 +186,14 @@ function install_redhat() {
 # Upgrade the bot
 function update() {
     git pull
+    if [ -f .env/bin/activate  ]; then
+        # Old environment found - updating to new environment.
+        recreate_environments
+    fi
     updateenv
+    echo "Update completed."
+    echo_block "Don't forget to activate your virtual enviorment with 'source .venv/bin/activate'!"
+
 }
 
 function check_git_changes() {
@@ -205,6 +212,10 @@ function recreate_environments() {
         echo "- Deleting your previous virtual env"
         echo "Warning: Your new environment will be at .venv!"
         rm -rf .env
+    fi
+    if [ -d ".venv" ]; then
+        echo "- Deleting your previous virtual env"
+        rm -rf .venv
     fi
 
     echo
@@ -274,9 +285,9 @@ function install() {
     reset
     config
     echo_block "Run the bot !"
-    echo "You can now use the bot by executing 'source .env/bin/activate; freqtrade <subcommand>'."
-    echo "You can see the list of available bot sub-commands by executing 'source .env/bin/activate; freqtrade --help'."
-    echo "You verify that freqtrade is installed successfully by running 'source .env/bin/activate; freqtrade --version'."
+    echo "You can now use the bot by executing 'source .venv/bin/activate; freqtrade <subcommand>'."
+    echo "You can see the list of available bot sub-commands by executing 'source .venv/bin/activate; freqtrade --help'."
+    echo "You verify that freqtrade is installed successfully by running 'source .venv/bin/activate; freqtrade --version'."
 }
 
 function plot() {

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ function check_installed_pip() {
    ${PYTHON} -m pip > /dev/null
    if [ $? -ne 0 ]; then
         echo_block "Installing Pip for ${PYTHON}"
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        curl https://bootstrap.pypa.io/get-pip.py -s -o get-pip.py
         ${PYTHON} get-pip.py
         rm get-pip.py
    fi

--- a/setup.sh
+++ b/setup.sh
@@ -199,6 +199,23 @@ function check_git_changes() {
     fi
 }
 
+function recreate_environments() {
+    if [ -d ".env" ]; then
+        # Remove old virtual env
+        echo "- Deleting your previous virtual env"
+        echo "Warning: Your new environment will be at .venv!"
+        rm -rf .env
+    fi
+
+    echo
+    ${PYTHON} -m venv .venv
+    if [ $? -ne 0 ]; then
+        echo "Could not create virtual environment. Leaving now"
+        exit 1
+    fi
+
+}
+
 # Reset Develop or Stable branch
 function reset() {
     echo_block "Resetting branch and virtual env"
@@ -225,17 +242,8 @@ function reset() {
     else
         echo "Reset ignored because you are not on 'stable' or 'develop'."
     fi
+    recreate_environments
 
-    if [ -d ".env" ]; then
-        echo "- Deleting your previous virtual env"
-        rm -rf .env
-    fi
-    echo
-    ${PYTHON} -m venv .env
-    if [ $? -ne 0 ]; then
-        echo "Could not create virtual environment. Leaving now"
-        exit 1
-    fi
     updateenv
 }
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

using `.env` is problematic, as that's a non-standard directory name  and effectively prevents the use of `.env` files (which serve a different purpose).

## Quick changelog

- Update `setup.sh` script to use `.venv` (auto-updates environments from `.env` to `.venv`)
- Update documentation to use `.venv` instead of `.env`.