### PR TITLE
Remove "activate" kwarg to xgboost calls

### DIFF
--- a/freqtrade/freqai/prediction_models/XGBoostRFRegressor.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRFRegressor.py
@@ -45,7 +45,7 @@ class XGBoostRFRegressor(BaseRegressionModel):
 
         model = XGBRFRegressor(**self.model_training_parameters)
 
-        model.set_params(callbacks=[TBCallback(dk.data_path)], activate=self.activate_tensorboard)
+        model.set_params(callbacks=[TBCallback(dk.data_path)])
         model.fit(X=X, y=y, sample_weight=sample_weight, eval_set=eval_set,
                   sample_weight_eval_set=eval_weights, xgb_model=xgb_model)
         # set the callbacks to empty so that we can serialize to disk later

--- a/freqtrade/freqai/prediction_models/XGBoostRegressor.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRegressor.py
@@ -45,7 +45,7 @@ class XGBoostRegressor(BaseRegressionModel):
 
         model = XGBRegressor(**self.model_training_parameters)
 
-        model.set_params(callbacks=[TBCallback(dk.data_path)], activate=self.activate_tensorboard)
+        model.set_params(callbacks=[TBCallback(dk.data_path)])
         model.fit(X=X, y=y, sample_weight=sample_weight, eval_set=eval_set,
                   sample_weight_eval_set=eval_weights, xgb_model=xgb_model)
         # set the callbacks to empty so that we can serialize to disk later


### PR DESCRIPTION

## Summary

Remove "activate" kwarg to xgboost calls, as they raise warnings as they're unused.

e.g.

```
                                                                                                                    
tests/freqai/test_freqai_interface.py::test_extract_data_and_train_model_Standard[XGBoostRFRegressor-False-False-Fal
se-True-False-0-0]                                                                                                  
  /home/xmatt/.pyenv/versions/3.11.4/envs/trade_3114/lib/python3.11/site-packages/xgboost/core.py:160: UserWarning: 
                                                                                                                    
  [19:44:20] WARNING: /workspace/src/learner.cc:742:                                                                
  Parameters: { "activate" } are not used.                                                                          
                                                                                                                    
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html  
```