### PR TITLE
Revert "Bump torch from 2.0.1 to 2.1.0"

### DIFF
--- a/requirements-freqai-rl.txt
+++ b/requirements-freqai-rl.txt
@@ -2,7 +2,7 @@
 -r requirements-freqai.txt
 
 # Required for freqai-rl
-torch==2.1.0
+torch==2.0.1
 #until these branches will be released we can use this
 gymnasium==0.29.1
 stable_baselines3==2.1.0


### PR DESCRIPTION
Reverts freqtrade/freqtrade#9281 for now, until windows CI failures is figured out.