### PR TITLE
Update kraken.py to change pagination type to use timestamp (instead of id)

### DIFF
--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -226,19 +226,3 @@ class Kraken(Exchange):
             fees = sum(df['open_fund'] * df['open_mark'] * amount * time_in_ratio)
 
         return fees if is_short else -fees
-
-    def _trades_contracts_to_amount(self, trades: List) -> List:
-        """
-        Fix "last" id issue for kraken data downloads
-        This whole override can probably be removed once the following
-        issue is closed in ccxt: https://github.com/ccxt/ccxt/issues/15827
-        """
-        super()._trades_contracts_to_amount(trades)
-        if (
-            len(trades) > 0
-            and isinstance(trades[-1].get('info'), list)
-            and len(trades[-1].get('info', [])) > 7
-        ):
-
-            trades[-1]['id'] = trades[-1].get('info', [])[-1]
-        return trades

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -29,7 +29,7 @@ class Kraken(Exchange):
         "order_time_in_force": ["GTC", "IOC", "PO"],
         "ohlcv_candle_limit": 720,
         "ohlcv_has_history": False,
-        "trades_pagination": "id",
+        "trades_pagination": "time",
         "trades_pagination_arg": "since",
         "mark_ohlcv_timeframe": "4h",
     }

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3489,7 +3489,7 @@ def test_merge_ft_has_dict(default_conf, mocker):
 
     ex = Kraken(default_conf)
     assert ex._ft_has != Exchange._ft_has_default
-    assert ex.get_option('trades_pagination') == 'id'
+    assert ex.get_option('trades_pagination') == 'time'
     assert ex.get_option('trades_pagination_arg') == 'since'
 
     # Binance defines different values


### PR DESCRIPTION
## Summary

Changes Kraken exchange default config to fix system losing track of trade history downloaded prior.

Solve the issue: #5578 

## What's new?

Switches Kraken exchange default config to use 'time' (from 'id') value for "trades_pagination" which fixes oddities surrounding system losing track of what trade history it has downloaded prior when creating historical candles. 

Relevant example CLI command: freqtrade download-data --exchange kraken --dl-trades

The existing config will frequently re-download all trade data for a pair instead of just the missing trade data.  No other code changes.

Reviewing the current Kraken API documentation, it seems the "since timestamp" method is the only method supported anymore, so a "since id" method doesn't seem to be desired behavior.  
