### PR TITLE
Improve funding fee calculation

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -725,16 +725,7 @@ class Backtesting:
             self, trade: LocalTrade, row: Tuple, current_time: datetime
     ) -> Optional[LocalTrade]:
 
-        if self.trading_mode == TradingMode.FUTURES:
-            trade.set_funding_fees(
-                self.exchange.calculate_funding_fees(
-                    self.futures_data[trade.pair],
-                    amount=trade.amount,
-                    is_short=trade.is_short,
-                    open_date=trade.date_last_filled_utc,
-                    close_date=current_time
-                )
-            )
+        self._run_funding_fees(trade, current_time)
 
         # Check if we need to adjust our current positions
         if self.strategy.position_adjustment_enable:
@@ -752,6 +743,21 @@ class Backtesting:
             if t:
                 return t
         return None
+
+    def _run_funding_fees(self, trade: Trade, current_time: datetime):
+        """
+        Calculate funding fees if necessary and add them to the trade.
+        """
+        if self.trading_mode == TradingMode.FUTURES:
+            trade.set_funding_fees(
+                self.exchange.calculate_funding_fees(
+                    self.futures_data[trade.pair],
+                    amount=trade.amount,
+                    is_short=trade.is_short,
+                    open_date=trade.date_last_filled_utc,
+                    close_date=current_time
+                )
+            )
 
     def get_valid_price_and_stake(
         self, pair: str, row: Tuple, propose_rate: float, stake_amount: float,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -748,7 +748,7 @@ class Backtesting:
                 return t
         return None
 
-    def _run_funding_fees(self, trade: Trade, current_time: datetime, force: bool = False):
+    def _run_funding_fees(self, trade: LocalTrade, current_time: datetime, force: bool = False):
         """
         Calculate funding fees if necessary and add them to the trade.
         """

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -606,6 +606,8 @@ class Backtesting:
         """
         if order and self._get_order_filled(order.ft_price, row):
             order.close_bt_order(current_date, trade)
+            self._run_funding_fees(trade, current_date, force=True)
+
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open
                 trade.set_liquidation_price(self.exchange.get_liquidation_price(

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -549,6 +549,7 @@ def test_backtest__enter_trade_futures(default_conf_usdt, fee, mocker) -> None:
     default_conf_usdt['exchange']['pair_whitelist'] = ['.*']
     backtesting = Backtesting(default_conf_usdt)
     backtesting._set_strategy(backtesting.strategylist[0])
+    mocker.patch('freqtrade.optimize.backtesting.Backtesting._run_funding_fees')
     pair = 'ETH/USDT:USDT'
     row = [
         pd.Timestamp(year=2020, month=1, day=1, hour=5, minute=0),

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -947,12 +947,13 @@ def test_backtest_one_detail_futures(
     # assert late_entry > 0
 
 
-@pytest.mark.parametrize('use_detail,entries,max_stake,expected_ff', [
-    (True, 50, 3000, -1.18038144),
-    (False, 6, 360, -0.14679994)])
+@pytest.mark.parametrize('use_detail,entries,max_stake,ff_updates,expected_ff', [
+    (True, 50, 3000, 54, -1.18038144),
+    (False, 6, 360, 10, -0.14679994),
+])
 def test_backtest_one_detail_futures_funding_fees(
         default_conf_usdt, fee, mocker, testdatadir, use_detail, entries, max_stake,
-        expected_ff,
+        ff_updates, expected_ff,
 ) -> None:
     """
     Funding fees are expected to differ, as the maximum position size differs.
@@ -1015,8 +1016,10 @@ def test_backtest_one_detail_futures_funding_fees(
     assert len(results) == 1
 
     assert 'orders' in results.columns
-    # funding_fees have been calculated for each candle
-    assert ff_spy.call_count == (324 if use_detail else 27)
+    # funding_fees have been calculated for each funding-fee candle
+    # the trade is open for 26 hours - hence we expect the 8h fee to apply 4 times.
+    # Additional counts will happen due each successful entry, which needs to call this, too.
+    assert ff_spy.call_count == ff_updates
 
     for t in Trade.trades:
         # At least 6 adjustment orders

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -853,8 +853,8 @@ def test_backtest_one_detail(default_conf_usdt, fee, mocker, testdatadir, use_de
 
 
 @pytest.mark.parametrize('use_detail,exp_funding_fee, exp_ff_updates', [
-    (True, -0.018054162, 44),
-    (False, -0.01780296, 8),
+    (True, -0.018054162, 11),
+    (False, -0.01780296, 5),
     ])
 def test_backtest_one_detail_futures(
         default_conf_usdt, fee, mocker, testdatadir, use_detail, exp_funding_fee,

--- a/tests/optimize/test_backtesting_adjust_position.py
+++ b/tests/optimize/test_backtesting_adjust_position.py
@@ -104,6 +104,7 @@ def test_backtest_position_adjustment_detailed(default_conf, fee, mocker, levera
     mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float('inf'))
     mocker.patch(f"{EXMS}.get_max_leverage", return_value=10)
     mocker.patch(f"{EXMS}.get_maintenance_ratio_and_amt", return_value=(0.1, 0.1))
+    mocker.patch('freqtrade.optimize.backtesting.Backtesting._run_funding_fees')
 
     patch_exchange(mocker)
     default_conf.update({


### PR DESCRIPTION
## Summary

This pull request refactors the funding fee calculation in the codebase to improve efficiency and readability. The following changes have been made:

## Quick changelog

- Extracted the funding fee calculation to a separate method for better code organization and reusability.
- Modified the code to avoid calculating funding fees on every iteration, reducing unnecessary computations.

I expect this to improve backtesting performance for futures - the actual impact will heavily depend on the strategy (how many trades, how long in a trade, ...), but there should be no change in results.

when testing, make sure to run with `--cache none`.