### PR TITLE
feat: Add OneTradeCross mode for Binance Futures

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -80,7 +80,7 @@ TRADES_DTYPES = {
     "cost": "float64",
 }
 TRADING_MODES = ["spot", "margin", "futures"]
-MARGIN_MODES = ["cross", "isolated", ""]
+MARGIN_MODES = ["cross", "isolated", "onetradecross", ""]
 
 LAST_BT_RESULT_FN = ".last_result.json"
 FTHYPT_FILEVERSION = "fthypt_fileversion"

--- a/freqtrade/enums/marginmode.py
+++ b/freqtrade/enums/marginmode.py
@@ -10,6 +10,7 @@ class MarginMode(str, Enum):
 
     CROSS = "cross"
     ISOLATED = "isolated"
+    ONETRADECROSS = "onetradecross"
     NONE = ""
 
     def __str__(self):

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -54,7 +54,8 @@ class Binance(Exchange):
         # TradingMode.SPOT always supported and not required in this list
         # (TradingMode.MARGIN, MarginMode.CROSS),
         # (TradingMode.FUTURES, MarginMode.CROSS),
-        (TradingMode.FUTURES, MarginMode.ISOLATED)
+        (TradingMode.FUTURES, MarginMode.ISOLATED),
+        (TradingMode.FUTURES, MarginMode.ONETRADECROSS),
     ]
 
     def get_tickers(
@@ -94,10 +95,15 @@ class Binance(Exchange):
                 if (
                     assets_margin.get("multiAssetsMargin") is True
                     and self.margin_mode != MarginMode.CROSS
+                    and not (
+                        self._config["margin_mode"] == MarginMode.ONETRADECROSS
+                        and self._config["max_open_trades"] == 1
+                    )
                 ):
                     msg += (
-                        "\nMulti-Asset Mode is not supported by freqtrade. "
-                        "Please change 'Asset Mode' on your binance futures account."
+                        "\nMulti-Asset Mode is not supported by freqtrade for multiple trades. "
+                        "ensure 'margin_mode' is set to 'OneTradeCross' and 'max_open_trades' is 1,"
+                        "or change 'Asset Mode' on your binance futures account."
                     )
                 if msg:
                     raise OperationalException(msg)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1224,7 +1224,8 @@ class Exchange:
 
     def _lev_prep(self, pair: str, leverage: float, side: BuySell, accept_fail: bool = False):
         if self.trading_mode != TradingMode.SPOT:
-            self.set_margin_mode(pair, self.margin_mode, accept_fail)
+            if self.margin_mode != MarginMode.ONETRADECROSS:
+                self.set_margin_mode(pair, self.margin_mode, accept_fail)
             self._set_leverage(leverage, pair, accept_fail)
 
     def _get_params(


### PR DESCRIPTION
## Summary

Introduce OneTradeCross mode for Binance Futures, allowing users to perform cross margin trading with the restriction of only one active trade at a time.

Partially Solve the issue: #10503 

## Quick changelog

- Added a new margin mode OneTradeCross to allow trading with cross margin and a single active position.
- Updated freqtrade/constants.py, freqtrade/enums/marginmode.py, freqtrade/exchange/binance.py, and freqtrade/exchange/exchange.py to support OneTradeCross.
- Ensured that max_open_trades is set to 1 when using OneTradeCross to avoid issues with high leverage calculations.

## What's new?
TDue to the complexity of calculating cross margin with multiple active trades, the solution restricts users to only one active trade at a time. Despite this limitation, the OneTradeCross mode effectively solves the problem for users who need cross margin functionality in Binance Futures while keeping the leverage manageable.

This implementation fills a gap in the current freqtrade platform where cross margin was not properly supported and provides an option for users to safely engage with futures trading while maintaining a single position.
