### PR TITLE
Add support for requests pool size configuration

### DIFF
--- a/ft_client/freqtrade_client/ft_rest_client.py
+++ b/ft_client/freqtrade_client/ft_rest_client.py
@@ -21,10 +21,19 @@ logger = logging.getLogger("ft_rest_client")
 
 class FtRestClient:
 
-    def __init__(self, serverurl, username=None, password=None):
+    def __init__(self, serverurl, username=None, password=None,
+                 pool_connections=10, pool_maxsize=10):
 
         self._serverurl = serverurl
         self._session = requests.Session()
+
+        # allow configuration of pool
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize
+        )
+        self._session.mount('http://', adapter)
+
         self._session.auth = (username, password)
 
     def _call(self, method, apipath, params: Optional[dict] = None, data=None, files=None):


### PR DESCRIPTION
## Summary

This PR adds support for configuration of the requests session pool size.

## Quick changelog

- add constructor and configuration for pool connection and maxsize properties

## What's new?

When running many bots, it can be easy to saturate the requests session pool. This PR introduces a non-breaking change to allow end users to configure the pool connection and size to avoid requests complaining about socket reuse. If users are running many bots on the same host, increasing maxsize helps with this. Most users would not need to use this feature, but with 10 or 20 bots, you can easily run into the issue of the pool becoming full.
