### PR TITLE
tiny bugfix for lookahead-analysis

### DIFF
--- a/docs/lookahead-analysis.md
+++ b/docs/lookahead-analysis.md
@@ -23,6 +23,7 @@ It also supports the lookahead-analysis of freqai strategies.
 - `--max-open-trades` is forced to be at least equal to the number of pairs.
 - `--dry-run-wallet` is forced to be basically infinite (1 billion).
 - `--stake-amount` is forced to be a static 10000 (10k).
+- `--enable-protections` is forced to be off.
 
 Those are set to avoid users accidentally generating false positives.
 
@@ -40,7 +41,6 @@ usage: freqtrade lookahead-analysis [-h] [-v] [--logfile FILE] [-V] [-c PATH]
                                     [--max-open-trades INT]
                                     [--stake-amount STAKE_AMOUNT]
                                     [--fee FLOAT] [-p PAIRS [PAIRS ...]]
-                                    [--enable-protections]
                                     [--dry-run-wallet DRY_RUN_WALLET]
                                     [--timeframe-detail TIMEFRAME_DETAIL]
                                     [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]

--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -121,14 +121,22 @@ class LookaheadAnalysisSubFunctions:
 
     @staticmethod
     def calculate_config_overrides(config: Config):
+        if config.get('enable_protections', False):
+            # if protections are used globally, they can produce false positives.
+            config['enable_protections'] = False
+            logger.info('Protections were enabled. '
+                        'Disabling protections now '
+                        'since they could otherwise produce false positives.')
         if config['targeted_trade_amount'] < config['minimum_trade_amount']:
             # this combo doesn't make any sense.
             raise OperationalException(
                 "Targeted trade amount can't be smaller than minimum trade amount."
             )
-        if len(config['pairs']) > config['max_open_trades']:
-            logger.info('Max_open_trades were less than amount of pairs. '
-                        'Set max_open_trades to amount of pairs just to avoid false positives.')
+        if len(config['pairs']) > config.get('max_open_trades', 0):
+            logger.info('Max_open_trades were less than amount of pairs '
+                        'or defined in the strategy. '
+                        'Set max_open_trades to amount of pairs '
+                        'just to avoid false positives.')
             config['max_open_trades'] = len(config['pairs'])
 
         min_dry_run_wallet = 1000000000


### PR DESCRIPTION
Fixed bugs for lookahead-analysis:
The command fails if trades were not defined inside the config (but in the strategy)
=> change check to .get and adjust logger-comment
The command produces false positives if protections are enabled and they work globally (since the verification checks only work with a single pair)
=> solution: disable all protections (they would just slow down the process and they are not being checked for lookahead anyways)