### PR TITLE
Improve freqAI RL (error) behavior

### DIFF
--- a/freqtrade/freqai/RL/BaseEnvironment.py
+++ b/freqtrade/freqai/RL/BaseEnvironment.py
@@ -159,7 +159,7 @@ class BaseEnvironment(gym.Env):
         function is designed for tracking incremented objects,
         events, actions inside the training environment.
         For example, a user can call this to track the
-        frequency of occurence of an `is_valid` call in
+        frequency of occurrence of an `is_valid` call in
         their `calculate_reward()`:
 
         def calculate_reward(self, action: int) -> float:

--- a/freqtrade/freqai/prediction_models/ReinforcementLearner.py
+++ b/freqtrade/freqai/prediction_models/ReinforcementLearner.py
@@ -85,7 +85,7 @@ class ReinforcementLearner(BaseReinforcementLearningModel):
             best_model = self.MODELCLASS.load(dk.data_path / "best_model")
             return best_model
 
-        logger.info('Couldnt find best model, using final model instead.')
+        logger.info("Couldn't find best model, using final model instead.")
 
         return model
 

--- a/freqtrade/freqai/tensorboard/TensorboardCallback.py
+++ b/freqtrade/freqai/tensorboard/TensorboardCallback.py
@@ -49,7 +49,7 @@ class TensorboardCallback(BaseCallback):
         local_info = self.locals["infos"][0]
         if self.training_env is None:
             return True
-        tensorboard_metrics = self.training_env.get_attr("tensorboard_metrics")[0]
+        tensorboard_metrics = self.training_env.envs[0].unwrapped.tensorboard_metrics
 
         for metric in local_info:
             if metric not in ["episode", "terminal_observation"]:

--- a/freqtrade/freqai/tensorboard/TensorboardCallback.py
+++ b/freqtrade/freqai/tensorboard/TensorboardCallback.py
@@ -49,7 +49,10 @@ class TensorboardCallback(BaseCallback):
         local_info = self.locals["infos"][0]
         if self.training_env is None:
             return True
-        tensorboard_metrics = self.training_env.envs[0].unwrapped.tensorboard_metrics
+
+        tensorboard_metrics = (
+            self.training_env.envs[0].unwrapped.tensorboard_metrics  # type: ignore[attr-defined]
+        )
 
         for metric in local_info:
             if metric not in ["episode", "terminal_observation"]:

--- a/freqtrade/freqai/tensorboard/TensorboardCallback.py
+++ b/freqtrade/freqai/tensorboard/TensorboardCallback.py
@@ -50,9 +50,12 @@ class TensorboardCallback(BaseCallback):
         if self.training_env is None:
             return True
 
-        tensorboard_metrics = (
-            self.training_env.envs[0].unwrapped.tensorboard_metrics  # type: ignore[attr-defined]
-        )
+        if hasattr(self.training_env, 'envs'):
+            tensorboard_metrics = self.training_env.envs[0].unwrapped.tensorboard_metrics
+
+        else:
+            # For RL-multiproc - usage of [0] might need to be evaluated
+            tensorboard_metrics = self.training_env.get_attr("tensorboard_metrics")[0]
 
         for metric in local_info:
             if metric not in ["episode", "terminal_observation"]:


### PR DESCRIPTION

## Summary

running FreqAI with RL with tensorboard-callback enabled will cause the following warnings (for every simulation, as far as i can tell) - which does severely impact performance, as logging / display output is pretty slow.

```
/home/xmatt/.pyenv/versions/3.11.2/envs/trade_3112_copy/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.tensorboard_metrics to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.tensorboard_metrics` for environment variables or `env.get_wrapper_attr('tensorboard_metrics')` that will search the reminding wrappers.
```

---

If the environment raises an exception, we're currently unable to continue training if progress_bar is enabled, since the progressbar-callback starts throwing exceptions.
Based on the recommendations in https://github.com/DLR-RM/stable-baselines3/issues/1645#issuecomment-1680395909 - this can be worked around by manually closing the progressbar Environment (still a bug in stable-baselines for me as it fails to close callbacks, but it doesn't seem like they're motivated to fix their bug).

A very minimal reproduction for this is the following model - which always fails (which is clearly syntetic and unrealistic).

In a realistic scenario, the code contained might error with some random error for only 1 pair - which shouldn't impact training for further pairs.

``` python
from freqtrade.freqai.prediction_models.ReinforcementLearner import ReinforcementLearner
from freqtrade.freqai.RL.Base5ActionRLEnv import Base5ActionRLEnv

class MyCoolRLModel(ReinforcementLearner):
    class MyRLEnv(Base5ActionRLEnv):
        def calculate_reward(self, action: int) -> float:
            raise ValueError("Not implemented")
```

While the new code will still show the error - it'll not prevent further training of other pairs - and will therefore not completely stop the bot from working (previously, the only way to have the bot train again was by restarting the bot).

closes #9206, closes #8959 


## Quick changelog

- fix tensorboard deprecation warning
- Fix LiveError causing training to stop for all pairs
