### PR TITLE
Revert "Bump tables from 3.9.1 to 3.9.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ technical==1.4.0
 tabulate==0.9.0
 pycoingecko==3.1.0
 jinja2==3.1.2
-tables==3.9.2
+tables==3.9.1
 joblib==1.3.2
 rich==13.7.0
 pyarrow==14.0.1; platform_machine != 'armv7l'


### PR DESCRIPTION
Reverts freqtrade/freqtrade#9500

This should fix flaky macos CI.