### PR TITLE
chore: fix future warning on pandas

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -317,9 +317,9 @@ class FreqaiDataDrawer:
         index = self.historic_predictions[pair].index[-1:]
         columns = self.historic_predictions[pair].columns
 
-        nan_df = pd.DataFrame(np.nan, index=index, columns=columns)
+        zeros_df = pd.DataFrame(np.zeros, index=index, columns=columns)
         self.historic_predictions[pair] = pd.concat(
-            [self.historic_predictions[pair], nan_df], ignore_index=True, axis=0)
+            [self.historic_predictions[pair], zeros_df], ignore_index=True, axis=0)
         df = self.historic_predictions[pair]
 
         # model outputs and associated statistics


### PR DESCRIPTION
Latest pandas versions are throwing a future warning:

```
freqtrade/freqai/data_drawer.py:400: FutureWarning:

The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
```

This PR fixes it.
