### PR TITLE
Improve log message when no good hyperopt result is found 

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -637,6 +637,8 @@ class Hyperopt:
 
             HyperoptTools.show_epoch_details(self.current_best_epoch, self.total_epochs,
                                              self.print_json)
+        elif self.num_epochs_saved > 0:
+            print("No good result found for given optimization function.")
         else:
             # This is printed when Ctrl+C is pressed quickly, before first epochs have
             # a chance to be evaluated.

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -638,7 +638,9 @@ class Hyperopt:
             HyperoptTools.show_epoch_details(self.current_best_epoch, self.total_epochs,
                                              self.print_json)
         elif self.num_epochs_saved > 0:
-            print("No good result found for given optimization function.")
+            print(
+                f"No good result found for given optimization function in {self.num_epochs_saved} "
+                f"{plural(self.num_epochs_saved, 'epoch')}.")
         else:
             # This is printed when Ctrl+C is pressed quickly, before first epochs have
             # a chance to be evaluated.


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

This PR improves log message for the user by differentiating between closing the hyperopt too soon and not finding result good enough.

## Quick changelog

- Differentiate log message for closing the hyperopt too soon and not finding result good enough.

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->

When running hyper optimization, if no good result is found `current_best_epoch` variable is not updated. Example of such run can be seen in screenshot below:

![image](https://github.com/freqtrade/freqtrade/assets/118190443/42f538b5-ae5f-4a1f-8351-12755878c84c)

This leads to print `No epochs evaluated yet, no best result.` which is not true. 

This PR differentiates between closing hyperopt too quick or not having a good result actually, by checking if there are some epochs saved which means they've been evaluated.