### PR TITLE
Add new column selection to ft_rest_client pair_candles

### DIFF
--- a/ft_client/freqtrade_client/ft_rest_client.py
+++ b/ft_client/freqtrade_client/ft_rest_client.py
@@ -397,12 +397,13 @@ class FtRestClient:
             "timeframe": timeframe if timeframe else '',
         })
 
-    def pair_candles(self, pair, timeframe, limit=None):
+    def pair_candles(self, pair, timeframe, limit=None, columns=None):
         """Return live dataframe for <pair><timeframe>.
 
         :param pair: Pair to get data for
         :param timeframe: Only pairs with this timeframe available.
         :param limit: Limit result to the last n candles.
+        :param columns: List of dataframe columns to return. Empty list will return OHLCV.
         :return: json object
         """
         params = {
@@ -411,6 +412,14 @@ class FtRestClient:
         }
         if limit:
             params['limit'] = limit
+
+        if columns is not None:
+            params['columns'] = columns
+            return self._post(
+                "pair_candles",
+                data=params
+            )
+
         return self._get("pair_candles", params=params)
 
     def pair_history(self, pair, timeframe, strategy, timerange=None, freqaimodel=None):


### PR DESCRIPTION
## Summary

Adds column selection feature to the freqtrade-client REST client.

## Quick changelog

- Add the columns parameter to the pair_candles function and performs a POST instead of a GET to the same endpoint