### PR TITLE
Add rich table width if jupyter in modules

### DIFF
--- a/freqtrade/util/rich_tables.py
+++ b/freqtrade/util/rich_tables.py
@@ -41,9 +41,7 @@ def print_rich_table(
     if any(module in ["pytest", "ipykernel"] for module in sys.modules):
         width = 200
 
-    console = Console(
-        width=width
-    )
+    console = Console(width=width)
     console.print(table)
 
 
@@ -79,7 +77,5 @@ def print_df_rich_table(
     if any(module in ["pytest", "ipykernel"] for module in sys.modules):
         width = 200
 
-    console = Console(
-        width=width
-    )
+    console = Console(width=width)
     console.print(table)

--- a/freqtrade/util/rich_tables.py
+++ b/freqtrade/util/rich_tables.py
@@ -37,8 +37,12 @@ def print_rich_table(
             row_to_add: List[Union[str, Text]] = [r if isinstance(r, Text) else str(r) for r in row]
             table.add_row(*row_to_add)
 
+    width = None
+    if any(module in ["pytest", "ipykernel"] for module in sys.modules):
+        width = 200
+
     console = Console(
-        width=200 if "pytest" in sys.modules else None,
+        width=width
     )
     console.print(table)
 
@@ -71,7 +75,11 @@ def print_df_rich_table(
         row = [_format_value(x, floatfmt=".3f") for x in value_list]
         table.add_row(*row)
 
+    width = None
+    if any(module in ["pytest", "ipykernel"] for module in sys.modules):
+        width = 200
+
     console = Console(
-        width=200 if "pytest" in sys.modules else None,
+        width=width
     )
     console.print(table)


### PR DESCRIPTION
## Summary

The new rich table outputs do not respect expanded width when outputted in jupyter output cells. You end up with truncated output like so:

![image](https://github.com/user-attachments/assets/63a81524-36e5-477e-8d37-a5e6d5c0e6c0)

This PR adds the check for `ipykernel` in `sys.modules`, thus setting the console output width in either case to 200

## Quick changelog

- Add "ipykernel" module check to adjust table width

P.S. as an aside, it might be good if there was also a `console_kwargs` option as well as the `table_kwargs` to allow further adjustment of the console output if necessary? Might be overkill so I didn't add it in this PR.
