### PR TITLE
Deprecate hdf5

### DIFF
--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -162,7 +162,7 @@ Freqtrade currently supports the following data-formats:
 * `feather` - a dataformat based on Apache Arrow
 * `json` -  plain "text" json files
 * `jsongz` - a gzip-zipped version of json files
-* `hdf5` - a high performance datastore
+* `hdf5` - a high performance datastore (deprecated)
 * `parquet` - columnar datastore (OHLCV only)
 
 By default, both OHLCV data and trades data are stored in the `feather` format.

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -81,4 +81,10 @@ version 2023.3 saw the removal of `populate_any_indicators` in favor of split me
 
 ## Removal of `protections` from configuration
 
- Setting protections from the configuration via `"protections": [],` has been removed in 2024.10, after having raised deprecation warnings for over 3 years.
+Setting protections from the configuration via `"protections": [],` has been removed in 2024.10, after having raised deprecation warnings for over 3 years.
+
+## hdf5 data storage
+
+Using hdf5 as data storage has been deprecated in 2024.12 and will be removed in 2025.1. We recommend switching to the feather data format.
+
+Please use the [`convert-data` subcommand](data-download.md#sub-command-convert-data) to convert your existing data to one of the supported formats.

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -551,6 +551,13 @@ def get_datahandlerclass(datatype: str) -> type[IDataHandler]:
     elif datatype == "hdf5":
         from .hdf5datahandler import HDF5DataHandler
 
+        logger.warning(
+            "DEPRECATED: The hdf5 dataformat is deprecated and will be removed in a the "
+            "next release. "
+            "Please use the convert-data command to convert your data to a supported format."
+            "We recommend using the feather format, as it is faster and is more space-efficient."
+        )
+
         return HDF5DataHandler
     elif datatype == "feather":
         from .featherdatahandler import FeatherDataHandler

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -552,7 +552,7 @@ def get_datahandlerclass(datatype: str) -> type[IDataHandler]:
         from .hdf5datahandler import HDF5DataHandler
 
         logger.warning(
-            "DEPRECATED: The hdf5 dataformat is deprecated and will be removed in a the "
+            "DEPRECATED: The hdf5 dataformat is deprecated and will be removed in the "
             "next release. "
             "Please use the convert-data command to convert your data to a supported format."
             "We recommend using the feather format, as it is faster and is more space-efficient."

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -360,6 +360,11 @@ def test_hdf5datahandler_trades_load(testdatadir):
     # assert len([t for t in trades2 if t[0] > timerange.stopts * 1000]) == 0
 
 
+def test_hdf5datahandler_deprecated(testdatadir, caplog):
+    get_datahandler(testdatadir, "hdf5")
+    log_has_re(r"DEPRECATED: The hdf5 dataformat is deprecated.*", caplog)
+
+
 @pytest.mark.parametrize(
     "pair,timeframe,candle_type,candle_append,startdt,enddt",
     [


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Deprecate hdf5 as data format.
This will allow us to remove hdf5 and blosc2 dependencies.

For now, this will only issue a warning message - but will allow us to remove it in the near future (planned is for 2025.1).