### PR TITLE
Fix failure on using FullTradesFilter on test-pairlist (and maybe other non-trading mode)

### DIFF
--- a/freqtrade/plugins/pairlist/FullTradesFilter.py
+++ b/freqtrade/plugins/pairlist/FullTradesFilter.py
@@ -48,8 +48,13 @@ class FullTradesFilter(IPairList):
         :return: new allowlist
         """
         # Get the number of open trades and max open trades config
-        num_open = Trade.get_open_trade_count()
-        max_trades = self._config['max_open_trades']
+        try:
+            num_open = Trade.get_open_trade_count()
+            max_trades = self._config['max_open_trades']
+        except AttributeError:
+            # Performancefilter does not work in backtesting.
+            self.log_once("FullTradesFilter is not available in this mode.", logger.warning)
+            return pairlist
 
         if (num_open >= max_trades) and (max_trades > 0):
             return []


### PR DESCRIPTION


<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

add Try block to catch the failure on using FullTradesFilter on non-dry/live run

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
