### PR TITLE
have to use bitwise operator on series comparison, otherwise ambiguous error is thrown

### DIFF
--- a/freqtrade/vendor/qtpylib/indicators.py
+++ b/freqtrade/vendor/qtpylib/indicators.py
@@ -226,7 +226,7 @@ def crossed(series1, series2, direction=None):
             series1.shift(1) >= series2.shift(1)))
 
     if direction is None:
-        return above or below
+        return above | below
 
     return above if direction == "above" else below
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

have to use bitwise operator on series comparison, otherwise ambiguous error is thrown

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
