### PR TITLE
Typo in docs

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -2,7 +2,7 @@
 
 ## FreqUI
 
-FreqUI now has it's own dedicated [documentation section](frequi.md) - please refer to that section for all information regarding the FreqUI.
+FreqUI now has it's own dedicated [documentation section](freq-ui.md) - please refer to that section for all information regarding the FreqUI.
 
 ## Configuration
 


### PR DESCRIPTION
Fix a small typo in the docs.

![image](https://github.com/user-attachments/assets/584f82d2-41aa-4c7d-81cf-146b19f544da)

