### PR TITLE
Add FIAT mapping for BTC

### DIFF
--- a/freqtrade/rpc/fiat_convert.py
+++ b/freqtrade/rpc/fiat_convert.py
@@ -28,6 +28,7 @@ coingecko_mapping = {
     'busd': 'binance-usd',
     'tusd': 'true-usd',
     'usdc': 'usd-coin',
+    'btc': 'bitcoin'
 }
 
 


### PR DESCRIPTION
## Summary

Add the missing mapping for BTC for Coingecko.

I noticed the 'WARNING - Found multiple mappings in CoinGecko for btc.' in the log of the bot, and since I've added usdc some weeks ago I repeated these steps for BTC.

## Quick changelog

- Add Coingecko mapping for BTC.

## What's new?

Correct reference to BTC on Coingeco.