### PR TITLE
Removed redudant negative from sentence

### DIFF
--- a/freqtrade/optimize/hyperopt_auto.py
+++ b/freqtrade/optimize/hyperopt_auto.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def _format_exception_message(space: str, ignore_missing_space: bool) -> None:
     msg = (f"The '{space}' space is included into the hyperoptimization "
-           f"but no parameter for this space was not found in your Strategy. "
+           f"but no parameter for this space was found in your Strategy. "
            )
     if ignore_missing_space:
         logger.warning(msg + "This space will be ignored.")


### PR DESCRIPTION

## Summary

Fix typo in hyperopt optimization

Solve the issue: # removed one word

## Quick changelog

- Removed 'not ' from printed string in hyperopt_auto.py

## What's new?

Small typo fix
