### PR TITLE
Fix setup.sh pip version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,7 @@ function updateenv() {
     source .venv/bin/activate
     SYS_ARCH=$(uname -m)
     echo "pip install in-progress. Please wait..."
-    ${PYTHON} -m pip install --upgrade "pip<=24.1" wheel setuptools
+    ${PYTHON} -m pip install --upgrade "pip<=24.0" wheel setuptools
     REQUIREMENTS_HYPEROPT=""
     REQUIREMENTS_PLOT=""
     REQUIREMENTS_FREQAI=""


### PR DESCRIPTION
The previous fix for the pip pinning had a typo. It should be 24.0 not 24.1.

This addresses #10350 
