### PR TITLE
Added escaping to enter and exit tags on telegram performance messages.

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -4,7 +4,6 @@
 This module manage Telegram communication
 """
 import asyncio
-import html
 import json
 import logging
 import re
@@ -1376,21 +1375,21 @@ class Telegram(RPCHandler):
             pair = context.args[0]
 
         trades = self._rpc._rpc_enter_tag_performance(pair)
-        output = "<b>Entry Tag Performance:</b>\n"
+        output = "*Entry Tag Performance:*\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{html.escape(trade['enter_tag'])}\t"
+                f"{i + 1}.\t `{trade['enter_tag']}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
-                f"({trade['count']})</code>\n")
+                f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.HTML)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.HTML,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
                              reload_able=True, callback_path="update_enter_tag_performance",
                              query=update.callback_query)
 
@@ -1408,21 +1407,21 @@ class Telegram(RPCHandler):
             pair = context.args[0]
 
         trades = self._rpc._rpc_exit_reason_performance(pair)
-        output = "<b>Exit Reason Performance:</b>\n"
+        output = "*Exit Reason Performance:*\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{html.escape(trade['exit_reason'])}\t"
+                f"{i + 1}\.\t `{html.escape(trade['exit_reason'])}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
-                f"({trade['count']})</code>\n")
+                f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.HTML)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.HTML,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
                              reload_able=True, callback_path="update_exit_reason_performance",
                              query=update.callback_query)
 
@@ -1440,21 +1439,21 @@ class Telegram(RPCHandler):
             pair = context.args[0]
 
         trades = self._rpc._rpc_mix_tag_performance(pair)
-        output = "<b>Mix Tag Performance:</b>\n"
+        output = "*Mix Tag Performance:*\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{html.escape(trade['mix_tag'])}\t"
+                f"{i + 1}\.\t `{trade['mix_tag']}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
-                f"({trade['count']})</code>\n")
+                f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.HTML)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.HTML,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
                              reload_able=True, callback_path="update_mix_tag_performance",
                              query=update.callback_query)
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -4,6 +4,7 @@
 This module manage Telegram communication
 """
 import asyncio
+import html
 import json
 import logging
 import re
@@ -1378,7 +1379,7 @@ class Telegram(RPCHandler):
         output = "<b>Entry Tag Performance:</b>\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{trade['enter_tag']}\t"
+                f"{i + 1}.\t <code>{html.escape(trade['enter_tag'])}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
                 f"({trade['count']})</code>\n")
@@ -1410,7 +1411,7 @@ class Telegram(RPCHandler):
         output = "<b>Exit Reason Performance:</b>\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{trade['exit_reason']}\t"
+                f"{i + 1}.\t <code>{html.escape(trade['exit_reason'])}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
                 f"({trade['count']})</code>\n")
@@ -1442,7 +1443,7 @@ class Telegram(RPCHandler):
         output = "<b>Mix Tag Performance:</b>\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}.\t <code>{trade['mix_tag']}\t"
+                f"{i + 1}.\t <code>{html.escape(trade['mix_tag'])}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
                 f"({trade['count']})</code>\n")

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1384,12 +1384,12 @@ class Telegram(RPCHandler):
                 f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN,
                              reload_able=True, callback_path="update_enter_tag_performance",
                              query=update.callback_query)
 
@@ -1410,18 +1410,18 @@ class Telegram(RPCHandler):
         output = "*Exit Reason Performance:*\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}\.\t `{html.escape(trade['exit_reason'])}\t"
+                f"{i + 1}.\t `{trade['exit_reason']}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
                 f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN,
                              reload_able=True, callback_path="update_exit_reason_performance",
                              query=update.callback_query)
 
@@ -1442,18 +1442,18 @@ class Telegram(RPCHandler):
         output = "*Mix Tag Performance:*\n"
         for i, trade in enumerate(trades):
             stat_line = (
-                f"{i + 1}\.\t `{trade['mix_tag']}\t"
+                f"{i + 1}.\t `{trade['mix_tag']}\t"
                 f"{fmt_coin(trade['profit_abs'], self._config['stake_currency'])} "
                 f"({trade['profit_ratio']:.2%}) "
                 f"({trade['count']})`\n")
 
             if len(output + stat_line) >= MAX_MESSAGE_LENGTH:
-                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2)
+                await self._send_msg(output, parse_mode=ParseMode.MARKDOWN)
                 output = stat_line
             else:
                 output += stat_line
 
-        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN_V2,
+        await self._send_msg(output, parse_mode=ParseMode.MARKDOWN,
                              reload_able=True, callback_path="update_mix_tag_performance",
                              query=update.callback_query)
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1507,7 +1507,7 @@ async def test_telegram_entry_tag_performance_handle(
     await telegram._enter_tag_performance(update=update, context=context)
     assert msg_mock.call_count == 1
     assert 'Entry Tag Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>TEST1\t3.987 USDT (5.00%) (1)</code>' in msg_mock.call_args_list[0][0][0]
+    assert '`TEST1\t3.987 USDT (5.00%) (1)`' in msg_mock.call_args_list[0][0][0]
 
     context.args = ['XRP/USDT']
     await telegram._enter_tag_performance(update=update, context=context)
@@ -1538,7 +1538,7 @@ async def test_telegram_exit_reason_performance_handle(
     await telegram._exit_reason_performance(update=update, context=context)
     assert msg_mock.call_count == 1
     assert 'Exit Reason Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>roi\t2.842 USDT (10.00%) (1)</code>' in msg_mock.call_args_list[0][0][0]
+    assert '`roi\t2.842 USDT (10.00%) (1)`' in msg_mock.call_args_list[0][0][0]
     context.args = ['XRP/USDT']
 
     await telegram._exit_reason_performance(update=update, context=context)
@@ -1570,7 +1570,7 @@ async def test_telegram_mix_tag_performance_handle(default_conf_usdt, update, ti
     await telegram._mix_tag_performance(update=update, context=context)
     assert msg_mock.call_count == 1
     assert 'Mix Tag Performance' in msg_mock.call_args_list[0][0][0]
-    assert ('<code>TEST3 roi\t2.842 USDT (10.00%) (1)</code>'
+    assert ('`TEST3 roi\t2.842 USDT (10.00%) (1)`'
             in msg_mock.call_args_list[0][0][0])
 
     context.args = ['XRP/USDT']


### PR DESCRIPTION
## Summary

Escaping entry and exit tags for telegram messages, as odd characters can break the functionality.

Solve the issue: no issue

## Quick changelog

- add escaping for `enter_tag`, `exit_tag` and `mix_tag` to telegram functions `_enter_tag_performance`, `_exit_reason_performance`, and `_mix_tag_performance`.

## What's new?

When a strategy uses odd characters such as `<, >, &` in the enter or exit tags, then the telegram commands /entries, /exits, and /mix_tags no longer return any result, and a warning is displayed in the log.  I have added escaping using `html.escape` to those tags when the message is being constructed.

```
2024-02-16 10:41:18,142 - freqtrade.rpc.telegram - WARNING - Telegram NetworkError: Can't parse entities: unsupported start tag "" at byte offset 97! Trying one more time.
2024-02-16 10:41:18,406 - freqtrade.rpc.telegram - WARNING - TelegramError: Can't parse entities: unsupported start tag "" at byte offset 97! Giving up on that message.
```
