### PR TITLE
Update PyTorchModelTrainer.py

### DIFF
--- a/freqtrade/freqai/torch/PyTorchModelTrainer.py
+++ b/freqtrade/freqai/torch/PyTorchModelTrainer.py
@@ -152,7 +152,7 @@ class PyTorchModelTrainer(PyTorchTrainerInterface):
         """
         assert isinstance(self.n_steps, int), "Either `n_steps` or `n_epochs` should be set."
         n_batches = n_obs // self.batch_size
-        n_epochs = min(self.n_steps // n_batches, 1)
+        n_epochs = max(self.n_steps // n_batches, 1)
         if n_epochs <= 10:
             logger.warning(
                 f"Setting low n_epochs: {n_epochs}. "


### PR DESCRIPTION
The n_epochs should be defined using the `max` not the `min` function.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
