### PR TITLE
remove old codes when we only can do partial entries

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -532,40 +532,24 @@ class Telegram(RPCHandler):
             cur_entry_amount = order["filled"] or order["amount"]
             cur_entry_average = order["safe_price"]
             lines.append("  ")
+            lines.append(f"*{wording} #{order_nr}:*")
             if order_nr == 1:
-                lines.append(f"*{wording} #{order_nr}:*")
                 lines.append(
                     f"*Amount:* {cur_entry_amount:.8g} "
                     f"({round_coin_value(order['cost'], quote_currency)})"
                 )
                 lines.append(f"*Average Price:* {cur_entry_average:.8g}")
             else:
-                sum_stake = 0
-                sum_amount = 0
-                for y in range(order_nr):
-                    loc_order = filled_orders[y]
-                    if loc_order['is_open'] is True:
-                        # Skip open orders (e.g. stop orders)
-                        continue
-                    amount = loc_order["filled"] or loc_order["amount"]
-                    sum_stake += amount * loc_order["safe_price"]
-                    sum_amount += amount
-                prev_avg_price = sum_stake / sum_amount
                 # TODO: This calculation ignores fees.
                 price_to_1st_entry = ((cur_entry_average - first_avg) / first_avg)
-                minus_on_entry = 0
-                if prev_avg_price:
-                    minus_on_entry = (cur_entry_average - prev_avg_price) / prev_avg_price
-
-                lines.append(f"*{wording} #{order_nr}:* at {minus_on_entry:.2%} avg Profit")
                 if is_open:
                     lines.append("({})".format(dt_humanize(order["order_filled_date"],
                                                            granularity=["day", "hour", "minute"])))
                 lines.append(f"*Amount:* {cur_entry_amount:.8g} "
                              f"({round_coin_value(order['cost'], quote_currency)})")
                 lines.append(f"*Average {wording} Price:* {cur_entry_average:.8g} "
-                             f"({price_to_1st_entry:.2%} from 1st entry Rate)")
-                lines.append(f"*Order filled:* {order['order_filled_date']}")
+                             f"({price_to_1st_entry:.2%} from 1st entry rate)")
+                lines.append(f"*Order Filled:* {order['order_filled_date']}")
 
             lines_detail.append("\n".join(lines))
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -347,8 +347,8 @@ async def test_telegram_status_multi_entry(default_conf, update, mocker, fee) ->
     msg = msg_mock.call_args_list[3][0][0]
     assert re.search(r'Number of Entries.*2', msg)
     assert re.search(r'Number of Exits.*1', msg)
-    assert re.search(r'Average Entry Price', msg)
-    assert re.search(r'Order filled', msg)
+    assert re.search(r'from 1st entry rate', msg)
+    assert re.search(r'Order Filled', msg)
     assert re.search(r'Close Date:', msg) is None
     assert re.search(r'Close Profit:', msg) is None
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Remove the "at xx% avg profit", since the formula to calculate it is totally wrong. It was made back then when we only have partial entries.

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
