### PR TITLE
Revert "Workaround macos CI fails"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
-        python-version: ["3.9", "3.10", "3.11", "3.12.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -134,8 +134,7 @@ jobs:
     strategy:
       matrix:
         os: [ "macos-12", "macos-13", "macos-14" ]
-        # TODO: Remove 3.12 hard-pin once https://github.com/actions/setup-python/issues/883 is fixed.
-        python-version: ["3.9", "3.10", "3.11", "3.12.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: "macos-14"
             python-version: "3.9"
@@ -259,7 +258,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        python-version: ["3.9", "3.10", "3.11", "3.12.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit d2da23f5d1bb7ad9bd90160c261317d76ba1206c.

should work once 3.12.4 is available and used in actions.