### PR TITLE
fix: logical error in the conditional checks for model classes

### DIFF
--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -123,7 +123,7 @@ def plot_feature_importance(model: Any, pair: str, dk: FreqaiDataKitchen,
         elif "xgb" in str(mdl.__class__):
             feature_importance = mdl.feature_importances_
         else:
-            logger.info('Model type does not support for generating feature importances.')
+            logger.info('Model type does not support generating feature importances.')
             return
 
         # Data preparation

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -118,10 +118,12 @@ def plot_feature_importance(model: Any, pair: str, dk: FreqaiDataKitchen,
         mdl = models[label]
         if "catboost.core" in str(mdl.__class__):
             feature_importance = mdl.get_feature_importance()
-        elif "lightgbm.sklearn" or "xgb" in str(mdl.__class__):
+        elif "lightgbm.sklearn" in str(mdl.__class__):
+            feature_importance = mdl.feature_importances_
+        elif "xgb" in str(mdl.__class__):
             feature_importance = mdl.feature_importances_
         else:
-            logger.info('Model type not support for generating feature importances.')
+            logger.info('Model type does not support for generating feature importances.')
             return
 
         # Data preparation


### PR DESCRIPTION
Fix logical error in the conditional checks for model classes. The `elif` statement that looks for "lightgbm.sklearn" or "xgb" in the model class string is now broken into two separate conditions because the old condition would always evaluate to `True` due to the non-empty string "xgb".