### PR TITLE
fix: orderflow data was missing for plotting

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -520,7 +520,7 @@ class DataProvider:
             return self._exchange.trades(
                 (pair, timeframe or self._config["timeframe"], _candle_type), copy=copy
             )
-        elif self.runmode in (RunMode.BACKTEST, RunMode.HYPEROPT):
+        else:
             data_handler = get_datahandler(
                 self._config["datadir"], data_format=self._config["dataformat_trades"]
             )
@@ -528,9 +528,6 @@ class DataProvider:
                 pair, self._config.get("trading_mode", TradingMode.SPOT)
             )
             return trades_df
-
-        else:
-            return DataFrame()
 
     def market(self, pair: str) -> Optional[Dict[str, Any]]:
         """

--- a/tests/data/test_dataprovider.py
+++ b/tests/data/test_dataprovider.py
@@ -90,13 +90,6 @@ def test_historic_trades(mocker, default_conf, trades_history_df):
     assert isinstance(data, DataFrame)
     assert len(data) == len(trades_history_df)
 
-    # Random other runmode
-    default_conf["runmode"] = RunMode.UTIL_EXCHANGE
-    dp = DataProvider(default_conf, None)
-    data = dp.trades("UNITTEST/BTC", "5m")
-    assert isinstance(data, DataFrame)
-    assert len(data) == 0
-
 
 def test_historic_ohlcv_dataformat(mocker, default_conf, ohlcv_history):
     hdf5loadmock = MagicMock(return_value=ohlcv_history)


### PR DESCRIPTION
## Summary

Orderflow data was missing when using `freqtrade plot-dataframe` because it wasn't loaded when running in runtime `PLOT`

Solve the issue: #6845

## What's new?
![image](https://github.com/user-attachments/assets/b53c5867-850a-4e39-bced-d525e3f91c51)

