### PR TITLE
Improved liquidation price logic

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -144,7 +144,9 @@ class Binance(Exchange):
         """
         return open_date.minute == 0 and open_date.second < 15
 
-    def fetch_funding_rates(self, symbols: Optional[List[str]] = None) -> Dict[str, float]:
+    def fetch_funding_rates(
+        self, symbols: Optional[List[str]] = None
+    ) -> Dict[str, Dict[str, float]]:
         """
         Fetch funding rates for the given symbols.
         :param symbols: List of symbols to fetch funding rates for

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -212,20 +212,20 @@ class Binance(Exchange):
         if self.margin_mode == MarginMode.CROSS:
             mm_ex_1: float = 0.0
             upnl_ex_1: float = 0.0
-            pairs = [trade["pair"] for trade in open_trades]
+            pairs = [trade.pair for trade in open_trades]
             funding_rates = self.fetch_funding_rates(pairs)
             for trade in open_trades:
-                if trade["pair"] == pair:
+                if trade.pair == pair:
                     # Only "other" trades are considered
                     continue
-                mark_price = funding_rates[trade["pair"]]["markPrice"]
+                mark_price = funding_rates[trade.pair]["markPrice"]
                 mm_ratio1, maint_amnt1 = self.get_maintenance_ratio_and_amt(
-                    trade["pair"], trade["stake_amount"]
+                    trade.pair, trade.stake_amount
                 )
-                maint_margin = trade["amount"] * mark_price * mm_ratio1 - maint_amnt1
+                maint_margin = trade.amount * mark_price * mm_ratio1 - maint_amnt1
                 mm_ex_1 += maint_margin
 
-                upnl_ex_1 += trade["amount"] * mark_price - trade["amount"] * trade["open_rate"]
+                upnl_ex_1 += trade.amount * mark_price - trade.amount * trade.open_rate
             cross_vars = upnl_ex_1 - mm_ex_1
 
         side_1 = -1 if is_short else 1

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -153,7 +153,7 @@ class Binance(Exchange):
         stake_amount: float,
         leverage: float,
         wallet_balance: float,  # Or margin balance
-        other_trades: list,
+        open_trades: list,
     ) -> Optional[float]:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
@@ -171,7 +171,7 @@ class Binance(Exchange):
         :param wallet_balance: Amount of margin_mode in the wallet being used to trade
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
-        :param other_trades: List of other open trades in the same wallet
+        :param open_trades: List of open trades in the same wallet
 
         # * Only required for Cross
         :param mm_ex_1: (TMM)
@@ -191,7 +191,7 @@ class Binance(Exchange):
         if self.margin_mode == MarginMode.CROSS:
             mm_ex_1: float = 0.0
             upnl_ex_1: float = 0.0
-            for trade in other_trades:
+            for trade in open_trades:
                 mm_ratio1, maint_amnt1 = self.get_maintenance_ratio_and_amt(
                     trade["pair"], trade["stake_amount"]
                 )

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -192,6 +192,9 @@ class Binance(Exchange):
             mm_ex_1: float = 0.0
             upnl_ex_1: float = 0.0
             for trade in open_trades:
+                if trade["pair"] == pair:
+                    # Only "other" trades are considered
+                    continue
                 mm_ratio1, maint_amnt1 = self.get_maintenance_ratio_and_amt(
                     trade["pair"], trade["stake_amount"]
                 )

--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -147,7 +147,7 @@ class Bybit(Exchange):
         stake_amount: float,
         leverage: float,
         wallet_balance: float,  # Or margin balance
-        other_trades: list,
+        open_trades: list,
     ) -> Optional[float]:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
@@ -177,7 +177,7 @@ class Bybit(Exchange):
         :param wallet_balance: Amount of margin_mode in the wallet being used to trade
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
-        :param other_trades: List of other open trades in the same wallet
+        :param open_trades: List of other open trades in the same wallet
         """
 
         market = self.markets[pair]

--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -147,8 +147,7 @@ class Bybit(Exchange):
         stake_amount: float,
         leverage: float,
         wallet_balance: float,  # Or margin balance
-        mm_ex_1: float = 0.0,  # (Binance) Cross only
-        upnl_ex_1: float = 0.0,  # (Binance) Cross only
+        other_trades: list,
     ) -> Optional[float]:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
@@ -178,6 +177,7 @@ class Bybit(Exchange):
         :param wallet_balance: Amount of margin_mode in the wallet being used to trade
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
+        :param other_trades: List of other open trades in the same wallet
         """
 
         market = self.markets[pair]

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -3532,8 +3532,7 @@ class Exchange:
         stake_amount: float,
         leverage: float,
         wallet_balance: float,
-        mm_ex_1: float = 0.0,  # (Binance) Cross only
-        upnl_ex_1: float = 0.0,  # (Binance) Cross only
+        other_trades: list,
     ) -> Optional[float]:
         """
         Set's the margin mode on the exchange to cross or isolated for a specific pair
@@ -3555,8 +3554,7 @@ class Exchange:
                 leverage=leverage,
                 stake_amount=stake_amount,
                 wallet_balance=wallet_balance,
-                mm_ex_1=mm_ex_1,
-                upnl_ex_1=upnl_ex_1,
+                other_trades=other_trades,
             )
         else:
             positions = self.fetch_positions(pair)
@@ -3582,8 +3580,7 @@ class Exchange:
         stake_amount: float,
         leverage: float,
         wallet_balance: float,  # Or margin balance
-        mm_ex_1: float = 0.0,  # (Binance) Cross only
-        upnl_ex_1: float = 0.0,  # (Binance) Cross only
+        other_trades: list,
     ) -> Optional[float]:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
@@ -3608,10 +3605,7 @@ class Exchange:
         :param wallet_balance: Amount of margin_mode in the wallet being used to trade
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
-
-        # * Not required by Gate or OKX
-        :param mm_ex_1:
-        :param upnl_ex_1:
+        :param other_trades: List of other open trades in the same wallet
         """
 
         market = self.markets[pair]

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -3532,7 +3532,7 @@ class Exchange:
         stake_amount: float,
         leverage: float,
         wallet_balance: float,
-        other_trades: list,
+        other_trades: Optional[list] = None,
     ) -> Optional[float]:
         """
         Set's the margin mode on the exchange to cross or isolated for a specific pair
@@ -3554,7 +3554,7 @@ class Exchange:
                 leverage=leverage,
                 stake_amount=stake_amount,
                 wallet_balance=wallet_balance,
-                other_trades=other_trades,
+                other_trades=other_trades or [],
             )
         else:
             positions = self.fetch_positions(pair)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -3532,7 +3532,7 @@ class Exchange:
         stake_amount: float,
         leverage: float,
         wallet_balance: float,
-        other_trades: Optional[list] = None,
+        open_trades: Optional[list] = None,
     ) -> Optional[float]:
         """
         Set's the margin mode on the exchange to cross or isolated for a specific pair
@@ -3554,7 +3554,7 @@ class Exchange:
                 leverage=leverage,
                 stake_amount=stake_amount,
                 wallet_balance=wallet_balance,
-                other_trades=other_trades or [],
+                open_trades=open_trades or [],
             )
         else:
             positions = self.fetch_positions(pair)
@@ -3580,7 +3580,7 @@ class Exchange:
         stake_amount: float,
         leverage: float,
         wallet_balance: float,  # Or margin balance
-        other_trades: list,
+        open_trades: list,
     ) -> Optional[float]:
         """
         Important: Must be fetching data from cached values as this is used by backtesting!
@@ -3605,7 +3605,7 @@ class Exchange:
         :param wallet_balance: Amount of margin_mode in the wallet being used to trade
             Cross-Margin Mode: crossWalletBalance
             Isolated-Margin Mode: isolatedWalletBalance
-        :param other_trades: List of other open trades in the same wallet
+        :param open_trades: List of other open trades in the same wallet
         """
 
         market = self.markets[pair]

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2157,6 +2157,45 @@ class FreqtradeBot(LoggingMixin):
     # Common update trade state methods
     #
 
+    def update_liquidation_prices(self, trade: Optional[Trade] = None):
+        """
+        Update trade liquidation price in isolated margin mode.
+        Updates liquidation price for all trades in cross margin mode.
+        TODO: this is missing a dedicated test!
+        """
+        total_wallet_stake = 0.0
+        if self.config["dry_run"] and self.exchange.margin_mode == MarginMode.CROSS:
+            # Parameters only needed for cross margin
+            total_wallet_stake = self.wallets.get_total(self.config["stake_currency"])
+
+        if self.exchange.margin_mode == MarginMode.CROSS:
+            logger.info("Updating liquidation price for all open trades.")
+            for t in Trade.get_open_trades():
+                # TODO: This should be done in a batch update
+                t.set_liquidation_price(
+                    self.exchange.get_liquidation_price(
+                        pair=t.pair,
+                        open_rate=t.open_rate,
+                        is_short=t.is_short,
+                        amount=t.amount,
+                        stake_amount=t.stake_amount,
+                        leverage=trade.leverage,
+                        wallet_balance=total_wallet_stake,
+                    )
+                )
+        elif trade:
+            trade.set_liquidation_price(
+                self.exchange.get_liquidation_price(
+                    pair=trade.pair,
+                    open_rate=trade.open_rate,
+                    is_short=trade.is_short,
+                    amount=trade.amount,
+                    stake_amount=trade.stake_amount,
+                    leverage=trade.leverage,
+                    wallet_balance=trade.stake_amount,
+                )
+            )
+
     def update_trade_state(
         self,
         trade: Trade,
@@ -2234,17 +2273,7 @@ class FreqtradeBot(LoggingMixin):
                 # TODO: Margin will need to use interest_rate as well.
                 # interest_rate = self.exchange.get_interest_rate()
                 try:
-                    trade.set_liquidation_price(
-                        self.exchange.get_liquidation_price(
-                            pair=trade.pair,
-                            open_rate=trade.open_rate,
-                            is_short=trade.is_short,
-                            amount=trade.amount,
-                            stake_amount=trade.stake_amount,
-                            leverage=trade.leverage,
-                            wallet_balance=trade.stake_amount,
-                        )
-                    )
+                    self.update_liquidation_prices(trade)
                 except DependencyException:
                     logger.warning("Unable to calculate liquidation price")
                 if self.strategy.use_custom_stoploss:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2163,12 +2163,11 @@ class FreqtradeBot(LoggingMixin):
         Updates liquidation price for all trades in cross margin mode.
         TODO: this is missing a dedicated test!
         """
-        total_wallet_stake = 0.0
-        if self.config["dry_run"] and self.exchange.margin_mode == MarginMode.CROSS:
-            # Parameters only needed for cross margin
-            total_wallet_stake = self.wallets.get_total(self.config["stake_currency"])
-
         if self.exchange.margin_mode == MarginMode.CROSS:
+            total_wallet_stake = 0.0
+            if self.config["dry_run"]:
+                # Parameters only needed for cross margin
+                total_wallet_stake = self.wallets.get_total(self.config["stake_currency"])
             logger.info("Updating liquidation price for all open trades.")
             for t in Trade.get_open_trades():
                 # TODO: This should be done in a batch update

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2233,16 +2233,13 @@ class FreqtradeBot(LoggingMixin):
                 # Must also run for partial exits
                 # TODO: Margin will need to use interest_rate as well.
                 # interest_rate = self.exchange.get_interest_rate()
-                try:
-                    update_liquidation_prices(
-                        trade,
-                        exchange=self.exchange,
-                        wallets=self.wallets,
-                        stake_currency=self.config["stake_currency"],
-                        dry_run=self.config["dry_run"],
-                    )
-                except DependencyException:
-                    logger.warning("Unable to calculate liquidation price")
+                update_liquidation_prices(
+                    trade,
+                    exchange=self.exchange,
+                    wallets=self.wallets,
+                    stake_currency=self.config["stake_currency"],
+                    dry_run=self.config["dry_run"],
+                )
                 if self.strategy.use_custom_stoploss:
                     current_rate = self.exchange.get_rate(
                         trade.pair, side="exit", is_short=trade.is_short, refresh=True

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -43,7 +43,7 @@ def update_liquidation_prices(
                         stake_amount=t.stake_amount,
                         leverage=trade.leverage,
                         wallet_balance=total_wallet_stake,
-                        other_trades=[tr for tr in open_trades if t.id != tr.id],
+                        open_trades=[tr for tr in open_trades],
                     )
                 )
         elif trade:

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -43,7 +43,7 @@ def update_liquidation_prices(
                         stake_amount=t.stake_amount,
                         leverage=trade.leverage,
                         wallet_balance=total_wallet_stake,
-                        open_trades=[tr for tr in open_trades],
+                        open_trades=open_trades,
                     )
                 )
         elif trade:

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -20,7 +20,6 @@ def update_liquidation_prices(
     """
     Update trade liquidation price in isolated margin mode.
     Updates liquidation price for all trades in cross margin mode.
-    TODO: this is missing a dedicated test!
     """
     if exchange.margin_mode == MarginMode.CROSS:
         total_wallet_stake = 0.0
@@ -42,7 +41,7 @@ def update_liquidation_prices(
                     wallet_balance=total_wallet_stake,
                 )
             )
-    elif trade:
+    else:
         trade.set_liquidation_price(
             exchange.get_liquidation_price(
                 pair=trade.pair,

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -39,6 +39,7 @@ def update_liquidation_prices(
                     stake_amount=t.stake_amount,
                     leverage=trade.leverage,
                     wallet_balance=total_wallet_stake,
+                    other_trades=[],  # TODO: Add other trades
                 )
             )
     else:
@@ -51,5 +52,6 @@ def update_liquidation_prices(
                 stake_amount=trade.stake_amount,
                 leverage=trade.leverage,
                 wallet_balance=trade.stake_amount,
+                other_trades=[],
             )
         )

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -56,7 +56,6 @@ def update_liquidation_prices(
                     stake_amount=trade.stake_amount,
                     leverage=trade.leverage,
                     wallet_balance=trade.stake_amount,
-                    other_trades=[],
                 )
             )
         else:

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -1,0 +1,56 @@
+import logging
+
+from freqtrade.enums import MarginMode
+from freqtrade.exchange import Exchange
+from freqtrade.persistence import LocalTrade, Trade
+from freqtrade.wallets import Wallets
+
+
+logger = logging.getLogger(__name__)
+
+
+def update_liquidation_prices(
+    trade: LocalTrade,
+    *,
+    exchange: Exchange,
+    wallets: Wallets,
+    stake_currency: str,
+    dry_run: bool = False,
+):
+    """
+    Update trade liquidation price in isolated margin mode.
+    Updates liquidation price for all trades in cross margin mode.
+    TODO: this is missing a dedicated test!
+    """
+    if exchange.margin_mode == MarginMode.CROSS:
+        total_wallet_stake = 0.0
+        if dry_run:
+            # Parameters only needed for cross margin
+            total_wallet_stake = wallets.get_total(stake_currency)
+
+        logger.info("Updating liquidation price for all open trades.")
+        for t in Trade.get_open_trades():
+            # TODO: This should be done in a batch update
+            t.set_liquidation_price(
+                exchange.get_liquidation_price(
+                    pair=t.pair,
+                    open_rate=t.open_rate,
+                    is_short=t.is_short,
+                    amount=t.amount,
+                    stake_amount=t.stake_amount,
+                    leverage=trade.leverage,
+                    wallet_balance=total_wallet_stake,
+                )
+            )
+    elif trade:
+        trade.set_liquidation_price(
+            exchange.get_liquidation_price(
+                pair=trade.pair,
+                open_rate=trade.open_rate,
+                is_short=trade.is_short,
+                amount=trade.amount,
+                stake_amount=trade.stake_amount,
+                leverage=trade.leverage,
+                wallet_balance=trade.stake_amount,
+            )
+        )

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -41,7 +41,7 @@ def update_liquidation_prices(
                         is_short=t.is_short,
                         amount=t.amount,
                         stake_amount=t.stake_amount,
-                        leverage=trade.leverage,
+                        leverage=t.leverage,
                         wallet_balance=total_wallet_stake,
                         open_trades=open_trades,
                     )

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -1,6 +1,7 @@
 import logging
 
 from freqtrade.enums import MarginMode
+from freqtrade.exceptions import DependencyException
 from freqtrade.exchange import Exchange
 from freqtrade.persistence import LocalTrade, Trade
 from freqtrade.wallets import Wallets
@@ -21,37 +22,40 @@ def update_liquidation_prices(
     Update trade liquidation price in isolated margin mode.
     Updates liquidation price for all trades in cross margin mode.
     """
-    if exchange.margin_mode == MarginMode.CROSS:
-        total_wallet_stake = 0.0
-        if dry_run:
-            # Parameters only needed for cross margin
-            total_wallet_stake = wallets.get_total(stake_currency)
+    try:
+        if exchange.margin_mode == MarginMode.CROSS:
+            total_wallet_stake = 0.0
+            if dry_run:
+                # Parameters only needed for cross margin
+                total_wallet_stake = wallets.get_total(stake_currency)
 
-        logger.info("Updating liquidation price for all open trades.")
-        for t in Trade.get_open_trades():
-            # TODO: This should be done in a batch update
-            t.set_liquidation_price(
+            logger.info("Updating liquidation price for all open trades.")
+            for t in Trade.get_open_trades():
+                # TODO: This should be done in a batch update
+                t.set_liquidation_price(
+                    exchange.get_liquidation_price(
+                        pair=t.pair,
+                        open_rate=t.open_rate,
+                        is_short=t.is_short,
+                        amount=t.amount,
+                        stake_amount=t.stake_amount,
+                        leverage=trade.leverage,
+                        wallet_balance=total_wallet_stake,
+                        other_trades=[],  # TODO: Add other trades
+                    )
+                )
+        else:
+            trade.set_liquidation_price(
                 exchange.get_liquidation_price(
-                    pair=t.pair,
-                    open_rate=t.open_rate,
-                    is_short=t.is_short,
-                    amount=t.amount,
-                    stake_amount=t.stake_amount,
+                    pair=trade.pair,
+                    open_rate=trade.open_rate,
+                    is_short=trade.is_short,
+                    amount=trade.amount,
+                    stake_amount=trade.stake_amount,
                     leverage=trade.leverage,
-                    wallet_balance=total_wallet_stake,
-                    other_trades=[],  # TODO: Add other trades
+                    wallet_balance=trade.stake_amount,
+                    other_trades=[],
                 )
             )
-    else:
-        trade.set_liquidation_price(
-            exchange.get_liquidation_price(
-                pair=trade.pair,
-                open_rate=trade.open_rate,
-                is_short=trade.is_short,
-                amount=trade.amount,
-                stake_amount=trade.stake_amount,
-                leverage=trade.leverage,
-                wallet_balance=trade.stake_amount,
-                other_trades=[],
-            )
-        )
+    except DependencyException:
+        logger.warning("Unable to calculate liquidation price")

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -37,6 +37,7 @@ from freqtrade.exchange import (
 )
 from freqtrade.exchange.exchange import Exchange
 from freqtrade.ft_types import BacktestResultType, get_BacktestResultType_default
+from freqtrade.leverage.liquidation_price import update_liquidation_prices
 from freqtrade.mixins import LoggingMixin
 from freqtrade.optimize.backtest_caching import get_strategy_run_id
 from freqtrade.optimize.bt_progress import BTProgress
@@ -700,16 +701,12 @@ class Backtesting:
 
             if not (order.ft_order_side == trade.exit_side and order.safe_amount == trade.amount):
                 # trade is still open
-                trade.set_liquidation_price(
-                    self.exchange.get_liquidation_price(
-                        pair=trade.pair,
-                        open_rate=trade.open_rate,
-                        is_short=trade.is_short,
-                        amount=trade.amount,
-                        stake_amount=trade.stake_amount,
-                        leverage=trade.leverage,
-                        wallet_balance=trade.stake_amount,
-                    )
+                update_liquidation_prices(
+                    trade,
+                    exchange=self.exchange,
+                    wallets=self.wallets,
+                    stake_currency=self.config["stake_currency"],
+                    dry_run=self.config["dry_run"],
                 )
                 self._call_adjust_stop(current_date, trade, order.ft_price)
                 # pass

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -760,7 +760,7 @@ class LocalTrade:
         Method you should use to set self.liquidation price.
         Assures stop_loss is not passed the liquidation price
         """
-        if not liquidation_price:
+        if liquidation_price is None:
             return
         self.liquidation_price = liquidation_price
 

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -7,7 +7,7 @@ import pytest
 
 from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import DependencyException, InvalidOrderException, OperationalException
-from freqtrade.persistence.trade_model import Trade
+from freqtrade.persistence import Trade
 from tests.conftest import EXMS, get_mock_coro, get_patched_exchange, log_has_re
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
 

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -7,6 +7,7 @@ import pytest
 
 from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import DependencyException, InvalidOrderException, OperationalException
+from freqtrade.persistence.trade_model import Trade
 from tests.conftest import EXMS, get_mock_coro, get_patched_exchange, log_has_re
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
 
@@ -313,6 +314,17 @@ def test_liquidation_price_binance(
     exchange.get_maintenance_ratio_and_amt = get_maint_ratio
     exchange.fetch_funding_rates = fetch_funding_rates
 
+    open_trade_objects = [
+        Trade(
+            pair=t["pair"],
+            open_rate=t["open_rate"],
+            amount=t["amount"],
+            stake_amount=t["stake_amount"],
+            fee_open=0,
+        )
+        for t in open_trades
+    ]
+
     assert (
         pytest.approx(
             round(
@@ -324,7 +336,7 @@ def test_liquidation_price_binance(
                     amount=amount,
                     stake_amount=open_rate * amount,
                     leverage=5,
-                    open_trades=open_trades,
+                    open_trades=open_trade_objects,
                 ),
                 2,
             )

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -294,8 +294,6 @@ def test_liquidation_price_binance(
                     stake_amount=open_rate * amount,
                     leverage=5,
                     other_trades=other_contracts,
-                    # mm_ex_1=mm_ex_1,
-                    # upnl_ex_1=upnl_ex_1,
                 ),
                 2,
             )

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -172,7 +172,7 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
 
 @pytest.mark.parametrize(
     "pair, is_short, trading_mode, margin_mode, wallet_balance, "
-    "maintenance_amt, amount, open_rate, mark_price, open_trades,"
+    "maintenance_amt, amount, open_rate, open_trades,"
     "mm_ratio, expected",
     [
         (
@@ -184,7 +184,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             135365.00,
             3683.979,
             1456.84,
-            1456.84,  # mark price
             [],
             0.10,
             1114.78,
@@ -197,7 +196,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             1535443.01,
             16300.000,
             109.488,
-            32481.980,
             32481.980,
             [],
             0.025,
@@ -214,7 +212,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             135365.00,
             3683.979,  # amount
             1456.84,  # open_rate
-            1335.18,  # mark_price
             [
                 {
                     # From calc example
@@ -251,7 +248,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             16300.0,
             109.488,  # amount
             32481.980,  # open_rate
-            31967.27,  # mark_price
             [
                 {
                     # From calc example
@@ -290,7 +286,6 @@ def test_liquidation_price_binance(
     maintenance_amt,
     amount,
     open_rate,
-    mark_price,
     open_trades,
     mm_ratio,
     expected,
@@ -306,7 +301,18 @@ def test_liquidation_price_binance(
             return oc["mm_ratio"], oc["maintenance_amt"]
         return mm_ratio, maintenance_amt
 
+    def fetch_funding_rates(*args, **kwargs):
+        return {
+            t["pair"]: {
+                "symbol": t["pair"],
+                "markPrice": t["mark_price"],
+            }
+            for t in open_trades
+        }
+
     exchange.get_maintenance_ratio_and_amt = get_maint_ratio
+    exchange.fetch_funding_rates = fetch_funding_rates
+
     assert (
         pytest.approx(
             round(

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -208,8 +208,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             "futures",
             "cross",
             1535443.01,
-            # 71200.81144,  # tmm1
-            # -56354.57,  # upnl1
             135365.00,
             3683.979,  # amount
             1456.84,  # open_rate
@@ -244,8 +242,6 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
             "futures",
             "cross",
             1535443.01,
-            # 356512.508,  # tmm1
-            # -448192.89,  # upnl1
             16300.0,
             109.488,  # amount
             32481.980,  # open_rate

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -5524,7 +5524,6 @@ def test_liquidation_price_is_none(
             stake_amount=open_rate * 71200.81144,
             leverage=5,
             wallet_balance=-56354.57,
-            other_trades=[],
         )
         is None
     )
@@ -5970,7 +5969,6 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
-        other_trades=[],
     )
     assert liq_price == 17.47
 
@@ -5984,7 +5982,6 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
-        other_trades=[],
     )
     assert liq_price == 17.540699999999998
 
@@ -5998,7 +5995,6 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
-        other_trades=[],
     )
     assert liq_price is None
     default_conf["trading_mode"] = "margin"

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -5524,8 +5524,7 @@ def test_liquidation_price_is_none(
             stake_amount=open_rate * 71200.81144,
             leverage=5,
             wallet_balance=-56354.57,
-            mm_ex_1=0.10,
-            upnl_ex_1=0.0,
+            other_trades=[],
         )
         is None
     )
@@ -5971,6 +5970,7 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
+        other_trades=[],
     )
     assert liq_price == 17.47
 
@@ -5984,6 +5984,7 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
+        other_trades=[],
     )
     assert liq_price == 17.540699999999998
 
@@ -5997,6 +5998,7 @@ def test_get_liquidation_price1(mocker, default_conf):
         stake_amount=18.884 * 0.8,
         leverage=leverage,
         wallet_balance=18.884 * 0.8,
+        other_trades=[],
     )
     assert liq_price is None
     default_conf["trading_mode"] = "margin"
@@ -6011,6 +6013,7 @@ def test_get_liquidation_price1(mocker, default_conf):
             stake_amount=18.884 * 0.8,
             leverage=leverage,
             wallet_balance=18.884 * 0.8,
+            other_trades=[],
         )
 
 
@@ -6141,6 +6144,7 @@ def test_get_liquidation_price(
         wallet_balance=amount * open_rate / leverage,
         leverage=leverage,
         is_short=is_short,
+        other_trades=[],
     )
     if expected_liq is None:
         assert liq is None

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -6009,7 +6009,7 @@ def test_get_liquidation_price1(mocker, default_conf):
             stake_amount=18.884 * 0.8,
             leverage=leverage,
             wallet_balance=18.884 * 0.8,
-            other_trades=[],
+            open_trades=[],
         )
 
 
@@ -6140,7 +6140,7 @@ def test_get_liquidation_price(
         wallet_balance=amount * open_rate / leverage,
         leverage=leverage,
         is_short=is_short,
-        other_trades=[],
+        open_trades=[],
     )
     if expected_liq is None:
         assert liq is None

--- a/tests/exchange_online/test_ccxt_compat.py
+++ b/tests/exchange_online/test_ccxt_compat.py
@@ -457,6 +457,7 @@ class TestCCXTExchange:
                 stake_amount=100,
                 leverage=5,
                 wallet_balance=100,
+                open_trades=[],
             )
             assert isinstance(liquidation_price, float)
             assert liquidation_price >= 0.0
@@ -469,6 +470,7 @@ class TestCCXTExchange:
                 stake_amount=100,
                 leverage=5,
                 wallet_balance=100,
+                open_trades=[],
             )
             assert isinstance(liquidation_price, float)
             assert liquidation_price >= 0.0

--- a/tests/leverage/test_update_liquidation_price.py
+++ b/tests/leverage/test_update_liquidation_price.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from freqtrade.enums.marginmode import MarginMode
+from freqtrade.leverage.liquidation_price import update_liquidation_prices
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+@pytest.mark.parametrize("margin_mode", [MarginMode.CROSS, MarginMode.ISOLATED])
+def test_update_liquidation_prices(mocker, margin_mode, dry_run):
+    # Heavily mocked test - Only testing the logic of the function
+    # update liquidation price for trade in isolated mode
+    # update liquidation price for all trades in cross mode
+    exchange = MagicMock()
+    exchange.margin_mode = margin_mode
+    wallets = MagicMock()
+    trade_mock = MagicMock()
+
+    mocker.patch("freqtrade.persistence.Trade.get_open_trades", return_value=[trade_mock])
+
+    update_liquidation_prices(
+        trade=trade_mock,
+        exchange=exchange,
+        wallets=wallets,
+        stake_currency="USDT",
+        dry_run=dry_run,
+    )
+
+    assert trade_mock.set_liquidation_price.call_count == 1
+
+    assert wallets.get_total.call_count == (
+        0 if margin_mode == MarginMode.ISOLATED or not dry_run else 1
+    )
+
+    # Test with multiple trades
+    trade_mock.reset_mock()
+    trade_mock_2 = MagicMock()
+
+    mocker.patch(
+        "freqtrade.persistence.Trade.get_open_trades", return_value=[trade_mock, trade_mock_2]
+    )
+
+    update_liquidation_prices(
+        trade=trade_mock,
+        exchange=exchange,
+        wallets=wallets,
+        stake_currency="USDT",
+        dry_run=dry_run,
+    )
+    # Trade2 is only updated in cross mode
+    assert trade_mock_2.set_liquidation_price.call_count == (
+        1 if margin_mode == MarginMode.CROSS else 0
+    )
+    assert trade_mock.set_liquidation_price.call_count == 1
+
+    assert wallets.call_count == 0 if not dry_run else 1


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

* Simplify liquidation price calculation function headers, moving exchange-specific calculations into the function itself.
* Simplify how to set liquidation prices by having a unified method between dry/live and backtesting.

The goal for this is to have an easier time modifying the logic for this should the need arise for new exchanges or modes.

## Quick changelog

- Better liquidation price function signatures
- Shared logic between live and test