### PR TITLE
Update freqai-configuration.md

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -32,6 +32,9 @@ FreqAI is configured through the typical [Freqtrade config file](configuration.m
 
 A full example config is available in `config_examples/config_freqai.example.json`.
 
+!!! Note
+    The `identifier` is commonly overlooked by newcomers, however, this value plays an important role in your configuration. This value is a unique ID that you choose to describe one of your runs. Keeping it the same allows you to maintain crash resilience as well as faster backtesting. As soon as you want to try a new run (new features, new model, etc.), you should change this value (or delete the `user_data/models/unique-id` folder. More details available in the [parameter table](freqai-parameter-table.md#feature-parameters).
+
 ## Building a FreqAI strategy
 
 The FreqAI strategy requires including the following lines of code in the standard [Freqtrade strategy](strategy-customization.md):


### PR DESCRIPTION
The documentation surrounding the `identifier` is limited to the parameter table. However, most people do not read the parameter table. This is unfortunate because the `identifier` plays an important role in the FreqAI configuration. Therefore, we add more information to the top of the freqai configuration documentation here.