### PR TITLE
Bump catboost to 1.2.3 

### DIFF
--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -5,7 +5,7 @@
 # Required for freqai
 scikit-learn==1.4.1.post1
 joblib==1.3.2
-catboost==1.2.2; 'arm' not in platform_machine and python_version < '3.12'
+catboost==1.2.3; 'arm' not in platform_machine
 lightgbm==4.3.0
 xgboost==2.0.3
 tensorboard==2.16.2

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -27,6 +27,9 @@ def is_arm() -> bool:
 def can_run_model(model: str) -> None:
     is_pytorch_model = 'Reinforcement' in model or 'PyTorch' in model
 
+    if is_py12() and is_pytorch_model:
+        pytest.skip("Model not supported on python 3.12 yet.")
+
     if is_arm() and "Catboost" in model:
         pytest.skip("CatBoost is not supported on ARM.")
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -27,9 +27,6 @@ def is_arm() -> bool:
 def can_run_model(model: str) -> None:
     is_pytorch_model = 'Reinforcement' in model or 'PyTorch' in model
 
-    if is_py12() and ("Catboost" in model or is_pytorch_model):
-        pytest.skip("Model not supported on python 3.12 yet.")
-
     if is_arm() and "Catboost" in model:
         pytest.skip("CatBoost is not supported on ARM.")
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This new version also supports 3.12 now, so it should be possible to remove restrictions we had in place.
