### PR TITLE
add is_number check to make sure we skip non-number columns

### DIFF
--- a/freqtrade/optimize/analysis/recursive.py
+++ b/freqtrade/optimize/analysis/recursive.py
@@ -1,4 +1,5 @@
 import logging
+import numbers
 import shutil
 from copy import deepcopy
 from datetime import timedelta
@@ -18,6 +19,10 @@ from freqtrade.resolvers import StrategyResolver
 
 
 logger = logging.getLogger(__name__)
+
+
+def is_number(variable):
+    return isinstance(variable, numbers.Number) and not isinstance(variable, bool)
 
 
 class RecursiveAnalysis(BaseAnalysis):
@@ -69,7 +74,12 @@ class RecursiveAnalysis(BaseAnalysis):
                         values_diff_self = values_diff.loc["self"]
                         values_diff_other = values_diff.loc["other"]
 
-                        if values_diff_self and values_diff_other:
+                        if (
+                            values_diff_self
+                            and values_diff_other
+                            and is_number(values_diff_self)
+                            and is_number(values_diff_other)
+                        ):
                             diff = (values_diff_other - values_diff_self) / values_diff_self * 100
                             str_diff = f"{diff:.3f}%"
                         else:

--- a/tests/strategy/strats/strategy_test_v3_recursive_issue.py
+++ b/tests/strategy/strats/strategy_test_v3_recursive_issue.py
@@ -33,6 +33,9 @@ class strategy_test_v3_recursive_issue(IStrategy):
             # Has both bias1 and bias2
             dataframe["rsi_lookahead"] = ta.RSI(dataframe, timeperiod=50).shift(-1)
 
+        # String columns shouldn't cause issues
+        dataframe["test_string_column"] = f"a{len(dataframe)}"
+
         return dataframe
 
     def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Add is_number check to make sure we skip non-number columns

Solve the issue: #10754 

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

Let's say I have this strategy
```
def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
        dataframe["ema100"] = ta.EMA(dataframe, 100)
        dataframe["test"] = f"a{len(dataframe)}"
        return dataframe
```

Now it will return
```
┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┓
┃ Indicators ┃     199 ┃    299 ┃     399 ┃     499 ┃    599 ┃    699 ┃     799 ┃    899 ┃ 999 (from strategy) ┃   1099 ┃   1199 ┃   1299 ┃    1399 ┃
┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━┩
│     ema100 │ -0.019% │ 0.003% │ -0.000% │ -0.000% │ 0.000% │ 0.000% │ -0.000% │ 0.000% │             -0.000% │ 0.000% │ 0.000% │ 0.000% │ -0.000% │
│       test │     NaN │    NaN │     NaN │     NaN │    NaN │    NaN │     NaN │    NaN │                 NaN │    NaN │    NaN │    NaN │     NaN │
└────────────┴─────────┴────────┴─────────┴─────────┴────────┴────────┴─────────┴────────┴─────────────────────┴────────┴────────┴────────┴─────────┘
```