### PR TITLE
fix: invert API download condition from `and` to `or`

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -136,7 +136,7 @@ class Binance(Exchange):
 
         if (
             self._config["exchange"].get("only_from_ccxt", False)
-            and
+            or
             # only download timeframes with significant improvements,
             # otherwise fall back to rest API
             not (

--- a/freqtrade/exchange/binance_public_data.py
+++ b/freqtrade/exchange/binance_public_data.py
@@ -89,7 +89,7 @@ async def download_archive_ohlcv(
         )
     except Exception as e:
         logger.warning(
-            "An exception occurred during fast download from Binance, falling back to"
+            "An exception occurred during fast download from Binance, falling back to "
             "the slower REST API, this can take more time.",
             exc_info=e,
         )


### PR DESCRIPTION
Got these warnings for every futures pair with the `and` logic.
```
2024-12-02 23:53:53,022 - freqtrade.data.history.history_utils - INFO - Downloaded data for DASH/USDT:USDT with length 26110.
2024-12-02 23:53:53,040 - freqtrade.data.history.history_utils - INFO - Download history data for "DASH/USDT:USDT", 8h, funding_rate and store in /Volumes/t7/repos/freqtrade/user_data/data/binance. From 2024-09-03T00:00:00 to now
2024-12-02 23:53:53,421 - freqtrade.exchange.binance_public_data - WARNING - An exception occurred during fast download from Binance, falling back tothe slower REST API, this can take more time.
Traceback (most recent call last):
  File "/Volumes/t7/repos/freqtrade/freqtrade/exchange/binance_public_data.py", line 71, in download_archive_ohlcv
    raise ValueError(f"Unsupported CandleType: {candle_type}")
ValueError: Unsupported CandleType: funding_rate
2024-12-02 23:53:53,599 - freqtrade.data.history.history_utils - INFO - Downloaded data for DASH/USDT:USDT with length 271.
2024-12-02 23:53:53,602 - freqtrade.data.history.history_utils - INFO - Download history data for "DASH/USDT:USDT", 8h, mark and store in /Volumes/t7/repos/freqtrade/user_data/data/binance. From 2024-09-03T00:00:00 to now
2024-12-02 23:53:53,769 - freqtrade.exchange.binance_public_data - WARNING - An exception occurred during fast download from Binance, falling back tothe slower REST API, this can take more time.
Traceback (most recent call last):
  File "/Volumes/t7/repos/freqtrade/freqtrade/exchange/binance_public_data.py", line 71, in download_archive_ohlcv
    raise ValueError(f"Unsupported CandleType: {candle_type}")
ValueError: Unsupported CandleType: mark
2024-12-02 23:53:54,123 - freqtrade.data.history.history_utils - INFO - Downloaded data for DASH/USDT:USDT with length 271.
```