### PR TITLE
add startup count from strategy to the analysis

### DIFF
--- a/freqtrade/optimize/analysis/recursive_helpers.py
+++ b/freqtrade/optimize/analysis/recursive_helpers.py
@@ -17,9 +17,13 @@ class RecursiveAnalysisSubFunctions:
     @staticmethod
     def text_table_recursive_analysis_instances(recursive_instances: List[RecursiveAnalysis]):
         startups = recursive_instances[0]._startup_candle
+        strat_scc = recursive_instances[0]._strat_scc
         headers = ["Indicators"]
         for candle in startups:
-            headers.append(str(candle))
+            if candle == strat_scc:
+                headers.append(f"{candle} (from strategy)")
+            else:
+                headers.append(str(candle))
 
         data = []
         for inst in recursive_instances:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Make it clearer to user about the real effect of the startup candle count set in the strategy file, and how the other numbers of startup count compared to it

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

```
┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃    Indicators ┃ 0 (from strategy) ┃     199 ┃     299 ┃     399 ┃     499 ┃     599 ┃     699 ┃     799 ┃     899 ┃     999 ┃    1099 ┃    1199 ┃    1299 ┃    1399 ┃
┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
```