### PR TITLE
Remotepairlist: fix parsing json exception , add saving to a file of processed pairlist + docs

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -210,8 +210,7 @@ The `pairlist_url` option specifies the URL of the remote server where the pairl
 
 The `save_to_file` option, when provided with a valid filename, saves the processed pairlist to that file in JSON format. This option is optional, and by default, the pairlist is not saved to a file.
 
-??? Note
-    Example:
+??? Example "Multi bot with shared pairlist example"
     
     `save_to_file` can be used to save the pairlist to a file with Bot1:
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -208,7 +208,42 @@ In "append" mode, the retrieved pairlist is added to the original pairlist. All 
 
 The `pairlist_url` option specifies the URL of the remote server where the pairlist is located, or the path to a local file (if file:/// is prepended). This allows the user to use either a remote server or a local file as the source for the pairlist.
 
-The `save_to_file` option, when provided with a valid filename, saves the processed pairlist to that file in JSON format. This option is optional, and by default, the pairlist is not saved.
+The `save_to_file` option, when provided with a valid filename, saves the processed pairlist to that file in JSON format. This option is optional, and by default, the pairlist is not saved to a file.
+
+??? Note
+    Example:
+    
+    `save_to_file` can be used to save the pairlist to a file with Bot1:
+
+    ```json
+    "pairlists": [
+        {
+            "method": "RemotePairList",
+            "mode": "whitelist",
+            "pairlist_url": "https://example.com/pairlist",
+            "number_assets": 10,
+            "refresh_period": 1800,
+            "keep_pairlist_on_failure": true,
+            "read_timeout": 60,
+            "save_to_file": "user_data/filename.json" 
+        }
+    ]
+    ```
+
+    This saved pairlist file can be loaded by Bot2, or any additional bot with this configuration:
+
+    ```json
+    "pairlists": [
+        {
+            "method": "RemotePairList",
+            "mode": "whitelist",
+            "pairlist_url": "file:///user_data/filename.json",
+            "number_assets": 10,
+            "refresh_period": 10,
+            "keep_pairlist_on_failure": true,
+        }
+    ]
+    ```    
 
 The user is responsible for providing a server or local file that returns a JSON object with the following structure:
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -192,7 +192,8 @@ The RemotePairList is defined in the pairlists section of the configuration sett
         "refresh_period": 1800,
         "keep_pairlist_on_failure": true,
         "read_timeout": 60,
-        "bearer_token": "my-bearer-token"
+        "bearer_token": "my-bearer-token",
+        "save_to_file": "user_data/filename.json" 
     }
 ]
 ```
@@ -206,6 +207,8 @@ In "filter" mode, the retrieved pairlist is used as a filter. Only the pairs pre
 In "append" mode, the retrieved pairlist is added to the original pairlist. All pairs from both lists are included in the final pairlist without any filtering.
 
 The `pairlist_url` option specifies the URL of the remote server where the pairlist is located, or the path to a local file (if file:/// is prepended). This allows the user to use either a remote server or a local file as the source for the pairlist.
+
+The `save_to_file` option, when provided with a valid filename, saves the processed pairlist to that file in JSON format. This option is optional, and by default, the pairlist is not saved.
 
 The user is responsible for providing a server or local file that returns a JSON object with the following structure:
 

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -137,6 +137,12 @@ class RemotePairList(IPairList):
                 "description": "Bearer token",
                 "help": "Bearer token - used for auth against the upstream service.",
             },
+            "save_to_file": {
+                "type": "string",
+                "default": "",
+                "description": "Filename to save processed pairlist to.",
+                "help": "Specify a filename to save the processed pairlist in JSON format.",
+            },
         }
 
     def process_json(self, jsonparse) -> List[str]:

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -281,8 +281,7 @@ class RemotePairList(IPairList):
 
     def save_pairlist(self, pairlist: List[str], filename: str) -> None:
         pairlist_data = {
-            "pairs": pairlist,
-            "refresh_period": self._refresh_period
+            "pairs": pairlist
         }
         try:
             file_path = Path(filename)

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -187,7 +187,7 @@ class RemotePairList(IPairList):
                 except Exception as e:
                     pairlist = self.init_check(f'Failed processing JSON data: {type(e)}')
             else:
-                pairlist = self.init_check(f'RemotePairList is not of type JSON: '
+                pairlist = self.init_check(f'RemotePairList is not of type JSON.'
                                            f' {self._pairlist_url}')
 
         except requests.exceptions.RequestException:

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -198,7 +198,7 @@ class RemotePairList(IPairList):
 
         return pairlist, time_elapsed
 
-    def init_check(self, error: str):
+    def init_check(self, error: str) -> List[str]:
         if self._init_done:
             self.log_once("Error: " + error, logger.info)
             pairlist = self.return_last_pairlist()

--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -185,26 +185,25 @@ class RemotePairList(IPairList):
                 try:
                     pairlist = self.process_json(jsonparse)
                 except Exception as e:
-                    pairlist = self.init_check(f'Failed processing JSON data: {type(e)}')
+                    pairlist = self._handle_error(f'Failed processing JSON data: {type(e)}')
             else:
-                pairlist = self.init_check(f'RemotePairList is not of type JSON.'
-                                           f' {self._pairlist_url}')
+                pairlist = self._handle_error(f'RemotePairList is not of type JSON.'
+                                              f' {self._pairlist_url}')
 
         except requests.exceptions.RequestException:
-            pairlist = self.init_check(f'Was not able to fetch pairlist from:'
-                                       f' {self._pairlist_url}')
+            pairlist = self._handle_error(f'Was not able to fetch pairlist from:'
+                                          f' {self._pairlist_url}')
 
             time_elapsed = 0
 
         return pairlist, time_elapsed
 
-    def init_check(self, error: str) -> List[str]:
+    def _handle_error(self, error: str) -> List[str]:
         if self._init_done:
             self.log_once("Error: " + error, logger.info)
-            pairlist = self.return_last_pairlist()
+            return self.return_last_pairlist()
         else:
             raise OperationalException(error)
-        return pairlist
 
     def gen_pairlist(self, tickers: Tickers) -> List[str]:
         """
@@ -238,9 +237,9 @@ class RemotePairList(IPairList):
                             jsonparse = rapidjson.load(json_file, parse_mode=CONFIG_PARSE_MODE)
                             pairlist = self.process_json(jsonparse)
                         except Exception as e:
-                            pairlist = self.init_check(f'processing JSON data: {type(e)}')
+                            pairlist = self._handle_error(f'processing JSON data: {type(e)}')
                 else:
-                    pairlist = self.init_check(f"{self._pairlist_url} does not exist.")
+                    pairlist = self._handle_error(f"{self._pairlist_url} does not exist.")
 
             else:
                 # Fetch Pairlist from Remote URL

--- a/tests/plugins/test_remotepairlist.py
+++ b/tests/plugins/test_remotepairlist.py
@@ -82,7 +82,7 @@ def test_fetch_pairlist_mock_response_html(mocker, rpl_config):
     remote_pairlist = RemotePairList(exchange, pairlistmanager, rpl_config,
                                      rpl_config['pairlists'][0], 0)
 
-    with pytest.raises(OperationalException, match='RemotePairList is not of type JSON, abort.'):
+    with pytest.raises(OperationalException, match='RemotePairList is not of type JSON.'):
         remote_pairlist.fetch_pairlist()
 
 
@@ -107,9 +107,11 @@ def test_fetch_pairlist_timeout_keep_last_pairlist(mocker, rpl_config, caplog):
                                      rpl_config['pairlists'][0], 0)
 
     remote_pairlist._last_pairlist = ["BTC/USDT", "ETH/USDT", "LTC/USDT"]
-
+    remote_pairlist._init_done = True
+    pairlist_url = rpl_config['pairlists'][0]['pairlist_url']
     pairs, _time_elapsed = remote_pairlist.fetch_pairlist()
-    assert log_has(f"Was not able to fetch pairlist from: {remote_pairlist._pairlist_url}", caplog)
+
+    assert log_has(f'Error: Was not able to fetch pairlist from: ' f'{pairlist_url}', caplog)
     assert log_has("Keeping last fetched pairlist", caplog)
     assert pairs == ["BTC/USDT", "ETH/USDT", "LTC/USDT"]
 


### PR DESCRIPTION
## Summary

Extend the exception catch to the parsing, so last pairlist is returned.
Add Saving to a file

Solve the issue: https://discord.com/channels/700048804539400213/824719649417199646/1200374477968654446
Parsing Json Exception

## What's new?

Add saving of processed pairlist to a file, to enable other freqtrade instances to read from that file. + preventing unnecessary requests and keeping the pairlist in sync.