### PR TITLE
Feature: trade lifecycle callbacks

### DIFF
--- a/docs/bot-basics.md
+++ b/docs/bot-basics.md
@@ -33,7 +33,6 @@ For spot pairs, naming will be `base/quote` (e.g. `ETH/USDT`).
 
 For futures pairs, naming will be `base/quote:settle` (e.g. `ETH/USDT:USDT`).
 
-
 ## Bot execution logic
 
 Starting freqtrade in dry-run or live mode (using `freqtrade trade`) will start the bot and start the bot iteration loop.
@@ -42,8 +41,6 @@ This will also run the `bot_start()` callback.
 By default, the bot loop runs every few seconds (`internals.process_throttle_secs`) and performs the following actions:
 
 * Fetch open trades from persistence.
-  * Update trades open order state from exchange
-  * Call `order_filled()` strategy callback for filled orders.
 * Calculate current list of tradable pairs.
 * Download OHLCV data for the pairlist including all [informative pairs](strategy-customization.md#get-data-for-non-tradeable-pairs)  
   This step is only executed once per Candle to avoid unnecessary network traffic.
@@ -52,10 +49,12 @@ By default, the bot loop runs every few seconds (`internals.process_throttle_sec
   * Call `populate_indicators()`
   * Call `populate_entry_trend()`
   * Call `populate_exit_trend()`
-* Check timeouts for open orders.
-  * Calls `check_entry_timeout()` strategy callback for open entry orders.
-  * Calls `check_exit_timeout()` strategy callback for open exit orders.
-  * Calls `adjust_entry_price()` strategy callback for open entry orders.
+* Update trades open order state from exchange.
+  * Call `order_filled()` strategy callback for filled orders.
+  * Check timeouts for open orders.
+    * Calls `check_entry_timeout()` strategy callback for open entry orders.
+    * Calls `check_exit_timeout()` strategy callback for open exit orders.
+    * Calls `adjust_entry_price()` strategy callback for open entry orders.
 * Verifies existing positions and eventually places exit orders.
   * Considers stoploss, ROI and exit-signal, `custom_exit()` and `custom_stoploss()`.
   * Determine exit-price based on `exit_pricing` configuration setting or by using the `custom_exit_price()` callback.

--- a/docs/bot-basics.md
+++ b/docs/bot-basics.md
@@ -43,7 +43,7 @@ By default, the bot loop runs every few seconds (`internals.process_throttle_sec
 
 * Fetch open trades from persistence.
   * Update trades open order state from exchange
-  * Call `order_filled()` stategy callback for filled orders.
+  * Call `order_filled()` strategy callback for filled orders.
 * Calculate current list of tradable pairs.
 * Download OHLCV data for the pairlist including all [informative pairs](strategy-customization.md#get-data-for-non-tradeable-pairs)  
   This step is only executed once per Candle to avoid unnecessary network traffic.
@@ -88,10 +88,10 @@ This loop will be repeated again and again until the bot is stopped.
   * In Margin and Futures mode, `leverage()` strategy callback is called to determine the desired leverage.
   * Determine stake size by calling the `custom_stake_amount()` callback.
   * Check position adjustments for open trades if enabled and call `adjust_trade_position()` to determine if an additional order is requested.
-  * Call `order_filled()` stategy callback for filled entry orders.
+  * Call `order_filled()` strategy callback for filled entry orders.
   * Call `custom_stoploss()` and `custom_exit()` to find custom exit points.
   * For exits based on exit-signal, custom-exit and partial exits: Call `custom_exit_price()` to determine exit price (Prices are moved to be within the closing candle).
-  * Call `order_filled()` stategy callback for filled exit orders.
+  * Call `order_filled()` strategy callback for filled exit orders.
 * Generate backtest report output
 
 !!! Note

--- a/docs/bot-basics.md
+++ b/docs/bot-basics.md
@@ -42,6 +42,8 @@ This will also run the `bot_start()` callback.
 By default, the bot loop runs every few seconds (`internals.process_throttle_secs`) and performs the following actions:
 
 * Fetch open trades from persistence.
+  * Update trades open order state from exchange
+  * Call `order_filled()` stategy callback for filled orders.
 * Calculate current list of tradable pairs.
 * Download OHLCV data for the pairlist including all [informative pairs](strategy-customization.md#get-data-for-non-tradeable-pairs)  
   This step is only executed once per Candle to avoid unnecessary network traffic.
@@ -86,8 +88,10 @@ This loop will be repeated again and again until the bot is stopped.
   * In Margin and Futures mode, `leverage()` strategy callback is called to determine the desired leverage.
   * Determine stake size by calling the `custom_stake_amount()` callback.
   * Check position adjustments for open trades if enabled and call `adjust_trade_position()` to determine if an additional order is requested.
+  * Call `order_filled()` stategy callback for filled entry orders.
   * Call `custom_stoploss()` and `custom_exit()` to find custom exit points.
   * For exits based on exit-signal, custom-exit and partial exits: Call `custom_exit_price()` to determine exit price (Prices are moved to be within the closing candle).
+  * Call `order_filled()` stategy callback for filled exit orders.
 * Generate backtest report output
 
 !!! Note

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -1028,7 +1028,7 @@ Defining a stoploss of 10% at 10x leverage would trigger the stoploss with a 1% 
 
 The `order_filled()` callback may be used by strategy developer to perform specific actions based on current trade state after an order is filled.
 
-Assuming that your strategy need to store the high value of the candle at trade entry, this is possible with this callback as the following exemple show.
+Assuming that your strategy need to store the high value of the candle at trade entry, this is possible with this callback as the following example show.
 
 ``` python
 class AwesomeStrategy(IStrategy):

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -19,6 +19,7 @@ Currently available callbacks:
 * [`adjust_trade_position()`](#adjust-trade-position)
 * [`adjust_entry_price()`](#adjust-entry-price)
 * [`leverage()`](#leverage-callback)
+* [`order_filled()`](#oder-filled-callback)
 
 !!! Tip "Callback calling sequence"
     You can find the callback calling sequence in [bot-basics](bot-basics.md#bot-execution-logic)
@@ -1022,3 +1023,30 @@ class AwesomeStrategy(IStrategy):
 
 All profit calculations include leverage. Stoploss / ROI also include leverage in their calculation.
 Defining a stoploss of 10% at 10x leverage would trigger the stoploss with a 1% move to the downside.
+
+## Order filled Callback
+
+The `order_filled()` callback may be used by strategy developer to perform specific actions based on current trade state after an order is filled.
+
+Assuming that your strategy need to store the high value of the candle at trade entry, this is possible with this callback as the following exemple show.
+
+``` python
+class AwesomeStrategy(IStrategy):
+    def order_filled(self, pair: str, trade: Trade, order: Order, current_time: datetime, **kwargs) -> None:
+        """
+        Called just ofter order filling
+        :param pair: Pair for trade that's just exited.
+        :param trade: trade object.
+        :param current_time: datetime object, containing the current datetime
+        :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+        """
+        # Obtain pair dataframe (just to show how to access it)
+        dataframe, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
+        last_candle = dataframe.iloc[-1].squeeze()
+        
+        if (trade.nr_of_successful_entries == 1) and (order.ft_order_side == trade.entry_side):
+            trade.set_custom_data(key='entry_candle_high', value=last_candle['high'])
+
+        return None
+
+```

--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -19,7 +19,7 @@ Currently available callbacks:
 * [`adjust_trade_position()`](#adjust-trade-position)
 * [`adjust_entry_price()`](#adjust-entry-price)
 * [`leverage()`](#leverage-callback)
-* [`order_filled()`](#oder-filled-callback)
+* [`order_filled()`](#order-filled-callback)
 
 !!! Tip "Callback calling sequence"
     You can find the callback calling sequence in [bot-basics](bot-basics.md#bot-execution-logic)
@@ -1026,17 +1026,20 @@ Defining a stoploss of 10% at 10x leverage would trigger the stoploss with a 1% 
 
 ## Order filled Callback
 
-The `order_filled()` callback may be used by strategy developer to perform specific actions based on current trade state after an order is filled.
+The `order_filled()` callback may be used to perform specific actions based on the current trade state after an order is filled.
+It will be called independently of the order type (entry, exit, stoploss or position adjustment).
 
-Assuming that your strategy need to store the high value of the candle at trade entry, this is possible with this callback as the following example show.
+Assuming that your strategy needs to store the high value of the candle at trade entry, this is possible with this callback as the following example show.
 
 ``` python
 class AwesomeStrategy(IStrategy):
     def order_filled(self, pair: str, trade: Trade, order: Order, current_time: datetime, **kwargs) -> None:
         """
-        Called just ofter order filling
-        :param pair: Pair for trade that's just exited.
+        Called right after an order fills. 
+        Will be called for all order types (entry, exit, stoploss, position adjustment).
+        :param pair: Pair for trade
         :param trade: trade object.
+        :param order: Order object.
         :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         """

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -478,7 +478,8 @@ class FreqtradeBot(LoggingMixin):
                 trade.close_date = trade.date_last_filled_utc
                 strategy_safe_wrapper(
                     self.strategy.order_filled, default_retval=None)(
-                    pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
+                    pair=trade.pair, trade=trade, order=order_obj,
+                    current_time=datetime.now(timezone.utc))
                 self.order_close_notify(trade, order_obj,
                                         order_obj.ft_order_side == 'stoploss',
                                         send_msg=prev_trade_state != trade.is_open)
@@ -1950,7 +1951,7 @@ class FreqtradeBot(LoggingMixin):
         if order.status in constants.NON_OPEN_EXCHANGE_STATES:
             strategy_safe_wrapper(
                 self.strategy.order_filled, default_retval=None)(
-                pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
+                pair=trade.pair, trade=trade, order=order, current_time=datetime.now(timezone.utc))
             # If a entry order was closed, force update on stoploss on exchange
             if order.ft_order_side == trade.entry_side:
                 trade = self.cancel_stoploss_on_exchange(trade)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -476,10 +476,6 @@ class FreqtradeBot(LoggingMixin):
             if not trade.is_open:
                 # Trade was just closed
                 trade.close_date = trade.date_last_filled_utc
-                strategy_safe_wrapper(
-                    self.strategy.order_filled, default_retval=None)(
-                    pair=trade.pair, trade=trade, order=order_obj,
-                    current_time=datetime.now(timezone.utc))
                 self.order_close_notify(trade, order_obj,
                                         order_obj.ft_order_side == 'stoploss',
                                         send_msg=prev_trade_state != trade.is_open)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1232,6 +1232,10 @@ class FreqtradeBot(LoggingMixin):
             # We check if stoploss order is fulfilled
             if stoploss_order and stoploss_order['status'] in ('closed', 'triggered'):
                 trade.exit_reason = ExitType.STOPLOSS_ON_EXCHANGE.value
+                strategy_safe_wrapper(
+                    self.strategy.order_filled, default_retval=None)(
+                    pair=trade.pair, trade=trade, order=slo,
+                    current_time=datetime.now(timezone.utc))
                 self._notify_exit(trade, "stoploss", True)
                 self.handle_protections(trade.pair, trade.trade_direction)
                 return True

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1942,16 +1942,15 @@ class FreqtradeBot(LoggingMixin):
         trade = self._update_trade_after_fill(trade, order_obj)
         Trade.commit()
 
-        strategy_safe_wrapper(
-            self.strategy.order_filled, default_retval=None)(
-            pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
-
         self.order_close_notify(trade, order_obj, stoploss_order, send_msg)
 
         return False
 
     def _update_trade_after_fill(self, trade: Trade, order: Order) -> Trade:
         if order.status in constants.NON_OPEN_EXCHANGE_STATES:
+            strategy_safe_wrapper(
+                self.strategy.order_filled, default_retval=None)(
+                pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
             # If a entry order was closed, force update on stoploss on exchange
             if order.ft_order_side == trade.entry_side:
                 trade = self.cancel_stoploss_on_exchange(trade)

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -476,6 +476,9 @@ class FreqtradeBot(LoggingMixin):
             if not trade.is_open:
                 # Trade was just closed
                 trade.close_date = trade.date_last_filled_utc
+                strategy_safe_wrapper(
+                    self.strategy.order_filled, default_retval=None)(
+                    pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
                 self.order_close_notify(trade, order_obj,
                                         order_obj.ft_order_side == 'stoploss',
                                         send_msg=prev_trade_state != trade.is_open)
@@ -1938,6 +1941,10 @@ class FreqtradeBot(LoggingMixin):
 
         trade = self._update_trade_after_fill(trade, order_obj)
         Trade.commit()
+
+        strategy_safe_wrapper(
+            self.strategy.order_filled, default_retval=None)(
+            pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
 
         self.order_close_notify(trade, order_obj, stoploss_order, send_msg)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1232,10 +1232,6 @@ class FreqtradeBot(LoggingMixin):
             # We check if stoploss order is fulfilled
             if stoploss_order and stoploss_order['status'] in ('closed', 'triggered'):
                 trade.exit_reason = ExitType.STOPLOSS_ON_EXCHANGE.value
-                strategy_safe_wrapper(
-                    self.strategy.order_filled, default_retval=None)(
-                    pair=trade.pair, trade=trade, order=slo,
-                    current_time=datetime.now(timezone.utc))
                 self._notify_exit(trade, "stoploss", True)
                 self.handle_protections(trade.pair, trade.trade_direction)
                 return True

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -603,6 +603,9 @@ class Backtesting:
         if order and self._get_order_filled(order.ft_price, row):
             order.close_bt_order(current_date, trade)
             self._run_funding_fees(trade, current_date, force=True)
+            strategy_safe_wrapper(
+                self.strategy.order_filled, default_retval=None)(
+                pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
 
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -604,8 +604,10 @@ class Backtesting:
             order.close_bt_order(current_date, trade)
             self._run_funding_fees(trade, current_date, force=True)
             strategy_safe_wrapper(
-                self.strategy.order_filled, default_retval=None)(
-                pair=trade.pair, trade=trade, order=order, current_time=datetime.now(timezone.utc))
+                self.strategy.order_filled,
+                default_retval=None)(
+                pair=trade.pair, trade=trade,  # type: ignore[arg-type]
+                order=order, current_time=datetime.now(timezone.utc))
 
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -607,7 +607,7 @@ class Backtesting:
                 self.strategy.order_filled,
                 default_retval=None)(
                 pair=trade.pair, trade=trade,  # type: ignore[arg-type]
-                order=order, current_time=datetime.now(timezone.utc))
+                order=order, current_time=current_date)
 
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -605,7 +605,7 @@ class Backtesting:
             self._run_funding_fees(trade, current_date, force=True)
             strategy_safe_wrapper(
                 self.strategy.order_filled, default_retval=None)(
-                pair=trade.pair, trade=trade, current_time=datetime.now(timezone.utc))
+                pair=trade.pair, trade=trade, order=order, current_time=datetime.now(timezone.utc))
 
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -372,6 +372,16 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return True
 
+    def order_filled(self, pair: str, trade: Trade, current_time: datetime, **kwargs) -> None:
+        """
+        Called just ofter order filling
+        :param pair: Pair for trade that's just exited.
+        :param trade: trade object.
+        :param current_time: datetime object, containing the current datetime
+        :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+        """
+        pass
+
     def custom_stoploss(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
                         current_profit: float, after_fill: bool, **kwargs) -> Optional[float]:
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -372,11 +372,13 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return True
 
-    def order_filled(self, pair: str, trade: Trade, current_time: datetime, **kwargs) -> None:
+    def order_filled(self, pair: str, trade: Trade, order: Order,
+                     current_time: datetime, **kwargs) -> None:
         """
         Called just ofter order filling
         :param pair: Pair for trade that's just exited.
         :param trade: trade object.
+        :param order: Order object.
         :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -375,8 +375,9 @@ class IStrategy(ABC, HyperStrategyMixin):
     def order_filled(self, pair: str, trade: Trade, order: Order,
                      current_time: datetime, **kwargs) -> None:
         """
-        Called just ofter order filling
-        :param pair: Pair for trade that's just exited.
+        Called right after an order fills.
+        Will be called for all order types (entry, exit, stoploss, position adjustment).
+        :param pair: Pair for trade
         :param trade: trade object.
         :param order: Order object.
         :param current_time: datetime object, containing the current datetime

--- a/freqtrade/templates/strategy_subtemplates/strategy_methods_advanced.j2
+++ b/freqtrade/templates/strategy_subtemplates/strategy_methods_advanced.j2
@@ -300,3 +300,17 @@ def leverage(self, pair: str, current_time: datetime, current_rate: float,
     :return: A leverage amount, which is between 1.0 and max_leverage.
     """
     return 1.0
+
+
+def order_filled(self, pair: str, trade: 'Trade', order: 'Order',
+                 current_time: datetime, **kwargs) -> None:
+    """
+    Called right after an order fills.
+    Will be called for all order types (entry, exit, stoploss, position adjustment).
+    :param pair: Pair for trade
+    :param trade: trade object.
+    :param order: Order object.
+    :param current_time: datetime object, containing the current datetime
+    :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
+    """
+    pass

--- a/tests/freqtradebot/test_stoploss_on_exchange.py
+++ b/tests/freqtradebot/test_stoploss_on_exchange.py
@@ -146,10 +146,12 @@ def test_handle_stoploss_on_exchange(mocker, default_conf_usdt, fee, caplog, is_
         'amount': enter_order['amount'],
     })
     mocker.patch(f'{EXMS}.fetch_stoploss_order', stoploss_order_hit)
+    freqtrade.strategy.order_filled = MagicMock(return_value=None)
     assert freqtrade.handle_stoploss_on_exchange(trade) is True
     assert log_has_re(r'STOP_LOSS_LIMIT is hit for Trade\(id=1, .*\)\.', caplog)
     assert len(trade.open_sl_orders) == 0
     assert trade.is_open is False
+    assert freqtrade.strategy.order_filled.call_count == 1
     caplog.clear()
 
     mocker.patch(f'{EXMS}.create_stoploss', side_effect=ExchangeError())

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -698,6 +698,7 @@ def test_backtest_one(default_conf, fee, mocker, testdatadir) -> None:
     data = history.load_data(datadir=testdatadir, timeframe='5m', pairs=['UNITTEST/BTC'],
                              timerange=timerange)
     processed = backtesting.strategy.advise_all_indicators(data)
+    backtesting.strategy.order_filled = MagicMock()
     min_date, max_date = get_timerange(processed)
 
     result = backtesting.backtest(
@@ -760,6 +761,8 @@ def test_backtest_one(default_conf, fee, mocker, testdatadir) -> None:
     pd.testing.assert_frame_equal(results, expected)
     assert 'orders' in results.columns
     data_pair = processed[pair]
+    # Called once per order
+    assert backtesting.strategy.order_filled.call_count == 4
     for _, t in results.iterrows():
         assert len(t['orders']) == 2
         ln = data_pair.loc[data_pair["date"] == t["open_date"]]


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
The goal of this PR is to give to the user the possibility to perform actions after trade order filled using new custom callbacks:
**"order_filled()"**

## What's new?
New custom callbacks:
"order_filled()"

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Now that users can store persistent custom data, the new callbacks will allow him to set those data at critical trade life cycle and not only within the process loop.
