### PR TITLE
Add No db context to protect certain functions that run in a backtest-like mode

### DIFF
--- a/freqtrade/commands/pairlist_commands.py
+++ b/freqtrade/commands/pairlist_commands.py
@@ -15,6 +15,7 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
     """
     Test Pairlist configuration
     """
+    from freqtrade.persistence import FtNoDBContext
     from freqtrade.plugins.pairlistmanager import PairListManager
     config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE)
 
@@ -24,11 +25,12 @@ def start_test_pairlist(args: Dict[str, Any]) -> None:
     if not quote_currencies:
         quote_currencies = [config.get('stake_currency')]
     results = {}
-    for curr in quote_currencies:
-        config['stake_currency'] = curr
-        pairlists = PairListManager(exchange, config)
-        pairlists.refresh_pairlist()
-        results[curr] = pairlists.whitelist
+    with FtNoDBContext():
+        for curr in quote_currencies:
+            config['stake_currency'] = curr
+            pairlists = PairListManager(exchange, config)
+            pairlists.refresh_pairlist()
+            results[curr] = pairlists.whitelist
 
     for curr, pairlist in results.items():
         if not args.get('print_one_column', False) and not args.get('list_pairs_print_json', False):

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -33,7 +33,8 @@ from freqtrade.optimize.optimize_reports import (generate_backtest_stats, genera
                                                  show_backtest_results,
                                                  store_backtest_analysis_results,
                                                  store_backtest_stats)
-from freqtrade.persistence import LocalTrade, Order, PairLocks, Trade
+from freqtrade.persistence import (LocalTrade, Order, PairLocks, Trade, disable_database_use,
+                                   enable_database_use)
 from freqtrade.plugins.pairlistmanager import PairListManager
 from freqtrade.plugins.protectionmanager import ProtectionManager
 from freqtrade.resolvers import ExchangeResolver, StrategyResolver
@@ -177,8 +178,7 @@ class Backtesting:
     @staticmethod
     def cleanup():
         LoggingMixin.show_output = True
-        PairLocks.use_db = True
-        Trade.use_db = True
+        enable_database_use()
 
     def init_backtest_detail(self) -> None:
         # Load detail timeframe if specified
@@ -325,9 +325,7 @@ class Backtesting:
             self.futures_data = {}
 
     def disable_database_use(self):
-        PairLocks.use_db = False
-        PairLocks.timeframe = self.timeframe
-        Trade.use_db = False
+        disable_database_use(self.timeframe)
 
     def prepare_backtest(self, enable_protections):
         """

--- a/freqtrade/persistence/__init__.py
+++ b/freqtrade/persistence/__init__.py
@@ -4,4 +4,5 @@ from freqtrade.persistence.key_value_store import KeyStoreKeys, KeyValueStore
 from freqtrade.persistence.models import init_db
 from freqtrade.persistence.pairlock_middleware import PairLocks
 from freqtrade.persistence.trade_model import LocalTrade, Order, Trade
-from freqtrade.persistence.usedb_context import disable_database_use, enable_database_use
+from freqtrade.persistence.usedb_context import (FtNoDBContext, disable_database_use,
+                                                 enable_database_use)

--- a/freqtrade/persistence/__init__.py
+++ b/freqtrade/persistence/__init__.py
@@ -4,3 +4,4 @@ from freqtrade.persistence.key_value_store import KeyStoreKeys, KeyValueStore
 from freqtrade.persistence.models import init_db
 from freqtrade.persistence.pairlock_middleware import PairLocks
 from freqtrade.persistence.trade_model import LocalTrade, Order, Trade
+from freqtrade.persistence.usedb_context import disable_database_use, enable_database_use

--- a/freqtrade/persistence/usedb_context.py
+++ b/freqtrade/persistence/usedb_context.py
@@ -20,3 +20,14 @@ def enable_database_use() -> None:
     PairLocks.use_db = True
     PairLocks.timeframe = ''
     Trade.use_db = True
+
+
+class FtNoDBContext:
+    def __init__(self, timeframe: str = ''):
+        self.timeframe = timeframe
+
+    def __enter__(self):
+        disable_database_use(self.timeframe)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        enable_database_use()

--- a/freqtrade/persistence/usedb_context.py
+++ b/freqtrade/persistence/usedb_context.py
@@ -1,0 +1,22 @@
+
+from freqtrade.persistence.pairlock_middleware import PairLocks
+from freqtrade.persistence.trade_model import Trade
+
+
+def disable_database_use(timeframe: str) -> None:
+    """
+    Disable database usage for PairLocks and Trade models.
+    Used for backtesting, and some other utility commands.
+    """
+    PairLocks.use_db = False
+    PairLocks.timeframe = timeframe
+    Trade.use_db = False
+
+
+def enable_database_use() -> None:
+    """
+    Cleanup function to restore database usage.
+    """
+    PairLocks.use_db = True
+    PairLocks.timeframe = ''
+    Trade.use_db = True

--- a/tests/persistence/test_db_context.py
+++ b/tests/persistence/test_db_context.py
@@ -1,0 +1,24 @@
+import pytest
+
+from freqtrade.persistence import FtNoDBContext, PairLocks, Trade
+
+
+@pytest.mark.parametrize('timeframe', ['', '5m', '1d'])
+def test_FtNoDBContext(timeframe):
+    assert Trade.use_db is True
+    assert PairLocks.use_db is True
+    assert PairLocks.timeframe == ''
+
+    with FtNoDBContext(timeframe):
+        assert Trade.use_db is False
+        assert PairLocks.use_db is False
+        assert PairLocks.timeframe == timeframe
+
+    with FtNoDBContext():
+        assert Trade.use_db is False
+        assert PairLocks.use_db is False
+        assert PairLocks.timeframe == ''
+
+    assert Trade.use_db is True
+    assert PairLocks.use_db is True
+

--- a/tests/persistence/test_db_context.py
+++ b/tests/persistence/test_db_context.py
@@ -5,6 +5,7 @@ from freqtrade.persistence import FtNoDBContext, PairLocks, Trade
 
 @pytest.mark.parametrize('timeframe', ['', '5m', '1d'])
 def test_FtNoDBContext(timeframe):
+    PairLocks.timeframe = ''
     assert Trade.use_db is True
     assert PairLocks.use_db is True
     assert PairLocks.timeframe == ''

--- a/tests/persistence/test_db_context.py
+++ b/tests/persistence/test_db_context.py
@@ -21,4 +21,3 @@ def test_FtNoDBContext(timeframe):
 
     assert Trade.use_db is True
     assert PairLocks.use_db is True
-


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Trade.use_db is not only used by backtesting, but is also assumed for pairlists if the bot is not in live-mode, hence we need a way to set this appropriately.

## Quick changelog

* Extract Trade.use_db setter methods
* Add context manager to set and unset Trade.use_db methods
