### PR TITLE
Correcting error in numpy import in rpc.py

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Union
 import psutil
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzlocal
-from numpy import NAN, inf, int64, mean
+from numpy import nan as NAN, inf, int64, mean
 from pandas import DataFrame, NaT
 from sqlalchemy import func, select
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

The goal is to correct an error message that occurs regarding an import after you initially build the repo after forking.

Solve the issue: #10401 

## Quick changelog

`from numpy import NAN, inf, int64, mean`    -->    `from numpy import nan as NAN, inf, int64, mean`

## What's new?

"import nan as NAN", rather than just "import NAN"
