### PR TITLE
fix: Update BasePyTorchRegressor.py

### DIFF
--- a/freqtrade/freqai/base_models/BasePyTorchRegressor.py
+++ b/freqtrade/freqai/base_models/BasePyTorchRegressor.py
@@ -86,9 +86,6 @@ class BasePyTorchRegressor(BasePyTorchModel):
         dk.feature_pipeline = self.define_data_pipeline(threads=dk.thread_count)
         dk.label_pipeline = self.define_label_pipeline(threads=dk.thread_count)
 
-        dd["train_labels"], _, _ = dk.label_pipeline.fit_transform(dd["train_labels"])
-        dd["test_labels"], _, _ = dk.label_pipeline.transform(dd["test_labels"])
-
         (dd["train_features"], dd["train_labels"], dd["train_weights"]) = (
             dk.feature_pipeline.fit_transform(
                 dd["train_features"], dd["train_labels"], dd["train_weights"]

--- a/freqtrade/freqai/prediction_models/PyTorchTransformerRegressor.py
+++ b/freqtrade/freqai/prediction_models/PyTorchTransformerRegressor.py
@@ -141,7 +141,7 @@ class PyTorchTransformerRegressor(BasePyTorchRegressor):
         pred_df = pd.DataFrame(yb.detach().numpy(), columns=dk.label_list)
         pred_df, _, _ = dk.label_pipeline.inverse_transform(pred_df)
 
-        if self.freqai_info.get("DI_threshold", 0) > 0:
+        if self.ft_params.get("DI_threshold", 0) > 0:
             dk.DI_values = dk.feature_pipeline["di"].di_values
         else:
             dk.DI_values = np.zeros(outliers.shape[0])


### PR DESCRIPTION
Thanks to @roozich, the scaling was identified as occurring twice which prevented proper inversion during prediction. This PR fixes it.