### PR TITLE
Add trade param to custom entry price

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -520,7 +520,7 @@ class AwesomeStrategy(IStrategy):
 
     # ... populate_* methods
 
-    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
 
         dataframe, last_updated = self.dp.get_analyzed_dataframe(pair=pair,

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -522,7 +522,7 @@ class AwesomeStrategy(IStrategy):
 
     # ... populate_* methods
 
-    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: Optional['Trade'], current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
 
         dataframe, last_updated = self.dp.get_analyzed_dataframe(pair=pair,

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -511,7 +511,7 @@ Each of these methods are called right before placing an order on the exchange.
     If your custom pricing function return None or an invalid value, price will fall back to `proposed_rate`, which is based on the regular pricing configuration.
 
 !!! Note
-    Within this function you will have access to the Trade object, giving you the flexibility to adjust your current entry or exit price in relation to the current trade status. This object is available as soon as the first entry order associated with the trade is created.
+    Using custom_entry_price, the Trade object will be available as soon as the first entry order associated with the trade is created, for the first entry, `trade` parameter value will be `None`.
 ### Custom order entry and exit price example
 
 ``` python

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -510,6 +510,8 @@ Each of these methods are called right before placing an order on the exchange.
 !!! Note
     If your custom pricing function return None or an invalid value, price will fall back to `proposed_rate`, which is based on the regular pricing configuration.
 
+!!! Note
+    Within this function you will have access to the Trade object, giving you the flexibility to adjust your current entry or exit price in relation to the current trade status. This object is available as soon as the first entry order associated with the trade is created.
 ### Custom order entry and exit price example
 
 ``` python

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -512,6 +512,7 @@ Each of these methods are called right before placing an order on the exchange.
 
 !!! Note
     Using custom_entry_price, the Trade object will be available as soon as the first entry order associated with the trade is created, for the first entry, `trade` parameter value will be `None`.
+
 ### Custom order entry and exit price example
 
 ``` python

--- a/docs/strategy_migration.md
+++ b/docs/strategy_migration.md
@@ -271,7 +271,7 @@ New string argument `side` - which can be either `"long"` or `"short"`.
 
 ``` python hl_lines="3"
 class AwesomeStrategy(IStrategy):
-    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], **kwargs) -> float:
       return proposed_rate
 ```
@@ -280,7 +280,7 @@ After:
 
 ``` python hl_lines="3"
 class AwesomeStrategy(IStrategy):
-    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
       return proposed_rate
 ```

--- a/docs/strategy_migration.md
+++ b/docs/strategy_migration.md
@@ -271,7 +271,7 @@ New string argument `side` - which can be either `"long"` or `"short"`.
 
 ``` python hl_lines="3"
 class AwesomeStrategy(IStrategy):
-    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], **kwargs) -> float:
       return proposed_rate
 ```
@@ -280,7 +280,7 @@ After:
 
 ``` python hl_lines="3"
 class AwesomeStrategy(IStrategy):
-    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: Optional[Trade], current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
       return proposed_rate
 ```

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -937,7 +937,7 @@ class FreqtradeBot(LoggingMixin):
             # Don't call custom_entry_price in order-adjust scenario
             custom_entry_price = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                                        default_retval=enter_limit_requested)(
-                pair=pair, current_time=datetime.now(timezone.utc),
+                pair=pair, trade=trade, current_time=datetime.now(timezone.utc),
                 proposed_rate=enter_limit_requested, entry_tag=entry_tag,
                 side=trade_side,
             )

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -937,8 +937,7 @@ class FreqtradeBot(LoggingMixin):
             # Don't call custom_entry_price in order-adjust scenario
             custom_entry_price = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                                        default_retval=enter_limit_requested)(
-                pair=pair,
-                trade=trade,
+                pair=pair, trade=trade,
                 current_time=datetime.now(timezone.utc),
                 proposed_rate=enter_limit_requested, entry_tag=entry_tag,
                 side=trade_side,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -937,7 +937,9 @@ class FreqtradeBot(LoggingMixin):
             # Don't call custom_entry_price in order-adjust scenario
             custom_entry_price = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                                        default_retval=enter_limit_requested)(
-                pair=pair, trade=trade, current_time=datetime.now(timezone.utc),
+                pair=pair,
+                trade=trade,  # type: ignore[arg-type]
+                current_time=datetime.now(timezone.utc),
                 proposed_rate=enter_limit_requested, entry_tag=entry_tag,
                 side=trade_side,
             )

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -938,7 +938,7 @@ class FreqtradeBot(LoggingMixin):
             custom_entry_price = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                                        default_retval=enter_limit_requested)(
                 pair=pair,
-                trade=trade,  # type: ignore[arg-type]
+                trade=trade,
                 current_time=datetime.now(timezone.utc),
                 proposed_rate=enter_limit_requested, entry_tag=entry_tag,
                 side=trade_side,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -738,7 +738,9 @@ class Backtesting:
         if order_type == 'limit':
             new_rate = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                              default_retval=propose_rate)(
-                pair=pair, trade=trade, current_time=current_time,
+                pair=pair,
+                trade=trade,  # type: ignore[arg-type]
+                current_time=current_time,
                 proposed_rate=propose_rate, entry_tag=entry_tag,
                 side=direction,
             )  # default value is the open rate

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -738,7 +738,7 @@ class Backtesting:
         if order_type == 'limit':
             new_rate = strategy_safe_wrapper(self.strategy.custom_entry_price,
                                              default_retval=propose_rate)(
-                pair=pair, current_time=current_time,
+                pair=pair, trade=trade, current_time=current_time,
                 proposed_rate=propose_rate, entry_tag=entry_tag,
                 side=direction,
             )  # default value is the open rate

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -16,7 +16,7 @@ from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirecti
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date, timeframe_to_seconds
 from freqtrade.misc import remove_entry_exit_signals
-from freqtrade.persistence import LocalTrade, Order, PairLocks, Trade
+from freqtrade.persistence import Order, PairLocks, Trade
 from freqtrade.strategy.hyper import HyperStrategyMixin
 from freqtrade.strategy.informative_decorator import (InformativeData, PopulateIndicators,
                                                       _create_and_merge_informative_pair,
@@ -395,7 +395,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return self.stoploss
 
-    def custom_entry_price(self, pair: str, trade: Union[Trade, LocalTrade, None],
+    def custom_entry_price(self, pair: str, trade: Trade,
                            current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -395,7 +395,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return self.stoploss
 
-    def custom_entry_price(self, pair: str, trade: Trade,
+    def custom_entry_price(self, pair: str, trade: Optional[Trade],
                            current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -395,7 +395,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return self.stoploss
 
-    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: Trade, current_time: datetime,
+                           proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
         """
         Custom entry price logic, returning the new entry price.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -16,7 +16,7 @@ from freqtrade.enums import (CandleType, ExitCheckTuple, ExitType, MarketDirecti
 from freqtrade.exceptions import OperationalException, StrategyError
 from freqtrade.exchange import timeframe_to_minutes, timeframe_to_next_date, timeframe_to_seconds
 from freqtrade.misc import remove_entry_exit_signals
-from freqtrade.persistence import Order, PairLocks, Trade
+from freqtrade.persistence import LocalTrade, Order, PairLocks, Trade
 from freqtrade.strategy.hyper import HyperStrategyMixin
 from freqtrade.strategy.informative_decorator import (InformativeData, PopulateIndicators,
                                                       _create_and_merge_informative_pair,
@@ -395,8 +395,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return self.stoploss
 
-    def custom_entry_price(self, pair: str, trade: Optional[Trade], current_time: datetime,
-                           proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: Union[Trade, LocalTrade, None],
+                           current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
         """
         Custom entry price logic, returning the new entry price.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -406,6 +406,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         When not implemented by a strategy, returns None, orderbook is used to set entry price
 
         :param pair: Pair that's currently analyzed
+        :param trade: trade object.
         :param current_time: datetime object, containing the current datetime
         :param proposed_rate: Rate, calculated based on pricing settings in exit_pricing.
         :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -395,7 +395,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return self.stoploss
 
-    def custom_entry_price(self, pair: str, trade: Trade, current_time: datetime,
+    def custom_entry_price(self, pair: str, trade: Optional[Trade], current_time: datetime,
                            proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -406,7 +406,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         When not implemented by a strategy, returns None, orderbook is used to set entry price
 
         :param pair: Pair that's currently analyzed
-        :param trade: trade object.
+        :param trade: trade object (None for initial entries).
         :param current_time: datetime object, containing the current datetime
         :param proposed_rate: Rate, calculated based on pricing settings in exit_pricing.
         :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.

--- a/freqtrade/templates/strategy_subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/strategy_subtemplates/strategy_methods_advanced.j2
@@ -13,7 +13,8 @@ def bot_loop_start(self, current_time: datetime, **kwargs) -> None:
     """
     pass
 
-def custom_entry_price(self, pair: str, current_time: 'datetime', proposed_rate: float,
+def custom_entry_price(self, pair: str, trade: Optional['Trade'],
+                       current_time: 'datetime', proposed_rate: float,
                        entry_tag: 'Optional[str]', side: str, **kwargs) -> float:
     """
     Custom entry price logic, returning the new entry price.
@@ -23,6 +24,7 @@ def custom_entry_price(self, pair: str, current_time: 'datetime', proposed_rate:
     When not implemented by a strategy, returns None, orderbook is used to set entry price
 
     :param pair: Pair that's currently analyzed
+    :param trade: trade object (None for initial entries).
     :param current_time: datetime object, containing the current datetime
     :param proposed_rate: Rate, calculated based on pricing settings in exit_pricing.
     :param entry_tag: Optional entry_tag (buy_tag) if provided with the buy signal.

--- a/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
+++ b/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
@@ -33,7 +33,7 @@ class StrategyTestV3CustomEntryPrice(StrategyTestV3):
     def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         return dataframe
 
-    def custom_entry_price(self, pair: str, trade: Trade, current_time: datetime,
+    def custom_entry_price(self, pair: str, trade: Optional[Trade], current_time: datetime,
                            proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
 

--- a/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
+++ b/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
@@ -6,6 +6,8 @@ from typing import Optional
 from pandas import DataFrame
 from strategy_test_v3 import StrategyTestV3
 
+from freqtrade.persistence import Trade
+
 
 class StrategyTestV3CustomEntryPrice(StrategyTestV3):
     """
@@ -31,7 +33,7 @@ class StrategyTestV3CustomEntryPrice(StrategyTestV3):
     def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         return dataframe
 
-    def custom_entry_price(self, pair: str, current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
 
         return self.new_entry_price

--- a/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
+++ b/tests/strategy/strats/strategy_test_v3_custom_entry_price.py
@@ -33,7 +33,8 @@ class StrategyTestV3CustomEntryPrice(StrategyTestV3):
     def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         return dataframe
 
-    def custom_entry_price(self, pair: str, trade: 'Trade', current_time: datetime, proposed_rate: float,
+    def custom_entry_price(self, pair: str, trade: Trade, current_time: datetime,
+                           proposed_rate: float,
                            entry_tag: Optional[str], side: str, **kwargs) -> float:
 
         return self.new_entry_price


### PR DESCRIPTION
Add trade parameter to custom_entry_price callback

## What's new?
Allow user to use trade object within the custom_entry_price callback, for example to set an entry price related to number of successful exits.
Note: I had some issues running tests, will fix bug if any, tomorrow
