### PR TITLE
docs: created a 404 documentation page

### DIFF
--- a/docs/overrides/404.html
+++ b/docs/overrides/404.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+
+<!-- Navigation -->
+{% block site_nav %}
+
+  <!-- Main navigation -->
+  {% if nav %}
+  {% if page and page.meta and page.meta.hide %}
+  {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+  {% endif %}
+  <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" {{ hidden }}>
+    <div class="md-sidebar__scrollwrap">
+      <div class="md-sidebar__inner">
+        {% include "partials/nav.html" %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Table of contents -->
+  {% if page.toc and not "toc.integrate" in features %}
+  {% if page and page.meta and page.meta.hide %}
+  {% set hidden = "hidden" if "toc" in page.meta.hide %}
+  {% endif %}
+  <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc" {{ hidden }}>
+    <div class="md-sidebar__scrollwrap">
+      <div class="md-sidebar__inner">
+        {% include "partials/toc.html" %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+    {{ super() }}
+
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"
+      integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,3 +109,5 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
   - mdx_truly_sane_lists
+static_templates:
+  - 404.html


### PR DESCRIPTION
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: [css doesn't load for 404 pages on the docs](https://github.com/ccxt/ccxt/issues/22032)

## Quick changelog

- adds 404.html
- adds 404.html to static templates of mkdocs.yml

## What's new?

I hope that this issue fixes the confusing 404 pages for the docs, but I don't really know, I couldn't test it, so I'm just guessing that something like this might fix the problem. I created the solution based on [this github post ](https://github.com/squidfunk/mkdocs-material/discussions/5018)

I don't really know how to make changes with mkdocs and don't really know how to test this out, I tried to contribute the best I could though