### PR TITLE
feat: include lookahead-analysis table caption when biased_indicator is likely from FreqAI target

### DIFF
--- a/docs/lookahead-analysis.md
+++ b/docs/lookahead-analysis.md
@@ -101,3 +101,4 @@ This could lead to a false-negative (the strategy will then be reported as non-b
 - `lookahead-analysis` has access to everything that backtesting has too.
 Please don't provoke any configs like enabling position stacking.
 If you decide to do so, then make doubly sure that you won't ever run out of `max_open_trades` amount and neither leftover money in your wallet.
+- `biased_indicators` will falsely flag FreqAI target indicators defined in `set_freqai_targets()` as biased. These are not biased and can safely be ignored.

--- a/docs/lookahead-analysis.md
+++ b/docs/lookahead-analysis.md
@@ -101,4 +101,4 @@ This could lead to a false-negative (the strategy will then be reported as non-b
 - `lookahead-analysis` has access to everything that backtesting has too.
 Please don't provoke any configs like enabling position stacking.
 If you decide to do so, then make doubly sure that you won't ever run out of `max_open_trades` amount and neither leftover money in your wallet.
-- `biased_indicators` will falsely flag FreqAI target indicators defined in `set_freqai_targets()` as biased. These are not biased and can safely be ignored.
+- In the results table, the `biased_indicators` column will falsely flag FreqAI target indicators defined in `set_freqai_targets()` as biased. These are not biased and can safely be ignored.

--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -68,10 +68,7 @@ class LookaheadAnalysisSubFunctions:
                 )
 
         print_rich_table(
-            data,
-            headers,
-            summary="Lookahead Analysis",
-            table_kwargs={"caption": caption}
+            data, headers, summary="Lookahead Analysis", table_kwargs={"caption": caption}
         )
         return data
 
@@ -247,12 +244,17 @@ class LookaheadAnalysisSubFunctions:
         # report the results
         if lookaheadAnalysis_instances:
             caption: Union[str, None] = None
-            if any([
-                any([
-                    indicator.startswith("&")
-                    for indicator in inst.current_analysis.false_indicators
-                ]) for inst in lookaheadAnalysis_instances
-            ]):
+            if any(
+                [
+                    any(
+                        [
+                            indicator.startswith("&")
+                            for indicator in inst.current_analysis.false_indicators
+                        ]
+                    )
+                    for inst in lookaheadAnalysis_instances
+                ]
+            ):
                 caption = (
                     "Any indicators in 'biased_indicators' which are used within "
                     "set_freqai_targets() can be ignored."

--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 from rich.text import Text
@@ -21,7 +21,7 @@ class LookaheadAnalysisSubFunctions:
     def text_table_lookahead_analysis_instances(
         config: Dict[str, Any],
         lookahead_instances: List[LookaheadAnalysis],
-        caption: str | None = None,
+        caption: Union[str, None] = None,
     ):
         headers = [
             "filename",
@@ -246,7 +246,7 @@ class LookaheadAnalysisSubFunctions:
 
         # report the results
         if lookaheadAnalysis_instances:
-            caption: str | None = None
+            caption: Union[str, None] = None
             if any([
                 any([
                     indicator.startswith("&")

--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 class LookaheadAnalysisSubFunctions:
     @staticmethod
     def text_table_lookahead_analysis_instances(
-        config: Dict[str, Any], lookahead_instances: List[LookaheadAnalysis]
+        config: Dict[str, Any],
+        lookahead_instances: List[LookaheadAnalysis],
+        caption: str | None = None,
     ):
         headers = [
             "filename",
@@ -65,7 +67,12 @@ class LookaheadAnalysisSubFunctions:
                     ]
                 )
 
-        print_rich_table(data, headers, summary="Lookahead Analysis")
+        print_rich_table(
+            data,
+            headers,
+            summary="Lookahead Analysis",
+            table_kwargs={"caption": caption}
+        )
         return data
 
     @staticmethod
@@ -239,8 +246,19 @@ class LookaheadAnalysisSubFunctions:
 
         # report the results
         if lookaheadAnalysis_instances:
+            caption: str | None = None
+            if any([
+                any([
+                    indicator.startswith("&")
+                    for indicator in inst.current_analysis.false_indicators
+                ]) for inst in lookaheadAnalysis_instances
+            ]):
+                caption = (
+                    "Any indicators in 'biased_indicators' which are used within "
+                    "set_freqai_targets() can be ignored."
+                )
             LookaheadAnalysisSubFunctions.text_table_lookahead_analysis_instances(
-                config, lookaheadAnalysis_instances
+                config, lookaheadAnalysis_instances, caption=caption
             )
             if config.get("lookahead_analysis_exportfilename") is not None:
                 LookaheadAnalysisSubFunctions.export_to_csv(config, lookaheadAnalysis_instances)

--- a/tests/optimize/test_lookahead_analysis.py
+++ b/tests/optimize/test_lookahead_analysis.py
@@ -154,14 +154,8 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
             ["&indicator1", "&indicator2"],
             IGNORE_BIASED_INDICATORS_CAPTION,
         ),
-        (
-            ["indicator1", "indicator2"],
-            None
-        ),
-        (
-            [],
-            None
-        ),
+        (["indicator1", "indicator2"], None),
+        ([], None),
     ],
     ids=(
         "First of two biased indicators starts with '&'",
@@ -172,10 +166,7 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
     ),
 )
 def test_lookahead_helper_start__caption_based_on_indicators(
-    indicators,
-    expected_caption_text,
-    lookahead_conf,
-    mocker
+    indicators, expected_caption_text, lookahead_conf, mocker
 ):
     """Test that the table caption is only populated if a biased_indicator starts with '&'."""
 
@@ -196,9 +187,7 @@ def test_lookahead_helper_start__caption_based_on_indicators(
     LookaheadAnalysisSubFunctions.start(lookahead_conf)
 
     text_table_mock.assert_called_once_with(
-        lookahead_conf,
-        [lookahead_analysis],
-        caption=expected_caption_text
+        lookahead_conf, [lookahead_analysis], caption=expected_caption_text
     )
 
 
@@ -300,7 +289,7 @@ def test_lookahead_helper_text_table_lookahead_analysis_instances__caption(
         {
             "name": "strategy_test_v3_with_lookahead_bias",
             "location": Path(lookahead_conf["strategy_path"], f"{lookahead_conf['strategy']}.py"),
-        }
+        },
     )
     kwargs = {}
     if caption is not False:

--- a/tests/optimize/test_lookahead_analysis.py
+++ b/tests/optimize/test_lookahead_analysis.py
@@ -265,7 +265,6 @@ def test_lookahead_helper_text_table_lookahead_analysis_instances(lookahead_conf
     assert len(data) == 3
 
 
-
 @pytest.mark.parametrize(
     "caption",
     [

--- a/tests/optimize/test_lookahead_analysis.py
+++ b/tests/optimize/test_lookahead_analysis.py
@@ -13,6 +13,12 @@ from freqtrade.optimize.analysis.lookahead_helpers import LookaheadAnalysisSubFu
 from tests.conftest import EXMS, get_args, log_has_re, patch_exchange
 
 
+IGNORE_BIASED_INDICATORS_CAPTION = (
+    "Any indicators in 'biased_indicators' which are used within "
+    "set_freqai_targets() can be ignored."
+)
+
+
 @pytest.fixture
 def lookahead_conf(default_conf_usdt, tmp_path):
     default_conf_usdt["user_data_dir"] = tmp_path
@@ -138,18 +144,15 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
     [
         (
             ["&indicator1", "indicator2"],
-            "Any indicators in 'biased_indicators' which are used "
-            "within set_freqai_targets() can be ignored."
+            IGNORE_BIASED_INDICATORS_CAPTION,
         ),
         (
             ["indicator1", "&indicator2"],
-            "Any indicators in 'biased_indicators' which are used "
-            "within set_freqai_targets() can be ignored."
+            IGNORE_BIASED_INDICATORS_CAPTION,
         ),
         (
             ["&indicator1", "&indicator2"],
-            "Any indicators in 'biased_indicators' which are used "
-            "within set_freqai_targets() can be ignored."
+            IGNORE_BIASED_INDICATORS_CAPTION,
         ),
         (
             ["indicator1", "indicator2"],
@@ -158,7 +161,7 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
         (
             [],
             None
-        )
+        ),
     ],
     ids=(
         "First of two biased indicators starts with '&'",
@@ -166,7 +169,7 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
         "Both biased indicators start with '&'",
         "No biased indicators start with '&'",
         "Empty biased indicators list",
-    )
+    ),
 )
 def test_lookahead_helper_start__caption_based_on_indicators(
     indicators,
@@ -278,7 +281,7 @@ def test_lookahead_helper_text_table_lookahead_analysis_instances(lookahead_conf
         "Pass non-empty string",
         "Pass None",
         "Don't pass caption",
-    )
+    ),
 )
 def test_lookahead_helper_text_table_lookahead_analysis_instances__caption(
     caption,

--- a/tests/optimize/test_lookahead_analysis.py
+++ b/tests/optimize/test_lookahead_analysis.py
@@ -133,6 +133,72 @@ def test_lookahead_helper_start(lookahead_conf, mocker) -> None:
     text_table_mock.reset_mock()
 
 
+@pytest.mark.parametrize(
+    "indicators, expected_caption_text",
+    [
+        (
+            ["&indicator1", "indicator2"],
+            "Any indicators in 'biased_indicators' which are used "
+            "within set_freqai_targets() can be ignored."
+        ),
+        (
+            ["indicator1", "&indicator2"],
+            "Any indicators in 'biased_indicators' which are used "
+            "within set_freqai_targets() can be ignored."
+        ),
+        (
+            ["&indicator1", "&indicator2"],
+            "Any indicators in 'biased_indicators' which are used "
+            "within set_freqai_targets() can be ignored."
+        ),
+        (
+            ["indicator1", "indicator2"],
+            None
+        ),
+        (
+            [],
+            None
+        )
+    ],
+    ids=(
+        "First of two biased indicators starts with '&'",
+        "Second of two biased indicators starts with '&'",
+        "Both biased indicators start with '&'",
+        "No biased indicators start with '&'",
+        "Empty biased indicators list",
+    )
+)
+def test_lookahead_helper_start__caption_based_on_indicators(
+    indicators,
+    expected_caption_text,
+    lookahead_conf,
+    mocker
+):
+    """Test that the table caption is only populated if a biased_indicator starts with '&'."""
+
+    single_mock = MagicMock()
+    lookahead_analysis = LookaheadAnalysis(
+        lookahead_conf,
+        {"name": "strategy_test_v3_with_lookahead_bias"},
+    )
+    lookahead_analysis.current_analysis.false_indicators = indicators
+    single_mock.return_value = lookahead_analysis
+    text_table_mock = MagicMock()
+    mocker.patch.multiple(
+        "freqtrade.optimize.analysis.lookahead_helpers.LookaheadAnalysisSubFunctions",
+        initialize_single_lookahead_analysis=single_mock,
+        text_table_lookahead_analysis_instances=text_table_mock,
+    )
+
+    LookaheadAnalysisSubFunctions.start(lookahead_conf)
+
+    text_table_mock.assert_called_once_with(
+        lookahead_conf,
+        [lookahead_analysis],
+        caption=expected_caption_text
+    )
+
+
 def test_lookahead_helper_text_table_lookahead_analysis_instances(lookahead_conf):
     analysis = Analysis()
     analysis.has_bias = True
@@ -197,6 +263,54 @@ def test_lookahead_helper_text_table_lookahead_analysis_instances(lookahead_conf
         lookahead_conf, [instance, instance, instance]
     )
     assert len(data) == 3
+
+
+
+@pytest.mark.parametrize(
+    "caption",
+    [
+        "",
+        "A test caption",
+        None,
+        False,
+    ],
+    ids=(
+        "Pass empty string",
+        "Pass non-empty string",
+        "Pass None",
+        "Don't pass caption",
+    )
+)
+def test_lookahead_helper_text_table_lookahead_analysis_instances__caption(
+    caption,
+    lookahead_conf,
+    mocker,
+):
+    """Test that the caption is passed in the table kwargs when calling print_rich_table()."""
+
+    print_rich_table_mock = MagicMock()
+    mocker.patch(
+        "freqtrade.optimize.analysis.lookahead_helpers.print_rich_table",
+        print_rich_table_mock,
+    )
+    lookahead_analysis = LookaheadAnalysis(
+        lookahead_conf,
+        {
+            "name": "strategy_test_v3_with_lookahead_bias",
+            "location": Path(lookahead_conf["strategy_path"], f"{lookahead_conf['strategy']}.py"),
+        }
+    )
+    kwargs = {}
+    if caption is not False:
+        kwargs["caption"] = caption
+
+    LookaheadAnalysisSubFunctions.text_table_lookahead_analysis_instances(
+        lookahead_conf, [lookahead_analysis], **kwargs
+    )
+
+    assert print_rich_table_mock.call_args[-1]["table_kwargs"]["caption"] == (
+        caption if caption is not False else None
+    )
 
 
 def test_lookahead_helper_export_to_csv(lookahead_conf):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

If a `biased_indicator` starting with `&` appears in a `lookahead-analysis`, caption the table with a note that FreqaAI targets appearing here can be ignored.

Solve the issue: #10620 

## Quick changelog

- Conditionally display a caption on the `lookahead-analysis` table when a `biased_indicator` starts with `&`, reminding the user that this is okay if they have used FreqAI and it is set in `set_freqai_targets()`.
- Updated docs to affirm FreqAI targets can be ignored in a `lookahead-analysis`.

## What's new?

Prevents confusion with an informative table caption when a lookahead-analysis yields a false positive on FreqAI targets. Will not show this caption unless a `biased_indicator` starts with `&`, which helps avoid confusion in the other direction from new users who may be confused by this new caption's meaning.

Instead of the result table looking like this:
![lookahead-analysis_no_caption](https://github.com/user-attachments/assets/038263c1-3ec8-4d1b-afa2-6784382451f8)

It will look like this, but only when there is a `biased_indicator` that starts with `&`. Note the caption below:
![image](https://github.com/user-attachments/assets/d71fa9bc-e6c9-41bf-a41e-bc27d297d978)

And if no `biased_indicators` start with `&`, there is no caption:
![image](https://github.com/user-attachments/assets/fc56a38a-c037-49f6-afb3-dfd11c6b103a)

This includes a result having no `biased_indicators`:
![image](https://github.com/user-attachments/assets/a3ab1dc3-577c-436e-833d-7107625dbc98)