### PR TITLE
Add initial_state option to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,6 +40,10 @@ This could be caused by the following reasons:
 * The installation did not complete successfully.
   * Please check the [Installation documentation](installation.md).
 
+### The bot starts, but in STOPPED mode
+
+Make sure you set the `initial_state` config option to `"running"` in your config.json
+
 ### I have waited 5 minutes, why hasn't the bot made any trades yet?
 
 * Depending on the buy strategy, the amount of whitelisted coins, the


### PR DESCRIPTION
Whilst it's clear in the config docs that the initial_state option defaults to "stopped", an FAQ entry might be useful. 