### PR TITLE
fix: bug in startup candle offset

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -296,8 +296,7 @@ class FreqaiDataDrawer:
                            f"for more than {len(dataframe.index)} candles.")
 
         df_concat = pd.concat([hist_preds, new_pred], ignore_index=True, keys=hist_preds.keys())
-        # remove last row because we will append that later in append_model_predictions()
-        df_concat = df_concat.iloc[:-1]
+
         # any missing values will get zeroed out so users can see the exact
         # downtime in FreqUI
         df_concat = df_concat.fillna(0)

--- a/tests/freqai/test_freqai_datadrawer.py
+++ b/tests/freqai/test_freqai_datadrawer.py
@@ -179,10 +179,9 @@ def test_set_initial_return_values(mocker, freqai_conf):
     hist_pred_df = freqai.dd.historic_predictions[pair]
     model_return_df = freqai.dd.model_return_values[pair]
 
-    assert (hist_pred_df['date_pred'].iloc[-1] ==
-            pd.Timestamp(end_x_plus_5) - pd.Timedelta(days=1))
+    assert hist_pred_df['date_pred'].iloc[-1] == pd.Timestamp(end_x_plus_5)
     assert 'date_pred' in hist_pred_df.columns
-    assert hist_pred_df.shape[0] == 7  # Total rows: 5 from historic and 2 new zeros
+    assert hist_pred_df.shape[0] == 8
 
     # compare values in model_return_df with hist_pred_df
     assert (model_return_df["value"].values ==
@@ -234,9 +233,9 @@ def test_set_initial_return_values_warning(mocker, freqai_conf):
     hist_pred_df = freqai.dd.historic_predictions[pair]
     model_return_df = freqai.dd.model_return_values[pair]
 
-    assert hist_pred_df['date_pred'].iloc[-1] == pd.Timestamp(end_x_plus_5) - pd.Timedelta(days=1)
+    assert hist_pred_df['date_pred'].iloc[-1] == pd.Timestamp(end_x_plus_5)
     assert 'date_pred' in hist_pred_df.columns
-    assert hist_pred_df.shape[0] == 9  # Total rows: 5 from historic and 4 new zeros
+    assert hist_pred_df.shape[0] == 10
 
     # compare values in model_return_df with hist_pred_df
     assert (model_return_df["value"].values == hist_pred_df.tail(


### PR DESCRIPTION
After we improved the FreqUI viewing for FreqAI restarts #9179 , we introduced a bug with the candle offset in the startup. 

Thanks to @smidelis for finding this bug and doing all the the leg work for resolution.