### PR TITLE
Zip backtest results

### DIFF
--- a/freqtrade/commands/analyze_commands.py
+++ b/freqtrade/commands/analyze_commands.py
@@ -1,51 +1,10 @@
 import logging
-from pathlib import Path
 from typing import Any
 
 from freqtrade.enums import RunMode
-from freqtrade.exceptions import ConfigurationError, OperationalException
 
 
 logger = logging.getLogger(__name__)
-
-
-def setup_analyze_configuration(args: dict[str, Any], method: RunMode) -> dict[str, Any]:
-    """
-    Prepare the configuration for the entry/exit reason analysis module
-    :param args: Cli args from Arguments()
-    :param method: Bot running mode
-    :return: Configuration
-    """
-    from freqtrade.configuration import setup_utils_configuration
-
-    config = setup_utils_configuration(args, method)
-
-    no_unlimited_runmodes = {
-        RunMode.BACKTEST: "backtesting",
-    }
-    if method in no_unlimited_runmodes.keys():
-        from freqtrade.data.btanalysis import get_latest_backtest_filename
-
-        if "exportfilename" in config:
-            if config["exportfilename"].is_dir():
-                btfile = Path(get_latest_backtest_filename(config["exportfilename"]))
-                signals_file = f"{config['exportfilename']}/{btfile.stem}_signals.pkl"
-            else:
-                if config["exportfilename"].exists():
-                    btfile = Path(config["exportfilename"])
-                    signals_file = f"{btfile.parent}/{btfile.stem}_signals.pkl"
-                else:
-                    raise ConfigurationError(f"{config['exportfilename']} does not exist.")
-        else:
-            raise ConfigurationError("exportfilename not in config.")
-
-        if not Path(signals_file).exists():
-            raise OperationalException(
-                f"Cannot find latest backtest signals file: {signals_file}."
-                "Run backtesting with `--export signals`."
-            )
-
-    return config
 
 
 def start_analysis_entries_exits(args: dict[str, Any]) -> None:
@@ -54,10 +13,11 @@ def start_analysis_entries_exits(args: dict[str, Any]) -> None:
     :param args: Cli args from Arguments()
     :return: None
     """
+    from freqtrade.configuration import setup_utils_configuration
     from freqtrade.data.entryexitanalysis import process_entry_exit_reasons
 
     # Initialize configuration
-    config = setup_analyze_configuration(args, RunMode.BACKTEST)
+    config = setup_utils_configuration(args, RunMode.BACKTEST)
 
     logger.info("Starting freqtrade in analysis mode")
 

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -414,11 +414,17 @@ def load_file_from_zip(zip_path: Path, filename: str) -> bytes:
     """
     try:
         with zipfile.ZipFile(zip_path) as zipf:
-            with zipf.open(filename) as file:
-                return file.read()
+            try:
+                with zipf.open(filename) as file:
+                    return file.read()
+            except KeyError:
+                logger.error(f"File {filename} not found in zip: {zip_path}")
+                raise ValueError(f"File {filename} not found in zip: {zip_path}") from None
+    except FileNotFoundError:
+        raise ValueError(f"Zip file {zip_path} not found.")
     except zipfile.BadZipFile:
-        logger.exception(f"Bad zip file: {zip_path}")
-        raise ValueError(f"Bad zip file: {zip_path}") from None
+        logger.error(f"Bad zip file: {zip_path}.")
+        raise ValueError(f"Bad zip file: {zip_path}.") from None
 
 
 def load_backtest_analysis_data(backtest_dir: Path, name: str):

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -279,7 +279,11 @@ def get_backtest_market_change(filename: Path, include_ts: bool = True) -> pd.Da
     """
     Read backtest market change file.
     """
-    df = pd.read_feather(filename)
+    if filename.suffix == ".zip":
+        data = load_file_from_zip(filename, f"{filename.stem}_market_change.feather")
+        df = pd.read_feather(BytesIO(data))
+    else:
+        df = pd.read_feather(filename)
     if include_ts:
         df.loc[:, "__date_ts"] = df.loc[:, "date"].astype(np.int64) // 1000 // 1000
     return df

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -404,12 +404,13 @@ def load_backtest_data(filename: Path | str, strategy: str | None = None) -> pd.
     return df
 
 
-def load_file_from_zip(zip_path: Path, filename: str) -> bytes | None:
+def load_file_from_zip(zip_path: Path, filename: str) -> bytes:
     """
     Load a file from a zip file
     :param zip_path: Path to the zip file
     :param filename: Name of the file to load
     :return: Bytes of the file
+    :raises: ValueError if loading goes wrong.
     """
     try:
         with zipfile.ZipFile(zip_path) as zipf:
@@ -417,7 +418,7 @@ def load_file_from_zip(zip_path: Path, filename: str) -> bytes | None:
                 return file.read()
     except zipfile.BadZipFile:
         logger.exception(f"Bad zip file: {zip_path}")
-        return None
+        raise ValueError(f"Bad zip file: {zip_path}") from None
 
 
 def load_backtest_analysis_data(backtest_dir: Path, name: str):

--- a/freqtrade/data/btanalysis.py
+++ b/freqtrade/data/btanalysis.py
@@ -211,8 +211,10 @@ def load_and_merge_backtest_result(strategy_name: str, filename: Path, results: 
 
 
 def _get_backtest_files(dirname: Path) -> list[Path]:
-    # Weird glob expression here avoids including .meta.json files.
-    return list(reversed(sorted(dirname.glob("backtest-result-*-[0-9][0-9].json"))))
+    # Get both json and zip files separately and combine the results
+    json_files = dirname.glob("backtest-result-*-[0-9][0-9]*.json")
+    zip_files = dirname.glob("backtest-result-*-[0-9][0-9]*.zip")
+    return list(reversed(sorted(list(json_files) + list(zip_files))))
 
 
 def _extract_backtest_result(filename: Path) -> list[BacktestHistoryEntryType]:

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -13,7 +13,7 @@ from freqtrade.data.btanalysis import (
     load_rejected_signals,
     load_signal_candles,
 )
-from freqtrade.exceptions import OperationalException
+from freqtrade.exceptions import ConfigurationError, OperationalException
 from freqtrade.util import print_df_rich_table
 
 
@@ -343,8 +343,10 @@ def process_entry_exit_reasons(config: Config):
         timerange = TimeRange.parse_timerange(
             None if config.get("timerange") is None else str(config.get("timerange"))
         )
-
-        backtest_stats = load_backtest_stats(config["exportfilename"])
+        try:
+            backtest_stats = load_backtest_stats(config["exportfilename"])
+        except ValueError as e:
+            raise ConfigurationError(e) from e
 
         for strategy_name, results in backtest_stats["strategy"].items():
             trades = load_backtest_data(config["exportfilename"], strategy_name)

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -32,8 +32,8 @@ def _load_backtest_analysis_data(backtest_dir: Path, name: str):
         with scpf.open("rb") as scp:
             loaded_data = joblib.load(scp)
             logger.info(f"Loaded {name} candles: {str(scpf)}")
-    except Exception as e:
-        logger.error(f"Cannot load {name} data from pickled results: ", e)
+    except Exception:
+        logger.exception(f"Cannot load {name} data from pickled results.")
         return None
 
     return loaded_data

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -19,6 +19,15 @@ from freqtrade.enums import SignalTagType, SignalType
 logger = logging.getLogger(__name__)
 
 
+def dump_json_to_file(file_obj: TextIO, data: Any) -> None:
+    """
+    Dump JSON data into a file object
+    :param file_obj: File object to write to
+    :param data: JSON Data to save
+    """
+    rapidjson.dump(data, file_obj, default=str, number_mode=rapidjson.NM_NATIVE)
+
+
 def file_dump_json(filename: Path, data: Any, is_zip: bool = False, log: bool = True) -> None:
     """
     Dump JSON data into a file
@@ -35,12 +44,12 @@ def file_dump_json(filename: Path, data: Any, is_zip: bool = False, log: bool = 
             logger.info(f'dumping json to "{filename}"')
 
         with gzip.open(filename, "wt", encoding="utf-8") as fpz:
-            rapidjson.dump(data, fpz, default=str, number_mode=rapidjson.NM_NATIVE)
+            dump_json_to_file(fpz, data)
     else:
         if log:
             logger.info(f'dumping json to "{filename}"')
         with filename.open("w") as fp:
-            rapidjson.dump(data, fp, default=str, number_mode=rapidjson.NM_NATIVE)
+            dump_json_to_file(fp, data)
 
     logger.debug(f'done json to "{filename}"')
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -54,22 +54,6 @@ def file_dump_json(filename: Path, data: Any, is_zip: bool = False, log: bool = 
     logger.debug(f'done json to "{filename}"')
 
 
-def file_dump_joblib(filename: Path, data: Any, log: bool = True) -> None:
-    """
-    Dump object data into a file
-    :param filename: file to create
-    :param data: Object data to save
-    :return:
-    """
-    import joblib
-
-    if log:
-        logger.info(f'dumping joblib to "{filename}"')
-    with filename.open("wb") as fp:
-        joblib.dump(data, fp)
-    logger.debug(f'done joblib dump to "{filename}"')
-
-
 def json_load(datafile: TextIO) -> Any:
     """
     load data with rapidjson

--- a/freqtrade/optimize/backtest_caching.py
+++ b/freqtrade/optimize/backtest_caching.py
@@ -40,4 +40,4 @@ def get_strategy_run_id(strategy) -> str:
 def get_backtest_metadata_filename(filename: Path | str) -> Path:
     """Return metadata filename for specified backtest results file."""
     filename = Path(filename)
-    return filename.parent / Path(f"{filename.stem}.meta{filename.suffix}")
+    return filename.parent / Path(f"{filename.stem}.meta.json")

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -1,4 +1,6 @@
 import logging
+import zipfile
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -7,7 +9,7 @@ from pandas import DataFrame
 from freqtrade.constants import LAST_BT_RESULT_FN
 from freqtrade.enums.runmode import RunMode
 from freqtrade.ft_types import BacktestResultType
-from freqtrade.misc import file_dump_json
+from freqtrade.misc import dump_json_to_file, file_dump_json
 from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename
 
 
@@ -52,75 +54,59 @@ def store_backtest_results(
     analysis_results: dict[str, dict[str, DataFrame]] | None = None,
 ) -> Path:
     """
-    Stores backtest results and analysis data
+    Stores backtest results and analysis data in a zip file, with metadata stored separately
+    for convenience.
     :param config: Configuration dictionary
     :param stats: Dataframe containing the backtesting statistics
     :param dtappendix: Datetime to use for the filename
     :param market_change_data: Dataframe containing market change data
     :param analysis_results: Dictionary containing analysis results
     """
-
-    # Path object, which can either be a filename or a directory.
-    # Filenames will be appended with a timestamp right before the suffix
-    # while for directories, <directory>/backtest-result-<datetime>.json will be used as filename
     recordfilename: Path = config["exportfilename"]
-    filename = _generate_filename(recordfilename, dtappendix, ".json")
+    zip_filename = _generate_filename(recordfilename, dtappendix, ".zip")
+    base_filename = _generate_filename(recordfilename, dtappendix, "")
+    json_filename = _generate_filename(recordfilename, dtappendix, ".json")
 
-    # Store metadata separately.
-    file_dump_json(get_backtest_metadata_filename(filename), stats["metadata"])
-    # Don't mutate the original stats dict.
-    stats_copy = {
-        "strategy": stats["strategy"],
-        "strategy_comparison": stats["strategy_comparison"],
-    }
+    # Store metadata separately with .json extension
+    file_dump_json(get_backtest_metadata_filename(json_filename), stats["metadata"])
 
-    file_dump_json(filename, stats_copy)
+    # Store latest backtest info separately
+    latest_filename = Path.joinpath(zip_filename.parent, LAST_BT_RESULT_FN)
+    file_dump_json(latest_filename, {"latest_backtest": str(zip_filename.name)})
 
-    latest_filename = Path.joinpath(filename.parent, LAST_BT_RESULT_FN)
-    file_dump_json(latest_filename, {"latest_backtest": str(filename.name)})
+    # Create zip file and add the files
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Store stats
+        stats_copy = {
+            "strategy": stats["strategy"],
+            "strategy_comparison": stats["strategy_comparison"],
+        }
+        stats_buf = StringIO()
+        dump_json_to_file(stats_buf, stats_copy)
+        zipf.writestr(json_filename, stats_buf.getvalue())
 
-    if market_change_data is not None:
-        filename_mc = _generate_filename(recordfilename, f"{dtappendix}_market_change", ".feather")
-        market_change_data.reset_index().to_feather(
-            filename_mc, compression_level=9, compression="lz4"
-        )
+        # Add market change data if present
+        if market_change_data is not None:
+            market_change_name = f"{base_filename.stem}_market_change.feather"
+            market_change_buf = BytesIO()
+            market_change_data.reset_index().to_feather(
+                market_change_buf, compression_level=9, compression="lz4"
+            )
+            market_change_buf.seek(0)
+            zipf.writestr(market_change_name, market_change_buf.getvalue())
 
-    if (
-        config.get("export", "none") == "signals"
-        and analysis_results is not None
-        and config.get("runmode", RunMode.OTHER) == RunMode.BACKTEST
-    ):
-        _store_backtest_analysis_data(
-            recordfilename, analysis_results["signals"], dtappendix, "signals"
-        )
-        _store_backtest_analysis_data(
-            recordfilename, analysis_results["rejected"], dtappendix, "rejected"
-        )
-        _store_backtest_analysis_data(
-            recordfilename, analysis_results["exited"], dtappendix, "exited"
-        )
+        # Add analysis results if present and running in backtest mode
+        if (
+            config.get("export", "none") == "signals"
+            and analysis_results is not None
+            and config.get("runmode", RunMode.OTHER) == RunMode.BACKTEST
+        ):
+            for name in ["signals", "rejected", "exited"]:
+                if name in analysis_results:
+                    analysis_name = f"{base_filename.stem}_{name}.pkl"
+                    analysis_buf = BytesIO()
+                    file_dump_joblib(analysis_buf, analysis_results[name])
+                    analysis_buf.seek(0)
+                    zipf.writestr(analysis_name, analysis_buf.getvalue())
 
-    return filename
-
-
-def _store_backtest_analysis_data(
-    recordfilename: Path, data: dict[str, dict], dtappendix: str, name: str
-) -> Path:
-    """
-    Stores backtest trade candles for analysis
-    :param recordfilename: Path object, which can either be a filename or a directory.
-        Filenames will be appended with a timestamp right before the suffix
-        while for directories, <directory>/backtest-result-<datetime>_<name>.pkl will be used
-        as filename
-    :param candles: Dict containing the backtesting data for analysis
-    :param dtappendix: Datetime to use for the filename
-    :param name: Name to use for the file, e.g. signals, rejected
-    """
-    filename = _generate_filename(recordfilename, f"{dtappendix}_{name}", ".pkl")
-
-    logger.info(f'dumping joblib to "{filename}"')
-    with filename.open("wb") as fp:
-        file_dump_joblib(fp, data)
-    logger.debug(f'done joblib dump to "{filename}"')
-
-    return filename
+    return zip_filename

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -1,16 +1,33 @@
 import logging
 from pathlib import Path
+from typing import Any
 
 from pandas import DataFrame
 
 from freqtrade.constants import LAST_BT_RESULT_FN
 from freqtrade.enums.runmode import RunMode
 from freqtrade.ft_types import BacktestResultType
-from freqtrade.misc import file_dump_joblib, file_dump_json
+from freqtrade.misc import file_dump_json
 from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename
 
 
 logger = logging.getLogger(__name__)
+
+
+def file_dump_joblib(filename: Path, data: Any, log: bool = True) -> None:
+    """
+    Dump object data into a file
+    :param filename: file to create
+    :param data: Object data to save
+    :return:
+    """
+    import joblib
+
+    if log:
+        logger.info(f'dumping joblib to "{filename}"')
+    with filename.open("wb") as fp:
+        joblib.dump(data, fp)
+    logger.debug(f'done joblib dump to "{filename}"')
 
 
 def _generate_filename(recordfilename: Path, appendix: str, suffix: str) -> Path:

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -1,8 +1,8 @@
 import logging
-import zipfile
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, TextIO
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from pandas import DataFrame
 
@@ -75,7 +75,7 @@ def store_backtest_results(
     file_dump_json(latest_filename, {"latest_backtest": str(zip_filename.name)}, log=False)
 
     # Create zip file and add the files
-    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+    with ZipFile(zip_filename, "w", ZIP_DEFLATED) as zipf:
         # Store stats
         stats_copy = {
             "strategy": stats["strategy"],

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -72,7 +72,7 @@ def store_backtest_results(
 
     # Store latest backtest info separately
     latest_filename = Path.joinpath(zip_filename.parent, LAST_BT_RESULT_FN)
-    file_dump_json(latest_filename, {"latest_backtest": str(zip_filename.name)})
+    file_dump_json(latest_filename, {"latest_backtest": str(zip_filename.name)}, log=False)
 
     # Create zip file and add the files
     with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
@@ -83,7 +83,7 @@ def store_backtest_results(
         }
         stats_buf = StringIO()
         dump_json_to_file(stats_buf, stats_copy)
-        zipf.writestr(json_filename, stats_buf.getvalue())
+        zipf.writestr(json_filename.name, stats_buf.getvalue())
 
         # Add market change data if present
         if market_change_data is not None:

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -1,7 +1,7 @@
 import logging
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pandas import DataFrame
@@ -16,7 +16,7 @@ from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename
 logger = logging.getLogger(__name__)
 
 
-def file_dump_joblib(file_obj: TextIO, data: Any, log: bool = True) -> None:
+def file_dump_joblib(file_obj: BytesIO, data: Any, log: bool = True) -> None:
     """
     Dump object data into a file
     :param filename: file to create

--- a/freqtrade/optimize/optimize_reports/bt_storage.py
+++ b/freqtrade/optimize/optimize_reports/bt_storage.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from pandas import DataFrame
 
@@ -14,7 +14,7 @@ from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename
 logger = logging.getLogger(__name__)
 
 
-def file_dump_joblib(filename: Path, data: Any, log: bool = True) -> None:
+def file_dump_joblib(file_obj: TextIO, data: Any, log: bool = True) -> None:
     """
     Dump object data into a file
     :param filename: file to create
@@ -23,11 +23,7 @@ def file_dump_joblib(filename: Path, data: Any, log: bool = True) -> None:
     """
     import joblib
 
-    if log:
-        logger.info(f'dumping joblib to "{filename}"')
-    with filename.open("wb") as fp:
-        joblib.dump(data, fp)
-    logger.debug(f'done joblib dump to "{filename}"')
+    joblib.dump(data, file_obj)
 
 
 def _generate_filename(recordfilename: Path, appendix: str, suffix: str) -> Path:
@@ -122,6 +118,9 @@ def _store_backtest_analysis_data(
     """
     filename = _generate_filename(recordfilename, f"{dtappendix}_{name}", ".pkl")
 
-    file_dump_joblib(filename, data)
+    logger.info(f'dumping joblib to "{filename}"')
+    with filename.open("wb") as fp:
+        file_dump_joblib(fp, data)
+    logger.debug(f'done joblib dump to "{filename}"')
 
     return filename

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -350,10 +350,17 @@ def api_update_backtest_history_entry(
 )
 def api_get_backtest_market_change(file: str, config=Depends(get_config)):
     bt_results_base: Path = config["user_data_dir"] / "backtest_results"
-    file_abs = (bt_results_base / f"{file}_market_change").with_suffix(".feather")
-    # Ensure file is in backtest_results directory
-    if not is_file_in_dir(file_abs, bt_results_base):
+    for fn in (
+        Path(file).with_suffix(".zip"),
+        Path(f"{file}_market_change").with_suffix(".feather"),
+    ):
+        file_abs = bt_results_base / fn
+        # Ensure file is in backtest_results directory
+        if is_file_in_dir(file_abs, bt_results_base):
+            break
+    else:
         raise HTTPException(status_code=404, detail="File not found.")
+
     df = get_backtest_market_change(file_abs)
 
     return {

--- a/freqtrade/rpc/api_server/api_backtest.py
+++ b/freqtrade/rpc/api_server/api_backtest.py
@@ -273,15 +273,18 @@ def api_backtest_history(config=Depends(get_config)):
 def api_backtest_history_result(filename: str, strategy: str, config=Depends(get_config)):
     # Get backtest result history, read from metadata files
     bt_results_base: Path = config["user_data_dir"] / "backtest_results"
-    fn = (bt_results_base / filename).with_suffix(".json")
+    for ext in [".zip", ".json"]:
+        fn = (bt_results_base / filename).with_suffix(ext)
+        if is_file_in_dir(fn, bt_results_base):
+            break
+    else:
+        raise HTTPException(status_code=404, detail="File not found.")
 
     results: dict[str, Any] = {
         "metadata": {},
         "strategy": {},
         "strategy_comparison": [],
     }
-    if not is_file_in_dir(fn, bt_results_base):
-        raise HTTPException(status_code=404, detail="File not found.")
     load_and_merge_backtest_result(strategy, fn, results)
     return {
         "status": "ended",
@@ -301,9 +304,12 @@ def api_backtest_history_result(filename: str, strategy: str, config=Depends(get
 def api_delete_backtest_history_entry(file: str, config=Depends(get_config)):
     # Get backtest result history, read from metadata files
     bt_results_base: Path = config["user_data_dir"] / "backtest_results"
-    file_abs = (bt_results_base / file).with_suffix(".json")
-    # Ensure file is in backtest_results directory
-    if not is_file_in_dir(file_abs, bt_results_base):
+    for ext in [".zip", ".json"]:
+        file_abs = (bt_results_base / file).with_suffix(ext)
+        # Ensure file is in backtest_results directory
+        if is_file_in_dir(file_abs, bt_results_base):
+            break
+    else:
         raise HTTPException(status_code=404, detail="File not found.")
 
     delete_backtest_result(file_abs)
@@ -320,10 +326,14 @@ def api_update_backtest_history_entry(
 ):
     # Get backtest result history, read from metadata files
     bt_results_base: Path = config["user_data_dir"] / "backtest_results"
-    file_abs = (bt_results_base / file).with_suffix(".json")
-    # Ensure file is in backtest_results directory
-    if not is_file_in_dir(file_abs, bt_results_base):
+    for ext in [".zip", ".json"]:
+        file_abs = (bt_results_base / file).with_suffix(ext)
+        # Ensure file is in backtest_results directory
+        if is_file_in_dir(file_abs, bt_results_base):
+            break
+    else:
         raise HTTPException(status_code=404, detail="File not found.")
+
     content = {"notes": body.notes}
     try:
         update_backtest_metadata(file_abs, body.strategy, content)

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -2660,7 +2660,7 @@ def test_get_backtest_metadata_filename():
 
     # Test with a string file path with no extension
     filename = "/path/to/backtest_results"
-    expected = Path("/path/to/backtest_results.meta")
+    expected = Path("/path/to/backtest_results.meta.json")
     assert get_backtest_metadata_filename(filename) == expected
 
     # Test with a string file path with multiple dots in the name
@@ -2671,4 +2671,9 @@ def test_get_backtest_metadata_filename():
     # Test with a string file path with no parent directory
     filename = "backtest_results.json"
     expected = Path("backtest_results.meta.json")
+    assert get_backtest_metadata_filename(filename) == expected
+    # Test with a string file path with no parent directory
+
+    filename = "backtest_results_zip.zip"
+    expected = Path("backtest_results_zip.meta.json")
     assert get_backtest_metadata_filename(filename) == expected

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -3,6 +3,7 @@ import re
 from datetime import timedelta
 from pathlib import Path
 from shutil import copyfile
+from zipfile import ZipFile
 
 import joblib
 import pandas as pd
@@ -275,67 +276,33 @@ def test_store_backtest_results_real(tmp_path):
     data = {"metadata": {}, "strategy": {}, "strategy_comparison": []}
     store_backtest_results({"exportfilename": tmp_path}, data, "2022_01_01_15_05_13")
 
-    assert (tmp_path / "backtest-result-2022_01_01_15_05_13.json").is_file()
+    zip_file = tmp_path / "backtest-result-2022_01_01_15_05_13.zip"
+    assert zip_file.is_file()
     assert (tmp_path / "backtest-result-2022_01_01_15_05_13.meta.json").is_file()
     assert not (tmp_path / "backtest-result-2022_01_01_15_05_13_market_change.feather").is_file()
+    with ZipFile(zip_file, "r") as zipf:
+        assert "backtest-result-2022_01_01_15_05_13.json" in zipf.namelist()
+        assert "backtest-result-2022_01_01_15_05_13_market_change.feather" not in zipf.namelist()
     assert (tmp_path / LAST_BT_RESULT_FN).is_file()
     fn = get_latest_backtest_filename(tmp_path)
-    assert fn == "backtest-result-2022_01_01_15_05_13.json"
+    assert fn == "backtest-result-2022_01_01_15_05_13.zip"
 
     store_backtest_results(
         {"exportfilename": tmp_path}, data, "2024_01_01_15_05_25", market_change_data=pd.DataFrame()
     )
-    assert (tmp_path / "backtest-result-2024_01_01_15_05_25.json").is_file()
+    zip_file = tmp_path / "backtest-result-2024_01_01_15_05_25.zip"
+    assert zip_file.is_file()
     assert (tmp_path / "backtest-result-2024_01_01_15_05_25.meta.json").is_file()
-    assert (tmp_path / "backtest-result-2024_01_01_15_05_25_market_change.feather").is_file()
+    assert not (tmp_path / "backtest-result-2024_01_01_15_05_25_market_change.feather").is_file()
+
+    with ZipFile(zip_file, "r") as zipf:
+        assert "backtest-result-2024_01_01_15_05_25.json" in zipf.namelist()
+        assert "backtest-result-2024_01_01_15_05_25_market_change.feather" in zipf.namelist()
     assert (tmp_path / LAST_BT_RESULT_FN).is_file()
 
     # Last file reference should be updated
     fn = get_latest_backtest_filename(tmp_path)
-    assert fn == "backtest-result-2024_01_01_15_05_25.json"
-
-
-def test_store_backtest_candles(tmp_path, mocker):
-    mocker.patch("freqtrade.optimize.optimize_reports.bt_storage.file_dump_json")
-    dump_mock = mocker.patch("freqtrade.optimize.optimize_reports.bt_storage.file_dump_joblib")
-
-    candle_dict = {"DefStrat": {"UNITTEST/BTC": pd.DataFrame()}}
-    bt_results = {"metadata": {}, "strategy": {}, "strategy_comparison": []}
-
-    mock_conf = {
-        "exportfilename": tmp_path,
-        "export": "signals",
-        "runmode": "backtest",
-    }
-
-    # mock directory exporting
-    data = {
-        "signals": candle_dict,
-        "rejected": {},
-        "exited": {},
-    }
-
-    store_backtest_results(mock_conf, bt_results, "2022_01_01_15_05_13", analysis_results=data)
-
-    assert dump_mock.call_count == 3
-    assert isinstance(dump_mock.call_args_list[0][0][0], Path)
-    assert str(dump_mock.call_args_list[0][0][0]).endswith("_signals.pkl")
-    assert str(dump_mock.call_args_list[1][0][0]).endswith("_rejected.pkl")
-    assert str(dump_mock.call_args_list[2][0][0]).endswith("_exited.pkl")
-
-    dump_mock.reset_mock()
-    # mock file exporting
-    filename = Path(tmp_path / "testresult")
-    mock_conf["exportfilename"] = filename
-    store_backtest_results(mock_conf, bt_results, "2022_01_01_15_05_13", analysis_results=data)
-    assert dump_mock.call_count == 3
-    assert isinstance(dump_mock.call_args_list[0][0][0], Path)
-    # result will be tmp_path / testresult-<timestamp>_signals.pkl
-    assert str(dump_mock.call_args_list[0][0][0]).endswith("_signals.pkl")
-    assert str(dump_mock.call_args_list[1][0][0]).endswith("_rejected.pkl")
-    assert str(dump_mock.call_args_list[2][0][0]).endswith("_exited.pkl")
-
-    dump_mock.reset_mock()
+    assert fn == "backtest-result-2024_01_01_15_05_25.zip"
 
 
 def test_write_read_backtest_candles(tmp_path):
@@ -355,9 +322,21 @@ def test_write_read_backtest_candles(tmp_path):
         "exited": {},
     }
     store_backtest_results(mock_conf, bt_results, sample_date, analysis_results=data)
-    stored_file = tmp_path / f"backtest-result-{sample_date}_signals.pkl"
-    with stored_file.open("rb") as scp:
-        pickled_signal_candles = joblib.load(scp)
+    stored_file = tmp_path / f"backtest-result-{sample_date}.zip"
+    signals_pkl = f"backtest-result-{sample_date}_signals.pkl"
+    rejected_pkl = f"backtest-result-{sample_date}_rejected.pkl"
+    exited_pkl = f"backtest-result-{sample_date}_exited.pkl"
+    assert not (tmp_path / signals_pkl).is_file()
+    assert stored_file.is_file()
+
+    with ZipFile(stored_file, "r") as zipf:
+        assert signals_pkl in zipf.namelist()
+        assert rejected_pkl in zipf.namelist()
+        assert exited_pkl in zipf.namelist()
+
+        # open and read the file
+        with zipf.open(signals_pkl) as scp:
+            pickled_signal_candles = joblib.load(scp)
 
     assert pickled_signal_candles.keys() == candle_dict.keys()
     assert pickled_signal_candles["DefStrat"].keys() == pickled_signal_candles["DefStrat"].keys()
@@ -371,14 +350,25 @@ def test_write_read_backtest_candles(tmp_path):
     filename = tmp_path / "testresult"
     mock_conf["exportfilename"] = filename
     store_backtest_results(mock_conf, bt_results, sample_date, analysis_results=data)
-    stored_file = tmp_path / f"testresult-{sample_date}_signals.pkl"
-    with stored_file.open("rb") as scp:
-        pickled_signal_candles = joblib.load(scp)
+    stored_file = tmp_path / f"testresult-{sample_date}.zip"
+    signals_pkl = f"testresult-{sample_date}_signals.pkl"
+    rejected_pkl = f"testresult-{sample_date}_rejected.pkl"
+    exited_pkl = f"testresult-{sample_date}_exited.pkl"
+    assert not (tmp_path / signals_pkl).is_file()
+    assert stored_file.is_file()
 
-    assert pickled_signal_candles.keys() == candle_dict.keys()
-    assert pickled_signal_candles["DefStrat"].keys() == pickled_signal_candles["DefStrat"].keys()
-    assert pickled_signal_candles["DefStrat"]["UNITTEST/BTC"].equals(
-        pickled_signal_candles["DefStrat"]["UNITTEST/BTC"]
+    with ZipFile(stored_file, "r") as zipf:
+        assert signals_pkl in zipf.namelist()
+        assert rejected_pkl in zipf.namelist()
+        assert exited_pkl in zipf.namelist()
+
+        with zipf.open(signals_pkl) as scp:
+            pickled_signal_candles2 = joblib.load(scp)
+
+    assert pickled_signal_candles2.keys() == candle_dict.keys()
+    assert pickled_signal_candles2["DefStrat"].keys() == pickled_signal_candles2["DefStrat"].keys()
+    assert pickled_signal_candles2["DefStrat"]["UNITTEST/BTC"].equals(
+        pickled_signal_candles2["DefStrat"]["UNITTEST/BTC"]
     )
 
     _clean_test_file(stored_file)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This will both save space on disk - and make the backtest result directory more concise by only having 2 files per backtest (.meta.json and .zip).

It'll also facilitate adding more data in a simpler way - as it can be added to the zip file as necessary.

## Quick changelog

- store backtest results as .zip file
- support loading different files from both zip and "non-zip" files.