### PR TITLE
Category for market cap pairlist

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -368,9 +368,13 @@ The optional `bearer_token` will be included in the requests Authorization Heade
 
 `number_assets` defines the maximum number of pairs returned by the pairlist. `max_rank` will determine the maximum rank used in creating/filtering the pairlist. It's expected that some coins within the top `max_rank` marketcap will not be included in the resulting pairlist since not all pairs will have active trading pairs in your preferred market/stake/exchange combination.
 
-`refresh_period` setting defines the period (in seconds) at which the marketcap rank data will be refreshed. Defaults to 86,400s (1 day). The pairlist cache (`refresh_period`) is applicable on both generating pairlists (first position in the list) and filtering instances (not the first position in the list).
+The `refresh_period` setting defines the interval (in seconds) at which the marketcap rank data will be refreshed. The default is 86,400 seconds (1 day). The pairlist cache (`refresh_period`) applies to both generating pairlists (when in the first position in the list) and filtering instances (when not in the first position in the list).
 
-`categories`  settings this defines takes the list of coins from a category on coingecko. (https://www.coingecko.com/en/categories). Defaults to []. If you choose a wrong category string the Plugin will print the categories you that you can choose from on coingecko. Category is the id of the category so e.g. https://www.coingecko.com/en/categories/layer-1 -> `layer-1` would be the category. You can pass in a list `["layer-1", "meme-token"]` is possible if you choose to.
+The `categories` setting specifies the [coingecko categories](https://www.coingecko.com/en/categories) from which to select coins from. The default is an empty list `[]`, meaning no category filtering is applied.
+If an incorrect category string is chosen, the plugin will print the available categories from CoinGecko and fail. The category should be the ID of the category, for example, for `https://www.coingecko.com/en/categories/layer-1`, the category ID would be `layer-1`. You can pass multiple categories such as `["layer-1", "meme-token"]` to select from several categories.
+
+!!! Warning "Many categories"
+    Each added category corresponds to one API call to CoinGecko. The more categories you add, the longer the pairlist generation will take, potentially causing rate limit issues.
 
 #### AgeFilter
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -361,7 +361,7 @@ The optional `bearer_token` will be included in the requests Authorization Heade
         "number_assets": 20,
         "max_rank": 50,
         "refresh_period": 86400,
-        "categories": ['layer-1']
+        "categories": ["layer-1"]
     }
 ]
 ```

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -360,7 +360,8 @@ The optional `bearer_token` will be included in the requests Authorization Heade
         "method": "MarketCapPairList",
         "number_assets": 20,
         "max_rank": 50,
-        "refresh_period": 86400
+        "refresh_period": 86400,
+        "categories": ['layer-1']
     }
 ]
 ```
@@ -368,6 +369,8 @@ The optional `bearer_token` will be included in the requests Authorization Heade
 `number_assets` defines the maximum number of pairs returned by the pairlist. `max_rank` will determine the maximum rank used in creating/filtering the pairlist. It's expected that some coins within the top `max_rank` marketcap will not be included in the resulting pairlist since not all pairs will have active trading pairs in your preferred market/stake/exchange combination.
 
 `refresh_period` setting defines the period (in seconds) at which the marketcap rank data will be refreshed. Defaults to 86,400s (1 day). The pairlist cache (`refresh_period`) is applicable on both generating pairlists (first position in the list) and filtering instances (not the first position in the list).
+
+`categories`  settings this defines takes the list of coins from a category on coingecko. (https://www.coingecko.com/en/categories). Defaults to []. If you choose a wrong category string the Plugin will print the categories you that you can choose from on coingecko. Category is the id of the category so e.g. https://www.coingecko.com/en/categories/layer-1 -> `layer-1` would be the category. You can pass in a list `["layer-1", "meme-token"]` is possible if you choose to.
 
 #### AgeFilter
 

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -38,6 +38,11 @@ class __OptionPairlistParameter(__PairlistParameterBase):
     default: Union[str, None]
     options: List[str]
 
+class __ListPairListParamenter(__PairlistParameterBase):
+    type: Literal["list"]
+    default: Union[List[str], None]
+    options: List[str]
+
 
 class __BoolPairlistParameter(__PairlistParameterBase):
     type: Literal["boolean"]
@@ -49,6 +54,7 @@ PairlistParameter = Union[
     __StringPairlistParameter,
     __OptionPairlistParameter,
     __BoolPairlistParameter,
+    __ListPairListParamenter
 ]
 
 
@@ -68,12 +74,12 @@ class IPairList(LoggingMixin, ABC):
     supports_backtesting: SupportsBacktesting = SupportsBacktesting.NO
 
     def __init__(
-        self,
-        exchange: Exchange,
-        pairlistmanager,
-        config: Config,
-        pairlistconfig: Dict[str, Any],
-        pairlist_pos: int,
+            self,
+            exchange: Exchange,
+            pairlistmanager,
+            config: Config,
+            pairlistconfig: Dict[str, Any],
+            pairlist_pos: int,
     ) -> None:
         """
         :param exchange: Exchange instance
@@ -213,7 +219,7 @@ class IPairList(LoggingMixin, ABC):
         return self._pairlistmanager.verify_blacklist(pairlist, logmethod)
 
     def verify_whitelist(
-        self, pairlist: List[str], logmethod, keep_invalid: bool = False
+            self, pairlist: List[str], logmethod, keep_invalid: bool = False
     ) -> List[str]:
         """
         Proxy method to verify_whitelist for easy access for child classes.

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -42,7 +42,6 @@ class __OptionPairlistParameter(__PairlistParameterBase):
 class __ListPairListParamenter(__PairlistParameterBase):
     type: Literal["list"]
     default: Union[List[str], None]
-    options: List[str]
 
 
 class __BoolPairlistParameter(__PairlistParameterBase):

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -38,6 +38,7 @@ class __OptionPairlistParameter(__PairlistParameterBase):
     default: Union[str, None]
     options: List[str]
 
+
 class __ListPairListParamenter(__PairlistParameterBase):
     type: Literal["list"]
     default: Union[List[str], None]
@@ -54,7 +55,7 @@ PairlistParameter = Union[
     __StringPairlistParameter,
     __OptionPairlistParameter,
     __BoolPairlistParameter,
-    __ListPairListParamenter
+    __ListPairListParamenter,
 ]
 
 
@@ -74,12 +75,12 @@ class IPairList(LoggingMixin, ABC):
     supports_backtesting: SupportsBacktesting = SupportsBacktesting.NO
 
     def __init__(
-            self,
-            exchange: Exchange,
-            pairlistmanager,
-            config: Config,
-            pairlistconfig: Dict[str, Any],
-            pairlist_pos: int,
+        self,
+        exchange: Exchange,
+        pairlistmanager,
+        config: Config,
+        pairlistconfig: Dict[str, Any],
+        pairlist_pos: int,
     ) -> None:
         """
         :param exchange: Exchange instance
@@ -219,7 +220,7 @@ class IPairList(LoggingMixin, ABC):
         return self._pairlistmanager.verify_blacklist(pairlist, logmethod)
 
     def verify_whitelist(
-            self, pairlist: List[str], logmethod, keep_invalid: bool = False
+        self, pairlist: List[str], logmethod, keep_invalid: bool = False
     ) -> List[str]:
         """
         Proxy method to verify_whitelist for easy access for child classes.

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -14,7 +14,6 @@ from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 from freqtrade.util.coin_gecko import FtCoinGeckoApi
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -34,11 +33,9 @@ class MarketCapPairList(IPairList):
         self._stake_currency = self._config["stake_currency"]
         self._number_assets = self._pairlistconfig["number_assets"]
         self._max_rank = self._pairlistconfig.get("max_rank", 30)
-        self._refresh_period = self._pairlistconfig.get(
-            "refresh_period", 86400)
+        self._refresh_period = self._pairlistconfig.get("refresh_period", 86400)
         self._category = self._pairlistconfig.get("category", None)
-        self._marketcap_cache: TTLCache = TTLCache(
-            maxsize=1, ttl=self._refresh_period)
+        self._marketcap_cache: TTLCache = TTLCache(maxsize=1, ttl=self._refresh_period)
         self._def_candletype = self._config["candle_type_def"]
 
         _coingecko_config = self._config.get("coingecko", {})
@@ -48,9 +45,14 @@ class MarketCapPairList(IPairList):
             is_demo=_coingecko_config.get("is_demo", True),
         )
 
+        categories = self._coingecko.get_coins_categories_list()
+        category_ids = [cat['category_id'] for cat in categories]
+
+        if self._category not in category_ids:
+            raise OperationalException(f"category not in coingecko category list you can choose from {category_ids}")
+
         if self._max_rank > 250:
-            raise OperationalException(
-                "This filter only support marketcap rank up to 250.")
+            raise OperationalException("This filter only support marketcap rank up to 250.")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -47,12 +47,13 @@ class MarketCapPairList(IPairList):
 
         if self._categories:
             categories = self._coingecko.get_coins_categories_list()
-            category_ids = [cat['category_id'] for cat in categories]
+            category_ids = [cat["category_id"] for cat in categories]
 
             for category in self._categories:
                 if category not in category_ids:
                     raise OperationalException(
-                        f"category not in coingecko category list you can choose from {category_ids}")
+                        f"category not in coingecko category list you can choose from {category_ids}"
+                    )
 
         if self._max_rank > 250:
             raise OperationalException("This filter only support marketcap rank up to 250.")
@@ -160,18 +161,15 @@ class MarketCapPairList(IPairList):
             data = []
 
             if not self._categories:
-                data = self._coingecko.get_coins_markets(
-                    **default_kwargs
-                )
+                data = self._coingecko.get_coins_markets(**default_kwargs)
             else:
                 for category in self._categories:
                     category_data = self._coingecko.get_coins_markets(
-                        **default_kwargs,
-                        **({"category": category} if category else {})
+                        **default_kwargs, **({"category": category} if category else {})
                     )
                     data += category_data
 
-            data.sort(key=lambda d: float(d['market_cap'] or 0.0), reverse=True)
+            data.sort(key=lambda d: float(d["market_cap"] or 0.0), reverse=True)
 
             if data:
                 marketcap_list = [row["symbol"] for row in data]
@@ -185,7 +183,7 @@ class MarketCapPairList(IPairList):
             if market == "futures":
                 pair_format += f":{self._stake_currency.upper()}"
 
-            top_marketcap = marketcap_list[: self._max_rank:]
+            top_marketcap = marketcap_list[: self._max_rank :]
 
             for mc_pair in top_marketcap:
                 test_pair = f"{mc_pair.upper()}/{pair_format}"

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -14,6 +14,7 @@ from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 from freqtrade.util.coin_gecko import FtCoinGeckoApi
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -46,10 +47,12 @@ class MarketCapPairList(IPairList):
         )
 
         categories = self._coingecko.get_coins_categories_list()
-        category_ids = [cat['category_id'] for cat in categories]
+        category_ids = [cat["category_id"] for cat in categories]
 
         if self._category not in category_ids:
-            raise OperationalException(f"category not in coingecko category list you can choose from {category_ids}")
+            raise OperationalException(
+                f"category not in coingecko category list you can choose from {category_ids}"
+            )
 
         if self._max_rank > 250:
             raise OperationalException("This filter only support marketcap rank up to 250.")
@@ -145,7 +148,6 @@ class MarketCapPairList(IPairList):
         marketcap_list = self._marketcap_cache.get("marketcap")
 
         if marketcap_list is None:
-
             data = self._coingecko.get_coins_markets(
                 vs_currency="usd",
                 order="market_cap_desc",
@@ -153,7 +155,7 @@ class MarketCapPairList(IPairList):
                 page="1",
                 sparkline="false",
                 locale="en",
-                **({"category": self._category} if self._category else {})
+                **({"category": self._category} if self._category else {}),
             )
             if data:
                 marketcap_list = [row["symbol"] for row in data]
@@ -167,7 +169,7 @@ class MarketCapPairList(IPairList):
             if market == "futures":
                 pair_format += f":{self._stake_currency.upper()}"
 
-            top_marketcap = marketcap_list[: self._max_rank:]
+            top_marketcap = marketcap_list[: self._max_rank :]
 
             for mc_pair in top_marketcap:
                 test_pair = f"{mc_pair.upper()}/{pair_format}"

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -173,7 +173,7 @@ class MarketCapPairList(IPairList):
                     )
                     data += category_data
 
-            data.sort(key=lambda d: float(d["market_cap"] or 0.0), reverse=True)
+            data.sort(key=lambda d: float(d.get("market_cap") or 0.0), reverse=True)
 
             if data:
                 marketcap_list = [row["symbol"] for row in data]

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -14,7 +14,6 @@ from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 from freqtrade.util.coin_gecko import FtCoinGeckoApi
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +34,7 @@ class MarketCapPairList(IPairList):
         self._number_assets = self._pairlistconfig["number_assets"]
         self._max_rank = self._pairlistconfig.get("max_rank", 30)
         self._refresh_period = self._pairlistconfig.get("refresh_period", 86400)
-        self._category = self._pairlistconfig.get("category", None)
+        self._categories = self._pairlistconfig.get("categories", [])
         self._marketcap_cache: TTLCache = TTLCache(maxsize=1, ttl=self._refresh_period)
         self._def_candletype = self._config["candle_type_def"]
 
@@ -46,14 +45,14 @@ class MarketCapPairList(IPairList):
             is_demo=_coingecko_config.get("is_demo", True),
         )
 
-        if self._category:
+        if self._categories:
             categories = self._coingecko.get_coins_categories_list()
-            category_ids = [cat["category_id"] for cat in categories]
+            category_ids = [cat['category_id'] for cat in categories]
 
-            if self._category not in category_ids:
-                raise OperationalException(
-                    f"category not in coingecko category list you can choose from {category_ids}"
-                )
+            for category in self._categories:
+                if category not in category_ids:
+                    raise OperationalException(
+                        f"category not in coingecko category list you can choose from {category_ids}")
 
         if self._max_rank > 250:
             raise OperationalException("This filter only support marketcap rank up to 250.")
@@ -95,11 +94,11 @@ class MarketCapPairList(IPairList):
                 "description": "Max rank of assets",
                 "help": "Maximum rank of assets to use from the pairlist",
             },
-            "category": {
-                "type": "string",
-                "default": None,
-                "description": "The Category",
-                "help": "Th Category of the coin e.g layer-1 default None",
+            "categories": {
+                "type": "list",
+                "default": [],
+                "description": "The Categories to be set",
+                "help": "The Category of the coin e.g layer-1 default [] (https://www.coingecko.com/en/categories)",
             },
             "refresh_period": {
                 "type": "number",
@@ -148,16 +147,32 @@ class MarketCapPairList(IPairList):
         """
         marketcap_list = self._marketcap_cache.get("marketcap")
 
+        default_kwargs = {
+            "vs_currency": "usd",
+            "order": "market_cap_desc",
+            "per_page": "250",
+            "page": "1",
+            "sparkline": "false",
+            "locale": "en",
+        }
+
         if marketcap_list is None:
-            data = self._coingecko.get_coins_markets(
-                vs_currency="usd",
-                order="market_cap_desc",
-                per_page="250",
-                page="1",
-                sparkline="false",
-                locale="en",
-                **({"category": self._category} if self._category else {}),
-            )
+            data = []
+
+            if not self._categories:
+                data = self._coingecko.get_coins_markets(
+                    **default_kwargs
+                )
+            else:
+                for category in self._categories:
+                    category_data = self._coingecko.get_coins_markets(
+                        **default_kwargs,
+                        **({"category": category} if category else {})
+                    )
+                    data += category_data
+
+            data.sort(key=lambda d: float(d['market_cap'] or 0.0), reverse=True)
+
             if data:
                 marketcap_list = [row["symbol"] for row in data]
                 self._marketcap_cache["marketcap"] = marketcap_list
@@ -170,11 +185,11 @@ class MarketCapPairList(IPairList):
             if market == "futures":
                 pair_format += f":{self._stake_currency.upper()}"
 
-            top_marketcap = marketcap_list[: self._max_rank :]
+            top_marketcap = marketcap_list[: self._max_rank:]
 
             for mc_pair in top_marketcap:
                 test_pair = f"{mc_pair.upper()}/{pair_format}"
-                if test_pair in pairlist:
+                if test_pair in pairlist and test_pair not in filtered_pairlist:
                     filtered_pairlist.append(test_pair)
                     if len(filtered_pairlist) == self._number_assets:
                         break

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -53,7 +53,7 @@ class MarketCapPairList(IPairList):
             for category in self._categories:
                 if category not in category_ids:
                     raise OperationalException(
-                        f"category {category} not in coingecko category list. "
+                        f"Category {category} not in coingecko category list. "
                         f"You can choose from {category_ids}"
                     )
 

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -143,8 +143,6 @@ class MarketCapPairList(IPairList):
         marketcap_list = self._marketcap_cache.get("marketcap")
 
         if marketcap_list is None:
-            # categories = self._coingecko.get_coins_categories()
-            # print([cat['id'] for cat in categories])
 
             data = self._coingecko.get_coins_markets(
                 vs_currency="usd",

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -34,9 +34,11 @@ class MarketCapPairList(IPairList):
         self._stake_currency = self._config["stake_currency"]
         self._number_assets = self._pairlistconfig["number_assets"]
         self._max_rank = self._pairlistconfig.get("max_rank", 30)
-        self._refresh_period = self._pairlistconfig.get("refresh_period", 86400)
+        self._refresh_period = self._pairlistconfig.get(
+            "refresh_period", 86400)
         self._category = self._pairlistconfig.get("category", None)
-        self._marketcap_cache: TTLCache = TTLCache(maxsize=1, ttl=self._refresh_period)
+        self._marketcap_cache: TTLCache = TTLCache(
+            maxsize=1, ttl=self._refresh_period)
         self._def_candletype = self._config["candle_type_def"]
 
         _coingecko_config = self._config.get("coingecko", {})
@@ -47,7 +49,8 @@ class MarketCapPairList(IPairList):
         )
 
         if self._max_rank > 250:
-            raise OperationalException("This filter only support marketcap rank up to 250.")
+            raise OperationalException(
+                "This filter only support marketcap rank up to 250.")
 
     @property
     def needstickers(self) -> bool:

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -46,13 +46,14 @@ class MarketCapPairList(IPairList):
             is_demo=_coingecko_config.get("is_demo", True),
         )
 
-        categories = self._coingecko.get_coins_categories_list()
-        category_ids = [cat["category_id"] for cat in categories]
+        if self._category:
+            categories = self._coingecko.get_coins_categories_list()
+            category_ids = [cat["category_id"] for cat in categories]
 
-        if self._category not in category_ids:
-            raise OperationalException(
-                f"category not in coingecko category list you can choose from {category_ids}"
-            )
+            if self._category not in category_ids:
+                raise OperationalException(
+                    f"category not in coingecko category list you can choose from {category_ids}"
+                )
 
         if self._max_rank > 250:
             raise OperationalException("This filter only support marketcap rank up to 250.")
@@ -173,7 +174,7 @@ class MarketCapPairList(IPairList):
 
             for mc_pair in top_marketcap:
                 test_pair = f"{mc_pair.upper()}/{pair_format}"
-                if test_pair in pairlist and test_pair not in filtered_pairlist:
+                if test_pair in pairlist:
                     filtered_pairlist.append(test_pair)
                     if len(filtered_pairlist) == self._number_assets:
                         break

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -53,7 +53,8 @@ class MarketCapPairList(IPairList):
             for category in self._categories:
                 if category not in category_ids:
                     raise OperationalException(
-                        f"category not in coingecko category list you can choose from {category_ids}"
+                        f"category {category} not in coingecko category list. "
+                        f"You can choose from {category_ids}"
                     )
 
         if self._max_rank > 250:

--- a/freqtrade/plugins/pairlist/MarketCapPairList.py
+++ b/freqtrade/plugins/pairlist/MarketCapPairList.py
@@ -14,6 +14,7 @@ from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 from freqtrade.util.coin_gecko import FtCoinGeckoApi
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -98,8 +99,11 @@ class MarketCapPairList(IPairList):
             "categories": {
                 "type": "list",
                 "default": [],
-                "description": "The Categories to be set",
-                "help": "The Category of the coin e.g layer-1 default [] (https://www.coingecko.com/en/categories)",
+                "description": "Coin Categories",
+                "help": (
+                    "The Category of the coin e.g layer-1 default [] "
+                    "(https://www.coingecko.com/en/categories)"
+                ),
             },
             "refresh_period": {
                 "type": "number",

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -2438,6 +2438,27 @@ def test_MarketCapPairList_exceptions(mocker, default_conf_usdt):
     ):
         PairListManager(exchange, default_conf_usdt)
 
+    # Test invalid coinmarkets list
+    mocker.patch(
+        "freqtrade.plugins.pairlist.MarketCapPairList.FtCoinGeckoApi.get_coins_categories_list",
+        return_value=[
+            {"category_id": "layer-1"},
+            {"category_id": "protocol"},
+            {"category_id": "defi"},
+        ],
+    )
+    default_conf_usdt["pairlists"] = [
+        {
+            "method": "MarketCapPairList",
+            "number_assets": 20,
+            "categories": ["layer-1", "defi", "layer250"],
+        }
+    ]
+    with pytest.raises(
+        OperationalException, match="category layer250 not in coingecko category list."
+    ):
+        PairListManager(exchange, default_conf_usdt)
+
 
 @pytest.mark.parametrize(
     "pairlists,expected_error,expected_warning",

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -2455,7 +2455,7 @@ def test_MarketCapPairList_exceptions(mocker, default_conf_usdt):
         }
     ]
     with pytest.raises(
-        OperationalException, match="category layer250 not in coingecko category list."
+        OperationalException, match="Category layer250 not in coingecko category list."
     ):
         PairListManager(exchange, default_conf_usdt)
 

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -2212,7 +2212,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
 
 
 @pytest.mark.parametrize(
-    "pairlists,trade_mode,result",
+    "pairlists,trade_mode,result,coin_market_calls",
     [
         (
             [
@@ -2222,6 +2222,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT"],
+            1,
         ),
         (
             [
@@ -2231,6 +2232,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT", "XRP/USDT", "ADA/USDT"],
+            1,
         ),
         (
             [
@@ -2240,6 +2242,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT", "XRP/USDT"],
+            1,
         ),
         (
             [
@@ -2249,6 +2252,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT", "XRP/USDT"],
+            1,
         ),
         (
             [
@@ -2257,6 +2261,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT", "XRP/USDT"],
+            1,
         ),
         (
             [
@@ -2265,6 +2270,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "spot",
             ["BTC/USDT", "ETH/USDT"],
+            1,
         ),
         (
             [
@@ -2273,6 +2279,7 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "futures",
             ["ETH/USDT:USDT"],
+            1,
         ),
         (
             [
@@ -2281,11 +2288,34 @@ def test_FullTradesFilter(mocker, default_conf_usdt, fee, caplog) -> None:
             ],
             "futures",
             ["ETH/USDT:USDT", "ADA/USDT:USDT"],
+            1,
+        ),
+        (
+            [
+                # MarketCapPairList as generator - futures, 1 category
+                {"method": "MarketCapPairList", "number_assets": 2, "categories": ["layer-1"]}
+            ],
+            "futures",
+            ["ETH/USDT:USDT", "ADA/USDT:USDT"],
+            ["layer-1"],
+        ),
+        (
+            [
+                # MarketCapPairList as generator - futures, 1 category
+                {
+                    "method": "MarketCapPairList",
+                    "number_assets": 2,
+                    "categories": ["layer-1", "protocol"],
+                }
+            ],
+            "futures",
+            ["ETH/USDT:USDT", "ADA/USDT:USDT"],
+            ["layer-1", "protocol"],
         ),
     ],
 )
 def test_MarketCapPairList_filter(
-    mocker, default_conf_usdt, trade_mode, markets, pairlists, result
+    mocker, default_conf_usdt, trade_mode, markets, pairlists, result, coin_market_calls
 ):
     test_value = [
         {"symbol": "btc"},
@@ -2309,8 +2339,16 @@ def test_MarketCapPairList_filter(
         markets=PropertyMock(return_value=markets),
         exchange_has=MagicMock(return_value=True),
     )
-
     mocker.patch(
+        "freqtrade.plugins.pairlist.MarketCapPairList.FtCoinGeckoApi.get_coins_categories_list",
+        return_value=[
+            {"category_id": "layer-1"},
+            {"category_id": "protocol"},
+            {"category_id": "defi"},
+        ],
+    )
+
+    gcm_mock = mocker.patch(
         "freqtrade.plugins.pairlist.MarketCapPairList.FtCoinGeckoApi.get_coins_markets",
         return_value=test_value,
     )
@@ -2319,6 +2357,15 @@ def test_MarketCapPairList_filter(
 
     pm = PairListManager(exchange, default_conf_usdt)
     pm.refresh_pairlist()
+    if isinstance(coin_market_calls, int):
+        assert gcm_mock.call_count == coin_market_calls
+    else:
+        assert gcm_mock.call_count == len(coin_market_calls)
+        for call in coin_market_calls:
+            assert any(
+                "category" in c.kwargs and c.kwargs["category"] == call
+                for c in gcm_mock.call_args_list
+            )
 
     assert pm.whitelist == result
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This will add the category  MarketCapPairlist 
e.g. you could use `layer-1` https://www.coingecko.com/en/categories/layer-1
so only the layer 1 pairs would appear in the pairlist

## Quick changelog

- adding category Filter for MarketCapPairlist

## What's new?

adding category Filter for MarketCapPairlist