### PR TITLE
Enable future positions to reverse their position

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -558,6 +558,7 @@ Since backtesting lacks some detailed information about what happens within a ca
   - Stoploss
   - ROI
   - Trailing stoploss
+- Position reversals (futures only) happen if an entry signal in the other direction than the closing trade triggers at the candle the existing trade closes.
 
 Taking these assumptions, backtesting tries to mirror real trading as closely as possible. However, backtesting will **never** replace running a strategy in dry-run mode.
 Also, keep in mind that past results don't guarantee future success.

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2284,7 +2284,7 @@ class FreqtradeBot(LoggingMixin):
 
     def handle_protections(self, pair: str, side: LongShort) -> None:
         # Lock pair for one candle to prevent immediate re-entries
-        self.strategy.lock_pair(pair, datetime.now(timezone.utc), reason="Auto lock")
+        self.strategy.lock_pair(pair, datetime.now(timezone.utc), reason="Auto lock", side=side)
         prot_trig = self.protections.stop_per_pair(pair, side=side)
         if prot_trig:
             msg: RPCProtectionMsg = {

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -3483,16 +3483,17 @@ def test_locked_pairs(
         exit_check=ExitCheckTuple(exit_type=ExitType.STOP_LOSS),
     )
     trade.close(ticker_usdt_sell_down()["bid"])
-    assert freqtrade.strategy.is_pair_locked(trade.pair, side="*")
+    assert not freqtrade.strategy.is_pair_locked(trade.pair, side="*")
     # Both sides are locked
-    assert freqtrade.strategy.is_pair_locked(trade.pair, side="long")
-    assert freqtrade.strategy.is_pair_locked(trade.pair, side="short")
+    assert freqtrade.strategy.is_pair_locked(trade.pair, side="long") != is_short
+    assert freqtrade.strategy.is_pair_locked(trade.pair, side="short") == is_short
 
     # reinit - should buy other pair.
     caplog.clear()
     freqtrade.enter_positions()
+    direction = "short" if is_short else "long"
 
-    assert log_has_re(rf"Pair {trade.pair} \* is locked.*", caplog)
+    assert log_has_re(rf"Pair {trade.pair} {direction} is locked.*", caplog)
 
 
 @pytest.mark.parametrize("is_short", [False, True])

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -1163,6 +1163,27 @@ tc55 = BTContainer(
     ],
 )
 
+# Test 56: Switch position from long to short
+tc56 = BTContainer(
+    data=[
+        # D   O     H     L     C    V    EL XL ES Xs  BT
+        [0, 5000, 5050, 4950, 5000, 6172, 1, 0, 0, 0],
+        [1, 5000, 5000, 4951, 5000, 6172, 0, 0, 0, 0],
+        [2, 4910, 5150, 4910, 5100, 6172, 0, 0, 1, 0],  # exit on stoploss - re-enter short
+        [3, 5100, 5100, 4888, 4950, 6172, 0, 0, 0, 0],
+        [4, 5000, 5100, 4950, 4950, 6172, 0, 0, 0, 1],
+        [5, 5000, 5100, 4950, 4950, 6172, 0, 0, 0, 0],
+    ],
+    stop_loss=-0.02,
+    roi={"0": 0.10},
+    profit_perc=-0.0,
+    use_exit_signal=True,
+    trades=[
+        BTrade(exit_reason=ExitType.STOP_LOSS, open_tick=1, close_tick=3, is_short=False),
+        BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=3, close_tick=5, is_short=True),
+    ],
+)
+
 
 TESTS = [
     tc0,
@@ -1221,6 +1242,7 @@ TESTS = [
     tc53,
     tc54,
     tc55,
+    tc56,
 ]
 
 

--- a/tests/optimize/test_backtest_detail.py
+++ b/tests/optimize/test_backtest_detail.py
@@ -1121,6 +1121,49 @@ tc53 = BTContainer(
     trades=[BTrade(exit_reason=ExitType.STOP_LOSS, open_tick=1, close_tick=2, is_short=True)],
 )
 
+# Test 54: Switch position from long to short
+tc54 = BTContainer(
+    data=[
+        # D   O     H     L     C    V    EL XL ES Xs  BT
+        [0, 5000, 5050, 4950, 5000, 6172, 1, 0, 0, 0],
+        [1, 5000, 5000, 4951, 5000, 6172, 0, 0, 0, 0],
+        [2, 4910, 5150, 4910, 5100, 6172, 0, 0, 1, 0],  # Enter short signal being ignored
+        [3, 5100, 5100, 4950, 4950, 6172, 0, 1, 1, 0],  # exit - re-enter short
+        [4, 5000, 5100, 4950, 4950, 6172, 0, 0, 0, 1],
+        [5, 5000, 5100, 4950, 4950, 6172, 0, 0, 0, 0],
+    ],
+    stop_loss=-0.10,
+    roi={"0": 0.10},
+    profit_perc=0.00,
+    use_exit_signal=True,
+    trades=[
+        BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=1, close_tick=4, is_short=False),
+        BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=4, close_tick=5, is_short=True),
+    ],
+)
+
+# Test 55: Switch position from short to long
+tc55 = BTContainer(
+    data=[
+        # D   O     H     L     C    V    EL XL ES Xs  BT
+        [0, 5000, 5050, 4950, 5000, 6172, 0, 0, 1, 0],
+        [1, 5000, 5000, 4951, 5000, 6172, 1, 0, 0, 0],  # Enter long signal being ignored
+        [2, 4910, 5150, 4910, 5100, 6172, 1, 0, 0, 1],  # Exit - reenter long
+        [3, 5100, 5100, 4950, 4950, 6172, 0, 0, 0, 0],
+        [4, 5000, 5100, 4950, 4950, 6172, 0, 1, 0, 0],
+        [5, 5000, 5100, 4950, 4950, 6172, 0, 0, 0, 0],
+    ],
+    stop_loss=-0.10,
+    roi={"0": 0.10},
+    profit_perc=-0.04,
+    use_exit_signal=True,
+    trades=[
+        BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=1, close_tick=3, is_short=True),
+        BTrade(exit_reason=ExitType.EXIT_SIGNAL, open_tick=3, close_tick=5, is_short=False),
+    ],
+)
+
+
 TESTS = [
     tc0,
     tc1,
@@ -1176,6 +1219,8 @@ TESTS = [
     tc51,
     tc52,
     tc53,
+    tc54,
+    tc55,
 ]
 
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1774,7 +1774,7 @@ def test_backtest_multi_pair_long_short_switch(
 
     if use_detail:
         # Backtest loop is called once per candle per pair
-        assert bl_spy.call_count == 1071
+        assert bl_spy.call_count == 1523
     else:
         assert bl_spy.call_count == 479
 
@@ -1784,7 +1784,7 @@ def test_backtest_multi_pair_long_short_switch(
     assert len(evaluate_result_multi(results["results"], "5m", 1)) == 0
 
     # Expect 26 results initially
-    assert len(results["results"]) == 30
+    assert len(results["results"]) == 53
 
 
 def test_backtest_start_timerange(default_conf, mocker, caplog, testdatadir):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This PR enables switching from long to short positions.

The simplest example has "enter_short" and "exit_long" both set to 1 within a candle (while being in a long position) - which will close the long trade, and open a new short trade.

This will also work for all other exit reasons like (trailing) stoploss, roi, or custom-exits.

To prevent a subsequent (despite having a signal in the other direction) - best use the [cooldown protection](https://www.freqtrade.io/en/stable/plugins/#cooldown-period) - which (with a setting of 1) can restore previous behavior.

Closes #9183

## Quick changelog

- Enable long/short switch within one candle for backtesting
- Change auto-lock to be towards the trade-side only (allowing to enter a short trade after closing out a long trade and viceversa).

## TODO:

* [x] Update docs / enhance docs in this regards