### PR TITLE
Revert "Bump ast-comments from 1.1.0 to 1.1.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,5 +60,5 @@ schedule==1.2.1
 websockets==11.0.3
 janus==1.0.0
 
-ast-comments==1.1.1
+ast-comments==1.1.0
 packaging==23.2


### PR DESCRIPTION
Reverts freqtrade/freqtrade#9250

no longer available on pypi ... ? 