### PR TITLE
Fix nulls in indicator list output and add expectancy ratio

### DIFF
--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -121,7 +121,7 @@ def _do_group_table_output(bigdf, glist, csv_path: Path, to_csv=False, ):
 
             new['exp_ratio'] = (
                 (
-                    (1 + (new['avg_win'] / abs(new['avg_loss']))) * (new['wl_ratio_pct']/100)
+                    (1 + (new['avg_win'] / abs(new['avg_loss']))) * (new['wl_ratio_pct'] / 100)
                 ) - 1).fillna(0)
 
             new.columns = ['total_num_buys', 'wins', 'losses',

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -211,7 +211,7 @@ def prepare_results(analysed_trades, stratname,
                     timerange=None):
     res_df = pd.DataFrame()
     for pair, trades in analysed_trades[stratname].items():
-        trades.dropna(subset['close_date'], inplace=True)
+        trades.dropna(subset=['close_date'], inplace=True)
         res_df = pd.concat([res_df, trades], ignore_index=True)
 
     res_df = _select_rows_within_dates(res_df, timerange)

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -119,8 +119,15 @@ def _do_group_table_output(bigdf, glist, csv_path: Path, to_csv=False, ):
             new['avg_win'] = (new['profit_abs_wins'] / new.iloc[:, 1]).fillna(0)
             new['avg_loss'] = (new['profit_abs_loss'] / new.iloc[:, 2]).fillna(0)
 
-            new.columns = ['total_num_buys', 'wins', 'losses', 'profit_abs_wins', 'profit_abs_loss',
-                           'profit_tot', 'wl_ratio_pct', 'avg_win', 'avg_loss']
+            new['exp_ratio'] = (
+                (
+                    (1 + (new['avg_win'] / abs(new['avg_loss']))) * (new['wl_ratio_pct']/100)
+                ) - 1).fillna(0)
+
+            new.columns = ['total_num_buys', 'wins', 'losses',
+                           'profit_abs_wins', 'profit_abs_loss',
+                           'profit_tot', 'wl_ratio_pct',
+                           'avg_win', 'avg_loss', 'exp_ratio']
 
             sortcols = ['total_num_buys']
 
@@ -204,6 +211,7 @@ def prepare_results(analysed_trades, stratname,
                     timerange=None):
     res_df = pd.DataFrame()
     for pair, trades in analysed_trades[stratname].items():
+        trades.dropna(subset['close_date'], inplace=True)
         res_df = pd.concat([res_df, trades], ignore_index=True)
 
     res_df = _select_rows_within_dates(res_df, timerange)


### PR DESCRIPTION
This PR addresses two issues in the `backtesting-analysis` command:

a) If two entry signals were detected on the same signal candle, this resulted in one correct entry, and one null row. This didn't affect any results or calculations, but it would be confusing for a user and is resolved.
b) Add expectancy ratio per entry tag in the analysis group 0 table output.