### PR TITLE
Fix KeyError: 'max_drawdown' in jupyter notebook

### DIFF
--- a/docs/strategy_analysis_example.md
+++ b/docs/strategy_analysis_example.md
@@ -152,7 +152,7 @@ print(stats["strategy"][strategy]["pairlist"])
 # Get market change (average change of all pairs from start to end of the backtest period)
 print(stats["strategy"][strategy]["market_change"])
 # Maximum drawdown ()
-print(stats["strategy"][strategy]["max_drawdown"])
+print(stats["strategy"][strategy]["max_drawdown_abs"])
 # Maximum drawdown start and end
 print(stats["strategy"][strategy]["drawdown_start"])
 print(stats["strategy"][strategy]["drawdown_end"])

--- a/freqtrade/templates/strategy_analysis_example.ipynb
+++ b/freqtrade/templates/strategy_analysis_example.ipynb
@@ -216,7 +216,7 @@
     "# Get market change (average change of all pairs from start to end of the backtest period)\n",
     "print(stats[\"strategy\"][strategy][\"market_change\"])\n",
     "# Maximum drawdown ()\n",
-    "print(stats[\"strategy\"][strategy][\"max_drawdown\"])\n",
+    "print(stats[\"strategy\"][strategy][\"max_drawdown_abs\"])\n",
     "# Maximum drawdown start and end\n",
     "print(stats[\"strategy\"][strategy][\"drawdown_start\"])\n",
     "print(stats[\"strategy\"][strategy][\"drawdown_end\"])\n",


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve 
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[43], line 16
     14 print(stats['strategy'][strategy]['market_change'])
     15 # Maximum drawdown ()
---> 16 print(stats['strategy'][strategy]['max_drawdown'])
     17 # Maximum drawdown start and end
     18 print(stats['strategy'][strategy]['drawdown_start'])
KeyError: 'max_drawdown'
```

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Rename `max_drawdown` to `max_drawdown_abs`
