### PR TITLE
10009: Add `max_value` to volume pair list

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -81,12 +81,14 @@ Filtering instances (not the first position in the list) will not apply any cach
         "number_assets": 20,
         "sort_key": "quoteVolume",
         "min_value": 0,
+        "max_value": 8000000,
         "refresh_period": 1800
     }
 ],
 ```
 
 You can define a minimum volume with `min_value` - which will filter out pairs with a volume lower than the specified value in the specified timerange.
+In addition to that, you can also define a maximum volume with `max_value` - which will filter out pairs with a volume higher than the specified value in the specified timerange.
 
 ##### VolumePairList Advanced mode
 

--- a/freqtrade/plugins/pairlist/VolumePairList.py
+++ b/freqtrade/plugins/pairlist/VolumePairList.py
@@ -41,6 +41,7 @@ class VolumePairList(IPairList):
         self._number_pairs = self._pairlistconfig['number_assets']
         self._sort_key: Literal['quoteVolume'] = self._pairlistconfig.get('sort_key', 'quoteVolume')
         self._min_value = self._pairlistconfig.get('min_value', 0)
+        self._max_value = self._pairlistconfig.get("max_value", None)
         self._refresh_period = self._pairlistconfig.get('refresh_period', 1800)
         self._pair_cache: TTLCache = TTLCache(maxsize=1, ttl=self._refresh_period)
         self._lookback_days = self._pairlistconfig.get('lookback_days', 0)
@@ -138,6 +139,12 @@ class VolumePairList(IPairList):
                 "default": 0,
                 "description": "Minimum value",
                 "help": "Minimum value to use for filtering the pairlist.",
+            },
+            "max_value": {
+                "type": "number",
+                "default": None,
+                "description": "Maximum value",
+                "help": "Maximum value to use for filtering the pairlist.",
             },
             **IPairList.refresh_period_parameter(),
             "lookback_days": {
@@ -270,6 +277,9 @@ class VolumePairList(IPairList):
         if self._min_value > 0:
             filtered_tickers = [
                 v for v in filtered_tickers if v[self._sort_key] > self._min_value]
+        if self._max_value is not None:
+            filtered_tickers = [
+                v for v in filtered_tickers if v[self._sort_key] < self._max_value]
 
         sorted_tickers = sorted(filtered_tickers, reverse=True, key=lambda t: t[self._sort_key])
 

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -406,6 +406,14 @@ def test_VolumePairList_refresh_empty(mocker, markets_empty, whitelist_conf):
     ([{"method": "VolumePairList", "number_assets": 5,
        "sort_key": "quoteVolume", "min_value": 1250}],
      "BTC", ['ETH/BTC', 'TKN/BTC', 'LTC/BTC']),
+    # HOT, XRP and FUEL whitelisted because they are below 1300 quoteVolume.
+    ([{"method": "VolumePairList", "number_assets": 5,
+       "sort_key": "quoteVolume", "max_value": 1300}],
+     "BTC", ['XRP/BTC', 'HOT/BTC', 'FUEL/BTC']),
+    # HOT, XRP whitelisted because they are between 100 and 1300 quoteVolume.
+    ([{"method": "VolumePairList", "number_assets": 5,
+       "sort_key": "quoteVolume", "min_value": 100, "max_value": 1300}],
+     "BTC", ['XRP/BTC', 'HOT/BTC']),
     # StaticPairlist only
     ([{"method": "StaticPairList"}],
      "BTC", ['ETH/BTC', 'TKN/BTC', 'HOT/BTC']),


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #10009 

## Quick changelog

- Add support for `max_value` in VolumePair list which will filter out pairs with quote volume higher than specified.
