### PR TITLE
fix: Support mps device where available

### DIFF
--- a/freqtrade/freqai/base_models/BasePyTorchModel.py
+++ b/freqtrade/freqai/base_models/BasePyTorchModel.py
@@ -20,7 +20,11 @@ class BasePyTorchModel(IFreqaiModel, ABC):
     def __init__(self, **kwargs):
         super().__init__(config=kwargs["config"])
         self.dd.model_type = "pytorch"
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = (
+            "mps"
+            if torch.backends.mps.is_available() and torch.backends.mps.is_built()
+            else ("cuda" if torch.cuda.is_available() else "cpu")
+        )
         test_size = self.freqai_info.get("data_split_parameters", {}).get("test_size")
         self.splits = ["train", "test"] if test_size != 0 else ["train"]
         self.window_size = self.freqai_info.get("conv_width", 1)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Based on https://github.com/freqtrade/freqtrade/issues/10542#issuecomment-2380836917 - mps is a separate device which needs to be instanciated (and is only available on Mac M _x_ machines)

While i don't see how not having that should cause a segfault (it'll simply use CPU in my understanding) - based on the comment, this seems to fix the problem.

closes #10542 

## Quick changelog

- use MPS device if available 