### PR TITLE
Add FIAT mapping for USDC

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -27,6 +27,7 @@ coingecko_mapping = {
     'usdt': 'tether',
     'busd': 'binance-usd',
     'tusd': 'true-usd',
+    'usdc': 'usd-coin',
 }
 
 


### PR DESCRIPTION
## Summary

Add the missing mapping for USDC for Coingecko.

I noticed the 'WARNING - Found multiple mappings in CoinGecko for usdc.' in the log of the bot, and checked what needed be done to fix this. This is my first change and PR for Freqtrade, so hope I didn't miss anything.

## Quick changelog

- Add Coingecko mapping for USDC.

## What's new?

Correct reference to USDC on Coingeco. Did check the automatic tests and did not see any specific test per mapping, except the general tests. 