### PR TITLE
Refactor calculate_max_drawdown

### DIFF
--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -171,7 +171,7 @@ class DrawDownResult:
     relative_account_drawdown: float = 0.0
 
 
-def calc_max_drawdown(
+def calculate_max_drawdown(
     trades: pd.DataFrame,
     *,
     date_col: str = "close_date",
@@ -185,7 +185,7 @@ def calc_max_drawdown(
     :param date_col: Column in DataFrame to use for dates (defaults to 'close_date')
     :param value_col: Column in DataFrame to use for values (defaults to 'profit_abs')
     :param starting_balance: Portfolio starting balance - properly calculate relative drawdown.
-    :return: Tuple (float, highdate, lowdate, highvalue, lowvalue, relative_drawdown)
+    :return: DrawDownResult object
              with absolute max drawdown, high and low time and high and low value,
              and the relative account drawdown
     :raise: ValueError if trade-dataframe was found empty.
@@ -219,44 +219,6 @@ def calc_max_drawdown(
         high_value=high_val,
         low_value=low_val,
         relative_account_drawdown=max_drawdown_rel,
-    )
-
-
-def calculate_max_drawdown(
-    trades: pd.DataFrame,
-    *,
-    date_col: str = "close_date",
-    value_col: str = "profit_abs",
-    starting_balance: float = 0,
-    relative: bool = False,
-) -> Tuple[float, pd.Timestamp, pd.Timestamp, float, float, float]:
-    """
-    Calculate max drawdown and the corresponding close dates
-    Deprecated, favor calc_max_drawdown instead!
-    :param trades: DataFrame containing trades (requires columns close_date and profit_ratio)
-    :param date_col: Column in DataFrame to use for dates (defaults to 'close_date')
-    :param value_col: Column in DataFrame to use for values (defaults to 'profit_abs')
-    :param starting_balance: Portfolio starting balance - properly calculate relative drawdown.
-    :return: Tuple (float, highdate, lowdate, highvalue, lowvalue, relative_drawdown)
-             with absolute max drawdown, high and low time and high and low value,
-             and the relative account drawdown
-    :raise: ValueError if trade-dataframe was found empty.
-    """
-    # TODO: add deprecation warning
-    res = calc_max_drawdown(
-        trades,
-        date_col=date_col,
-        value_col=value_col,
-        starting_balance=starting_balance,
-        relative=relative,
-    )
-    return (
-        res.drawdown_abs,
-        res.high_date,
-        res.low_date,
-        res.high_value,
-        res.low_value,
-        res.relative_account_drawdown,
     )
 
 
@@ -399,7 +361,7 @@ def calculate_calmar(
 
     # calculate max drawdown
     try:
-        drawdown = calc_max_drawdown(
+        drawdown = calculate_max_drawdown(
             trades, value_col="profit_abs", starting_balance=starting_balance
         )
         max_drawdown = drawdown.relative_account_drawdown

--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -163,21 +163,12 @@ def calculate_underwater(
 
 @dataclass()
 class DrawDownResult:
-    __slots__ = [
-        "drawdown_abs",
-        "high_date",
-        "low_date",
-        "high_value",
-        "low_value",
-        "relative_account_drawdown",
-    ]
-
-    drawdown_abs: float
-    high_date: datetime
-    low_date: datetime
-    high_value: float
-    low_value: float
-    relative_account_drawdown: float
+    drawdown_abs: float = 0.0
+    high_date: datetime = None
+    low_date: datetime = None
+    high_value: float = 0.0
+    low_value: float = 0.0
+    relative_account_drawdown: float = 0.0
 
 
 def calc_max_drawdown(

--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -408,9 +408,10 @@ def calculate_calmar(
 
     # calculate max drawdown
     try:
-        _, _, _, _, _, max_drawdown = calculate_max_drawdown(
+        drawdown = calc_max_drawdown(
             trades, value_col="profit_abs", starting_balance=starting_balance
         )
+        max_drawdown = drawdown.relative_account_drawdown
     except ValueError:
         max_drawdown = 0
 

--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -164,8 +164,8 @@ def calculate_underwater(
 @dataclass()
 class DrawDownResult:
     drawdown_abs: float = 0.0
-    high_date: datetime = None
-    low_date: datetime = None
+    high_date: pd.Timestamp = None
+    low_date: pd.Timestamp = None
     high_value: float = 0.0
     low_value: float = 0.0
     relative_account_drawdown: float = 0.0

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_max_drawdown.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from pandas import DataFrame
 
-from freqtrade.data.metrics import calc_max_drawdown
+from freqtrade.data.metrics import calculate_max_drawdown
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
@@ -38,7 +38,7 @@ class MaxDrawDownHyperOptLoss(IHyperOptLoss):
         """
         total_profit = results["profit_abs"].sum()
         try:
-            max_drawdown = calc_max_drawdown(results, value_col="profit_abs")
+            max_drawdown = calculate_max_drawdown(results, value_col="profit_abs")
         except ValueError:
             # No losing trade, therefore no drawdown.
             return -total_profit

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_max_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_max_drawdown.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from pandas import DataFrame
 
-from freqtrade.data.metrics import calculate_max_drawdown
+from freqtrade.data.metrics import calc_max_drawdown
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
@@ -38,8 +38,8 @@ class MaxDrawDownHyperOptLoss(IHyperOptLoss):
         """
         total_profit = results["profit_abs"].sum()
         try:
-            max_drawdown = calculate_max_drawdown(results, value_col="profit_abs")
+            max_drawdown = calc_max_drawdown(results, value_col="profit_abs")
         except ValueError:
             # No losing trade, therefore no drawdown.
             return -total_profit
-        return -total_profit / max_drawdown[0]
+        return -total_profit / max_drawdown.drawdown_abs

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
@@ -10,7 +10,7 @@ individual needs.
 
 from pandas import DataFrame
 
-from freqtrade.data.metrics import calc_max_drawdown
+from freqtrade.data.metrics import calculate_max_drawdown
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
@@ -24,7 +24,7 @@ class ProfitDrawDownHyperOptLoss(IHyperOptLoss):
         total_profit = results["profit_abs"].sum()
 
         try:
-            drawdown = calc_max_drawdown(results, value_col="profit_abs")
+            drawdown = calculate_max_drawdown(results, value_col="profit_abs")
             relative_account_drawdown = drawdown.relative_account_drawdown
         except ValueError:
             relative_account_drawdown = 0

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
@@ -10,7 +10,7 @@ individual needs.
 
 from pandas import DataFrame
 
-from freqtrade.data.metrics import calculate_max_drawdown
+from freqtrade.data.metrics import calc_max_drawdown
 from freqtrade.optimize.hyperopt import IHyperOptLoss
 
 
@@ -24,8 +24,9 @@ class ProfitDrawDownHyperOptLoss(IHyperOptLoss):
         total_profit = results["profit_abs"].sum()
 
         try:
-            max_drawdown_abs = calculate_max_drawdown(results, value_col="profit_abs")[5]
+            drawdown = calc_max_drawdown(results, value_col="profit_abs")
+            relative_account_drawdown = drawdown.relative_account_drawdown
         except ValueError:
-            max_drawdown_abs = 0
+            relative_account_drawdown = 0
 
-        return -1 * (total_profit * (1 - max_drawdown_abs * DRAWDOWN_MULT))
+        return -1 * (total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT))

--- a/freqtrade/optimize/optimize_reports/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports/optimize_reports.py
@@ -8,12 +8,12 @@ from pandas import DataFrame, Series, concat, to_datetime
 
 from freqtrade.constants import BACKTEST_BREAKDOWNS, DATETIME_PRINT_FORMAT
 from freqtrade.data.metrics import (
-    calc_max_drawdown,
     calculate_cagr,
     calculate_calmar,
     calculate_csum,
     calculate_expectancy,
     calculate_market_change,
+    calculate_max_drawdown,
     calculate_sharpe,
     calculate_sortino,
 )
@@ -497,12 +497,12 @@ def generate_strategy_stats(
     }
 
     try:
-        max_drawdown_legacy = calc_max_drawdown(results, value_col="profit_ratio")
-        drawdown = calc_max_drawdown(
+        max_drawdown_legacy = calculate_max_drawdown(results, value_col="profit_ratio")
+        drawdown = calculate_max_drawdown(
             results, value_col="profit_abs", starting_balance=start_balance
         )
         # max_relative_drawdown = Underwater
-        underwater = calc_max_drawdown(
+        underwater = calculate_max_drawdown(
             results, value_col="profit_abs", starting_balance=start_balance, relative=True
         )
 

--- a/freqtrade/optimize/optimize_reports/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports/optimize_reports.py
@@ -8,12 +8,12 @@ from pandas import DataFrame, Series, concat, to_datetime
 
 from freqtrade.constants import BACKTEST_BREAKDOWNS, DATETIME_PRINT_FORMAT
 from freqtrade.data.metrics import (
+    calc_max_drawdown,
     calculate_cagr,
     calculate_calmar,
     calculate_csum,
     calculate_expectancy,
     calculate_market_change,
-    calculate_max_drawdown,
     calculate_sharpe,
     calculate_sortino,
 )
@@ -497,29 +497,27 @@ def generate_strategy_stats(
     }
 
     try:
-        max_drawdown_legacy, _, _, _, _, _ = calculate_max_drawdown(
-            results, value_col="profit_ratio"
-        )
-        (drawdown_abs, drawdown_start, drawdown_end, high_val, low_val, max_drawdown) = (
-            calculate_max_drawdown(results, value_col="profit_abs", starting_balance=start_balance)
+        max_drawdown_legacy = calc_max_drawdown(results, value_col="profit_ratio")
+        drawdown = calc_max_drawdown(
+            results, value_col="profit_abs", starting_balance=start_balance
         )
         # max_relative_drawdown = Underwater
-        (_, _, _, _, _, max_relative_drawdown) = calculate_max_drawdown(
+        underwater = calc_max_drawdown(
             results, value_col="profit_abs", starting_balance=start_balance, relative=True
         )
 
         strat_stats.update(
             {
-                "max_drawdown": max_drawdown_legacy,  # Deprecated - do not use
-                "max_drawdown_account": max_drawdown,
-                "max_relative_drawdown": max_relative_drawdown,
-                "max_drawdown_abs": drawdown_abs,
-                "drawdown_start": drawdown_start.strftime(DATETIME_PRINT_FORMAT),
-                "drawdown_start_ts": drawdown_start.timestamp() * 1000,
-                "drawdown_end": drawdown_end.strftime(DATETIME_PRINT_FORMAT),
-                "drawdown_end_ts": drawdown_end.timestamp() * 1000,
-                "max_drawdown_low": low_val,
-                "max_drawdown_high": high_val,
+                "max_drawdown": max_drawdown_legacy.drawdown_abs,  # Deprecated - do not use
+                "max_drawdown_account": drawdown.relative_account_drawdown,
+                "max_relative_drawdown": underwater.relative_account_drawdown,
+                "max_drawdown_abs": drawdown.drawdown_abs,
+                "drawdown_start": drawdown.high_date.strftime(DATETIME_PRINT_FORMAT),
+                "drawdown_start_ts": drawdown.high_date.timestamp() * 1000,
+                "drawdown_end": drawdown.low_date.strftime(DATETIME_PRINT_FORMAT),
+                "drawdown_end_ts": drawdown.low_date.timestamp() * 1000,
+                "max_drawdown_low": drawdown.low_value,
+                "max_drawdown_high": drawdown.high_value,
             }
         )
 

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -16,7 +16,7 @@ from freqtrade.data.converter import trim_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange, load_data
 from freqtrade.data.metrics import (
-    calculate_max_drawdown,
+    calc_max_drawdown,
     calculate_underwater,
     combine_dataframes_with_mean,
     create_cum_profit,
@@ -179,19 +179,17 @@ def add_max_drawdown(
     Add scatter points indicating max drawdown
     """
     try:
-        _, highdate, lowdate, _, _, max_drawdown = calculate_max_drawdown(
-            trades, starting_balance=starting_balance
-        )
+        drawdown = calc_max_drawdown(trades, starting_balance=starting_balance)
 
         drawdown = go.Scatter(
-            x=[highdate, lowdate],
+            x=[drawdown.high_date, drawdown.low_date],
             y=[
-                df_comb.loc[timeframe_to_prev_date(timeframe, highdate), "cum_profit"],
-                df_comb.loc[timeframe_to_prev_date(timeframe, lowdate), "cum_profit"],
+                df_comb.loc[timeframe_to_prev_date(timeframe, drawdown.high_date), "cum_profit"],
+                df_comb.loc[timeframe_to_prev_date(timeframe, drawdown.low_date), "cum_profit"],
             ],
             mode="markers",
-            name=f"Max drawdown {max_drawdown:.2%}",
-            text=f"Max drawdown {max_drawdown:.2%}",
+            name=f"Max drawdown {drawdown.relative_account_drawdown:.2%}",
+            text=f"Max drawdown {drawdown.relative_account_drawdown:.2%}",
             marker=dict(symbol="square-open", size=9, line=dict(width=2), color="green"),
         )
         fig.add_trace(drawdown, row, 1)

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -16,7 +16,7 @@ from freqtrade.data.converter import trim_dataframe
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import get_timerange, load_data
 from freqtrade.data.metrics import (
-    calc_max_drawdown,
+    calculate_max_drawdown,
     calculate_underwater,
     combine_dataframes_with_mean,
     create_cum_profit,
@@ -179,7 +179,7 @@ def add_max_drawdown(
     Add scatter points indicating max drawdown
     """
     try:
-        drawdown = calc_max_drawdown(trades, starting_balance=starting_balance)
+        drawdown = calculate_max_drawdown(trades, starting_balance=starting_balance)
 
         drawdown = go.Scatter(
             x=[drawdown.high_date, drawdown.low_date],

--- a/freqtrade/plugins/protections/max_drawdown_protection.py
+++ b/freqtrade/plugins/protections/max_drawdown_protection.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from freqtrade.constants import Config, LongShort
-from freqtrade.data.metrics import calc_max_drawdown
+from freqtrade.data.metrics import calculate_max_drawdown
 from freqtrade.persistence import Trade
 from freqtrade.plugins.protections import IProtection, ProtectionReturn
 
@@ -59,7 +59,7 @@ class MaxDrawdown(IProtection):
         # Drawdown is always positive
         try:
             # TODO: This should use absolute profit calculation, considering account balance.
-            drawdown_obj = calc_max_drawdown(trades_df, value_col="close_profit")
+            drawdown_obj = calculate_max_drawdown(trades_df, value_col="close_profit")
             drawdown = drawdown_obj.drawdown_abs
         except ValueError:
             return None

--- a/freqtrade/plugins/protections/max_drawdown_protection.py
+++ b/freqtrade/plugins/protections/max_drawdown_protection.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from freqtrade.constants import Config, LongShort
-from freqtrade.data.metrics import calculate_max_drawdown
+from freqtrade.data.metrics import calc_max_drawdown
 from freqtrade.persistence import Trade
 from freqtrade.plugins.protections import IProtection, ProtectionReturn
 
@@ -59,7 +59,8 @@ class MaxDrawdown(IProtection):
         # Drawdown is always positive
         try:
             # TODO: This should use absolute profit calculation, considering account balance.
-            drawdown, _, _, _, _, _ = calculate_max_drawdown(trades_df, value_col="close_profit")
+            drawdown_obj = calc_max_drawdown(trades_df, value_col="close_profit")
+            drawdown = drawdown_obj.drawdown_abs
         except ValueError:
             return None
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -21,8 +21,8 @@ from freqtrade.constants import CANCEL_REASON, DEFAULT_DATAFRAME_COLUMNS, Config
 from freqtrade.data.history import load_data
 from freqtrade.data.metrics import (
     DrawDownResult,
-    calc_max_drawdown,
     calculate_expectancy,
+    calculate_max_drawdown,
 )
 from freqtrade.enums import (
     CandleType,
@@ -599,7 +599,7 @@ class RPC:
         drawdown = DrawDownResult()
         if len(trades_df) > 0:
             try:
-                drawdown = calc_max_drawdown(
+                drawdown = calculate_max_drawdown(
                     trades_df,
                     value_col="profit_abs",
                     date_col="close_date_dt",

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -596,7 +596,7 @@ class RPC:
 
         expectancy, expectancy_ratio = calculate_expectancy(trades_df)
 
-        drawdown = DrawDownResult(0.0, 0.0, None, None, 0.0)
+        drawdown = DrawDownResult()
         if len(trades_df) > 0:
             try:
                 drawdown = calc_max_drawdown(

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -19,7 +19,11 @@ from freqtrade import __version__
 from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CANCEL_REASON, DEFAULT_DATAFRAME_COLUMNS, Config
 from freqtrade.data.history import load_data
-from freqtrade.data.metrics import calculate_expectancy, calculate_max_drawdown
+from freqtrade.data.metrics import (
+    DrawDownResult,
+    calc_max_drawdown,
+    calculate_expectancy,
+)
 from freqtrade.enums import (
     CandleType,
     ExitCheckTuple,
@@ -592,21 +596,10 @@ class RPC:
 
         expectancy, expectancy_ratio = calculate_expectancy(trades_df)
 
-        max_drawdown_abs = 0.0
-        max_drawdown = 0.0
-        drawdown_start: Optional[datetime] = None
-        drawdown_end: Optional[datetime] = None
-        dd_high_val = dd_low_val = 0.0
+        drawdown = DrawDownResult(0.0, 0.0, None, None, 0.0)
         if len(trades_df) > 0:
             try:
-                (
-                    max_drawdown_abs,
-                    drawdown_start,
-                    drawdown_end,
-                    dd_high_val,
-                    dd_low_val,
-                    max_drawdown,
-                ) = calculate_max_drawdown(
+                drawdown = calc_max_drawdown(
                     trades_df,
                     value_col="profit_abs",
                     date_col="close_date_dt",
@@ -663,14 +656,14 @@ class RPC:
             "winrate": winrate,
             "expectancy": expectancy,
             "expectancy_ratio": expectancy_ratio,
-            "max_drawdown": max_drawdown,
-            "max_drawdown_abs": max_drawdown_abs,
-            "max_drawdown_start": format_date(drawdown_start),
-            "max_drawdown_start_timestamp": dt_ts_def(drawdown_start),
-            "max_drawdown_end": format_date(drawdown_end),
-            "max_drawdown_end_timestamp": dt_ts_def(drawdown_end),
-            "drawdown_high": dd_high_val,
-            "drawdown_low": dd_low_val,
+            "max_drawdown": drawdown.relative_account_drawdown,
+            "max_drawdown_abs": drawdown.drawdown_abs,
+            "max_drawdown_start": format_date(drawdown.high_date),
+            "max_drawdown_start_timestamp": dt_ts_def(drawdown.high_date),
+            "max_drawdown_end": format_date(drawdown.low_date),
+            "max_drawdown_end_timestamp": dt_ts_def(drawdown.low_date),
+            "drawdown_high": drawdown.high_value,
+            "drawdown_low": drawdown.low_value,
             "trading_volume": trading_volume,
             "bot_start_timestamp": dt_ts_def(bot_start, 0),
             "bot_start_date": format_date(bot_start),

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -19,11 +19,7 @@ from freqtrade import __version__
 from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CANCEL_REASON, DEFAULT_DATAFRAME_COLUMNS, Config
 from freqtrade.data.history import load_data
-from freqtrade.data.metrics import (
-    DrawDownResult,
-    calculate_expectancy,
-    calculate_max_drawdown,
-)
+from freqtrade.data.metrics import DrawDownResult, calculate_expectancy, calculate_max_drawdown
 from freqtrade.enums import (
     CandleType,
     ExitCheckTuple,

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -20,6 +20,7 @@ from freqtrade.data.btanalysis import (
 )
 from freqtrade.data.history import load_data, load_pair_history
 from freqtrade.data.metrics import (
+    calc_max_drawdown,
     calculate_cagr,
     calculate_calmar,
     calculate_csum,
@@ -343,23 +344,21 @@ def test_create_cum_profit1(testdatadir):
 def test_calculate_max_drawdown(testdatadir):
     filename = testdatadir / "backtest_results/backtest-result.json"
     bt_data = load_backtest_data(filename)
-    _, hdate, lowdate, hval, lval, drawdown = calculate_max_drawdown(
-        bt_data, value_col="profit_abs"
-    )
-    assert isinstance(drawdown, float)
-    assert pytest.approx(drawdown) == 0.29753914
-    assert isinstance(hdate, Timestamp)
-    assert isinstance(lowdate, Timestamp)
-    assert isinstance(hval, float)
-    assert isinstance(lval, float)
-    assert hdate == Timestamp("2018-01-16 19:30:00", tz="UTC")
-    assert lowdate == Timestamp("2018-01-16 22:25:00", tz="UTC")
+    drawdown = calc_max_drawdown(bt_data, value_col="profit_abs")
+    assert isinstance(drawdown.relative_account_drawdown, float)
+    assert pytest.approx(drawdown.relative_account_drawdown) == 0.29753914
+    assert isinstance(drawdown.high_date, Timestamp)
+    assert isinstance(drawdown.low_date, Timestamp)
+    assert isinstance(drawdown.high_value, float)
+    assert isinstance(drawdown.low_value, float)
+    assert drawdown.high_date == Timestamp("2018-01-16 19:30:00", tz="UTC")
+    assert drawdown.low_date == Timestamp("2018-01-16 22:25:00", tz="UTC")
 
     underwater = calculate_underwater(bt_data)
     assert isinstance(underwater, DataFrame)
 
     with pytest.raises(ValueError, match="Trade dataframe empty."):
-        calculate_max_drawdown(DataFrame())
+        calc_max_drawdown(DataFrame())
 
     with pytest.raises(ValueError, match="Trade dataframe empty."):
         calculate_underwater(DataFrame())

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -20,7 +20,6 @@ from freqtrade.data.btanalysis import (
 )
 from freqtrade.data.history import load_data, load_pair_history
 from freqtrade.data.metrics import (
-    calc_max_drawdown,
     calculate_cagr,
     calculate_calmar,
     calculate_csum,
@@ -344,7 +343,7 @@ def test_create_cum_profit1(testdatadir):
 def test_calculate_max_drawdown(testdatadir):
     filename = testdatadir / "backtest_results/backtest-result.json"
     bt_data = load_backtest_data(filename)
-    drawdown = calc_max_drawdown(bt_data, value_col="profit_abs")
+    drawdown = calculate_max_drawdown(bt_data, value_col="profit_abs")
     assert isinstance(drawdown.relative_account_drawdown, float)
     assert pytest.approx(drawdown.relative_account_drawdown) == 0.29753914
     assert isinstance(drawdown.high_date, Timestamp)
@@ -358,7 +357,7 @@ def test_calculate_max_drawdown(testdatadir):
     assert isinstance(underwater, DataFrame)
 
     with pytest.raises(ValueError, match="Trade dataframe empty."):
-        calc_max_drawdown(DataFrame())
+        calculate_max_drawdown(DataFrame())
 
     with pytest.raises(ValueError, match="Trade dataframe empty."):
         calculate_underwater(DataFrame())
@@ -508,7 +507,7 @@ def test_calculate_max_drawdown2():
     # sort by profit and reset index
     df = df.sort_values("profit").reset_index(drop=True)
     df1 = df.copy()
-    drawdown = calc_max_drawdown(df, date_col="open_date", value_col="profit")
+    drawdown = calculate_max_drawdown(df, date_col="open_date", value_col="profit")
     # Ensure df has not been altered.
     assert df.equals(df1)
 
@@ -522,12 +521,12 @@ def test_calculate_max_drawdown2():
 
     df = DataFrame(zip(values[:5], dates[:5]), columns=["profit", "open_date"])
     with pytest.raises(ValueError, match="No losing trade, therefore no drawdown."):
-        calc_max_drawdown(df, date_col="open_date", value_col="profit")
+        calculate_max_drawdown(df, date_col="open_date", value_col="profit")
 
     df1 = DataFrame(zip(values[:5], dates[:5]), columns=["profit", "open_date"])
     df1.loc[:, "profit"] = df1["profit"] * -1
     # No winning trade ...
-    drawdown = calc_max_drawdown(df1, date_col="open_date", value_col="profit")
+    drawdown = calculate_max_drawdown(df1, date_col="open_date", value_col="profit")
     assert drawdown.drawdown_abs == 0.043965
 
 
@@ -550,7 +549,9 @@ def test_calculate_max_drawdown_abs(profits, relative, highd, lowdays, result, r
     # sort by profit and reset index
     df = df.sort_values("profit_abs").reset_index(drop=True)
     df1 = df.copy()
-    drawdown = calc_max_drawdown(df, date_col="open_date", starting_balance=1000, relative=relative)
+    drawdown = calculate_max_drawdown(
+        df, date_col="open_date", starting_balance=1000, relative=relative
+    )
     # Ensure df has not been altered.
     assert df.equals(df1)
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Change the return value of calculate_max_drawdown from a tuple to a dataclass.
The tuple makes identifying "which value am i using" rather difficult, and can lead to bugs easily - so this will be a great DX enhancement.

## Quick changelog

- Update return value for calculate_max_drawdown
- update variable name in ProfitDrawDownHyperOptLoss to correspond to what was actuallly used