### PR TITLE
chore(deps): upgrade CCXT from 4.4.47 to 4.4.48

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bottleneck==1.4.2
 numexpr==2.10.2
 pandas-ta==0.3.14b
 
-ccxt==4.4.47
+ccxt==4.4.48
 cryptography==42.0.8; platform_machine == 'armv7l'
 cryptography==44.0.0; platform_machine != 'armv7l'
 aiohttp==3.10.11


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Current `fetch_balance` CCXT method for perpetual futures returns the wrong free amount of dollar (older version of CCXT returns `None`). It occurs after the latest Bybit updates to unified accounts in combination with isolated margin mode.

## Quick changelog

- Bumpt `ccxt` version from `4.4.47` to `4.4.48` ([release notes](https://github.com/ccxt/ccxt/releases/tag/4.4.48))

## What's new?

Fixes an issue with incorrectly fetched free balances from Bybit accounts.
