### PR TITLE
allow json in environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,17 @@ Please note that Environment variables will overwrite corresponding settings in 
 
 Common example:
 
-```
+``` bash
 FREQTRADE__TELEGRAM__CHAT_ID=<telegramchatid>
 FREQTRADE__TELEGRAM__TOKEN=<telegramToken>
 FREQTRADE__EXCHANGE__KEY=<yourExchangeKey>
 FREQTRADE__EXCHANGE__SECRET=<yourExchangeSecret>
+```
+
+Json lists are parsed as json - so you can use the following to set a list of pairs:
+
+``` bash
+export FREQTRADE__EXCHANGE__PAIR_WHITELIST='["BTC/USDT", "ETH/USDT"]'
 ```
 
 !!! Note
@@ -54,7 +60,7 @@ FREQTRADE__EXCHANGE__SECRET=<yourExchangeSecret>
 
 ??? Warning "Loading sequence"
     Environment variables are loaded after the initial configuration. As such, you cannot provide the path to the configuration through environment variables. Please use `--config path/to/config.json` for that.
-    This also applies to user_dir to some degree. while the user directory can be set through environment variables - the configuration will **not** be loaded from that location.
+    This also applies to `user_dir` to some degree. while the user directory can be set through environment variables - the configuration will **not** be loaded from that location.
 
 ### Multiple configuration files
 

--- a/freqtrade/configuration/environment_vars.py
+++ b/freqtrade/configuration/environment_vars.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import Any
@@ -20,6 +21,11 @@ def _get_var_typed(val):
                 return True
             elif val.lower() in ("f", "false"):
                 return False
+            # try to convert from json
+            try:
+                return json.loads(val)
+            except json.decoder.JSONDecodeError:
+                pass
     # keep as string
     return val
 

--- a/freqtrade/configuration/environment_vars.py
+++ b/freqtrade/configuration/environment_vars.py
@@ -1,7 +1,8 @@
-import json
 import logging
 import os
 from typing import Any
+
+import rapidjson
 
 from freqtrade.constants import ENV_VAR_PREFIX
 from freqtrade.misc import deep_merge_dicts
@@ -23,8 +24,11 @@ def _get_var_typed(val):
                 return False
             # try to convert from json
             try:
-                return json.loads(val)
-            except json.decoder.JSONDecodeError:
+                value = rapidjson.loads(val)
+                # Limited to lists for now
+                if isinstance(value, list):
+                    return value
+            except rapidjson.JSONDecodeError:
                 pass
     # keep as string
     return val

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1481,6 +1481,12 @@ def test_flat_vars_to_nested_dict(caplog):
         "FREQTRADE__STAKE_AMOUNT": "200.05",
         "FREQTRADE__TELEGRAM__CHAT_ID": "2151",
         "NOT_RELEVANT": "200.0",  # Will be ignored
+        "FREQTRADE__ARRAY": '[{"name":"default","host":"xxx"}]',
+        "FREQTRADE__EXCHANGE__PAIR_WHITELIST": '["BTC/USDT", "ETH/USDT"]',
+        # Fails due to trailing comma
+        "FREQTRADE__ARRAY_TRAIL_COMMA": '[{"name":"default","host":"xxx",}]',
+        # Object fails
+        "FREQTRADE__OBJECT": '{"name":"default","host":"xxx"}',
     }
     expected = {
         "stake_amount": 200.05,
@@ -1494,8 +1500,12 @@ def test_flat_vars_to_nested_dict(caplog):
             },
             "some_setting": True,
             "some_false_setting": False,
+            "pair_whitelist": ["BTC/USDT", "ETH/USDT"],
         },
         "telegram": {"chat_id": "2151"},
+        "array": [{"name": "default", "host": "xxx"}],
+        "object": '{"name":"default","host":"xxx"}',
+        "array_trail_comma": '[{"name":"default","host":"xxx",}]',
     }
     res = _flat_vars_to_nested_dict(test_args, ENV_VAR_PREFIX)
     assert res == expected


### PR DESCRIPTION
## Summary
Allow setting json in the environment vairables

## What's new?
For example you can set producers from environment and many more like ccxt options etc.

FREQTRADE__EXTERNAL_MESSAGE_CONSUMER__PRODUCERS:  [{"name": "default", "host": "xxx", "port": 4711, "secure": true, "ws_token": "xxx"}]

This is useful if for example you try to run freqtrade on PaaS like dokku/heroku and use variable storage of that platform in order to not expose config with secrets.