### PR TITLE
added check for Kraken exchange

### DIFF
--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -78,7 +78,7 @@ class Kraken(Exchange):
                     # x["side"], x["amount"],
                 )
                 for x in orders
-                if x["price"] is not None
+                if (x["price"] is not None or x["side"] != "sell") and x["remaining"] is not None
             ]
             for bal in balances:
                 if not isinstance(balances[bal], dict):

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -78,6 +78,7 @@ class Kraken(Exchange):
                     # x["side"], x["amount"],
                 )
                 for x in orders
+                if x["price"] is not None
             ]
             for bal in balances:
                 if not isinstance(balances[bal], dict):

--- a/freqtrade/exchange/kraken.py
+++ b/freqtrade/exchange/kraken.py
@@ -78,7 +78,7 @@ class Kraken(Exchange):
                     # x["side"], x["amount"],
                 )
                 for x in orders
-                if (x["price"] is not None or x["side"] != "sell") and x["remaining"] is not None
+                if x["remaining"] is not None and (x["side"] == "sell" or x["price"] is not None)
             ]
             for bal in balances:
                 if not isinstance(balances[bal], dict):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Fixes an issue of mine where kraken does report a trade with Price set to None which crashes the bot.

Solve the issue: -

## Quick changelog

- Implemented check to see if price reports as none

## What's new?
Basically, my bot randomly crashed after I made a trade on Kraken with a Conditional sell order set. As this made Krakens API report a trade with `price: None,` which caused an Error as the line `x["remaining"] if x["side"] == "sell" else x["remaining"] * x["price"],` cannot execute as python cannot comprehend multiplying by None. Since this great project is open source, I've decided to fix it by simply adding the check whether price is None. My bot worked fine and executed trades without any issue, therefore I've decided to do a PR as there may be other people facing this issue in some time.