### PR TITLE
Fix:orderflow returns a list for stacked imbalances

### DIFF
--- a/docs/advanced-orderflow.md
+++ b/docs/advanced-orderflow.md
@@ -70,8 +70,8 @@ dataframe["delta"] # Difference between ask and bid volume.
 dataframe["min_delta"] # Minimum delta within the candle
 dataframe["max_delta"] # Maximum delta within the candle
 dataframe["total_trades"] # Total number of trades
-dataframe["stacked_imbalances_bid"] # Price level of stacked bid imbalance 
-dataframe["stacked_imbalances_ask"] # Price level of stacked ask imbalance  
+dataframe["stacked_imbalances_bid"] # List of price levels of stacked bid imbalance range beginnings
+dataframe["stacked_imbalances_ask"] # List of price levels of stacked ask imbalance range beginnings
 ```
 
 You can access these columns in your strategy code for further analysis. Here's an example:

--- a/freqtrade/data/converter/orderflow.py
+++ b/freqtrade/data/converter/orderflow.py
@@ -269,16 +269,18 @@ def stacked_imbalance(
         int_series.groupby((int_series != int_series.shift()).cumsum()).cumcount() + 1
     )
 
-    max_stacked_imbalance_idx = stacked.index[stacked >= stacked_imbalance_range]
-    stacked_imbalance_price = np.nan
-    if not max_stacked_imbalance_idx.empty:
-        idx = (
-            max_stacked_imbalance_idx[0]
+    stacked_imbalance_idx = stacked.index[stacked >= stacked_imbalance_range]
+    stacked_imbalance_prices = []
+    
+    if not stacked_imbalance_idx.empty:
+        indices = (
+            stacked_imbalance_idx
             if not should_reverse
-            else np.flipud(max_stacked_imbalance_idx)[0]
+            else np.flipud(stacked_imbalance_idx)
         )
-        stacked_imbalance_price = imbalance.index[idx]
-    return stacked_imbalance_price
+        stacked_imbalance_prices = [float(imbalance.index[idx]) for idx in indices]
+    
+    return stacked_imbalance_prices if stacked_imbalance_prices else [np.nan]
 
 
 def stacked_imbalance_ask(df: pd.DataFrame, stacked_imbalance_range: int):

--- a/freqtrade/data/converter/orderflow.py
+++ b/freqtrade/data/converter/orderflow.py
@@ -276,4 +276,4 @@ def stacked_imbalance(df: pd.DataFrame, label: str, stacked_imbalance_range: int
         stacked_imbalance_prices = [
             imbalance.index.values[idx - (stacked_imbalance_range - 1)] for idx in valid_indices
         ]
-    return stacked_imbalance_prices if stacked_imbalance_prices else []
+    return stacked_imbalance_prices

--- a/tests/data/test_converter_orderflow.py
+++ b/tests/data/test_converter_orderflow.py
@@ -535,8 +535,7 @@ def test_analyze_with_orderflow(
         assert col in df1.columns, f"Column {col} not found in df.columns"
 
         if col not in ("stacked_imbalances_bid", "stacked_imbalances_ask"):
-            assert df1[col].count() == 5, f"Column {col} has {
-                df1[col].count()} non-NaN values"
+            assert df1[col].count() == 5, f"Column {col} has {df1[col].count()} non-NaN values"
 
     assert len(strategy._cached_grouped_trades_per_pair[pair]) == 5
 
@@ -554,8 +553,7 @@ def test_analyze_with_orderflow(
     assert "open" in df2.columns
     assert spy.call_count == 0
     for col in ORDERFLOW_ADDED_COLUMNS:
-        assert col in df2.columns, f"Round2: Column {
-            col} not found in df.columns"
+        assert col in df2.columns, f"Round2: Column {col} not found in df.columns"
 
         if col not in ("stacked_imbalances_bid", "stacked_imbalances_ask"):
             assert (

--- a/tests/data/test_converter_orderflow.py
+++ b/tests/data/test_converter_orderflow.py
@@ -193,8 +193,8 @@ def test_public_trades_mock_populate_dataframe_with_trades__check_orderflow(
     assert pytest.approx(results["delta"]) == -20.862
     assert pytest.approx(results["min_delta"]) == -54.559999
     assert 82.842 == results["max_delta"]
-    assert results["stacked_imbalances_bid"] == [234.99]
-    assert results["stacked_imbalances_ask"] == [234.96]
+    assert results["stacked_imbalances_bid"] == [234.97]
+    assert results["stacked_imbalances_ask"] == [234.94]
 
     # Repeat assertions for the last row
     results = df.iloc[-1]
@@ -586,22 +586,22 @@ def test_stacked_imbalances_multiple_prices():
     # Create a sample DataFrame with known imbalances
     df = pd.DataFrame(
         {
-            'bid_imbalance': [True, True, True, False, False, True, True, False],
-            'ask_imbalance': [False, False, True, True, True, False, False, True]
+            'bid_imbalance': [True, True, True, False, False, True, True, False, True],
+            'ask_imbalance': [False, False, True, True, True, False, False, True, True]
         },
-        index=[234.95, 234.96, 234.97, 234.98, 234.99, 235.00, 235.01, 235.02]
+        index=[234.95, 234.96, 234.97, 234.98, 234.99, 235.00, 235.01, 235.02, 235.03]
     )
     # Test bid imbalances (should return prices in ascending order)
     bid_prices = stacked_imbalance(df, "bid", stacked_imbalance_range=2, should_reverse=False)
-    assert bid_prices == [234.95, 234.96, 234.97, 235.00, 235.01]
+    assert bid_prices == [234.95, 234.96, 235.00]
     
     # Test ask imbalances (should return prices in descending order)
     ask_prices = stacked_imbalance(df, "ask", stacked_imbalance_range=2, should_reverse=True)
-    assert ask_prices == [235.02, 234.99, 234.98, 234.97]
+    assert ask_prices == [235.02, 234.98, 234.97]
     
     # Test with higher stacked_imbalance_range
     bid_prices_higher = stacked_imbalance(df, "bid", stacked_imbalance_range=3, should_reverse=False)
-    assert bid_prices_higher == [234.95, 234.96, 234.97]
+    assert bid_prices_higher == [234.95]
     
 
 

--- a/tests/data/test_converter_orderflow.py
+++ b/tests/data/test_converter_orderflow.py
@@ -5,9 +5,9 @@ from freqtrade.constants import DEFAULT_TRADES_COLUMNS
 from freqtrade.data.converter import populate_dataframe_with_trades
 from freqtrade.data.converter.orderflow import (
     ORDERFLOW_ADDED_COLUMNS,
+    stacked_imbalance,
     timeframe_to_DateOffset,
     trades_to_volumeprofile_with_total_delta_bid_ask,
-    stacked_imbalance,
 )
 from freqtrade.data.converter.trade_converter import trades_list_to_df
 from freqtrade.data.dataprovider import DataProvider
@@ -185,8 +185,8 @@ def test_public_trades_mock_populate_dataframe_with_trades__check_orderflow(
     assert results["max_delta"] == 17.298
 
     # Assert that stacked imbalances are NaN (not applicable in this test)
-    assert results["stacked_imbalances_bid"] == [np.nan]
-    assert results["stacked_imbalances_ask"] == [np.nan]
+    assert results["stacked_imbalances_bid"] == []
+    assert results["stacked_imbalances_ask"] == []
 
     # Repeat assertions for the third from last row
     results = df.iloc[-2]
@@ -201,8 +201,8 @@ def test_public_trades_mock_populate_dataframe_with_trades__check_orderflow(
     assert pytest.approx(results["delta"]) == -49.302
     assert results["min_delta"] == -70.222
     assert pytest.approx(results["max_delta"]) == 11.213
-    assert results["stacked_imbalances_bid"] == [np.nan]
-    assert results["stacked_imbalances_ask"] == [np.nan]
+    assert results["stacked_imbalances_bid"] == []
+    assert results["stacked_imbalances_ask"] == []
 
 
 def test_public_trades_trades_mock_populate_dataframe_with_trades__check_trades(
@@ -575,34 +575,33 @@ def test_stacked_imbalances_multiple_prices():
     # Test with empty result
     df_no_stacks = pd.DataFrame(
         {
-            'bid_imbalance': [False, False, True, False],
-            'ask_imbalance': [False, True, False, False]
+            "bid_imbalance": [False, False, True, False],
+            "ask_imbalance": [False, True, False, False],
         },
-        index=[234.95, 234.96, 234.97, 234.98]
+        index=[234.95, 234.96, 234.97, 234.98],
     )
-    no_stacks = stacked_imbalance(df_no_stacks, "bid", stacked_imbalance_range=2, should_reverse=False)
-    assert no_stacks == [np.nan]
-    
+    no_stacks = stacked_imbalance(df_no_stacks, "bid", stacked_imbalance_range=2)
+    assert no_stacks == []
+
     # Create a sample DataFrame with known imbalances
     df = pd.DataFrame(
         {
-            'bid_imbalance': [True, True, True, False, False, True, True, False, True],
-            'ask_imbalance': [False, False, True, True, True, False, False, True, True]
+            "bid_imbalance": [True, True, True, False, False, True, True, False, True],
+            "ask_imbalance": [False, False, True, True, True, False, False, True, True],
         },
-        index=[234.95, 234.96, 234.97, 234.98, 234.99, 235.00, 235.01, 235.02, 235.03]
+        index=[234.95, 234.96, 234.97, 234.98, 234.99, 235.00, 235.01, 235.02, 235.03],
     )
     # Test bid imbalances (should return prices in ascending order)
-    bid_prices = stacked_imbalance(df, "bid", stacked_imbalance_range=2, should_reverse=False)
+    bid_prices = stacked_imbalance(df, "bid", stacked_imbalance_range=2)
     assert bid_prices == [234.95, 234.96, 235.00]
-    
+
     # Test ask imbalances (should return prices in descending order)
-    ask_prices = stacked_imbalance(df, "ask", stacked_imbalance_range=2, should_reverse=True)
-    assert ask_prices == [235.02, 234.98, 234.97]
-    
+    ask_prices = stacked_imbalance(df, "ask", stacked_imbalance_range=2)
+    assert ask_prices == [234.97, 234.98, 235.02]
+
     # Test with higher stacked_imbalance_range
-    bid_prices_higher = stacked_imbalance(df, "bid", stacked_imbalance_range=3, should_reverse=False)
+    bid_prices_higher = stacked_imbalance(df, "bid", stacked_imbalance_range=3)
     assert bid_prices_higher == [234.95]
-    
 
 
 def test_timeframe_to_DateOffset():

--- a/tests/data/test_converter_orderflow.py
+++ b/tests/data/test_converter_orderflow.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -185,24 +184,24 @@ def test_public_trades_mock_populate_dataframe_with_trades__check_orderflow(
     assert results["max_delta"] == 17.298
 
     # Assert that stacked imbalances are NaN (not applicable in this test)
-    assert np.isnan(results["stacked_imbalances_bid"])
-    assert np.isnan(results["stacked_imbalances_ask"])
+    assert results["stacked_imbalances_bid"] == [np.nan]
+    assert results["stacked_imbalances_ask"] == [np.nan]
 
     # Repeat assertions for the third from last row
     results = df.iloc[-2]
     assert pytest.approx(results["delta"]) == -20.862
     assert pytest.approx(results["min_delta"]) == -54.559999
     assert 82.842 == results["max_delta"]
-    assert 234.99 == results["stacked_imbalances_bid"]
-    assert 234.96 == results["stacked_imbalances_ask"]
+    assert results["stacked_imbalances_bid"] == [234.99]
+    assert results["stacked_imbalances_ask"] == [234.96]
 
     # Repeat assertions for the last row
     results = df.iloc[-1]
     assert pytest.approx(results["delta"]) == -49.302
     assert results["min_delta"] == -70.222
     assert pytest.approx(results["max_delta"]) == 11.213
-    assert np.isnan(results["stacked_imbalances_bid"])
-    assert np.isnan(results["stacked_imbalances_ask"])
+    assert results["stacked_imbalances_bid"] == [np.nan]
+    assert results["stacked_imbalances_ask"] == [np.nan]
 
 
 def test_public_trades_trades_mock_populate_dataframe_with_trades__check_trades(
@@ -358,7 +357,8 @@ def test_public_trades_binned_big_sample_list(public_trades_list):
     assert 197.512 == df["bid_amount"].iloc[0]  # total bid amount
     assert 88.98 == df["ask_amount"].iloc[0]  # total ask amount
     assert 26 == df["ask"].iloc[0]  # ask price
-    assert -108.532 == pytest.approx(df["delta"].iloc[0])  # delta (bid amount - ask amount)
+    # delta (bid amount - ask amount)
+    assert -108.532 == pytest.approx(df["delta"].iloc[0])
 
     assert 3 == df["bid"].iloc[-1]  # bid price
     assert 50.659 == df["bid_amount"].iloc[-1]  # total bid amount
@@ -534,7 +534,8 @@ def test_analyze_with_orderflow(
         assert col in df1.columns, f"Column {col} not found in df.columns"
 
         if col not in ("stacked_imbalances_bid", "stacked_imbalances_ask"):
-            assert df1[col].count() == 5, f"Column {col} has {df1[col].count()} non-NaN values"
+            assert df1[col].count() == 5, f"Column {col} has {
+                df1[col].count()} non-NaN values"
 
     assert len(strategy._cached_grouped_trades_per_pair[pair]) == 5
 
@@ -552,7 +553,8 @@ def test_analyze_with_orderflow(
     assert "open" in df2.columns
     assert spy.call_count == 0
     for col in ORDERFLOW_ADDED_COLUMNS:
-        assert col in df2.columns, f"Round2: Column {col} not found in df.columns"
+        assert col in df2.columns, f"Round2: Column {
+            col} not found in df.columns"
 
         if col not in ("stacked_imbalances_bid", "stacked_imbalances_ask"):
             assert (


### PR DESCRIPTION
## Summary
> Ideally, you would want to know all the price levels where the stacked imbalance occurs within a candle, so listing all price levels with a stacked imbalance in dataframe["stacked_imbalances_bid"]
dataframe["stacked_imbalances_ask"] would help a lot.


Solve the issue: #11008

## What's new?
- stacked imbalances are not sorted by "ask", "bid" direction anymore, I figure this didn't make any sense in the first way
- stacked imbalances are now lists
- adapted and new tests
- fix: the returned price of the stacked imbalance is the beginning of the range and not the last item

