### PR TITLE
Convert add_state_info warning into a OperationalException

### DIFF
--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -11,6 +11,8 @@ from gymnasium import spaces
 from gymnasium.utils import seeding
 from pandas import DataFrame
 
+from freqtrade.exceptions import OperationalException
+
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +82,9 @@ class BaseEnvironment(gym.Env):
         self.can_short: bool = can_short
         self.live: bool = live
         if not self.live and self.add_state_info:
-            self.add_state_info = False
-            logger.warning("add_state_info is not available in backtesting. Deactivating.")
+            raise OperationalException("`add_state_info` is not available in backtesting. Change "
+                                       "parameter to false in your rl_config. See `add_state_info` "
+                                       "docs for more info.")
         self.seed(seed)
         self.reset_env(df, prices, window_size, reward_kwargs, starting_point)
 


### PR DESCRIPTION
We have quite a few users who are backtesting with RL + adding `add_state_info: true` to their `rl_config`s. This is not permitted in FreqAI, since state info is only available in dry/live deployments.

Despite the fact that we have documented this in the `rl_config` parameter table of the [docs](https://www.freqtrade.io/en/stable/freqai-parameter-table/#reinforcement-learning-parameters), and we also log a warning to the [user console](https://github.com/freqtrade/freqtrade/blob/develop/freqtrade/freqai/RL/BaseEnvironment.py#L84), users are still confused. This is evidenced by multiple issues posted lately:

https://github.com/freqtrade/freqtrade/issues/7982
https://github.com/freqtrade/freqtrade/issues/8763

@xmatthias and I discussed multiple solutions to this problem - including storing some global metadata during backtesting and then enforcing it during dry/live. But that just encourages users to continue avoiding docs/logs. I prefer to raise an `OperationalException` telling users that the parameter they are trying to use is not available to them and that they need to deactivate it if they intend to continue.


