### PR TITLE
Help direct people to freqai support

### DIFF
--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -117,7 +117,7 @@ Here we compile some external materials that provide deeper looks into various c
 
 ## Support
 
-You can find support for FreqAI in a variety of places, including the (Freqtrade discord)[https://discord.gg/Jd8JYeWHc4], the dedicated (FreqAI discord)[https://discord.gg/7AMWACmbjT], and in (github issues)[https://github.com/freqtrade/freqtrade/issues].
+You can find support for FreqAI in a variety of places, including the [Freqtrade discord](https://discord.gg/Jd8JYeWHc4), the dedicated [FreqAI discord](https://discord.gg/7AMWACmbjT), and in [github issues](https://github.com/freqtrade/freqtrade/issues).
 
 ## Credits
 

--- a/docs/freqai.md
+++ b/docs/freqai.md
@@ -114,6 +114,11 @@ Here we compile some external materials that provide deeper looks into various c
 - [Real-time head-to-head: Adaptive modeling of financial market data using XGBoost and CatBoost](https://emergentmethods.medium.com/real-time-head-to-head-adaptive-modeling-of-financial-market-data-using-xgboost-and-catboost-995a115a7495)
 - [FreqAI - from price to prediction](https://emergentmethods.medium.com/freqai-from-price-to-prediction-6fadac18b665)
 
+
+## Support
+
+You can find support for FreqAI in a variety of places, including the (Freqtrade discord)[https://discord.gg/Jd8JYeWHc4], the dedicated (FreqAI discord)[https://discord.gg/7AMWACmbjT], and in (github issues)[https://github.com/freqtrade/freqtrade/issues].
+
 ## Credits
 
 FreqAI is developed by a group of individuals who all contribute specific skillsets to the project.


### PR DESCRIPTION
It seems relatively common for users to struggle to find the FreqAI discord. Here we add a link to it, in addition to links to the general Freqtrade discord and to github issues, so that people know where they can go to find help.