### PR TITLE
Update setup.sh to check for Python 3.13 too.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ function check_installed_python() {
         exit 2
     fi
 
-    for v in 12 11 10
+    for v in 13 12 11 10
     do
         PYTHON="python3.${v}"
         which $PYTHON


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Updated setup.sh to check for Python 3.13 after .10, .11, .12 which caused it to abort installation if the python version was above 3.12.

Solve the issue: #___

## Quick changelog

- Changed `for v in 12 11 10` to `for v in 13 12 11 10`
