### PR TITLE
fix: check if days is None before conversion

### DIFF
--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -604,7 +604,7 @@ def download_data(
     Download data function. Used from both cli and API.
     """
     timerange = TimeRange()
-    if "days" in config:
+    if "days" in config and config["days"] is not None:
         time_since = (datetime.now() - timedelta(days=config["days"])).strftime("%Y%m%d")
         timerange = TimeRange.parse_timerange(f"{time_since}-")
 


### PR DESCRIPTION
freqUI version: main
freqtrade version: develop

Got the error when download data from freqUI with `Use custom timerange` in the UI (I also use `Custom Exchange` in the UI.):

```
2024-12-03 00:15:33,983 - freqtrade.rpc.api_server.api_download_data - ERROR - unsupported type for timedelta days component: NoneType
Traceback (most recent call last):
  File "/Volumes/t7/repos/freqtrade/freqtrade/rpc/api_server/api_download_data.py", line 40, in __run_download
    download_data(config_loc, exchange, progress_tracker=pt)
  File "/Volumes/t7/repos/freqtrade/freqtrade/data/history/history_utils.py", line 608, in download_data
    time_since = (datetime.now() - timedelta(days=config["days"])).strftime("%Y%m%d")
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported type for timedelta days component: NoneType
```
