### PR TITLE
freqAI bug causing failures on 2nd backtest

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -849,7 +849,7 @@ class FreqaiDataKitchen:
             dataframe = strategy.set_freqai_targets(dataframe.copy(), metadata=metadata)
             dataframe = self.remove_special_chars_from_feature_names(dataframe)
 
-        self.get_unique_classes_from_labels(dataframe)
+            self.get_unique_classes_from_labels(dataframe)
 
         if self.config.get("reduce_df_footprint", False):
             dataframe = reduce_dataframe_footprint(dataframe)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

if we don't call `freqai_set_targets()` - we can't get `.find_labels()` either (nested in `get_unique_classes_from_labels()` - as there won't be targets assigned to the dataframe.
This overwrites the data loaded from the metadata file to `dk.unique_class_list` and `dk.label_list` - causing them to be empty - and subsequently, failures like the following:

```
  File freqtrade/freqai/freqai_interface.py", line 901, in backtesting_fit_live_predictions        
    dk.full_df.at[index, f"{label}_mean"] = self.dk.data["labels_mean"][                                                                     
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                     
KeyError: '&-target'  
```

closes #10997 

## Quick changelog

- update indentation to not run `get_unique_classes_from_labels()` if `set_freqai_targets()` hasn't been ran.


