### PR TITLE
fix: try plotting as much info in xgboost tensorboard as possible

### DIFF
--- a/freqtrade/freqai/prediction_models/XGBoostRegressor.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRegressor.py
@@ -36,8 +36,15 @@ class XGBoostRegressor(BaseRegressionModel):
             eval_set = None
             eval_weights = None
         else:
-            eval_set = [(data_dictionary["test_features"], data_dictionary["test_labels"])]
-            eval_weights = [data_dictionary['test_weights']]
+            eval_set = [
+                (data_dictionary["test_features"],
+                 data_dictionary["test_labels"]),
+                (X, y)
+            ]
+            eval_weights = [
+                data_dictionary['test_weights'],
+                data_dictionary['train_weights']
+            ]
 
         sample_weight = data_dictionary["train_weights"]
 

--- a/freqtrade/freqai/tensorboard/tensorboard.py
+++ b/freqtrade/freqai/tensorboard/tensorboard.py
@@ -46,8 +46,7 @@ class TensorBoardCallback(BaseTensorBoardCallback):
         for data, metric in evals_log.items():
             for metric_name, log in metric.items():
                 score = log[-1][0] if isinstance(log[-1], tuple) else log[-1]
-                key = self._get_key(data, metric_name)
-                self.writer.add_scalar(f"{key}_loss", score, epoch)
+                self.writer.add_scalar(f"{data}-{metric_name}", score, epoch)
 
         return False
 

--- a/freqtrade/freqai/tensorboard/tensorboard.py
+++ b/freqtrade/freqai/tensorboard/tensorboard.py
@@ -46,10 +46,8 @@ class TensorBoardCallback(BaseTensorBoardCallback):
         for data, metric in evals_log.items():
             for metric_name, log in metric.items():
                 score = log[-1][0] if isinstance(log[-1], tuple) else log[-1]
-                if data == "train":
-                    self.writer.add_scalar("train_loss", score, epoch)
-                else:
-                    self.writer.add_scalar("valid_loss", score, epoch)
+                key = self._get_key(data, metric_name)
+                self.writer.add_scalar(f"{key}_loss", score, epoch)
 
         return False
 

--- a/freqtrade/freqai/tensorboard/tensorboard.py
+++ b/freqtrade/freqai/tensorboard/tensorboard.py
@@ -43,10 +43,11 @@ class TensorBoardCallback(BaseTensorBoardCallback):
         if not evals_log:
             return False
 
-        for data, metric in evals_log.items():
-            for metric_name, log in metric.items():
+        evals = ["validation", "train"]
+        for metric, eval in zip(evals_log.items(), evals):
+            for metric_name, log in metric[1].items():
                 score = log[-1][0] if isinstance(log[-1], tuple) else log[-1]
-                self.writer.add_scalar(f"{data}-{metric_name}", score, epoch)
+                self.writer.add_scalar(f"{eval}-{metric_name}", score, epoch)
 
         return False
 


### PR DESCRIPTION
Right now, the logic may be blocking extra information that is provided in the eval_log. This PR is aimed at exposing more of XGBoost eval_log info in tensorboard.
