### PR TITLE
Remove catboost stdout workaround

### DIFF
--- a/freqtrade/freqai/prediction_models/CatboostClassifier.py
+++ b/freqtrade/freqai/prediction_models/CatboostClassifier.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -57,8 +56,6 @@ class CatboostClassifier(BaseClassifierModel):
             X=train_data,
             eval_set=test_data,
             init_model=init_model,
-            log_cout=sys.stdout,
-            log_cerr=sys.stderr,
         )
 
         return cbr

--- a/freqtrade/freqai/prediction_models/CatboostClassifierMultiTarget.py
+++ b/freqtrade/freqai/prediction_models/CatboostClassifierMultiTarget.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -68,8 +67,6 @@ class CatboostClassifierMultiTarget(BaseClassifierModel):
                 {
                     "eval_set": eval_sets[i],
                     "init_model": init_models[i],
-                    "log_cout": sys.stdout,
-                    "log_cerr": sys.stderr,
                 }
             )
 

--- a/freqtrade/freqai/prediction_models/CatboostRegressor.py
+++ b/freqtrade/freqai/prediction_models/CatboostRegressor.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -56,8 +55,6 @@ class CatboostRegressor(BaseRegressionModel):
             X=train_data,
             eval_set=test_data,
             init_model=init_model,
-            log_cout=sys.stdout,
-            log_cerr=sys.stderr,
         )
 
         return model

--- a/freqtrade/freqai/prediction_models/CatboostRegressorMultiTarget.py
+++ b/freqtrade/freqai/prediction_models/CatboostRegressorMultiTarget.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -67,8 +66,6 @@ class CatboostRegressorMultiTarget(BaseRegressionModel):
                 {
                     "eval_set": eval_sets[i],
                     "init_model": init_models[i],
-                    "log_cout": sys.stdout,
-                    "log_cerr": sys.stderr,
                 }
             )
 


### PR DESCRIPTION


<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

https://github.com/catboost/catboost/issues/2195 is fixed, so this SHOULD work

Will be running Ci a few times on this branch ton ensure it's not randomly regressing (as we had before).
