### PR TITLE
Revert "Merge pull request #9450 from freqtrade/fix/startup-candle-count"

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -147,9 +147,7 @@ class Backtesting:
 
         if self.config.get('freqai', {}).get('enabled', False):
             # For FreqAI, increase the required_startup to includes the training data
-            self.freqai_startup_candles = self.dataprovider.get_required_startup(
-                                                self.timeframe
-                                           )
+            self.required_startup = self.dataprovider.get_required_startup(self.timeframe)
 
         # Add maximum startup candle count to configuration for informative pairs support
         self.config['startup_candle_count'] = self.required_startup
@@ -236,17 +234,12 @@ class Backtesting:
         """
         self.progress.init_step(BacktestState.DATALOAD, 1)
 
-        if self.config.get('freqai', {}).get('enabled', False):
-            startup_candle_count = self.freqai_startup_candles
-        else:
-            startup_candle_count = self.required_startup
-
         data = history.load_data(
             datadir=self.config['datadir'],
             pairs=self.pairlists.whitelist,
             timeframe=self.timeframe,
             timerange=self.timerange,
-            startup_candles=startup_candle_count,
+            startup_candles=self.config['startup_candle_count'],
             fail_without_data=True,
             data_format=self.config['dataformat_ohlcv'],
             candle_type=self.config.get('candle_type_def', CandleType.SPOT)


### PR DESCRIPTION
This reverts commit 15771043f7ed73d7cc85ff2468bf8ef680a242c0, reversing changes made to b417a0297baf1db67b4ee7a57b49bbbc9639f525.

It is clear that this previous MR was incorrectly handled for the niche use-case that it aimed to fix. We have reports in the discord of backtesting dropping all data points due to improperly loaded candles. Further, we had someone run into this and come up with a solution to the self-imposed bug (#9552 ). However, the solution of #9552 ignores the backtesting statistics fix that was implemented a year-ish ago(#7454 ). 

The general "problem" still exists: the issue is that all timeframes get loaded using the base timeframe startup_candle_count. This will lead to overloading of data - but will not break code unless someone is trying to backtest 5m + 1D timeframes with large `train_period_days`. I don't pretend that this large timeframe+train range is not a valid use-case, but I simply point out that it is a rare use case based on my observations of users in the discords.

We will work on a better solution to the original problem, but for now we need to revert this change to get the majority of users back to a the original clean backtesting module.
