### PR TITLE
Fix backtesting-analysis when no trades for a pair

### DIFF
--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -211,8 +211,9 @@ def prepare_results(analysed_trades, stratname,
                     timerange=None):
     res_df = pd.DataFrame()
     for pair, trades in analysed_trades[stratname].items():
-        trades.dropna(subset=['close_date'], inplace=True)
-        res_df = pd.concat([res_df, trades], ignore_index=True)
+        if (trades.shape[0] > 0):
+            trades.dropna(subset=['close_date'], inplace=True)
+            res_df = pd.concat([res_df, trades], ignore_index=True)
 
     res_df = _select_rows_within_dates(res_df, timerange)
 


### PR DESCRIPTION
## Summary

When calling backtesting-analysis with results where a pair has no trades, a KeyError exception will be thrown:

```
Traceback (most recent call last):
  File "/home/froggleston/git/freqtrade/main.py", line 42, in main
    return_code = args['func'](args)
                  ^^^^^^^^^^^^^^^^^^
  File "/home/froggleston/git/freqtrade/commands/analyze_commands.py", line 63, in start_analysis_entries_exits
    process_entry_exit_reasons(config)
  File "/home/froggleston/git/freqtrade/data/entryexitanalysis.py", line 320, in process_entry_exit_reasons
    res_df = prepare_results(analysed_trades_dict, strategy_name,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/froggleston/git/freqtrade/data/entryexitanalysis.py", line 215, in prepare_results
    trades.dropna(subset=['close_date'], inplace=True)
  File "/home/froggleston/git/freqtrade/.venv/lib/python3.11/site-packages/pandas/core/frame.py", line 6418, in dropna
    raise KeyError(np.array(subset)[check].tolist())
KeyError: ['close_date']
```

## Quick changelog

- Add a length check to the trades object for each analysed pair