### PR TITLE
docs: Add 1 in ignored custom_stoploss return

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -173,7 +173,7 @@ During backtesting, `current_rate` (and `current_profit`) are provided against t
 
 The absolute value of the return value is used (the sign is ignored), so returning `0.05` or `-0.05` have the same result, a stoploss 5% below the current price.
 Returning `None` will be interpreted as "no desire to change", and is the only safe way to return when you'd like to not modify the stoploss.
-`NaN` and `inf` values are considered invalid and will be ignored (identical to `None`).
+`NaN`, `inf` and `1` values are considered invalid and will be ignored (identical to `None`).
 
 Stoploss on exchange works similar to `trailing_stop`, and the stoploss on exchange is updated as configured in `stoploss_on_exchange_interval` ([More details about stoploss on exchange](stoploss.md#stop-loss-on-exchangefreqtrade)).
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Add `1` in the list of ignored custom_stoploss return value since value `1` also doesn't change initial stop-loss as stated in [following section Note](https://www.freqtrade.io/en/stable/strategy-callbacks/#stoploss-relative-to-open-price)
