### PR TITLE
fix cases where losing epoch get a huge negative loss value

### DIFF
--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
@@ -29,4 +29,9 @@ class ProfitDrawDownHyperOptLoss(IHyperOptLoss):
         except ValueError:
             relative_account_drawdown = 0
 
-        return -1 * (total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT))
+        loss_value = (total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT))
+
+        if((total_profit < 0) and (loss_value > 0)):
+            return loss_value
+
+        return -1 * loss_value

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
@@ -29,9 +29,9 @@ class ProfitDrawDownHyperOptLoss(IHyperOptLoss):
         except ValueError:
             relative_account_drawdown = 0
 
-        loss_value = (total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT))
+        loss_value = total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT)
 
-        if ((total_profit < 0) and (loss_value > 0)):
+        if (total_profit < 0) and (loss_value > 0):
             return loss_value
 
         return -1 * loss_value

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_profit_drawdown.py
@@ -31,7 +31,7 @@ class ProfitDrawDownHyperOptLoss(IHyperOptLoss):
 
         loss_value = (total_profit * (1 - relative_account_drawdown * DRAWDOWN_MULT))
 
-        if((total_profit < 0) and (loss_value > 0)):
+        if ((total_profit < 0) and (loss_value > 0)):
             return loss_value
 
         return -1 * loss_value


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

On some cases, you can have losing epoch (total profit< 0), but it can have a big negative loss value, which make the bot think it's the best epoch. This should fix such bug

Solve the issue: #10192 

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
