### PR TITLE
informative assets -> {base}

### DIFF
--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -486,17 +486,18 @@ for more information.
 
         :param timeframe: Informative timeframe. Must always be equal or higher than strategy timeframe.
         :param asset: Informative asset, for example BTC, BTC/USDT, ETH/BTC. Do not specify to use
-        current pair.
+                    current pair. Also supports limited pair format strings (see below)
         :param fmt: Column format (str) or column formatter (callable(name, asset, timeframe)). When not
         specified, defaults to:
-        * {base}_{quote}_{column}_{timeframe} if asset is specified. 
+        * {base}_{quote}_{column}_{timeframe} if asset is specified.
         * {column}_{timeframe} if asset is not specified.
-        Format string supports these format variables:
-        * {asset} - full name of the asset, for example 'BTC/USDT'.
+        Pair format supports these format variables:
         * {base} - base currency in lower case, for example 'eth'.
         * {BASE} - same as {base}, except in upper case.
         * {quote} - quote currency in lower case, for example 'usdt'.
         * {QUOTE} - same as {quote}, except in upper case.
+        Format string additionally supports this variables.
+        * {asset} - full name of the asset, for example 'BTC/USDT'.
         * {column} - name of dataframe column.
         * {timeframe} - timeframe of informative dataframe.
         :param ffill: ffill dataframe after merging informative pair.

--- a/freqtrade/strategy/informative_decorator.py
+++ b/freqtrade/strategy/informative_decorator.py
@@ -38,17 +38,18 @@ def informative(timeframe: str, asset: str = '',
 
     :param timeframe: Informative timeframe. Must always be equal or higher than strategy timeframe.
     :param asset: Informative asset, for example BTC, BTC/USDT, ETH/BTC. Do not specify to use
-    current pair.
+                  current pair. Also supports limited pair format strings (see below)
     :param fmt: Column format (str) or column formatter (callable(name, asset, timeframe)). When not
     specified, defaults to:
     * {base}_{quote}_{column}_{timeframe} if asset is specified.
     * {column}_{timeframe} if asset is not specified.
-    Format string supports these format variables:
-    * {asset} - full name of the asset, for example 'BTC/USDT'.
+    Pair format supports these format variables:
     * {base} - base currency in lower case, for example 'eth'.
     * {BASE} - same as {base}, except in upper case.
     * {quote} - quote currency in lower case, for example 'usdt'.
     * {QUOTE} - same as {quote}, except in upper case.
+    Format string additionally supports this variables.
+    * {asset} - full name of the asset, for example 'BTC/USDT'.
     * {column} - name of dataframe column.
     * {timeframe} - timeframe of informative dataframe.
     :param ffill: ffill dataframe after merging informative pair.

--- a/freqtrade/strategy/informative_decorator.py
+++ b/freqtrade/strategy/informative_decorator.py
@@ -81,9 +81,12 @@ def __get_pair_formats(market: Optional[Dict[str, Any]]) -> Dict[str, str]:
     }
 
 
-def _format_pair_name(config, pair: str) -> str:
-    return pair.format(stake_currency=config['stake_currency'],
-                       stake=config['stake_currency']).upper()
+def _format_pair_name(config, pair: str, market: Optional[Dict[str, Any]] = None) -> str:
+    return pair.format(
+        stake_currency=config['stake_currency'],
+        stake=config['stake_currency'],
+        **__get_pair_formats(market),
+    ).upper()
 
 
 def _create_and_merge_informative_pair(strategy, dataframe: DataFrame, metadata: dict,
@@ -98,7 +101,8 @@ def _create_and_merge_informative_pair(strategy, dataframe: DataFrame, metadata:
 
     if asset:
         # Insert stake currency if needed.
-        asset = _format_pair_name(config, asset)
+        market1 = strategy.dp.market(metadata['pair'])
+        asset = _format_pair_name(config, asset, market1)
     else:
         # Not specifying an asset will define informative dataframe for current pair.
         asset = metadata['pair']

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -756,12 +756,23 @@ class IStrategy(ABC, HyperStrategyMixin):
             candle_type = (inf_data.candle_type if inf_data.candle_type
                            else self.config.get('candle_type_def', CandleType.SPOT))
             if inf_data.asset:
-                pair_tf = (
-                    _format_pair_name(self.config, inf_data.asset),
-                    inf_data.timeframe,
-                    candle_type,
-                )
-                informative_pairs.append(pair_tf)
+                if any(s in inf_data.asset for s in ("{BASE}", "{base}")):
+                    for pair in self.dp.current_whitelist():
+
+                        pair_tf = (
+                            _format_pair_name(self.config, inf_data.asset, self.dp.market(pair)),
+                            inf_data.timeframe,
+                            candle_type,
+                        )
+                        informative_pairs.append(pair_tf)
+
+                else:
+                    pair_tf = (
+                        _format_pair_name(self.config, inf_data.asset),
+                        inf_data.timeframe,
+                        candle_type,
+                    )
+                    informative_pairs.append(pair_tf)
             else:
                 for pair in self.dp.current_whitelist():
                     informative_pairs.append((pair, inf_data.timeframe, candle_type))

--- a/tests/strategy/strats/informative_decorator_strategy.py
+++ b/tests/strategy/strats/informative_decorator_strategy.py
@@ -47,6 +47,11 @@ class InformativeDecoratorTest(IStrategy):
         dataframe['rsi'] = 14
         return dataframe
 
+    @informative('1h', '{base}/BTC')
+    def populate_indicators_base_1h(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe['rsi'] = 14
+        return dataframe
+
     # Quote currency different from stake currency test.
     @informative('1h', 'ETH/BTC', candle_type='spot')
     def populate_indicators_eth_btc_1h(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/tests/strategy/test_strategy_helpers.py
+++ b/tests/strategy/test_strategy_helpers.py
@@ -277,9 +277,11 @@ def test_informative_decorator(mocker, default_conf_usdt, trading_mode):
         ('XRP/USDT', '5m', candle_def): test_data_5m,
         ('XRP/USDT', '30m', candle_def): test_data_30m,
         ('XRP/USDT', '1h', candle_def): test_data_1h,
+        ('XRP/BTC', '1h', candle_def): test_data_1h,  # from {base}/BTC
         ('LTC/USDT', '5m', candle_def): test_data_5m,
         ('LTC/USDT', '30m', candle_def): test_data_30m,
         ('LTC/USDT', '1h', candle_def): test_data_1h,
+        ('LTC/BTC', '1h', candle_def): test_data_1h,  # from {base}/BTC
         ('NEO/USDT', '30m', candle_def): test_data_30m,
         ('NEO/USDT', '5m', CandleType.SPOT): test_data_5m,  # Explicit request with '' as candletype
         ('NEO/USDT', '15m', candle_def): test_data_5m,  # Explicit request with '' as candletype
@@ -296,10 +298,12 @@ def test_informative_decorator(mocker, default_conf_usdt, trading_mode):
         'XRP/USDT', 'LTC/USDT', 'NEO/USDT'
     ])
 
-    assert len(strategy._ft_informative) == 6   # Equal to number of decorators used
+    assert len(strategy._ft_informative) == 7   # Equal to number of decorators used
     informative_pairs = [
         ('XRP/USDT', '1h', candle_def),
+        ('XRP/BTC', '1h', candle_def),
         ('LTC/USDT', '1h', candle_def),
+        ('LTC/BTC', '1h', candle_def),
         ('XRP/USDT', '30m', candle_def),
         ('LTC/USDT', '30m', candle_def),
         ('NEO/USDT', '1h', candle_def),


### PR DESCRIPTION
## Summary
Support passing `"{BASE}/USDT"` as asset to `@informative`.
This will simplify usecases as the one shown in #9367.

## Quick changelog

- Support `{base}` and `{BASE}` (and `{quote}`, `{QUOTE}` respectively) in asset field.
- tests for these methods
