### PR TITLE
Bug: FreqAI fit_live_predictions()

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -244,6 +244,14 @@ class FreqaiDataKitchen:
                 f"{self.pair}: dropped {len(unfiltered_df) - len(filtered_df)} training points"
                 f" due to NaNs in populated dataset {len(unfiltered_df)}."
             )
+            if len(unfiltered_df) == 0 and not self.live:
+                raise OperationalException(
+                    f"{self.pair}: all training data dropped due to NaNs. "
+                    "You likely did not download enough training data prior "
+                    "to your backtest timerange. Hint:\n"
+                    "https://www.freqtrade.io/en/stable/freqai-running/"
+                    "#downloading-data-to-cover-the-full-backtest-period"
+                )
             if (1 - len(filtered_df) / len(unfiltered_df)) > 0.1 and self.live:
                 worst_indicator = str(unfiltered_df.count().idxmin())
                 logger.warning(

--- a/tests/freqai/test_freqai_datadrawer.py
+++ b/tests/freqai/test_freqai_datadrawer.py
@@ -181,7 +181,6 @@ def test_set_initial_return_values(mocker, freqai_conf):
 
     assert (hist_pred_df['date_pred'].iloc[-1] ==
             pd.Timestamp(end_x_plus_5) - pd.Timedelta(days=1))
-    assert 'date' not in hist_pred_df.columns
     assert 'date_pred' in hist_pred_df.columns
     assert hist_pred_df.shape[0] == 7  # Total rows: 5 from historic and 2 new zeros
 
@@ -236,7 +235,6 @@ def test_set_initial_return_values_warning(mocker, freqai_conf):
     model_return_df = freqai.dd.model_return_values[pair]
 
     assert hist_pred_df['date_pred'].iloc[-1] == pd.Timestamp(end_x_plus_5) - pd.Timedelta(days=1)
-    assert 'date' not in hist_pred_df.columns
     assert 'date_pred' in hist_pred_df.columns
     assert hist_pred_df.shape[0] == 9  # Total rows: 5 from historic and 4 new zeros
 


### PR DESCRIPTION
The latest PR #9179 introduced a bug that only crops up when users engage `fit_live_predictions()` to analyze their historic predictions on the fly. The issue was a creation of duplicate `date_pred` columns, which introduced type checking issues for some users (depends on how the user wants to use `self.historic_predictions` inside `fit_live_predictions()`).

This PR fixes the duplicate column problem.
