### PR TITLE
Ensure we include `high_price` in the historic predictions

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -675,6 +675,8 @@ class IFreqaiModel(ABC):
         for return_str in dk.data['extra_returns_per_train']:
             hist_preds_df[return_str] = dk.data['extra_returns_per_train'][return_str]
 
+        hist_preds_df['high_price'] = strat_df['high']
+        hist_preds_df['low_price'] = strat_df['low']
         hist_preds_df['close_price'] = strat_df['close']
         hist_preds_df['date_pred'] = strat_df['date']
 


### PR DESCRIPTION
There is a bug where this key is currently not specified, which is causing issues in the data appending methods.

```
    self.dd.append_model_predictions(pair, pred_df, do_preds, dk, dataframe)
  File "/home/smarm/freqqav4/freqtrade/freqtrade/freqai/data_drawer.py", line 380, in append_model_predictions
    high_price_loc = df.columns.get_loc("high_price")
  File "/home/smarm/freqqav4/freqtrade/.venv/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: 'high_price'
```

Thanks to @smarmau for finding and reporting this.
