### PR TITLE
Download Data for Open Positions in FreqAI

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from collections import defaultdict
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from freqtrade.configuration import TimeRange, setup_utils_configuration
 from freqtrade.constants import DATETIME_PRINT_FORMAT, DL_DATA_TIMEFRAMES, Config
@@ -15,6 +15,7 @@ from freqtrade.enums import CandleType, RunMode, TradingMode
 from freqtrade.exceptions import ConfigurationError
 from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.misc import plural
+from freqtrade.persistence import Trade
 from freqtrade.plugins.pairlist.pairlist_helpers import dynamic_expand_pairlist
 from freqtrade.resolvers import ExchangeResolver
 from freqtrade.util import print_rich_table
@@ -78,6 +79,11 @@ def start_convert_trades(args: Dict[str, Any]) -> None:
     ]
 
     expanded_pairs = dynamic_expand_pairlist(config, available_pairs)
+
+    # ensure we download data for opened positions pairs
+    trades: List[Trade] = Trade.get_open_trades()
+    info_list = [trade.pair for trade in trades if trade.pair not in expanded_pairs]
+    expanded_pairs += info_list
 
     # Convert downloaded trade data to different timeframes
     convert_trades_to_ohlcv(

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -15,6 +15,7 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_seconds
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+from freqtrade.persistence import Trade
 from freqtrade.plugins.pairlist.pairlist_helpers import dynamic_expand_pairlist
 
 
@@ -40,6 +41,11 @@ def download_all_data_for_training(dp: DataProvider, config: Config) -> None:
     ]
 
     all_pairs = dynamic_expand_pairlist(config, markets)
+
+    # ensure we download data for opened positions pairs
+    trades: List[Trade] = Trade.get_open_trades()
+    new_pairs_list = [trade.pair for trade in trades if trade.pair not in all_pairs]
+    all_pairs += new_pairs_list
 
     timerange = get_required_data_timerange(config)
 


### PR DESCRIPTION
## Summary

Previously, FreqAI didn't download OHLC dataframes for pairs with open positions when the whitelist was changed. This could lead to training issues. This pull request modifies three files (freqtrade/freqai/utils.py, freqtrade/commands/data_commands.py, and freqtrade/freqai/freqai_interface.py) to ensure FreqAI downloads data for both pairs specified in the whitelist and pairs with open positions.


## Quick changelog

- Added code to retrieve open trades and add their pairs to the download list.
- Improved data retrieval for FreqAI to include pairs with open positions.

## What's new?

This pull request enhances FreqAI's data handling capabilities by ensuring that it downloads data for open positions, even when the whitelist is updated. This is crucial for maintaining accurate training and predictions.
