### PR TITLE
delist schedule

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import ccxt
-from cachetools import TTLCache
+from cachetools import TTLCache, cached
 from threading import Lock
 
 from freqtrade.enums import CandleType, MarginMode, PriceType, TradingMode
@@ -225,37 +225,16 @@ class Binance(Exchange):
         else:
             return {}
 
-    def get_spot_pair_delist_time(self, pair, refresh: bool) -> int | None:
-        """
-        Get the delisting time for a pair if it will be delisted
-        :param pair: Pair to get the delisting time for
-        :param refresh: true if you need fresh data
-        :return: int: delisting time None if not delisting
-        """
 
-        cache = self._spot_delist_schedule_cache
-        lock = self._spot_delist_schedule_cache_lock
 
-        if not refresh:
-            with lock:
-                delist_time = cache.get(f"{pair}")
-                if delist_time:
-                    return delist_time
-
+    @retrier
+    @cached(cache=TTLCache(maxsize=100, ttl=10), lock=Lock())
+    def get_deslist_schedule(self):
         try:
+
             delist_schedule = self._api.sapi_get_spot_delist_schedule()
 
-            if delist_schedule is None:
-                return None
-
-            with lock:
-                for schedule in delist_schedule:
-                    for pair in schedule['symbols']:
-                        cache[f"{pair}"] = int(schedule['delistTime'])
-
-            with lock:
-                return cache.get(f"{pair}")
-
+            return delist_schedule
         except ccxt.DDoSProtection as e:
             raise DDosProtection(e) from e
         except (ccxt.NetworkError, ccxt.ExchangeError) as e:
@@ -263,3 +242,40 @@ class Binance(Exchange):
                 f'Could not get delist schedule {e.__class__.__name__}. Message: {e}') from e
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
+
+    def get_spot_pair_delist_time(self, pair, refresh: bool = True) -> int | None:
+        """
+        Get the delisting time for a pair if it will be delisted
+        :param pair: Pair to get the delisting time for
+        :param refresh: true if you need fresh data
+        :return: int: delisting time None if not delisting
+        """
+
+        if not pair:
+            return
+
+        cache = self._spot_delist_schedule_cache
+        lock = self._spot_delist_schedule_cache_lock
+
+        schedule_pair = pair.replace('/', '')
+
+        if not refresh:
+            with lock:
+                delist_time = cache[f"{schedule_pair}"]
+
+                if delist_time:
+                    return delist_time
+
+        delist_schedule = self.get_deslist_schedule()
+
+        if delist_schedule is None:
+            return None
+
+        with lock:
+            for schedule in delist_schedule:
+                for symbol in schedule['symbols']:
+                    cache[f"{symbol}"] = int(schedule['delistTime'])
+
+
+        with lock:
+            return cache.get(f"{schedule_pair}")

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -53,7 +53,7 @@ class Binance(Exchange):
     ]
 
     def __init__(self, *args, **kwargs) -> None:
-        super(__class__, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._spot_delist_schedule_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
         self._spot_delist_schedule_cache_lock = Lock()
 
@@ -246,7 +246,7 @@ class Binance(Exchange):
             delist_schedule = self._api.sapi_get_spot_delist_schedule()
 
             if delist_schedule is None:
-                return
+                return None
 
             with lock:
                 for schedule in delist_schedule:

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -54,8 +54,7 @@ class Binance(Exchange):
 
     def __init__(self, *args, **kwargs) -> None:
         super(__class__, self).__init__(*args, **kwargs)
-        self._spot_delist_schedule_cache: TTLCache = TTLCache(
-            maxsize=100, ttl=300)
+        self._spot_delist_schedule_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
         self._spot_delist_schedule_cache_lock = Lock()
 
     def get_tickers(self, symbols: Optional[List[str]] = None, cached: bool = False) -> Tickers:
@@ -64,8 +63,7 @@ class Binance(Exchange):
             # Binance's future result has no bid/ask values.
             # Therefore we must fetch that from fetch_bids_asks and combine the two results.
             bidsasks = self.fetch_bids_asks(symbols, cached)
-            tickers = deep_merge_dicts(
-                bidsasks, tickers, allow_null_overrides=False)
+            tickers = deep_merge_dicts(bidsasks, tickers, allow_null_overrides=False)
         return tickers
 
     @retrier
@@ -78,11 +76,9 @@ class Binance(Exchange):
         try:
             if self.trading_mode == TradingMode.FUTURES and not self._config['dry_run']:
                 position_side = self._api.fapiPrivateGetPositionSideDual()
-                self._log_exchange_response(
-                    'position_side_setting', position_side)
+                self._log_exchange_response('position_side_setting', position_side)
                 assets_margin = self._api.fapiPrivateGetMultiAssetsMargin()
-                self._log_exchange_response(
-                    'multi_asset_margin', assets_margin)
+                self._log_exchange_response('multi_asset_margin', assets_margin)
                 msg = ""
                 if position_side.get('dualSidePosition') is True:
                     msg += (
@@ -98,7 +94,7 @@ class Binance(Exchange):
         except (ccxt.NetworkError, ccxt.ExchangeError) as e:
             raise TemporaryError(
                 f'Error in additional_exchange_init due to {e.__class__.__name__}. Message: {e}'
-            ) from e
+                ) from e
 
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
@@ -186,8 +182,7 @@ class Binance(Exchange):
 
         # mm_ratio: Binance's formula specifies maintenance margin rate which is mm_ratio * 100%
         # maintenance_amt: (CUM) Maintenance Amount of position
-        mm_ratio, maintenance_amt = self.get_maintenance_ratio_and_amt(
-            pair, stake_amount)
+        mm_ratio, maintenance_amt = self.get_maintenance_ratio_and_amt(pair, stake_amount)
 
         if (maintenance_amt is None):
             raise OperationalException(

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -53,8 +53,9 @@ class Binance(Exchange):
     ]
 
     def __init__(self, *args, **kwargs) -> None:
-        super(Binance, self).__init__(*args, **kwargs)
-        self._spot_delist_schedule_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
+        super(__class__, self).__init__(*args, **kwargs)
+        self._spot_delist_schedule_cache: TTLCache = TTLCache(
+            maxsize=100, ttl=300)
         self._spot_delist_schedule_cache_lock = Lock()
 
     def get_tickers(self, symbols: Optional[List[str]] = None, cached: bool = False) -> Tickers:
@@ -63,7 +64,8 @@ class Binance(Exchange):
             # Binance's future result has no bid/ask values.
             # Therefore we must fetch that from fetch_bids_asks and combine the two results.
             bidsasks = self.fetch_bids_asks(symbols, cached)
-            tickers = deep_merge_dicts(bidsasks, tickers, allow_null_overrides=False)
+            tickers = deep_merge_dicts(
+                bidsasks, tickers, allow_null_overrides=False)
         return tickers
 
     @retrier
@@ -76,9 +78,11 @@ class Binance(Exchange):
         try:
             if self.trading_mode == TradingMode.FUTURES and not self._config['dry_run']:
                 position_side = self._api.fapiPrivateGetPositionSideDual()
-                self._log_exchange_response('position_side_setting', position_side)
+                self._log_exchange_response(
+                    'position_side_setting', position_side)
                 assets_margin = self._api.fapiPrivateGetMultiAssetsMargin()
-                self._log_exchange_response('multi_asset_margin', assets_margin)
+                self._log_exchange_response(
+                    'multi_asset_margin', assets_margin)
                 msg = ""
                 if position_side.get('dualSidePosition') is True:
                     msg += (
@@ -94,7 +98,7 @@ class Binance(Exchange):
         except (ccxt.NetworkError, ccxt.ExchangeError) as e:
             raise TemporaryError(
                 f'Error in additional_exchange_init due to {e.__class__.__name__}. Message: {e}'
-                ) from e
+            ) from e
 
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
@@ -182,7 +186,8 @@ class Binance(Exchange):
 
         # mm_ratio: Binance's formula specifies maintenance margin rate which is mm_ratio * 100%
         # maintenance_amt: (CUM) Maintenance Amount of position
-        mm_ratio, maintenance_amt = self.get_maintenance_ratio_and_amt(pair, stake_amount)
+        mm_ratio, maintenance_amt = self.get_maintenance_ratio_and_amt(
+            pair, stake_amount)
 
         if (maintenance_amt is None):
             raise OperationalException(
@@ -242,7 +247,7 @@ class Binance(Exchange):
                 if delist_time:
                     return delist_time
 
-        try: 
+        try:
             delist_schedule = self._api.sapi_get_spot_delist_schedule()
 
             if delist_schedule is None:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -187,7 +187,7 @@ class Exchange:
         self._api_async = self._init_ccxt(
             exchange_conf, ccxt_async, ccxt_kwargs=ccxt_async_config)
 
-        if exchange_config.get('sandboxMode'):
+        if exchange_conf.get('sandboxMode'):
             self._api.set_sandbox_mode(True)
             self._api_async.set_sandbox_mode(True)
             logger.info('Using ccxt with sandbox mode for paper trading')

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -187,6 +187,11 @@ class Exchange:
         self._api_async = self._init_ccxt(
             exchange_conf, ccxt_async, ccxt_kwargs=ccxt_async_config)
 
+        if exchange_config.get('sandboxMode'):
+            self._api.set_sandbox_mode(True)
+            self._api_async.set_sandbox_mode(True)
+            logger.info('Using ccxt with sandbox mode for paper trading')
+
         logger.info(f'Using Exchange "{self.name}"')
         self.required_candle_call_count = 1
         if validate:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -187,11 +187,6 @@ class Exchange:
         self._api_async = self._init_ccxt(
             exchange_conf, ccxt_async, ccxt_kwargs=ccxt_async_config)
 
-        if exchange_conf.get('sandboxMode'):
-            self._api.set_sandbox_mode(True)
-            self._api_async.set_sandbox_mode(True)
-            logger.info('Using ccxt with sandbox mode for paper trading')
-
         logger.info(f'Using Exchange "{self.name}"')
         self.required_candle_call_count = 1
         if validate:

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -628,4 +628,5 @@ def test_get_spot_delist_schedule(mocker, default_conf) -> None:
 
     exchange._api.sapi_get_spot_delist_schedule =  MagicMock(return_value=return_value)
 
-    assert exchange.get_spot_pair_delist_time('DREP/USDT', False) == 1712113200000
+    assert exchange.get_spot_pair_delist_time('DREP/USDT') == 1712113200000
+    assert exchange.get_spot_pair_delist_time('BTC/USDT') is None

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -621,7 +621,7 @@ def test_get_maintenance_ratio_and_amt_binance(
 
 def test_get_spot_delist_schedule(mocker, default_conf) -> None:
     exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    exchange._api.sapi_get_spot_delist_schedule = get_mock_coro([{'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
+    exchange._api.sapi_get_spot_delist_schedule =  MagicMock(return_value=[{'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
 
 
-    assert exchange.get_spot_delist_schedule(True) == ['DREP/BTC', 'DREP/USDT', 'MOB/BTC', 'MOB/USDT', 'PNT/USDT']
+    assert exchange.get_spot_pair_delist_time('DREP/USDT', False) == 1712113200000

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -18,10 +18,11 @@ from tests.exchange.test_exchange import ccxt_exceptionhandlers
     ('buy', 'limit', 'PO', {'timeInForce': 'PO'}),
     ('sell', 'limit', 'PO', {'timeInForce': 'PO'}),
     ('sell', 'market', 'PO', {}),
-    ])
+])
 def test__get_params_binance(default_conf, mocker, side, type, time_in_force, expected):
     exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    assert exchange._get_params(side, type, 1, False, time_in_force) == expected
+    assert exchange._get_params(
+        side, type, 1, False, time_in_force) == expected
 
 
 @pytest.mark.parametrize('trademode', [TradingMode.FUTURES, TradingMode.SPOT])
@@ -58,7 +59,8 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
             amount=1,
             stop_price=190,
             side=side,
-            order_types={'stoploss': 'limit', 'stoploss_on_exchange_limit_ratio': 1.05},
+            order_types={'stoploss': 'limit',
+                         'stoploss_on_exchange_limit_ratio': 1.05},
             leverage=1.0
         )
 
@@ -88,13 +90,16 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
     if trademode == TradingMode.SPOT:
         params_dict = {'stopPrice': 220}
     else:
-        params_dict = {'stopPrice': 220, 'reduceOnly': True, 'workingType': 'MARK_PRICE'}
+        params_dict = {'stopPrice': 220,
+                       'reduceOnly': True, 'workingType': 'MARK_PRICE'}
     assert api_mock.create_order.call_args_list[0][1]['params'] == params_dict
 
     # test exception handling
     with pytest.raises(DependencyException):
-        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds("0 balance"))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        api_mock.create_order = MagicMock(
+            side_effect=ccxt.InsufficientFunds("0 balance"))
+        exchange = get_patched_exchange(
+            mocker, default_conf, api_mock, 'binance')
         exchange.create_stoploss(
             pair='ETH/BTC',
             amount=1,
@@ -106,7 +111,8 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
     with pytest.raises(InvalidOrderException):
         api_mock.create_order = MagicMock(
             side_effect=ccxt.InvalidOrder("binance Order would trigger immediately."))
-        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
+        exchange = get_patched_exchange(
+            mocker, default_conf, api_mock, 'binance')
         exchange.create_stoploss(
             pair='ETH/BTC',
             amount=1,
@@ -383,7 +389,8 @@ def test_fill_leverage_tiers_binance(default_conf, mocker):
     default_conf['dry_run'] = False
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(
+        mocker, default_conf, api_mock, id="binance")
     exchange.fill_leverage_tiers()
 
     assert exchange._leverage_tiers == {
@@ -486,7 +493,8 @@ def test_fill_leverage_tiers_binance(default_conf, mocker):
 
     api_mock = MagicMock()
     api_mock.load_leverage_tiers = MagicMock()
-    type(api_mock).has = PropertyMock(return_value={'fetchLeverageTiers': True})
+    type(api_mock).has = PropertyMock(
+        return_value={'fetchLeverageTiers': True})
 
     ccxt_exceptionhandlers(
         mocker,
@@ -502,7 +510,8 @@ def test_fill_leverage_tiers_binance_dryrun(default_conf, mocker, leverage_tiers
     api_mock = MagicMock()
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(
+        mocker, default_conf, api_mock, id="binance")
     exchange.fill_leverage_tiers()
     assert len(exchange._leverage_tiers.keys()) > 100
     for key, value in leverage_tiers.items():
@@ -514,17 +523,23 @@ def test_fill_leverage_tiers_binance_dryrun(default_conf, mocker, leverage_tiers
 
 def test_additional_exchange_init_binance(default_conf, mocker):
     api_mock = MagicMock()
-    api_mock.fapiPrivateGetPositionSideDual = MagicMock(return_value={"dualSidePosition": True})
-    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(return_value={"multiAssetsMargin": True})
+    api_mock.fapiPrivateGetPositionSideDual = MagicMock(
+        return_value={"dualSidePosition": True})
+    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(
+        return_value={"multiAssetsMargin": True})
     default_conf['dry_run'] = False
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
     with pytest.raises(OperationalException,
                        match=r"Hedge Mode is not supported.*\nMulti-Asset Mode is not supported.*"):
-        get_patched_exchange(mocker, default_conf, id="binance", api_mock=api_mock)
-    api_mock.fapiPrivateGetPositionSideDual = MagicMock(return_value={"dualSidePosition": False})
-    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(return_value={"multiAssetsMargin": False})
-    exchange = get_patched_exchange(mocker, default_conf, id="binance", api_mock=api_mock)
+        get_patched_exchange(mocker, default_conf,
+                             id="binance", api_mock=api_mock)
+    api_mock.fapiPrivateGetPositionSideDual = MagicMock(
+        return_value={"dualSidePosition": False})
+    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(
+        return_value={"multiAssetsMargin": False})
+    exchange = get_patched_exchange(
+        mocker, default_conf, id="binance", api_mock=api_mock)
     assert exchange
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, 'binance',
                            "additional_exchange_init", "fapiPrivateGetPositionSideDual")
@@ -539,7 +554,8 @@ def test__set_leverage_binance(mocker, default_conf):
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
 
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(
+        mocker, default_conf, api_mock, id="binance")
     exchange._set_leverage(3.2, 'BTC/USDT:USDT')
     assert api_mock.set_leverage.call_count == 1
     # Leverage is rounded to 3.
@@ -592,7 +608,8 @@ async def test__async_get_historic_ohlcv_binance(default_conf, mocker, caplog, c
     # Called twice - one "init" call - and one to get the actual data.
     assert exchange._api_async.fetch_ohlcv.call_count == 2
     assert res == ohlcv
-    assert log_has_re(r"Candle-data for ETH/BTC available starting with .*", caplog)
+    assert log_has_re(
+        r"Candle-data for ETH/BTC available starting with .*", caplog)
 
 
 @pytest.mark.parametrize('pair,nominal_value,mm_ratio,amt', [
@@ -615,13 +632,15 @@ def test_get_maintenance_ratio_and_amt_binance(
     mocker.patch(f'{EXMS}.exchange_has', return_value=True)
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
     exchange._leverage_tiers = leverage_tiers
-    (result_ratio, result_amt) = exchange.get_maintenance_ratio_and_amt(pair, nominal_value)
+    (result_ratio, result_amt) = exchange.get_maintenance_ratio_and_amt(
+        pair, nominal_value)
     assert (round(result_ratio, 8), round(result_amt, 8)) == (mm_ratio, amt)
 
 
 def test_get_spot_delist_schedule(mocker, default_conf) -> None:
     exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    exchange._api.sapi_get_spot_delist_schedule =  MagicMock(return_value=[{'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
+    exchange._api.sapi_get_spot_delist_schedule = MagicMock(return_value=[
+                                                            {'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
 
-
-    assert exchange.get_spot_pair_delist_time('DREP/USDT', False) == 1712113200000
+    assert exchange.get_spot_pair_delist_time(
+        'DREP/USDT', False) == 1712113200000

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -18,11 +18,10 @@ from tests.exchange.test_exchange import ccxt_exceptionhandlers
     ('buy', 'limit', 'PO', {'timeInForce': 'PO'}),
     ('sell', 'limit', 'PO', {'timeInForce': 'PO'}),
     ('sell', 'market', 'PO', {}),
-])
+    ])
 def test__get_params_binance(default_conf, mocker, side, type, time_in_force, expected):
     exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    assert exchange._get_params(
-        side, type, 1, False, time_in_force) == expected
+    assert exchange._get_params(side, type, 1, False, time_in_force) == expected
 
 
 @pytest.mark.parametrize('trademode', [TradingMode.FUTURES, TradingMode.SPOT])
@@ -59,8 +58,7 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
             amount=1,
             stop_price=190,
             side=side,
-            order_types={'stoploss': 'limit',
-                         'stoploss_on_exchange_limit_ratio': 1.05},
+            order_types={'stoploss': 'limit', 'stoploss_on_exchange_limit_ratio': 1.05},
             leverage=1.0
         )
 
@@ -90,16 +88,13 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
     if trademode == TradingMode.SPOT:
         params_dict = {'stopPrice': 220}
     else:
-        params_dict = {'stopPrice': 220,
-                       'reduceOnly': True, 'workingType': 'MARK_PRICE'}
+        params_dict = {'stopPrice': 220, 'reduceOnly': True, 'workingType': 'MARK_PRICE'}
     assert api_mock.create_order.call_args_list[0][1]['params'] == params_dict
 
     # test exception handling
     with pytest.raises(DependencyException):
-        api_mock.create_order = MagicMock(
-            side_effect=ccxt.InsufficientFunds("0 balance"))
-        exchange = get_patched_exchange(
-            mocker, default_conf, api_mock, 'binance')
+        api_mock.create_order = MagicMock(side_effect=ccxt.InsufficientFunds("0 balance"))
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
         exchange.create_stoploss(
             pair='ETH/BTC',
             amount=1,
@@ -111,8 +106,7 @@ def test_create_stoploss_order_binance(default_conf, mocker, limitratio, expecte
     with pytest.raises(InvalidOrderException):
         api_mock.create_order = MagicMock(
             side_effect=ccxt.InvalidOrder("binance Order would trigger immediately."))
-        exchange = get_patched_exchange(
-            mocker, default_conf, api_mock, 'binance')
+        exchange = get_patched_exchange(mocker, default_conf, api_mock, 'binance')
         exchange.create_stoploss(
             pair='ETH/BTC',
             amount=1,
@@ -389,8 +383,7 @@ def test_fill_leverage_tiers_binance(default_conf, mocker):
     default_conf['dry_run'] = False
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
-    exchange = get_patched_exchange(
-        mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
     exchange.fill_leverage_tiers()
 
     assert exchange._leverage_tiers == {
@@ -493,8 +486,7 @@ def test_fill_leverage_tiers_binance(default_conf, mocker):
 
     api_mock = MagicMock()
     api_mock.load_leverage_tiers = MagicMock()
-    type(api_mock).has = PropertyMock(
-        return_value={'fetchLeverageTiers': True})
+    type(api_mock).has = PropertyMock(return_value={'fetchLeverageTiers': True})
 
     ccxt_exceptionhandlers(
         mocker,
@@ -510,8 +502,7 @@ def test_fill_leverage_tiers_binance_dryrun(default_conf, mocker, leverage_tiers
     api_mock = MagicMock()
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
-    exchange = get_patched_exchange(
-        mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
     exchange.fill_leverage_tiers()
     assert len(exchange._leverage_tiers.keys()) > 100
     for key, value in leverage_tiers.items():
@@ -523,23 +514,17 @@ def test_fill_leverage_tiers_binance_dryrun(default_conf, mocker, leverage_tiers
 
 def test_additional_exchange_init_binance(default_conf, mocker):
     api_mock = MagicMock()
-    api_mock.fapiPrivateGetPositionSideDual = MagicMock(
-        return_value={"dualSidePosition": True})
-    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(
-        return_value={"multiAssetsMargin": True})
+    api_mock.fapiPrivateGetPositionSideDual = MagicMock(return_value={"dualSidePosition": True})
+    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(return_value={"multiAssetsMargin": True})
     default_conf['dry_run'] = False
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
     with pytest.raises(OperationalException,
                        match=r"Hedge Mode is not supported.*\nMulti-Asset Mode is not supported.*"):
-        get_patched_exchange(mocker, default_conf,
-                             id="binance", api_mock=api_mock)
-    api_mock.fapiPrivateGetPositionSideDual = MagicMock(
-        return_value={"dualSidePosition": False})
-    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(
-        return_value={"multiAssetsMargin": False})
-    exchange = get_patched_exchange(
-        mocker, default_conf, id="binance", api_mock=api_mock)
+        get_patched_exchange(mocker, default_conf, id="binance", api_mock=api_mock)
+    api_mock.fapiPrivateGetPositionSideDual = MagicMock(return_value={"dualSidePosition": False})
+    api_mock.fapiPrivateGetMultiAssetsMargin = MagicMock(return_value={"multiAssetsMargin": False})
+    exchange = get_patched_exchange(mocker, default_conf, id="binance", api_mock=api_mock)
     assert exchange
     ccxt_exceptionhandlers(mocker, default_conf, api_mock, 'binance',
                            "additional_exchange_init", "fapiPrivateGetPositionSideDual")
@@ -554,8 +539,7 @@ def test__set_leverage_binance(mocker, default_conf):
     default_conf['trading_mode'] = TradingMode.FUTURES
     default_conf['margin_mode'] = MarginMode.ISOLATED
 
-    exchange = get_patched_exchange(
-        mocker, default_conf, api_mock, id="binance")
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, id="binance")
     exchange._set_leverage(3.2, 'BTC/USDT:USDT')
     assert api_mock.set_leverage.call_count == 1
     # Leverage is rounded to 3.
@@ -608,8 +592,7 @@ async def test__async_get_historic_ohlcv_binance(default_conf, mocker, caplog, c
     # Called twice - one "init" call - and one to get the actual data.
     assert exchange._api_async.fetch_ohlcv.call_count == 2
     assert res == ohlcv
-    assert log_has_re(
-        r"Candle-data for ETH/BTC available starting with .*", caplog)
+    assert log_has_re(r"Candle-data for ETH/BTC available starting with .*", caplog)
 
 
 @pytest.mark.parametrize('pair,nominal_value,mm_ratio,amt', [
@@ -632,15 +615,17 @@ def test_get_maintenance_ratio_and_amt_binance(
     mocker.patch(f'{EXMS}.exchange_has', return_value=True)
     exchange = get_patched_exchange(mocker, default_conf, id="binance")
     exchange._leverage_tiers = leverage_tiers
-    (result_ratio, result_amt) = exchange.get_maintenance_ratio_and_amt(
-        pair, nominal_value)
+    (result_ratio, result_amt) = exchange.get_maintenance_ratio_and_amt(pair, nominal_value)
     assert (round(result_ratio, 8), round(result_amt, 8)) == (mm_ratio, amt)
 
 
 def test_get_spot_delist_schedule(mocker, default_conf) -> None:
     exchange = get_patched_exchange(mocker, default_conf, id='binance')
-    exchange._api.sapi_get_spot_delist_schedule = MagicMock(return_value=[
-                                                            {'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
+    return_value = [{
+        'delistTime': '1712113200000',
+        'symbols':  ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']
+    }]
 
-    assert exchange.get_spot_pair_delist_time(
-        'DREP/USDT', False) == 1712113200000
+    exchange._api.sapi_get_spot_delist_schedule =  MagicMock(return_value=return_value)
+
+    assert exchange.get_spot_pair_delist_time('DREP/USDT', False) == 1712113200000

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -617,3 +617,11 @@ def test_get_maintenance_ratio_and_amt_binance(
     exchange._leverage_tiers = leverage_tiers
     (result_ratio, result_amt) = exchange.get_maintenance_ratio_and_amt(pair, nominal_value)
     assert (round(result_ratio, 8), round(result_amt, 8)) == (mm_ratio, amt)
+
+
+def test_get_spot_delist_schedule(mocker, default_conf) -> None:
+    exchange = get_patched_exchange(mocker, default_conf, id='binance')
+    exchange._api.sapi_get_spot_delist_schedule = get_mock_coro([{'delistTime': '1712113200000', 'symbols': ['DREPBTC', 'DREPUSDT', 'MOBBTC', 'MOBUSDT', 'PNTUSDT']}])
+
+
+    assert exchange.get_spot_delist_schedule(True) == ['DREP/BTC', 'DREP/USDT', 'MOB/BTC', 'MOB/USDT', 'PNT/USDT']


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This will implement exchange function to check whether a pair is delisting 
If it will be delisting it will return the delisting time.

Solve the issue: [9985](https://github.com/freqtrade/freqtrade/issues/9985)

Probably this need some more to have this working in the strategy with the `confirm_trade_entry`
or `custom_trade_exit`

but not sure yet - requesting some review if thats the right way to go 


One thing I'm not sure of yet this will work in the end
Because essentially - what if binance does not activate have the delist schedule api entry with the announcements of the announcements page.
Because when there was the last announcement I looked that the pairs in the Binance app and they have not been marked to be delisted yet. Might als have been a caching issue or something - but not sure 
i guess this can only be really tested with next announcement :smile: 


## Quick changelog

- <change log 1>
- <change log 1>

## What's new?
