### PR TITLE
updates for #10617

### DIFF
--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -1232,7 +1232,7 @@ class LocalTrade:
         current_amount_tr = amount_to_contract_precision(
             float(current_amount), self.amount_precision, self.precision_mode, self.contract_size
         )
-        if current_amount_tr > 0.0:
+        if current_amount_tr >= 0.0:
             # Trade is still open
             # Leverage not updated, as we don't allow changing leverage through DCA at the moment.
             self.open_rate = float(current_stake / current_amount)


### PR DESCRIPTION
## Summary

Solve the issue: #10617

## Quick changelog

- allow wallet update also when all orders produce a zero amount

## What's new?

Updated check to allow wallet update on zero trade amounts (all trade orders balance out each other).
