### PR TITLE
Fix multiple new Pandas 2.1 future warnings in FreqAI startup

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -285,8 +285,8 @@ class FreqaiDataDrawer:
         hist_preds = self.historic_predictions[pair].copy()
 
         # ensure both dataframes have the same date format so they can be merged
-        new_pred["date_pred"] = pd.to_datetime(new_pred["date_pred"], utc=True)
-        hist_preds["date_pred"] = pd.to_datetime(hist_preds["date_pred"], utc=True)
+        new_pred["date_pred"] = pd.to_datetime(new_pred["date_pred"])
+        hist_preds["date_pred"] = pd.to_datetime(hist_preds["date_pred"])
 
         # find the closest common date between new_pred and historic predictions
         # and cut off the new_pred dataframe at that date

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -284,6 +284,10 @@ class FreqaiDataDrawer:
         new_pred["date_pred"] = dataframe["date"]
         hist_preds = self.historic_predictions[pair].copy()
 
+        # ensure both dataframes have the same date format so they can be merged
+        new_pred["date_pred"] = pd.to_datetime(new_pred["date_pred"], utc=True)
+        hist_preds["date_pred"] = pd.to_datetime(hist_preds["date_pred"], utc=True)
+
         # find the closest common date between new_pred and historic predictions
         # and cut off the new_pred dataframe at that date
         common_dates = pd.merge(new_pred, hist_preds, on="date_pred", how="inner")
@@ -294,7 +298,9 @@ class FreqaiDataDrawer:
                            "predictions. You likely left your FreqAI instance offline "
                            f"for more than {len(dataframe.index)} candles.")
 
-        df_concat = pd.concat([hist_preds, new_pred], ignore_index=True, keys=hist_preds.keys())
+        # reindex new_pred columns to match the historic predictions dataframe
+        new_pred_reindexed = new_pred.reindex(columns=hist_preds.columns)
+        df_concat = pd.concat([hist_preds, new_pred_reindexed], ignore_index=True)
 
         # any missing values will get zeroed out so users can see the exact
         # downtime in FreqUI


### PR DESCRIPTION
Pandas 2.1 brought with it a slew of future warnings. Two more fixed here including:

```
FutureWarning:

The behavior of pd.concat with len(keys) != len(objs) is deprecated. In a future version this will raise instead of truncating to the smaller of the two sequences
```

And

```
You are trying to merge on datetime64[ns, UTC] and object columns for key 'date_pred'. If you wish to proceed you should use pd.concat
```

