### PR TITLE
Bybit: Fetch order one more time to allow exchange to set correct value

### DIFF
--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -240,7 +240,7 @@ class Bybit(Exchange):
 
         # Currently bybit does not update status of the cancelled order on time.
         # Even though endpoint returns proper response and code 200, the status stays open.
-        # This re-fetches the order giving vyvit enough time to update the status.
+        # This re-fetches the order giving bybit enough time to update the status.
         if order.get("status") == "open" and order.get("filled") == 0.0:
             try:
                 order = self.fetch_order(order_id, pair)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #9273

## Quick changelog

- Re-fetch the cancelled order in order to give enough time to bybit to update order status correctly to canceled.