### PR TITLE
Improve Cancel order messaging behavior

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1336,6 +1336,7 @@ class FreqtradeBot(LoggingMixin):
         :return: None
         """
         for trade in Trade.get_open_trades():
+            open_order: Order
             for open_order in trade.open_orders:
                 try:
                     order = self.exchange.fetch_order(open_order.order_id, trade.pair)

--- a/freqtrade/persistence/migrations.py
+++ b/freqtrade/persistence/migrations.py
@@ -220,6 +220,7 @@ def migrate_orders_table(engine, table_back_name: str, cols_order: List):
     funding_fee = get_column_def(cols_order, 'funding_fee', '0.0')
     ft_amount = get_column_def(cols_order, 'ft_amount', 'coalesce(amount, 0.0)')
     ft_price = get_column_def(cols_order, 'ft_price', 'coalesce(price, 0.0)')
+    ft_cancel_reason = get_column_def(cols_order, 'ft_cancel_reason', 'null')
 
     # sqlite does not support literals for booleans
     with engine.begin() as connection:
@@ -227,13 +228,13 @@ def migrate_orders_table(engine, table_back_name: str, cols_order: List):
             insert into orders (id, ft_trade_id, ft_order_side, ft_pair, ft_is_open, order_id,
             status, symbol, order_type, side, price, amount, filled, average, remaining, cost,
             stop_price, order_date, order_filled_date, order_update_date, ft_fee_base, funding_fee,
-            ft_amount, ft_price
+            ft_amount, ft_price, ft_cancel_reason
             )
             select id, ft_trade_id, ft_order_side, ft_pair, ft_is_open, order_id,
             status, symbol, order_type, side, price, amount, filled, {average} average, remaining,
             cost, {stop_price} stop_price, order_date, order_filled_date,
             order_update_date, {ft_fee_base} ft_fee_base, {funding_fee} funding_fee,
-            {ft_amount} ft_amount, {ft_price} ft_price
+            {ft_amount} ft_amount, {ft_price} ft_price, {ft_cancel_reason} ft_cancel_reason
             from {table_back_name}
             """))
 
@@ -328,8 +329,8 @@ def check_migrate(engine, decl_base, previous_tables) -> None:
     # if ('orders' not in previous_tables
     # or not has_column(cols_orders, 'funding_fee')):
     migrating = False
-    # if not has_column(cols_orders, 'ft_price'):
-    if not has_column(cols_trades, 'is_stop_loss_trailing'):
+    # if not has_column(cols_trades, 'is_stop_loss_trailing'):
+    if not has_column(cols_orders, 'ft_cancel_reason'):
         migrating = True
         logger.info(f"Running database migration for trades - "
                     f"backup: {table_back_name}, {order_table_bak_name}")

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -68,6 +68,7 @@ class Order(ModelBase):
     ft_is_open: Mapped[bool] = mapped_column(nullable=False, default=True, index=True)
     ft_amount: Mapped[float] = mapped_column(Float(), nullable=False)
     ft_price: Mapped[float] = mapped_column(Float(), nullable=False)
+    ft_cancel_reason: Mapped[str] = mapped_column(String(CUSTOM_TAG_MAX_LENGTH), nullable=True)
 
     order_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     status: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -795,14 +795,14 @@ class RPC:
 
             if order['side'] == trade.entry_side:
                 fully_canceled = self._freqtrade.handle_cancel_enter(
-                    trade, order, oo.order_id, CANCEL_REASON['FORCE_EXIT'])
+                    trade, order, oo, CANCEL_REASON['FORCE_EXIT'])
                 trade_entry_cancelation_res['cancel_state'] = fully_canceled
                 trade_entry_cancelation_registry.append(trade_entry_cancelation_res)
 
             if order['side'] == trade.exit_side:
                 # Cancel order - so it is placed anew with a fresh price.
                 self._freqtrade.handle_cancel_exit(
-                    trade, order, oo.order_id, CANCEL_REASON['FORCE_EXIT'])
+                    trade, order, oo, CANCEL_REASON['FORCE_EXIT'])
 
         if all(tocr['cancel_state'] is False for tocr in trade_entry_cancelation_registry):
             if trade.has_open_orders:
@@ -955,7 +955,7 @@ class RPC:
                     logger.info(f"Cannot query order for {trade} due to {e}.", exc_info=True)
                     raise RPCException("Order not found.")
                 self._freqtrade.handle_cancel_order(
-                    order, open_order.order_id, trade, CANCEL_REASON['USER_CANCEL'])
+                    order, open_order, trade, CANCEL_REASON['USER_CANCEL'])
             Trade.commit()
 
     def _rpc_delete(self, trade_id: int) -> Dict[str, Union[str, int]]:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

If an order doesn't cancel immediately (due to delayed exchange messaging) - we should still know the original cancel reason to avoid confusing messaging.

## Quick changelog

- add cancel_reason column to order object
- Improve messaging