### PR TITLE
exposing bot_name to discord rpc field

### DIFF
--- a/freqtrade/rpc/discord.py
+++ b/freqtrade/rpc/discord.py
@@ -15,6 +15,7 @@ class Discord(Webhook):
         self.rpc = rpc
         self.strategy = config.get('strategy', '')
         self.timeframe = config.get('timeframe', '')
+        self.bot_name = config.get('bot_name', '')
 
         self._url = config['discord']['webhook_url']
         self._format = 'json'
@@ -36,6 +37,7 @@ class Discord(Webhook):
 
             msg['strategy'] = self.strategy
             msg['timeframe'] = self.timeframe
+            msg['bot_name'] = self.bot_name
             color = 0x0000FF
             if msg['type'] in (RPCMessageType.EXIT, RPCMessageType.EXIT_FILL):
                 profit_ratio = msg.get('profit_ratio')


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Sometimes users will use one same strategy on multiple bots. Having bot_name available will make it easier to diferentiate which bot send which message

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
