### PR TITLE
Freqai small enhancements

### DIFF
--- a/freqtrade/freqai/base_models/FreqaiMultiOutputClassifier.py
+++ b/freqtrade/freqai/base_models/FreqaiMultiOutputClassifier.py
@@ -2,8 +2,8 @@ import numpy as np
 from joblib import Parallel
 from sklearn.base import is_classifier
 from sklearn.multioutput import MultiOutputClassifier, _fit_estimator
-from sklearn.utils.fixes import delayed
 from sklearn.utils.multiclass import check_classification_targets
+from sklearn.utils.parallel import delayed
 from sklearn.utils.validation import has_fit_parameter
 
 from freqtrade.exceptions import OperationalException

--- a/freqtrade/freqai/base_models/FreqaiMultiOutputClassifier.py
+++ b/freqtrade/freqai/base_models/FreqaiMultiOutputClassifier.py
@@ -1,9 +1,8 @@
 import numpy as np
-from joblib import Parallel
 from sklearn.base import is_classifier
 from sklearn.multioutput import MultiOutputClassifier, _fit_estimator
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.parallel import delayed
+from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import has_fit_parameter
 
 from freqtrade.exceptions import OperationalException

--- a/freqtrade/freqai/base_models/FreqaiMultiOutputRegressor.py
+++ b/freqtrade/freqai/base_models/FreqaiMultiOutputRegressor.py
@@ -1,6 +1,5 @@
-from joblib import Parallel
 from sklearn.multioutput import MultiOutputRegressor, _fit_estimator
-from sklearn.utils.parallel import delayed
+from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import has_fit_parameter
 
 

--- a/freqtrade/freqai/base_models/FreqaiMultiOutputRegressor.py
+++ b/freqtrade/freqai/base_models/FreqaiMultiOutputRegressor.py
@@ -1,6 +1,6 @@
 from joblib import Parallel
 from sklearn.multioutput import MultiOutputRegressor, _fit_estimator
-from sklearn.utils.fixes import delayed
+from sklearn.utils.parallel import delayed
 from sklearn.utils.validation import has_fit_parameter
 
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -20,8 +20,8 @@ from tests.freqai.conftest import (get_patched_freqai_strategy, is_mac, make_rl_
                                    mock_pytorch_mlp_model_training_parameters)
 
 
-def is_py11() -> bool:
-    return sys.version_info >= (3, 11)
+def is_py12() -> bool:
+    return sys.version_info >= (3, 12)
 
 
 def is_arm() -> bool:
@@ -523,8 +523,8 @@ def test_get_state_info(mocker, freqai_conf, dp_exists, caplog, tickers):
 
     if is_mac():
         pytest.skip("Reinforcement learning module not available on intel based Mac OS")
-    if is_py11():
-        pytest.skip("Reinforcement learning currently not available on python 3.11.")
+    if is_py12():
+        pytest.skip("Reinforcement learning currently not available on python 3.12.")
 
     freqai_conf.update({"freqaimodel": "ReinforcementLearner"})
     freqai_conf.update({"timerange": "20180110-20180130"})


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Fix some imports to fix some deprecation warnings 

```
.../envs/trade_3114/lib/python3.11/site-packages/sklearn/utils/deprecation.py:86: FutureWarning: Function d
elayed is deprecated; The function `delayed` has been moved from `sklearn.utils.fixes` to `sklearn.utils.parallel`. This import path will be
 removed in 1.5.                                                                                                                            
    warnings.warn(msg, category=FutureWarning
```
as well as 

```
.../envs/trade_3114/lib/python3.11/site-packages/sklearn/utils/parallel.py:116: UserWarning: `sklearn.utils
.parallel.delayed` should be used with `sklearn.utils.parallel.Parallel` to make it possible to propagate the scikit-learn configuration of 
the current thread to the joblib workers.                                                                                                   
    warnings.warn(    
```