### PR TITLE
remove duplicate stat from BT table

### DIFF
--- a/freqtrade/optimize/optimize_reports/bt_output.py
+++ b/freqtrade/optimize/optimize_reports/bt_output.py
@@ -221,7 +221,6 @@ def text_table_add_metrics(strat_results: Dict) -> str:
             ('Expectancy (Ratio)', (
                 f"{strat_results['expectancy']:.2f} ({strat_results['expectancy_ratio']:.2f})" if
                 'expectancy_ratio' in strat_results else 'N/A')),
-            ('Trades per day', strat_results['trades_per_day']),
             ('Avg. daily profit %',
              f"{(strat_results['profit_total'] / strat_results['backtest_days']):.2%}"),
             ('Avg. stake amount', fmt_coin(strat_results['avg_stake_amount'],


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Example of current table
```
| Total/Daily Avg Trades      | 333 / 0.31               |
| Starting balance            | 16 USDT                  |
| Final balance               | 38185.415 USDT           |
| Absolute profit             | 38169.415 USDT           |
| Total profit %              | 238558.84%               |
| CAGR %                      | 1309.32%                 |
| Sortino                     | 25.65                    |
| Sharpe                      | 3.37                     |
| Calmar                      | 719789.70                |
| Profit factor               | 175.60                   |
| Expectancy (Ratio)          | 114.62 (3.67)            |
| Trades per day              | 0.31                     |
```

We already have `Daily Avg Trades` above, so there is no need to have separate row for `Trades per day`, especially since both of them are using the same `strat_results['trades_per_day']` value

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
