### PR TITLE
Fix: Add create-userdir command to docker-compose for permission handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,11 @@ services:
       - "127.0.0.1:8080:8080"
     # Default command used when running `docker compose up`
     command: >
+      /bin/bash -c "
+      create-userdir --userdir user_data &&
       trade
       --logfile /freqtrade/user_data/logs/freqtrade.log
       --db-url sqlite:////freqtrade/user_data/tradesv3.sqlite
       --config /freqtrade/user_data/config.json
       --strategy SampleStrategy
+      "

--- a/docker/docker-compose-freqai.yml
+++ b/docker/docker-compose-freqai.yml
@@ -28,9 +28,12 @@ services:
       - "127.0.0.1:8080:8080"
     # Default command used when running `docker compose up`
     command: >
+      /bin/bash -c "
+      create-userdir --userdir user_data &&
       trade
       --logfile /freqtrade/user_data/logs/freqtrade.log
       --db-url sqlite:////freqtrade/user_data/tradesv3.sqlite
       --config /freqtrade/user_data/config.json
       --freqaimodel XGBoostRegressor
       --strategy FreqaiExampleStrategy
+      "


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? More details
-->
## Summary

This PR adds a command to the Docker Compose file to create the user directory with the correct permissions, which solves a common permission error.

Solve the issue: #4917

## Quick changelog

- Added `create-userdir --userdir user_data` command to Docker Compose file.

## What's new?

This PR improves the Docker Compose file by adding a command to create the user directory with the correct permissions every time the Docker container starts. This change helps prevent a common permission error that occurs when the Docker container does not have the necessary permissions to access certain files or directories. This change should make the software more robust and user-friendly.