### PR TITLE
Add sorting to volatility and RangeStability pairlists

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -460,7 +460,7 @@ Volatility is the degree of historical variation of a pairs over time, it is mea
 
 This filter removes pairs if the average volatility over a `lookback_days` days is below `min_volatility` or above `max_volatility`. Since this is a filter that requires additional data, the results are cached for `refresh_period`.
 
-This filter can be used to narrow down your pairs to a certain volatility or avoid very volatile pairs. 
+This filter can be used to narrow down your pairs to a certain volatility or avoid very volatile pairs.
 
 In the below example:
 If the volatility over the last 10 days is not in the range of 0.05-0.50, remove the pair from the whitelist. The filter is applied every 24h.
@@ -476,6 +476,9 @@ If the volatility over the last 10 days is not in the range of 0.05-0.50, remove
     }
 ]
 ```
+
+Adding `"sort_direction": "asc"` or `"sort_direction": "desc"` enables sorting mode for this pairlist.
+When sorting, caching will be applied at the candle level - ignoring `refresh_period` (the candle's won't change anyway).
 
 ### Full example of Pairlist Handlers
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -478,7 +478,6 @@ If the volatility over the last 10 days is not in the range of 0.05-0.50, remove
 ```
 
 Adding `"sort_direction": "asc"` or `"sort_direction": "desc"` enables sorting mode for this pairlist.
-When sorting, caching will be applied at the candle level - ignoring `refresh_period` (the candle's won't change anyway).
 
 ### Full example of Pairlist Handlers
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -450,6 +450,8 @@ If the trading range over the last 10 days is <1% or >99%, remove the pair from 
 ]
 ```
 
+Adding `"sort_direction": "asc"` or `"sort_direction": "desc"` enables sorting for this pairlist.
+
 !!! Tip
     This Filter can be used to automatically remove stable coin pairs, which have a very low trading range, and are therefore extremely difficult to trade with profit.
     Additionally, it can also be used to automatically remove pairs with extreme high/low variance over a given amount of time.

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -105,13 +105,13 @@ class VolatilityFilter(IPairList):
         since_ms = dt_ts(dt_floor_day(dt_now()) - timedelta(days=self._days))
         candles = self._exchange.refresh_ohlcv_with_cache(needed_pairs, since_ms=since_ms)
 
-        if self._enabled:
-            for p in deepcopy(pairlist):
-                daily_candles = candles[(p, '1d', self._def_candletype)] if (
-                    p, '1d', self._def_candletype) in candles else None
-                if not self._validate_pair_loc(p, daily_candles):
-                    pairlist.remove(p)
-        return pairlist
+        resulting_pairlist: List[str] = []
+        for p in pairlist:
+            daily_candles = candles[(p, '1d', self._def_candletype)] if (
+                p, '1d', self._def_candletype) in candles else None
+            if self._validate_pair_loc(p, daily_candles):
+                resulting_pairlist.append(p)
+        return resulting_pairlist
 
     def _validate_pair_loc(self, pair: str, daily_candles: Optional[DataFrame]) -> bool:
         """

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -47,6 +47,9 @@ class VolatilityFilter(IPairList):
         if self._days > candle_limit:
             raise OperationalException("VolatilityFilter requires lookback_days to not "
                                        f"exceed exchange max request size ({candle_limit})")
+        if self._sort_direction not in [None, 'asc', 'desc']:
+            raise OperationalException("VolatilityFilter requires sort_direction to be "
+                                       "either None (undefined), 'asc' or 'desc'")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -123,8 +123,12 @@ class VolatilityFilter(IPairList):
 
             volatility_avg = self._calculate_volatility(p, daily_candles)
 
-            if volatility_avg is not None and self._validate_pair_loc(p, volatility_avg):
-                resulting_pairlist.append(p)
+            if volatility_avg is not None:
+                if self._validate_pair_loc(p, volatility_avg):
+                    resulting_pairlist.append(p)
+            else:
+                self.log_once(f"Removed {p} from whitelist, no candles found.", logger.info)
+
             if self._sort_direction:
                 volatilitys[p] = volatility_avg if not np.isnan(volatility_avg) else 0
 

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -98,7 +98,7 @@ class VolatilityFilter(IPairList):
                 "default": None,
                 "options": [None, "asc", "desc"],
                 "description": "Sort pairlist",
-                "help": "Sort Pairlist",
+                "help": "Sort Pairlist ascending or descending by volatility.",
             },
             **IPairList.refresh_period_parameter()
         }

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -148,7 +148,7 @@ class VolatilityFilter(IPairList):
         """
         Validate trading range
         :param pair: Pair that's currently validated
-        :param daily_candles: Downloaded daily candles
+        :param volatility_avg: Average volatility
         :return: True if the pair can stay, false if it should be removed
         """
         # Check symbol in cache

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -95,7 +95,7 @@ class VolatilityFilter(IPairList):
             "sort_direction": {
                 "type": "option",
                 "default": None,
-                "options": [None, "asc", "desc"],
+                "options": ["", "asc", "desc"],
                 "description": "Sort pairlist",
                 "help": "Sort Pairlist ascending or descending by volatility.",
             },
@@ -125,11 +125,11 @@ class VolatilityFilter(IPairList):
             if volatility_avg is not None:
                 if self._validate_pair_loc(p, volatility_avg):
                     resulting_pairlist.append(p)
+                    volatilitys[p] = (
+                        volatility_avg if volatility_avg and not np.isnan(volatility_avg) else 0
+                    )
             else:
                 self.log_once(f"Removed {p} from whitelist, no candles found.", logger.info)
-
-            if self._sort_direction:
-                volatilitys[p] = volatility_avg if not np.isnan(volatility_avg) else 0
 
         if self._sort_direction:
             resulting_pairlist = sorted(resulting_pairlist,
@@ -137,7 +137,7 @@ class VolatilityFilter(IPairList):
                                         reverse=self._sort_direction == 'desc')
         return resulting_pairlist
 
-    def _calculate_volatility(self, pair: str,  daily_candles: DataFrame) -> float:
+    def _calculate_volatility(self, pair: str,  daily_candles: DataFrame) -> Optional[float]:
         # Check symbol in cache
         if (volatility_avg := self._pair_cache.get(pair, None)) is not None:
             return volatility_avg

--- a/freqtrade/plugins/pairlist/VolatilityFilter.py
+++ b/freqtrade/plugins/pairlist/VolatilityFilter.py
@@ -3,7 +3,6 @@ Volatility pairlist filter
 """
 import logging
 import sys
-from copy import deepcopy
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -93,7 +93,7 @@ class RangeStabilityFilter(IPairList):
             "sort_direction": {
                 "type": "option",
                 "default": None,
-                "options": [None, "asc", "desc"],
+                "options": ["", "asc", "desc"],
                 "description": "Sort pairlist",
                 "help": "Sort Pairlist ascending or descending by rate of change.",
             },
@@ -134,7 +134,7 @@ class RangeStabilityFilter(IPairList):
                                         reverse=self._sort_direction == 'desc')
         return resulting_pairlist
 
-    def _calculate_rate_of_change(self, pair: str, daily_candles: DataFrame) -> float:
+    def _calculate_rate_of_change(self, pair: str, daily_candles: DataFrame) -> Optional[float]:
         # Check symbol in cache
         if (pct_change := self._pair_cache.get(pair, None)) is not None:
             return pct_change

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -44,6 +44,7 @@ class RangeStabilityFilter(IPairList):
         if self._sort_direction not in [None, 'asc', 'desc']:
             raise OperationalException("RangeStabilityFilter requires sort_direction to be "
                                        "either None (undefined), 'asc' or 'desc'")
+
     @property
     def needstickers(self) -> bool:
         """

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -109,8 +109,9 @@ class RangeStabilityFilter(IPairList):
 
             pct_change = self._calculate_rate_of_change(p, daily_candles)
 
-            if pct_change is not None and self._validate_pair_loc(p, pct_change):
-                resulting_pairlist.append(p)
+            if pct_change is not None:
+                if self._validate_pair_loc(p, pct_change):
+                    resulting_pairlist.append(p)
             else:
                 self.log_once(f"Removed {p} from whitelist, no candles found.", logger.info)
 

--- a/freqtrade/plugins/pairlist/rangestabilityfilter.py
+++ b/freqtrade/plugins/pairlist/rangestabilityfilter.py
@@ -2,9 +2,8 @@
 Rate of change pairlist filter
 """
 import logging
-from copy import deepcopy
 from datetime import timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from cachetools import TTLCache
 from pandas import DataFrame
@@ -103,45 +102,55 @@ class RangeStabilityFilter(IPairList):
         since_ms = dt_ts(dt_floor_day(dt_now()) - timedelta(days=self._days + 1))
         candles = self._exchange.refresh_ohlcv_with_cache(needed_pairs, since_ms=since_ms)
 
-        if self._enabled:
-            for p in deepcopy(pairlist):
-                daily_candles = candles[(p, '1d', self._def_candletype)] if (
-                    p, '1d', self._def_candletype) in candles else None
-                if not self._validate_pair_loc(p, daily_candles):
-                    pairlist.remove(p)
-        return pairlist
+        resulting_pairlist: List[str] = []
 
-    def _validate_pair_loc(self, pair: str, daily_candles: Optional[DataFrame]) -> bool:
-        """
-        Validate trading range
-        :param pair: Pair that's currently validated
-        :param daily_candles: Downloaded daily candles
-        :return: True if the pair can stay, false if it should be removed
-        """
+        for p in pairlist:
+            daily_candles = candles.get((p, '1d', self._def_candletype), None)
+
+            pct_change = self._calculate_rate_of_change(p, daily_candles)
+
+            if pct_change is not None and self._validate_pair_loc(p, pct_change):
+                resulting_pairlist.append(p)
+            else:
+                self.log_once(f"Removed {p} from whitelist, no candles found.", logger.info)
+
+        return resulting_pairlist
+
+    def _calculate_rate_of_change(self, pair: str, daily_candles: DataFrame) -> float:
         # Check symbol in cache
-        if (cached_res := self._pair_cache.get(pair, None)) is not None:
-            return cached_res
-
-        result = True
+        if (pct_change := self._pair_cache.get(pair, None)) is not None:
+            return pct_change
         if daily_candles is not None and not daily_candles.empty:
+
             highest_high = daily_candles['high'].max()
             lowest_low = daily_candles['low'].min()
             pct_change = ((highest_high - lowest_low) / lowest_low) if lowest_low > 0 else 0
-            if pct_change < self._min_rate_of_change:
-                self.log_once(f"Removed {pair} from whitelist, because rate of change "
-                              f"over {self._days} {plural(self._days, 'day')} is {pct_change:.3f}, "
-                              f"which is below the threshold of {self._min_rate_of_change}.",
-                              logger.info)
-                result = False
-            if self._max_rate_of_change:
-                if pct_change > self._max_rate_of_change:
-                    self.log_once(
-                        f"Removed {pair} from whitelist, because rate of change "
-                        f"over {self._days} {plural(self._days, 'day')} is {pct_change:.3f}, "
-                        f"which is above the threshold of {self._max_rate_of_change}.",
-                        logger.info)
-                    result = False
-            self._pair_cache[pair] = result
+            self._pair_cache[pair] = pct_change
+            return pct_change
         else:
-            self.log_once(f"Removed {pair} from whitelist, no candles found.", logger.info)
+            return None
+
+    def _validate_pair_loc(self, pair: str, pct_change: float) -> bool:
+        """
+        Validate trading range
+        :param pair: Pair that's currently validated
+        :param pct_change: Rate of change
+        :return: True if the pair can stay, false if it should be removed
+        """
+
+        result = True
+        if pct_change < self._min_rate_of_change:
+            self.log_once(f"Removed {pair} from whitelist, because rate of change "
+                          f"over {self._days} {plural(self._days, 'day')} is {pct_change:.3f}, "
+                          f"which is below the threshold of {self._min_rate_of_change}.",
+                          logger.info)
+            result = False
+        if self._max_rate_of_change:
+            if pct_change > self._max_rate_of_change:
+                self.log_once(
+                    f"Removed {pair} from whitelist, because rate of change "
+                    f"over {self._days} {plural(self._days, 'day')} is {pct_change:.3f}, "
+                    f"which is above the threshold of {self._max_rate_of_change}.",
+                    logger.info)
+                result = False
         return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,8 +142,8 @@ def generate_trades_history(n_rows, start_date: Optional[datetime] = None, days=
     return df
 
 
-def generate_test_data(timeframe: str, size: int, start: str = '2020-07-05'):
-    np.random.seed(42)
+def generate_test_data(timeframe: str, size: int, start: str = '2020-07-05', random_seed=42):
+    np.random.seed(random_seed)
 
     base = np.random.normal(20, 2, size=size)
     if timeframe == '1y':
@@ -174,9 +174,9 @@ def generate_test_data(timeframe: str, size: int, start: str = '2020-07-05'):
     return df
 
 
-def generate_test_data_raw(timeframe: str, size: int, start: str = '2020-07-05'):
+def generate_test_data_raw(timeframe: str, size: int, start: str = '2020-07-05', random_seed=42):
     """ Generates data in the ohlcv format used by ccxt """
-    df = generate_test_data(timeframe, size, start)
+    df = generate_test_data(timeframe, size, start, random_seed)
     df['date'] = df.loc[:, 'date'].view(np.int64) // 1000 // 1000
     return list(list(x) for x in zip(*(df[x].values.tolist() for x in df.columns)))
 

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -1160,6 +1160,13 @@ def test_rangestabilityfilter_checks(mocker, default_conf, markets, tickers):
                        match='RangeStabilityFilter requires lookback_days to be >= 1'):
         get_patched_freqtradebot(mocker, default_conf)
 
+    default_conf['pairlists'] = [{'method': 'VolumePairList', 'number_assets': 10},
+                                 {'method': 'RangeStabilityFilter', 'sort_direction': 'something'}]
+
+    with pytest.raises(OperationalException,
+                       match='RangeStabilityFilter requires sort_direction to be either None.*'):
+        get_patched_freqtradebot(mocker, default_conf)
+
 
 @pytest.mark.parametrize('min_rate_of_change,max_rate_of_change,expected_length', [
     (0.01, 0.99, 5),

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -789,10 +789,11 @@ def test_VolatilityFilter_sort(mocker, whitelist_conf, time_machine, sort_direct
         ('TKN/BTC', '1d', CandleType.SPOT): df2,
 
     }
+    ohlcv_mock = MagicMock(return_value=ohlcv_data)
     mocker.patch.multiple(
         EXMS,
         exchange_has=MagicMock(return_value=True),
-        refresh_latest_ohlcv=MagicMock(return_value=ohlcv_data),
+        refresh_latest_ohlcv=ohlcv_mock,
     )
 
     exchange = get_patched_exchange(mocker, whitelist_conf)
@@ -801,10 +802,15 @@ def test_VolatilityFilter_sort(mocker, whitelist_conf, time_machine, sort_direct
 
     assert exchange.ohlcv_candle_limit.call_count == 1
     plm.refresh_pairlist()
+    assert ohlcv_mock.call_count == 1
     assert exchange.ohlcv_candle_limit.call_count == 1
     assert plm.whitelist == (
         ['ETH/BTC', 'TKN/BTC'] if sort_direction == 'asc' else ['TKN/BTC', 'ETH/BTC']
     )
+
+    plm.refresh_pairlist()
+    assert exchange.ohlcv_candle_limit.call_count == 1
+    assert ohlcv_mock.call_count == 1
 
 
 def test_ShuffleFilter_init(mocker, whitelist_conf, caplog) -> None:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Add sorting to range and volatility pairlists

closes #9667 

## Quick changelog

- Add sorting to RangeStabilityPairlist
- Add sorting to VolatilityPairlist
