### PR TITLE
Fix duplicated data loading and timerange for populate_features

### DIFF
--- a/docs/freqai-running.md
+++ b/docs/freqai-running.md
@@ -68,7 +68,7 @@ Backtesting mode requires [downloading the necessary data](#downloading-data-to-
     This way, you can return to using any model you wish by simply specifying the `identifier`.
 
 !!! Note
-    Backtesting calls `set_freqai_targets()` one time for each backtest window (where the number of windows is the full backtest timerange divided by the `backtest_period_days` parameter). Doing this means that the targets simulate dry/live behavior without look ahead bias. However, the definition of the features in `feature_engineering_*()` is performed once on the entire backtest timerange. This means that you should be sure that features do look-ahead into the future.
+    Backtesting calls `set_freqai_targets()` one time for each backtest window (where the number of windows is the full backtest timerange divided by the `backtest_period_days` parameter). Doing this means that the targets simulate dry/live behavior without look ahead bias. However, the definition of the features in `feature_engineering_*()` is performed once on the entire training timerange. This means that you should be sure that features do not look-ahead into the future.
     More details about look-ahead bias can be found in [Common Mistakes](strategy-customization.md#common-mistakes-when-developing-strategies).
 
 ---

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -329,7 +329,7 @@ class DataProvider:
             )
         return self.__cached_pairs_backtesting[saved_pair].copy()
 
-    def get_required_startup(self, timeframe: str, add_train_candles: bool = True) -> int:
+    def get_required_startup(self, timeframe: str) -> int:
         freqai_config = self._config.get('freqai', {})
         if not freqai_config.get('enabled', False):
             return self._config.get('startup_candle_count', 0)
@@ -339,9 +339,7 @@ class DataProvider:
             # make sure the startupcandles is at least the set maximum indicator periods
             self._config['startup_candle_count'] = max(startup_candles, max(indicator_periods))
             tf_seconds = timeframe_to_seconds(timeframe)
-            train_candles = 0
-            if add_train_candles:
-                train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
+            train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
             total_candles = int(self._config['startup_candle_count'] + train_candles)
             logger.info(
                 f'Increasing startup_candle_count for freqai on {timeframe} to {total_candles}')

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -316,8 +316,7 @@ class DataProvider:
             timerange.subtract_start(tf_seconds * startup_candles)
 
             logger.info(f"Loading data for {pair} {timeframe} "
-                        f"from {timerange.start_fmt} "
-                        f"to {timerange.stop_fmt}")
+                        f"from {timerange.start_fmt} to {timerange.stop_fmt}")
 
             self.__cached_pairs_backtesting[saved_pair] = load_pair_history(
                 pair=pair,
@@ -344,9 +343,9 @@ class DataProvider:
             if add_train_candles:
                 train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
             total_candles = int(self._config['startup_candle_count'] + train_candles)
-            logger.info(f'Increasing startup_candle_count for freqai on {timeframe} '
-                        f'to {total_candles}')
-            return total_candles
+            logger.info(
+                f'Increasing startup_candle_count for freqai on {timeframe} to {total_candles}')
+        return total_candles
 
     def get_pair_dataframe(
         self,

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -311,11 +311,14 @@ class DataProvider:
             timerange = TimeRange.parse_timerange(None if self._config.get(
                 'timerange') is None else str(self._config.get('timerange')))
 
-            # It is not necessary to add the training candles, as they
-            # were already added at the beginning of the backtest.
-            startup_candles = self.get_required_startup(str(timeframe), False)
+            startup_candles = self.get_required_startup(str(timeframe))
             tf_seconds = timeframe_to_seconds(str(timeframe))
             timerange.subtract_start(tf_seconds * startup_candles)
+
+            logger.info(f"Loading data for {pair} {timeframe} "
+                        f"from {timerange.start_fmt} "
+                        f"to {timerange.stop_fmt}")
+
             self.__cached_pairs_backtesting[saved_pair] = load_pair_history(
                 pair=pair,
                 timeframe=timeframe,

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -344,7 +344,8 @@ class DataProvider:
             if add_train_candles:
                 train_candles = freqai_config['train_period_days'] * 86400 / tf_seconds
             total_candles = int(self._config['startup_candle_count'] + train_candles)
-            logger.info(f'Increasing startup_candle_count for freqai to {total_candles}')
+            logger.info(f'Increasing startup_candle_count for freqai on {timeframe} '
+                        f'to {total_candles}')
             return total_candles
 
     def get_pair_dataframe(

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -709,6 +709,8 @@ class FreqaiDataKitchen:
                 pair, tf, strategy, corr_dataframes, base_dataframes, is_corr_pairs)
             informative_copy = informative_df.copy()
 
+            logger.debug(f"Populating features for {pair} {tf}")
+
             for t in self.freqai_config["feature_parameters"]["indicator_periods_candles"]:
                 df_features = strategy.feature_engineering_expand_all(
                     informative_copy.copy(), t, metadata=metadata)
@@ -788,6 +790,7 @@ class FreqaiDataKitchen:
 
         if not prediction_dataframe.empty:
             dataframe = prediction_dataframe.copy()
+            base_dataframes[self.config["timeframe"]] = dataframe.copy()
         else:
             dataframe = base_dataframes[self.config["timeframe"]].copy()
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -145,12 +145,13 @@ class Backtesting:
         self.required_startup = max([strat.startup_candle_count for strat in self.strategylist])
         self.exchange.validate_required_startup_candles(self.required_startup, self.timeframe)
 
-        if self.config.get('freqai', {}).get('enabled', False):
-            # For FreqAI, increase the required_startup to includes the training data
-            self.required_startup = self.dataprovider.get_required_startup(self.timeframe)
-
         # Add maximum startup candle count to configuration for informative pairs support
         self.config['startup_candle_count'] = self.required_startup
+
+        if self.config.get('freqai', {}).get('enabled', False):
+            # For FreqAI, increase the required_startup to includes the training data
+            # This value should NOT be written to startup_candle_count
+            self.required_startup = self.dataprovider.get_required_startup(self.timeframe)
 
         self.trading_mode: TradingMode = config.get('trading_mode', TradingMode.SPOT)
         # strategies which define "can_short=True" will fail to load in Spot mode.
@@ -239,7 +240,7 @@ class Backtesting:
             pairs=self.pairlists.whitelist,
             timeframe=self.timeframe,
             timerange=self.timerange,
-            startup_candles=self.config['startup_candle_count'],
+            startup_candles=self.required_startup,
             fail_without_data=True,
             data_format=self.config['dataformat_ohlcv'],
             candle_type=self.config.get('candle_type_def', CandleType.SPOT)

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -508,16 +508,13 @@ def test_dp_get_required_startup(default_conf_usdt):
     dp = DataProvider(default_conf_usdt, None)
 
     # No FreqAI config
-    assert dp.get_required_startup('5m', False) == 0
-    assert dp.get_required_startup('1h', False) == 0
-    assert dp.get_required_startup('1d', False) == 0
-    assert dp.get_required_startup('1d', True) == 0
+    assert dp.get_required_startup('5m') == 0
+    assert dp.get_required_startup('1h') == 0
     assert dp.get_required_startup('1d') == 0
 
     dp._config['startup_candle_count'] = 20
-    assert dp.get_required_startup('5m', False) == 20
-    assert dp.get_required_startup('5m', True) == 20
-    assert dp.get_required_startup('1h', False) == 20
+    assert dp.get_required_startup('5m') == 20
+    assert dp.get_required_startup('1h') == 20
     assert dp.get_required_startup('1h') == 20
 
     # With freqAI config
@@ -532,37 +529,19 @@ def test_dp_get_required_startup(default_conf_usdt):
             ]
         }
     }
-    assert dp.get_required_startup('5m', False) == 20
-    assert dp.get_required_startup('5m', True) == 5780
-
-    assert dp.get_required_startup('1h', False) == 20
-    assert dp.get_required_startup('1h', True) == 500
-
-    assert dp.get_required_startup('1d', False) == 20
-    assert dp.get_required_startup('1d', True) == 40
+    assert dp.get_required_startup('5m') == 5780
+    assert dp.get_required_startup('1h') == 500
     assert dp.get_required_startup('1d') == 40
 
     # FreqAI kindof ignores startup_candle_count if it's below indicator_periods_candles
     dp._config['startup_candle_count'] = 0
-    assert dp.get_required_startup('5m', False) == 20
-    assert dp.get_required_startup('5m', True) == 5780
-
-    assert dp.get_required_startup('1h', False) == 20
-    assert dp.get_required_startup('1h', True) == 500
-
-    assert dp.get_required_startup('1d', False) == 20
-    assert dp.get_required_startup('1d', True) == 40
+    assert dp.get_required_startup('5m') == 5780
+    assert dp.get_required_startup('1h') == 500
     assert dp.get_required_startup('1d') == 40
 
     dp._config['freqai']['feature_parameters']['indicator_periods_candles'][1] = 50
-    assert dp.get_required_startup('5m', False) == 50
-    assert dp.get_required_startup('5m', True) == 5810
-
-    assert dp.get_required_startup('1h', False) == 50
-    assert dp.get_required_startup('1h', True) == 530
-
-    assert dp.get_required_startup('1d', False) == 50
-    assert dp.get_required_startup('1d', True) == 70
+    assert dp.get_required_startup('5m') == 5810
+    assert dp.get_required_startup('1h') == 530
     assert dp.get_required_startup('1d') == 70
 
     # scenario from issue https://github.com/freqtrade/freqtrade/issues/9432
@@ -577,12 +556,6 @@ def test_dp_get_required_startup(default_conf_usdt):
         }
     }
     dp._config['startup_candle_count'] = 40
-    assert dp.get_required_startup('5m', False) == 40
-    assert dp.get_required_startup('5m', True) == 51880
-
-    assert dp.get_required_startup('1h', False) == 40
-    assert dp.get_required_startup('1h', True) == 4360
-
-    assert dp.get_required_startup('1d', False) == 40
-    assert dp.get_required_startup('1d', True) == 220
+    assert dp.get_required_startup('5m') == 51880
+    assert dp.get_required_startup('1h') == 4360
     assert dp.get_required_startup('1d') == 220

--- a/tests/freqai/test_freqai_backtesting.py
+++ b/tests/freqai/test_freqai_backtesting.py
@@ -51,7 +51,7 @@ def test_freqai_backtest_load_data(freqai_conf, mocker, caplog):
     backtesting = Backtesting(deepcopy(freqai_conf))
     backtesting.load_bt_data()
 
-    assert log_has_re('Increasing startup_candle_count for freqai to.*', caplog)
+    assert log_has_re('Increasing startup_candle_count for freqai on.*to.*', caplog)
 
     Backtesting.cleanup()
 

--- a/tests/freqai/test_freqai_backtesting.py
+++ b/tests/freqai/test_freqai_backtesting.py
@@ -6,11 +6,17 @@ from unittest.mock import PropertyMock
 import pytest
 
 from freqtrade.commands.optimize_commands import setup_optimize_configuration
+from freqtrade.configuration.timerange import TimeRange
+from freqtrade.data import history
+from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RunMode
+from freqtrade.enums.candletype import CandleType
 from freqtrade.exceptions import OperationalException
+from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.optimize.backtesting import Backtesting
-from tests.conftest import (CURRENT_TEST_STRATEGY, get_args, log_has_re, patch_exchange,
-                            patched_configuration_load_config_file)
+from tests.conftest import (CURRENT_TEST_STRATEGY, get_args, get_patched_exchange, log_has_re,
+                            patch_exchange, patched_configuration_load_config_file)
+from tests.freqai.conftest import get_patched_freqai_strategy
 
 
 def test_freqai_backtest_start_backtest_list(freqai_conf, mocker, testdatadir, caplog):
@@ -40,7 +46,16 @@ def test_freqai_backtest_start_backtest_list(freqai_conf, mocker, testdatadir, c
     Backtesting.cleanup()
 
 
-def test_freqai_backtest_load_data(freqai_conf, mocker, caplog):
+@pytest.mark.parametrize(
+    "timeframe, expected_startup_candle_count",
+    [
+        ("5m", 876),
+        ("15m", 492),
+        ("1d", 302),
+    ],
+)
+def test_freqai_backtest_load_data(freqai_conf, mocker, caplog,
+                                   timeframe, expected_startup_candle_count):
     patch_exchange(mocker)
 
     now = datetime.now(timezone.utc)
@@ -48,10 +63,14 @@ def test_freqai_backtest_load_data(freqai_conf, mocker, caplog):
                  PropertyMock(return_value=['HULUMULU/USDT', 'XRP/USDT']))
     mocker.patch('freqtrade.optimize.backtesting.history.load_data')
     mocker.patch('freqtrade.optimize.backtesting.history.get_timerange', return_value=(now, now))
+    freqai_conf['timeframe'] = timeframe
+    freqai_conf.get('freqai', {}).get('feature_parameters', {}).update({'include_timeframes': []})
     backtesting = Backtesting(deepcopy(freqai_conf))
     backtesting.load_bt_data()
 
-    assert log_has_re('Increasing startup_candle_count for freqai on.*to.*', caplog)
+    assert log_has_re(f'Increasing startup_candle_count for freqai on {timeframe} '
+                      f'to {expected_startup_candle_count}', caplog)
+    assert history.load_data.call_args[1]['startup_candles'] == expected_startup_candle_count
 
     Backtesting.cleanup()
 
@@ -85,3 +104,33 @@ def test_freqai_backtest_live_models_model_not_found(freqai_conf, mocker, testda
         Backtesting(bt_config)
 
     Backtesting.cleanup()
+
+
+def test_freqai_backtest_consistent_timerange(mocker, freqai_conf):
+    mocker.patch('freqtrade.plugins.pairlistmanager.PairListManager.whitelist',
+                 PropertyMock(return_value=['XRP/USDT:USDT']))
+
+    gbs = mocker.patch('freqtrade.optimize.backtesting.generate_backtest_stats')
+
+    freqai_conf['candle_type_def'] = CandleType.FUTURES
+    freqai_conf.get('exchange', {}).update({'pair_whitelist': ['XRP/USDT:USDT']})
+    freqai_conf.get('freqai', {}).get('feature_parameters', {}).update(
+        {'include_timeframes': ['5m', '1h'], 'include_corr_pairlist': []})
+    freqai_conf['timerange'] = '20211120-20211121'
+
+    strategy = get_patched_freqai_strategy(mocker, freqai_conf)
+    exchange = get_patched_exchange(mocker, freqai_conf)
+
+    strategy.dp = DataProvider(freqai_conf, exchange)
+    strategy.freqai_info = freqai_conf.get("freqai", {})
+    freqai = strategy.freqai
+    freqai.dk = FreqaiDataKitchen(freqai_conf)
+
+    timerange = TimeRange.parse_timerange("20211115-20211122")
+    freqai.dd.load_all_pair_histories(timerange, freqai.dk)
+
+    backtesting = Backtesting(deepcopy(freqai_conf))
+    backtesting.start()
+
+    gbs.call_args[1]['min_date'] == datetime(2021, 11, 20, 0, 0, tzinfo=timezone.utc)
+    gbs.call_args[1]['max_date'] == datetime(2021, 11, 21, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
<!-- Thank you for submitting your pull request. Before proceeding, please ensure that you have included unit tests and that your code adheres to PEP8 standards. For more details, refer to the [Contributing Guidelines](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md). -->
## Summary

Solve the issue: #9547

## Quick Changelog

- Avoid reloading the dataset for the specified timeframe in FreqAI backtesting.
- Provide a dataframe containing the complete training set to the `feature_engineering_*` function.

## What's New?

### Steps to Reproduce:

1. Execute the provided backtesting command:
    ```
    freqtrade backtesting --config user_data/config.json --strategy RLStrategy --freqaimodel ReinforcementLearner --timerange 20231001-20231031 -vv
    ```
    Refer to the config.json and strategy file below.

2. Observe the log output and confirm that no rows are dropped due to NaN values. Additionally, ensure that training data points remain consistent throughout the entire backtest.

### Observed Results:

1. The initial training period spans from **2023-09-01 00:00:00** to **2023-10-01 00:00:00**.
2. The initially loaded dataset has the expected timerange from **2023-08-31 20:00:00** to **2023-10-31 00:00:00** (60 days + 240 timesteps).
3. The dataset for the strategy-specific timeframe is not reloaded.
4. The 5m dataset loaded for indicator calculation and passed to `feature_engineering_*` has a timerange from 2023-08-31 04:00:00 to 2023-10-31 00:00:00 (30 days + 240 timesteps * 5m).
5. The final dataset contains 43,200 rows, and none are dropped due to NaN values.

### Relevant Code Exceptions or Logs

Config:
```

{
    "max_open_trades": 1,
    "stake_currency": "USDT",
    "stake_amount": "unlimited",
    "tradable_balance_ratio": 0.99,
    "fiat_display_currency": "USD",
    "dry_run": true,
    "dry_run_wallet": 1000,
    "timeframe": "1m",
    "cancel_open_orders_on_exit": false,
    "trading_mode": "futures",
    "margin_mode": "isolated",
    "unfilledtimeout": {
        "entry": 10,
        "exit": 10,
        "exit_timeout_count": 0,
        "unit": "minutes"
    },
    "entry_pricing": {
        "price_side": "same",
        "use_order_book": true,
        "order_book_top": 1,
        "price_last_balance": 0.0,
        "check_depth_of_market": {
            "enabled": false,
            "bids_to_ask_delta": 1
        }
    },
    "exit_pricing":{
        "price_side": "same",
        "use_order_book": true,
        "order_book_top": 1
    },
    "exchange": {
        "name": "bybit",
        "key": "",
        "secret": "",
        "ccxt_config": {},
        "ccxt_async_config": {},
        "pair_whitelist": [
            "BTC/USDT:USDT"
        ],
        "pair_blacklist": [
        ]
    },
    "pairlists": [
        {"method": "StaticPairList" }
    ],
    "telegram": {
        "enabled": true,
        "token": "",
        "chat_id": ""
    },
    "api_server": {
        "enabled": false,
        "listen_ip_address": "0.0.0.0",
        "listen_port": 8080,
        "verbosity": "error",
        "enable_openapi": true,
        "username": "admin",
        "password": "admin"
    },
    "bot_name": "freqtrade",
    "initial_state": "running",
    "force_entry_enable": false,
    "internals": {
        "process_throttle_secs": 5
    },
    "freqai": {
        "enabled": true,
        "identifier" : "hugh_drop7",
        "train_period_days": 30,
        "backtest_period_days": 7,
        "purge_old_models": 2,
        "live_retrain_hours": 12,
        "expiration_hours": 96,
        "save_backtest_models": true,
        "continual_learning": true,
        "write_metrics_to_disk": true,
        "activate_tensorboard": false,
        "feature_parameters" : {
            "include_timeframes": ["5m"],
            "include_corr_pairlist": [],
            "label_period_candles": 0,
            "include_shifted_candles": 0,
            "indicator_periods_candles": [10, 20, 50, 100],
            "plot_feature_importances": 0,
            "shuffle_after_split": false
        },
        "data_split_parameters": {
            "test_size": 0.25
        },
        "rl_config": {
            "train_cycles": 1,
            "add_state_info": false,
            "max_trade_duration_candles": 60,
            "max_training_drawdown_pct": 0.02,
            "model_type": "PPO",
            "policy_type": "MlpPolicy",
            "drop_ohlc_from_features": false,
            "model_reward_parameters": {
                "win_reward_factor": 10,
                "rr": 1,
                "profit_aim": 0.025
            },
            "progress_bar": true,
            "cpu_count": 4
        }
    }
}

```

Strategy:
```
import logging
from functools import reduce
import talib.abstract as ta
from pandas import DataFrame
from freqtrade.strategy import IStrategy
import numpy as np

logger = logging.getLogger(__name__)

class RLStrategy(IStrategy):
    process_only_new_candles = True
    #stoploss = -0.05
    use_exit_signal = True
    # this is the maximum period fed to talib (timeframe independent)
    startup_candle_count: int = 240
    stoploss = -0.10
    can_short = True
    timeframe = "1m"

    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        dataframe = self.freqai.start(dataframe, metadata, self)
        return dataframe
    

    def populate_entry_trend(self, df: DataFrame, metadata: dict) -> DataFrame:
        enter_long_conditions = [df["do_predict"] == 1, df["&-action"] == 1]

        if enter_long_conditions:
            df.loc[
                reduce(lambda x, y: x & y, enter_long_conditions), ["enter_long", "enter_tag"]
            ] = (1, "long")

        enter_short_conditions = [df["do_predict"] == 1, df["&-action"] == 3]

        if enter_short_conditions:
            df.loc[
                reduce(lambda x, y: x & y, enter_short_conditions), ["enter_short", "enter_tag"]
            ] = (1, "short")
        
        return df


    def populate_exit_trend(self, df: DataFrame, metadata: dict) -> DataFrame:
        exit_long_conditions = [df["do_predict"] == 1, df["&-action"] == 2]
        if exit_long_conditions:
            df.loc[reduce(lambda x, y: x & y, exit_long_conditions), "exit_long"] = 1

        exit_short_conditions = [df["do_predict"] == 1, df["&-action"] == 4]
        if exit_short_conditions:
            df.loc[reduce(lambda x, y: x & y, exit_short_conditions), "exit_short"] = 1

        return df
    

    def feature_engineering_expand_all(self, dataframe: DataFrame, period, **kwargs) -> DataFrame:
        dataframe["%-ema-period"] = ta.EMA(dataframe, timeperiod=period)
        
        return dataframe
    

    def feature_engineering_expand_basic(self, dataframe: DataFrame, **kwargs) -> DataFrame:
        dataframe["%-pct-change"] = dataframe["close"].pct_change()
        dataframe["%-raw_volume"] = dataframe["volume"]
        dataframe["%-raw_price"] = dataframe["close"]
        return dataframe
    

    def feature_engineering_standard(self, dataframe: DataFrame, **kwargs) -> DataFrame:
        dataframe[f"%-raw_close"] = dataframe["close"]
        dataframe[f"%-raw_open"] = dataframe["open"]
        dataframe[f"%-raw_high"] = dataframe["high"]
        dataframe[f"%-raw_low"] = dataframe["low"]
        dataframe["%-day_of_week"] = (dataframe["date"].dt.dayofweek + 1) / 7
        dataframe["%-hour_of_day"] = (dataframe["date"].dt.hour + 1) / 25

        return dataframe
    

    def set_freqai_targets(self, dataframe, **kwargs) -> DataFrame:
        dataframe["&-action"] = 0
        
        return dataframe
```

Full Log:
```
2023-12-14 20:46:48,092 - freqtrade - INFO - freqtrade 2023.12-dev-ed6b31130
2023-12-14 20:46:48,101 - freqtrade.configuration.load_config - INFO - Using config: user_data/config.json ...
2023-12-14 20:46:48,102 - freqtrade.loggers - INFO - Verbosity set to 2
2023-12-14 20:46:48,102 - freqtrade.configuration.configuration - INFO - Using max_open_trades: 1 ...
2023-12-14 20:46:48,102 - freqtrade.configuration.configuration - INFO - Parameter --timerange detected: 20231001-20231031 ...
2023-12-14 20:46:48,108 - freqtrade.configuration.configuration - INFO - Using user-data directory: /workspaces/freqtrade/user_data ...
2023-12-14 20:46:48,108 - freqtrade.configuration.configuration - INFO - Using data directory: /workspaces/freqtrade/user_data/data/bybit ...
2023-12-14 20:46:48,108 - freqtrade.configuration.configuration - INFO - Parameter --cache=day detected ...
2023-12-14 20:46:48,108 - freqtrade.configuration.configuration - INFO - Filter trades by timerange: 20231001-20231031
2023-12-14 20:46:48,109 - freqtrade.configuration.configuration - INFO - Using freqaimodel class name: ReinforcementLearner
2023-12-14 20:46:48,109 - freqtrade.exchange.check_exchange - INFO - Checking exchange...
2023-12-14 20:46:48,120 - freqtrade.exchange.check_exchange - WARNING - Exchange "bybit" is known to the the ccxt library, available for the bot, but not officially supported by the Freqtrade development team. It may work flawlessly (please report back) or have serious issues. Use it at your own discretion.
2023-12-14 20:46:48,120 - freqtrade.configuration.configuration - INFO - Using pairlist from configuration.
2023-12-14 20:46:48,121 - freqtrade.configuration.config_validation - INFO - Validating configuration ...
2023-12-14 20:46:48,128 - freqtrade.commands.optimize_commands - INFO - Starting freqtrade in Backtesting mode
2023-12-14 20:46:48,128 - asyncio - DEBUG - Using selector: EpollSelector
2023-12-14 20:46:48,128 - freqtrade.exchange.exchange - INFO - Instance is running with dry_run enabled
2023-12-14 20:46:48,128 - freqtrade.exchange.exchange - INFO - Using CCXT 4.1.84
2023-12-14 20:46:48,129 - freqtrade.exchange.exchange - INFO - Applying additional ccxt config: {'options': {'defaultType': 'swap'}}
2023-12-14 20:46:48,140 - freqtrade.exchange.exchange - INFO - Applying additional ccxt config: {'options': {'defaultType': 'swap'}}
2023-12-14 20:46:48,151 - freqtrade.exchange.exchange - INFO - Using Exchange "Bybit"
2023-12-14 20:46:48,154 - urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): api.bybit.com:443
2023-12-14 20:46:48,408 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=spot HTTP/1.1" 200 None
2023-12-14 20:46:49,094 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=linear&limit=1000 HTTP/1.1" 200 None
2023-12-14 20:46:49,920 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=inverse&limit=1000 HTTP/1.1" 200 None
2023-12-14 20:46:50,105 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=option&baseCoin=BTC HTTP/1.1" 200 None
2023-12-14 20:46:51,116 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=option&baseCoin=ETH HTTP/1.1" 200 None
2023-12-14 20:46:52,131 - urllib3.connectionpool - DEBUG - https://api.bybit.com:443 "GET /v5/market/instruments-info?category=option&baseCoin=SOL HTTP/1.1" 200 None
2023-12-14 20:46:55,718 - freqtrade.misc - DEBUG - Loading historical data from file /workspaces/freqtrade/user_data/data/bybit/futures/leverage_tiers_USDT.json
2023-12-14 20:46:55,740 - freqtrade.exchange.exchange - INFO - Using cached leverage_tiers.
2023-12-14 20:46:55,740 - freqtrade.exchange.exchange - INFO - Done initializing 290 markets.
2023-12-14 20:46:55,753 - freqtrade.resolvers.exchange_resolver - INFO - Using resolved exchange 'Bybit'...
2023-12-14 20:46:55,754 - freqtrade.resolvers.iresolver - DEBUG - Searching for IStrategy RLStrategy in '/workspaces/freqtrade/user_data/strategies'
2023-12-14 20:46:55,768 - freqtrade.resolvers.iresolver - INFO - Using resolved strategy RLStrategy from '/workspaces/freqtrade/user_data/strategies/RLStrategy.py'...
2023-12-14 20:46:55,768 - freqtrade.strategy.hyper - INFO - Found no parameter file.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'timeframe' with value in config file: 1m.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'stake_currency' with value in config file: USDT.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'stake_amount' with value in config file: unlimited.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'unfilledtimeout' with value in config file: {'entry': 10, 'exit': 10, 'exit_timeout_count': 0, 'unit': 'minutes'}.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Override strategy 'max_open_trades' with value in config file: 1.
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using minimal_roi: {}
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using timeframe: 1m
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stoploss: -0.1
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop: False
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_stop_positive_offset: 0.0
2023-12-14 20:46:55,769 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using trailing_only_offset_is_reached: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using use_custom_stoploss: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using process_only_new_candles: True
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_types: {'entry': 'limit', 'exit': 'limit', 'stoploss': 'limit', 'stoploss_on_exchange': False, 'stoploss_on_exchange_interval': 60}
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using order_time_in_force: {'entry': 'GTC', 'exit': 'GTC'}
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stake_currency: USDT
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using stake_amount: unlimited
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using protections: []
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using startup_candle_count: 240
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using unfilledtimeout: {'entry': 10, 'exit': 10, 'exit_timeout_count': 0, 'unit': 'minutes'}
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using use_exit_signal: True
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using exit_profit_only: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using ignore_roi_if_entry_signal: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using exit_profit_offset: 0.0
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using disable_dataframe_checks: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using ignore_buying_expired_candle_after: 0
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using position_adjustment_enable: False
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using max_entry_position_adjustment: -1
2023-12-14 20:46:55,770 - freqtrade.resolvers.strategy_resolver - INFO - Strategy using max_open_trades: 1
2023-12-14 20:46:55,771 - freqtrade.configuration.config_validation - INFO - Validating configuration ...
2023-12-14 20:46:55,778 - freqtrade.resolvers.iresolver - DEBUG - Searching for IPairList StaticPairList in '/workspaces/freqtrade/freqtrade/plugins/pairlist'
2023-12-14 20:46:55,787 - freqtrade.resolvers.iresolver - INFO - Using resolved pairlist StaticPairList from '/workspaces/freqtrade/freqtrade/plugins/pairlist/StaticPairList.py'...
2023-12-14 20:46:55,804 - freqtrade.plugins.pairlistmanager - DEBUG - Whitelist with 1 pairs: ['BTC/USDT:USDT']
2023-12-14 20:46:55,806 - freqtrade.data.dataprovider - INFO - Increasing startup_candle_count for freqai to 43440
2023-12-14 20:46:55,806 - freqtrade.data.history.history_utils - INFO - Using indicator startup period: 43440 ...
2023-12-14 20:46:55,893 - freqtrade.optimize.backtesting - INFO - Loading data from 2023-08-31 20:00:00 up to 2023-10-31 00:00:00 (60 days).
2023-12-14 20:46:55,911 - freqtrade.data.converter.converter - INFO - Missing data fillup for BTC/USDT:USDT, 4h: before: 91 - after: 181 - 98.90%
2023-12-14 20:46:55,930 - freqtrade.optimize.backtesting - INFO - Dataload complete. Calculating indicators
2023-12-14 20:46:55,933 - freqtrade.optimize.backtesting - INFO - Running backtesting for Strategy RLStrategy
2023-12-14 20:46:55,972 - freqtrade.resolvers.iresolver - DEBUG - Searching for IFreqaiModel ReinforcementLearner in '/workspaces/freqtrade/user_data/freqaimodels'
2023-12-14 20:46:57,524 - matplotlib - DEBUG - matplotlib data path: /home/ftuser/.local/lib/python3.11/site-packages/matplotlib/mpl-data
2023-12-14 20:46:57,534 - matplotlib - DEBUG - CONFIGDIR=/home/ftuser/.config/matplotlib
2023-12-14 20:46:57,537 - matplotlib - DEBUG - interactive is False
2023-12-14 20:46:57,537 - matplotlib - DEBUG - platform is linux
2023-12-14 20:46:57,558 - matplotlib - DEBUG - CACHEDIR=/home/ftuser/.cache/matplotlib
2023-12-14 20:46:57,559 - matplotlib.font_manager - DEBUG - Using fontManager instance from /home/ftuser/.cache/matplotlib/fontlist-v330.json
2023-12-14 20:46:58,061 - freqtrade.resolvers.iresolver - DEBUG - Ignoring /workspaces/freqtrade/user_data/freqaimodels/.gitkeep
2023-12-14 20:46:58,061 - freqtrade.resolvers.iresolver - DEBUG - Searching for IFreqaiModel ReinforcementLearner in '/workspaces/freqtrade/freqtrade/freqai/prediction_models'
2023-12-14 20:46:58,089 - graphviz._tools - DEBUG - deprecate positional args: graphviz.backend.piping.pipe(['renderer', 'formatter', 'neato_no_op', 'quiet'])
2023-12-14 20:46:58,090 - graphviz._tools - DEBUG - deprecate positional args: graphviz.backend.rendering.render(['renderer', 'formatter', 'neato_no_op', 'quiet'])
2023-12-14 20:46:58,091 - graphviz._tools - DEBUG - deprecate positional args: graphviz.backend.unflattening.unflatten(['stagger', 'fanout', 'chain', 'encoding'])
2023-12-14 20:46:58,091 - graphviz._tools - DEBUG - deprecate positional args: graphviz.backend.viewing.view(['quiet'])
2023-12-14 20:46:58,095 - graphviz._tools - DEBUG - deprecate positional args: graphviz.quoting.quote(['is_html_string', 'is_valid_id', 'dot_keywords', 'endswith_odd_number_of_backslashes', 'escape_unescaped_quotes'])
2023-12-14 20:46:58,095 - graphviz._tools - DEBUG - deprecate positional args: graphviz.quoting.a_list(['kwargs', 'attributes'])
2023-12-14 20:46:58,095 - graphviz._tools - DEBUG - deprecate positional args: graphviz.quoting.attr_list(['kwargs', 'attributes'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.clear(['keep_attrs'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.__iter__(['subgraph'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.node(['_attributes'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.edge(['_attributes'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.attr(['_attributes'])
2023-12-14 20:46:58,096 - graphviz._tools - DEBUG - deprecate positional args: graphviz.dot.Dot.subgraph(['name', 'comment', 'graph_attr', 'node_attr', 'edge_attr', 'body'])
2023-12-14 20:46:58,097 - graphviz._tools - DEBUG - deprecate positional args: graphviz.piping.Pipe._pipe_legacy(['renderer', 'formatter', 'neato_no_op', 'quiet'])
2023-12-14 20:46:58,098 - graphviz._tools - DEBUG - deprecate positional args: graphviz.saving.Save.save(['directory'])
2023-12-14 20:46:58,098 - graphviz._tools - DEBUG - deprecate positional args: graphviz.rendering.Render.render(['directory', 'view', 'cleanup', 'format', 'renderer', 'formatter', 'neato_no_op', 'quiet', 'quiet_view'])
2023-12-14 20:46:58,098 - graphviz._tools - DEBUG - deprecate positional args: graphviz.rendering.Render.view(['directory', 'cleanup', 'quiet', 'quiet_view'])
2023-12-14 20:46:58,099 - graphviz._tools - DEBUG - deprecate positional args: graphviz.unflattening.Unflatten.unflatten(['stagger', 'fanout', 'chain'])
2023-12-14 20:46:58,099 - graphviz._tools - DEBUG - deprecate positional args: graphviz.graphs.BaseGraph.__init__(['comment', 'filename', 'directory', 'format', 'engine', 'encoding', 'graph_attr', 'node_attr', 'edge_attr', 'body', 'strict'])
2023-12-14 20:46:58,100 - graphviz._tools - DEBUG - deprecate positional args: graphviz.sources.Source.from_file(['directory', 'format', 'engine', 'encoding', 'renderer', 'formatter'])
2023-12-14 20:46:58,100 - graphviz._tools - DEBUG - deprecate positional args: graphviz.sources.Source.__init__(['filename', 'directory', 'format', 'engine', 'encoding'])
2023-12-14 20:46:58,100 - graphviz._tools - DEBUG - deprecate positional args: graphviz.sources.Source.save(['directory'])
2023-12-14 20:46:58,133 - freqtrade.resolvers.iresolver - INFO - Using resolved freqaimodel ReinforcementLearner from '/workspaces/freqtrade/freqtrade/freqai/prediction_models/ReinforcementLearner.py'...
2023-12-14 20:46:58,134 - freqtrade.freqai.freqai_interface - INFO - Backtesting module configured to save all models.
2023-12-14 20:46:58,134 - freqtrade.freqai.data_drawer - INFO - Could not find existing datadrawer, starting from scratch
2023-12-14 20:46:58,134 - freqtrade.freqai.data_drawer - INFO - Could not find existing historic_predictions, starting from scratch
2023-12-14 20:46:58,134 - freqtrade.freqai.data_drawer - INFO - Could not find existing metric tracker, starting from scratch
2023-12-14 20:46:58,134 - freqtrade.freqai.freqai_interface - INFO - Set fresh train queue from whitelist. Queue: ['BTC/USDT:USDT']
2023-12-14 20:46:58,146 - freqtrade.strategy.hyper - INFO - No params for buy found, using default values.
2023-12-14 20:46:58,147 - freqtrade.strategy.hyper - INFO - No params for sell found, using default values.
2023-12-14 20:46:58,147 - freqtrade.strategy.hyper - INFO - No params for protection found, using default values.
2023-12-14 20:46:58,155 - freqtrade.strategy.interface - DEBUG - Populating indicators for pair BTC/USDT:USDT.
2023-12-14 20:46:58,157 - freqtrade.freqai.freqai_interface - INFO - Training 5 timeranges
2023-12-14 20:46:58,193 - matplotlib.pyplot - DEBUG - Loaded backend agg version v2.2.
2023-12-14 20:47:05,135 - freqtrade.freqai.freqai_interface - INFO - Training BTC/USDT:USDT, 1/1 pairs from 2023-09-01 00:00:00 to 2023-10-01 00:00:00, 1/5 trains
2023-12-14 20:47:05,135 - freqtrade.freqai.data_kitchen - INFO - Could not find backtesting prediction file at /workspaces/freqtrade/user_data/models/hugh_drop7/backtesting_predictions/cb_btc_1696118400_prediction.feather
2023-12-14 20:47:09,862 - freqtrade.freqai.data_kitchen - DEBUG - Populating features for BTC/USDT:USDT 1m
2023-12-14 20:47:10,092 - freqtrade.data.dataprovider - INFO - Increasing startup_candle_count for freqai to 8880
2023-12-14 20:47:10,092 - freqtrade.data.dataprovider - INFO - Loading data for BTC/USDT:USDT 5m from 2023-08-31 04:00:00 to 2023-10-31 00:00:00 
2023-12-14 20:47:10,131 - freqtrade.freqai.data_kitchen - DEBUG - Populating features for BTC/USDT:USDT 5m
2023-12-14 20:47:10,229 - freqtrade.freqai.freqai_interface - INFO - Could not find model at /workspaces/freqtrade/user_data/models/hugh_drop7/sub-train-BTC_1696118400/cb_btc_1696118400
2023-12-14 20:47:10,229 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------Starting training BTC/USDT:USDT --------------------
2023-12-14 20:47:10,253 - freqtrade.freqai.data_kitchen - INFO - BTC/USDT:USDT: dropped 0 training points due to NaNs in populated dataset 43200.
2023-12-14 20:47:10,258 - datasieve.pipeline - DEBUG - Fit transforming const
2023-12-14 20:47:10,261 - datasieve.pipeline - DEBUG - Fit transforming scaler
2023-12-14 20:47:10,265 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:47:10,265 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:47:10,265 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - Training model on 20 features and 32400 data points
Eval num_timesteps=32400, episode_reward=-21596.00 +/- 0.00
Episode length: 10798.00 +/- 0.00
New best mean reward!
 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32,768/32,400  [ 0:00:49 < 0:00:00 , 21 it/s ]
2023-12-14 20:48:18,466 - ReinforcementLearner - INFO - Callback found a best model.
2023-12-14 20:48:18,488 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------done training BTC/USDT:USDT--------------------
2023-12-14 20:48:18,488 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2023-12-14 20:48:18,510 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:48:18,510 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:48:23,771 - freqtrade.freqai.freqai_interface - INFO - Training BTC/USDT:USDT, 1/1 pairs from 2023-09-08 00:00:00 to 2023-10-08 00:00:00, 2/5 trains
2023-12-14 20:48:23,772 - freqtrade.freqai.data_kitchen - INFO - Could not find backtesting prediction file at /workspaces/freqtrade/user_data/models/hugh_drop7/backtesting_predictions/cb_btc_1696723200_prediction.feather
2023-12-14 20:48:23,783 - freqtrade.freqai.freqai_interface - INFO - Could not find model at /workspaces/freqtrade/user_data/models/hugh_drop7/sub-train-BTC_1696723200/cb_btc_1696723200
2023-12-14 20:48:23,784 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------Starting training BTC/USDT:USDT --------------------
2023-12-14 20:48:23,805 - freqtrade.freqai.data_kitchen - INFO - BTC/USDT:USDT: dropped 0 training points due to NaNs in populated dataset 43200.
2023-12-14 20:48:23,810 - datasieve.pipeline - DEBUG - Fit transforming const
2023-12-14 20:48:23,812 - datasieve.pipeline - DEBUG - Fit transforming scaler
2023-12-14 20:48:23,815 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:48:23,815 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:48:23,815 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - Training model on 20 features and 32400 data points
2023-12-14 20:48:23,816 - ReinforcementLearner - INFO - Continual training activated - starting training from previously trained agent.
Eval num_timesteps=32400, episode_reward=-21596.00 +/- 0.00
Episode length: 10798.00 +/- 0.00
New best mean reward!
 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32,768/32,400  [ 0:00:56 < 0:00:00 , 36 it/s ]
2023-12-14 20:49:31,002 - ReinforcementLearner - INFO - Callback found a best model.
2023-12-14 20:49:31,009 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------done training BTC/USDT:USDT--------------------
2023-12-14 20:49:31,009 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2023-12-14 20:49:31,029 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:49:31,029 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:49:36,313 - freqtrade.freqai.freqai_interface - INFO - Training BTC/USDT:USDT, 1/1 pairs from 2023-09-15 00:00:00 to 2023-10-15 00:00:00, 3/5 trains
2023-12-14 20:49:36,314 - freqtrade.freqai.data_kitchen - INFO - Could not find backtesting prediction file at /workspaces/freqtrade/user_data/models/hugh_drop7/backtesting_predictions/cb_btc_1697328000_prediction.feather
2023-12-14 20:49:36,327 - freqtrade.freqai.freqai_interface - INFO - Could not find model at /workspaces/freqtrade/user_data/models/hugh_drop7/sub-train-BTC_1697328000/cb_btc_1697328000
2023-12-14 20:49:36,327 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------Starting training BTC/USDT:USDT --------------------
2023-12-14 20:49:36,349 - freqtrade.freqai.data_kitchen - INFO - BTC/USDT:USDT: dropped 0 training points due to NaNs in populated dataset 43200.
2023-12-14 20:49:36,354 - datasieve.pipeline - DEBUG - Fit transforming const
2023-12-14 20:49:36,356 - datasieve.pipeline - DEBUG - Fit transforming scaler
2023-12-14 20:49:36,359 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:49:36,359 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:49:36,359 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - Training model on 20 features and 32400 data points
2023-12-14 20:49:36,360 - ReinforcementLearner - INFO - Continual training activated - starting training from previously trained agent.
Eval num_timesteps=32400, episode_reward=-9926.36 +/- 0.00
Episode length: 5194.00 +/- 0.00
New best mean reward!
 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32,768/32,400  [ 0:00:52 < 0:00:00 , 413 it/s ]
2023-12-14 20:50:29,804 - ReinforcementLearner - INFO - Callback found a best model.
2023-12-14 20:50:29,810 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------done training BTC/USDT:USDT--------------------
2023-12-14 20:50:29,811 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2023-12-14 20:50:29,831 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:50:29,831 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:50:35,047 - freqtrade.freqai.freqai_interface - INFO - Training BTC/USDT:USDT, 1/1 pairs from 2023-09-22 00:00:00 to 2023-10-22 00:00:00, 4/5 trains
2023-12-14 20:50:35,047 - freqtrade.freqai.data_kitchen - INFO - Could not find backtesting prediction file at /workspaces/freqtrade/user_data/models/hugh_drop7/backtesting_predictions/cb_btc_1697932800_prediction.feather
2023-12-14 20:50:35,064 - freqtrade.freqai.freqai_interface - INFO - Could not find model at /workspaces/freqtrade/user_data/models/hugh_drop7/sub-train-BTC_1697932800/cb_btc_1697932800
2023-12-14 20:50:35,064 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------Starting training BTC/USDT:USDT --------------------
2023-12-14 20:50:35,084 - freqtrade.freqai.data_kitchen - INFO - BTC/USDT:USDT: dropped 0 training points due to NaNs in populated dataset 43200.
2023-12-14 20:50:35,089 - datasieve.pipeline - DEBUG - Fit transforming const
2023-12-14 20:50:35,092 - datasieve.pipeline - DEBUG - Fit transforming scaler
2023-12-14 20:50:35,094 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:50:35,094 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:50:35,095 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - Training model on 20 features and 32400 data points
2023-12-14 20:50:35,096 - ReinforcementLearner - INFO - Continual training activated - starting training from previously trained agent.
Eval num_timesteps=32400, episode_reward=-21424.07 +/- 0.00
Episode length: 10798.00 +/- 0.00
New best mean reward!
 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32,768/32,400  [ 0:00:55 < 0:00:00 , 27 it/s ]
2023-12-14 20:51:44,205 - ReinforcementLearner - INFO - Callback found a best model.
2023-12-14 20:51:44,212 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------done training BTC/USDT:USDT--------------------
2023-12-14 20:51:44,212 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2023-12-14 20:51:44,232 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:51:44,232 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:51:49,583 - freqtrade.freqai.freqai_interface - INFO - Training BTC/USDT:USDT, 1/1 pairs from 2023-09-29 00:00:00 to 2023-10-29 00:00:00, 5/5 trains
2023-12-14 20:51:49,584 - freqtrade.freqai.data_kitchen - INFO - Could not find backtesting prediction file at /workspaces/freqtrade/user_data/models/hugh_drop7/backtesting_predictions/cb_btc_1698537600_prediction.feather
2023-12-14 20:51:49,603 - freqtrade.freqai.freqai_interface - INFO - Could not find model at /workspaces/freqtrade/user_data/models/hugh_drop7/sub-train-BTC_1698537600/cb_btc_1698537600
2023-12-14 20:51:49,603 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------Starting training BTC/USDT:USDT --------------------
2023-12-14 20:51:49,625 - freqtrade.freqai.data_kitchen - INFO - BTC/USDT:USDT: dropped 0 training points due to NaNs in populated dataset 43200.
2023-12-14 20:51:49,631 - datasieve.pipeline - DEBUG - Fit transforming const
2023-12-14 20:51:49,633 - datasieve.pipeline - DEBUG - Fit transforming scaler
2023-12-14 20:51:49,635 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:51:49,635 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:51:49,636 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - Training model on 20 features and 32400 data points
2023-12-14 20:51:49,637 - ReinforcementLearner - INFO - Continual training activated - starting training from previously trained agent.
Eval num_timesteps=32400, episode_reward=-21596.00 +/- 0.00
Episode length: 10798.00 +/- 0.00
New best mean reward!
 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32,768/32,400  [ 0:00:51 < 0:00:00 , 22 it/s ]
2023-12-14 20:52:57,172 - ReinforcementLearner - INFO - Callback found a best model.
2023-12-14 20:52:57,179 - freqtrade.freqai.RL.BaseReinforcementLearningModel - INFO - --------------------done training BTC/USDT:USDT--------------------
2023-12-14 20:52:57,179 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2023-12-14 20:52:57,196 - datasieve.pipeline - DEBUG - Transforming const
2023-12-14 20:52:57,196 - datasieve.pipeline - DEBUG - Transforming scaler
2023-12-14 20:52:58,799 - freqtrade.optimize.backtesting - INFO - Backtesting with data from 2023-09-01 00:00:00 up to 2023-10-31 00:00:00 (60 days).
2023-12-14 20:52:58,801 - freqtrade.strategy.interface - DEBUG - Populating enter signals for pair BTC/USDT:USDT.
/workspaces/freqtrade/user_data/strategies/RLStrategy.py:34: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value 'long' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
  df.loc[
2023-12-14 20:52:58,806 - freqtrade.strategy.interface - DEBUG - Populating exit signals for pair BTC/USDT:USDT.
```
---

Best regards