### PR TITLE
Bug: freqai backtesting startup_candle_count handling

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -332,15 +332,14 @@ class DataProvider:
         if not freqai_config.get('enabled', False):
             return self._config.get('startup_candle_count', 0)
         else:
-            startup_candles = self._config.get('startup_candle_count', 0)
             indicator_periods = freqai_config['feature_parameters']['indicator_periods_candles']
             # make sure the startupcandles is at least the set maximum indicator periods
-            self._config['startup_candle_count'] = max(startup_candles, max(indicator_periods))
+            needed_candles = max(indicator_periods)
             tf_seconds = timeframe_to_seconds(timeframe)
             train_candles = 0
             if add_train_candles:
                 train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
-            total_candles = int(self._config['startup_candle_count'] + train_candles)
+            total_candles = int(needed_candles + train_candles)
             logger.info(f'Increasing startup_candle_count for freqai to {total_candles}')
             return total_candles
 

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -332,14 +332,15 @@ class DataProvider:
         if not freqai_config.get('enabled', False):
             return self._config.get('startup_candle_count', 0)
         else:
+            startup_candles = self._config.get('startup_candle_count', 0)
             indicator_periods = freqai_config['feature_parameters']['indicator_periods_candles']
             # make sure the startupcandles is at least the set maximum indicator periods
-            needed_candles = max(indicator_periods)
+            self._config['startup_candle_count'] = max(startup_candles, max(indicator_periods))
             tf_seconds = timeframe_to_seconds(timeframe)
             train_candles = 0
             if add_train_candles:
                 train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
-            total_candles = int(needed_candles + train_candles)
+            total_candles = int(self._config['startup_candle_count'] + train_candles)
             logger.info(f'Increasing startup_candle_count for freqai to {total_candles}')
             return total_candles
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -147,7 +147,9 @@ class Backtesting:
 
         if self.config.get('freqai', {}).get('enabled', False):
             # For FreqAI, increase the required_startup to includes the training data
-            self.required_startup = self.dataprovider.get_required_startup(self.timeframe)
+            self.freqai_startup_candles = self.dataprovider.get_required_startup(
+                                                self.timeframe
+                                           )
 
         # Add maximum startup candle count to configuration for informative pairs support
         self.config['startup_candle_count'] = self.required_startup
@@ -234,12 +236,17 @@ class Backtesting:
         """
         self.progress.init_step(BacktestState.DATALOAD, 1)
 
+        if self.config.get('freqai', {}).get('enabled', False):
+            startup_candle_count = self.freqai_startup_candles
+        else:
+            startup_candle_count = self.config['startup_candle_count']
+
         data = history.load_data(
             datadir=self.config['datadir'],
             pairs=self.pairlists.whitelist,
             timeframe=self.timeframe,
             timerange=self.timerange,
-            startup_candles=self.config['startup_candle_count'],
+            startup_candles=startup_candle_count,
             fail_without_data=True,
             data_format=self.config['dataformat_ohlcv'],
             candle_type=self.config.get('candle_type_def', CandleType.SPOT)


### PR DESCRIPTION
Backtesting with FreqAI introduces a bug with large timeframes as indicated by this issue #9432. This bug is not present in dry/live operations.

The function `get_required_startup()` assumes that the `startup_candle_count` is set in the highest timeframe candle size (so in #9432 it assumes that `startup_candle_count` is in days. However, FreqAI (and FT normal) uses `startup_candle_count` inside  `load_bt_data()` to get the full training period loaded in for the user on the **base timeframe**. So currently we are setting this `startup_candle_count` for the base timeframe including the training period as an effort to ensure `load_bt_data()` gets the full training data for the base timeframe. But after setting `startup_candle_count` to this large basetimeframe value, the `get_required_startup()` would use this higher `startup_candle_count` value for higher timeframes in combination with the user set `train_period_days`. Although for the current typical FreqAI usecases, this was not noticeable (usually users stick to 5m, - 4h timeframes together), it could be catastrophic for users who have unexpectedly broad ranges of parameters set. For example, we see thousands of days would become "required" for a config where the user set a base timeframe of `5m` with a high `train_period_days` in combination with a high maximum `include_timeframes`. In #9432, the user set `train_period_days` to 180 and also uses `include_timeframes` of `1d`.

