### PR TITLE
Improved Backtest timeframe-detail execution logic 

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1527,6 +1527,15 @@ class Backtesting:
                     row = detail_data[idx]
                     trade_dir = pair_tradedir_cache.get(pair)
 
+                    if self.strategy.ignore_expired_candle(
+                        current_time - self.timeframe_td,  # last closed candle is 1 timeframe away.
+                        current_time_det,
+                        self.timeframe_secs,
+                        trade_dir is not None,
+                    ):
+                        # Ignore late entries eventually
+                        trade_dir = None
+
                 self.dataprovider._set_dataframe_max_date(current_time_det)
 
                 pair_has_open_trades = len(LocalTrade.bt_trades_open_pp[pair]) > 0

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1386,7 +1386,7 @@ class Backtesting:
             and (self._position_stacking or len(LocalTrade.bt_trades_open_pp[pair]) == 0)
             and not PairLocks.is_pair_locked(pair, row[DATE_IDX], trade_dir)
         ):
-            if self.trade_slot_available(LocalTrade.bt_open_open_trade_count_candle):
+            if self.trade_slot_available(LocalTrade.bt_open_open_trade_count):
                 trade = self._enter_trade(pair, row, trade_dir)
                 if trade:
                     self.wallets.update()

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1483,6 +1483,7 @@ class Backtesting:
             )
             pair_detail_cache: dict[str, list[tuple]] = {}
             pair_tradedir_cache: dict[str, LongShort | None] = {}
+            pairs_with_open_trades = [t.pair for t in LocalTrade.bt_trades_open]
             for current_time_det, is_first, has_detail, idx in self.time_generator_det(
                 current_time, current_time + increment
             ):
@@ -1523,6 +1524,10 @@ class Backtesting:
                     self.dataprovider._set_dataframe_max_date(current_time_det)
 
                     pair_has_open_trades = len(LocalTrade.bt_trades_open_pp[pair]) > 0
+                    if pair in pairs_with_open_trades and not pair_has_open_trades:
+                        # Pair has had open trades which closed in the current main candle.
+                        # Skip this pair for this timeframe
+                        continue
 
                     if (
                         is_first

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1433,13 +1433,13 @@ class Backtesting:
         detail_data.loc[:, "exit_tag"] = row[EXIT_TAG_IDX]
         return detail_data[HEADERS].values.tolist()
 
-    def time_generator(self, start_date: datetime, end_date: datetime):
+    def _time_generator(self, start_date: datetime, end_date: datetime):
         current_time = start_date + self.timeframe_td
         while current_time <= end_date:
             yield current_time
             current_time += self.timeframe_td
 
-    def time_generator_det(self, start_date: datetime, end_date: datetime):
+    def _time_generator_det(self, start_date: datetime, end_date: datetime):
         if not self.timeframe_detail_td:
             yield start_date, True, False, 0
             return
@@ -1451,8 +1451,8 @@ class Backtesting:
             i += 1
             current_time += self.timeframe_detail_td
 
-    def time_pair_generator_det(self, current_time: datetime, pairs: list[str]):
-        for current_time_det, is_first, has_detail, idx in self.time_generator_det(
+    def _time_pair_generator_det(self, current_time: datetime, pairs: list[str]):
+        for current_time_det, is_first, has_detail, idx in self._time_generator_det(
             current_time, current_time + self.timeframe_td
         ):
             # Loop for each detail candle.
@@ -1482,7 +1482,7 @@ class Backtesting:
         # Indexes per pair, so some pairs are allowed to have a missing start.
         indexes: dict = defaultdict(int)
 
-        for current_time in self.time_generator(start_date, end_date):
+        for current_time in self._time_generator(start_date, end_date):
             # Loop for each main candle.
             self.check_abort()
             # Reset open trade count for this candle
@@ -1496,11 +1496,11 @@ class Backtesting:
             pair_tradedir_cache: dict[str, LongShort | None] = {}
             pairs_with_open_trades = [t.pair for t in LocalTrade.bt_trades_open]
 
-            for current_time_det, is_first, has_detail, idx, pair in self.time_pair_generator_det(
+            for current_time_det, is_first, has_detail, idx, pair in self._time_pair_generator_det(
                 current_time, pairs
             ):
                 # Loop for each detail candle (if necessary) and pair
-                # Yields only the start date if no detail timeframe is set.
+                # Yields only the main date if no detail timeframe is set.
 
                 # Pairs that have open trades should be processed first
                 trade_dir: LongShort | None = None

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1488,7 +1488,6 @@ class Backtesting:
             # Reset open trade count for this candle
             # Critical to avoid exceeding max_open_trades in backtesting
             # when timeframe-detail is used and trades close within the opening candle.
-            LocalTrade.bt_open_open_trade_count_candle = LocalTrade.bt_open_open_trade_count
             strategy_safe_wrapper(self.strategy.bot_loop_start, supress_error=True)(
                 current_time=current_time
             )

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1455,7 +1455,6 @@ class Backtesting:
         self,
         start_date: datetime,
         end_date: datetime,
-        increment: timedelta,
         pairs: list[str],
         data: dict[str, list[tuple]],
     ):
@@ -1464,7 +1463,7 @@ class Backtesting:
         :returns: generator of (current_time, pair, is_first)
             where is_first is True for the first pair of each new candle
         """
-        current_time = start_date + increment
+        current_time = start_date + self.timeframe_td
         self.progress.init_step(
             BacktestState.BACKTEST, int((end_date - start_date) / self.timeframe_td)
         )
@@ -1484,8 +1483,9 @@ class Backtesting:
             pair_detail_cache: dict[str, list[tuple]] = {}
             pair_tradedir_cache: dict[str, LongShort | None] = {}
             pairs_with_open_trades = [t.pair for t in LocalTrade.bt_trades_open]
+
             for current_time_det, is_first, has_detail, idx in self.time_generator_det(
-                current_time, current_time + increment
+                current_time, current_time + self.timeframe_td
             ):
                 # Loop for each detail candle.
                 # Yields only the start date if no detail timeframe is set.
@@ -1584,9 +1584,7 @@ class Backtesting:
             row,
             is_last_row,
             trade_dir,
-        ) in self.time_pair_generator(
-            start_date, end_date, self.timeframe_td, list(data.keys()), data
-        ):
+        ) in self.time_pair_generator(start_date, end_date, list(data.keys()), data):
             self.backtest_loop(row, pair, current_time, trade_dir, not is_last_row)
 
         self.handle_left_open(LocalTrade.bt_trades_open_pp, data=data)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1481,8 +1481,8 @@ class Backtesting:
             strategy_safe_wrapper(self.strategy.bot_loop_start, supress_error=True)(
                 current_time=current_time
             )
-            pair_detail_cache = {}
-            pair_tradedir_cache: dict[LongShort | None] = {}
+            pair_detail_cache: dict[str, list[tuple]] = {}
+            pair_tradedir_cache: dict[str, LongShort | None] = {}
             for current_time_det, is_first, has_detail, idx in self.time_generator_det(
                 current_time, current_time + increment
             ):
@@ -1530,11 +1530,14 @@ class Backtesting:
                         and has_detail
                         and pair not in pair_detail_cache
                         and pair in self.detail_data
+                        and row
                     ):
                         # Spread candle into detail timeframe and cache that -
                         # only once per main candle
                         # and only if we can expect activity.
-                        pair_detail_cache[pair] = self.get_detail_data(pair, row)
+                        pair_detail = self.get_detail_data(pair, row)
+                        if pair_detail is not None:
+                            pair_detail_cache[pair] = pair_detail
                         row = pair_detail_cache[pair][idx]
 
                     is_last_row = current_time_det == end_date

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1418,6 +1418,10 @@ class Backtesting:
             current_time += self.timeframe_td
 
     def _time_generator_det(self, start_date: datetime, end_date: datetime):
+        """
+        Loop for each detail candle.
+        Yields only the start date if no detail timeframe is set.
+        """
         if not self.timeframe_detail_td:
             yield start_date, True, False, 0
             return
@@ -1433,9 +1437,6 @@ class Backtesting:
         for current_time_det, is_first, has_detail, idx in self._time_generator_det(
             current_time, current_time + self.timeframe_td
         ):
-            # Loop for each detail candle.
-            # Yields only the start date if no detail timeframe is set.
-
             # Pairs that have open trades should be processed first
             new_pairlist = list(dict.fromkeys([t.pair for t in LocalTrade.bt_trades_open] + pairs))
             for pair in new_pairlist:
@@ -1450,8 +1451,8 @@ class Backtesting:
     ):
         """
         Backtest time and pair generator
-        :returns: generator of (current_time, pair, is_first)
-            where is_first is True for the first pair of each new candle
+        :returns: generator of (current_time, pair, row, is_last_row, trade_dir)
+            where is_last_row is a boolean indicating if this is the data end date.
         """
         current_time = start_date + self.timeframe_td
         self.progress.init_step(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1534,6 +1534,11 @@ class Backtesting:
                     # Pair has had open trades which closed in the current main candle.
                     # Skip this pair for this timeframe
                     continue
+                if pair_has_open_trades and pair not in pairs_with_open_trades:
+                    # auto-lock for pairs that have open trades
+                    # Necessary for detail - to capture trades that open and close within
+                    # the same main candle
+                    pairs_with_open_trades.append(pair)
 
                 if (
                     is_first

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -391,7 +391,6 @@ class LocalTrade:
     # Copy of trades_open - but indexed by pair
     bt_trades_open_pp: dict[str, list["LocalTrade"]] = defaultdict(list)
     bt_open_open_trade_count: int = 0
-    bt_open_open_trade_count_candle: int = 0
     bt_total_profit: float = 0
     realized_profit: float = 0
 
@@ -760,7 +759,6 @@ class LocalTrade:
         LocalTrade.bt_trades_open = []
         LocalTrade.bt_trades_open_pp = defaultdict(list)
         LocalTrade.bt_open_open_trade_count = 0
-        LocalTrade.bt_open_open_trade_count_candle = 0
         LocalTrade.bt_total_profit = 0
 
     def adjust_min_max_rates(self, current_price: float, current_price_low: float) -> None:
@@ -1462,11 +1460,6 @@ class LocalTrade:
         LocalTrade.bt_trades_open.remove(trade)
         LocalTrade.bt_trades_open_pp[trade.pair].remove(trade)
         LocalTrade.bt_open_open_trade_count -= 1
-        if (trade.close_date_utc - trade.open_date_utc) > timedelta(minutes=trade.timeframe):
-            # Only subtract trades that are open for more than 1 candle
-            # To avoid exceeding max_open_trades.
-            # Must be reset at the start of every candle during backesting.
-            LocalTrade.bt_open_open_trade_count_candle -= 1
         LocalTrade.bt_trades.append(trade)
         LocalTrade.bt_total_profit += trade.close_profit_abs
 
@@ -1476,7 +1469,6 @@ class LocalTrade:
             LocalTrade.bt_trades_open.append(trade)
             LocalTrade.bt_trades_open_pp[trade.pair].append(trade)
             LocalTrade.bt_open_open_trade_count += 1
-            LocalTrade.bt_open_open_trade_count_candle += 1
         else:
             LocalTrade.bt_trades.append(trade)
 
@@ -1485,9 +1477,6 @@ class LocalTrade:
         LocalTrade.bt_trades_open.remove(trade)
         LocalTrade.bt_trades_open_pp[trade.pair].remove(trade)
         LocalTrade.bt_open_open_trade_count -= 1
-        # TODO: The below may have odd behavior in case of canceled entries
-        # It might need to be removed so the trade "counts" as open for this candle.
-        LocalTrade.bt_open_open_trade_count_candle -= 1
 
     @staticmethod
     def get_open_trades() -> list[Any]:

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1907,9 +1907,9 @@ def test_backtest_multi_pair_long_short_switch(
 
     if use_detail:
         # Backtest loop is called once per candle per pair
-        assert bl_spy.call_count == 1482
+        assert bl_spy.call_count == 1511
     else:
-        assert bl_spy.call_count == 479
+        assert bl_spy.call_count == 508
 
     # Make sure we have parallel trades
     assert len(evaluate_result_multi(results["results"], "5m", 0)) > 0

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1773,16 +1773,18 @@ def test_backtest_multi_pair_detail_simplified(
     if use_detail:
         # Backtest loop is called once per candle per pair
         # Exact numbers depend on trade state - but should be around 3_800
-        assert bl_spy.call_count > 2_250
+        assert bl_spy.call_count > 2_170
         assert bl_spy.call_count < 2_800
+        assert len(evaluate_result_multi(results["results"], "1h", 3)) > 0
     else:
         assert bl_spy.call_count < 995
+        assert len(evaluate_result_multi(results["results"], "1h", 3)) == 0
 
     # Make sure we have parallel trades
     assert len(evaluate_result_multi(results["results"], "1h", 2)) > 0
+    assert len(evaluate_result_multi(results["results"], "5m", 2)) > 0
     # make sure we don't have trades with more than configured max_open_trades
     # This must evaluate on detail timeframe - as we can have entries within the candle.
-    assert len(evaluate_result_multi(results["results"], "1h", 3)) == 0
     assert len(evaluate_result_multi(results["results"], "5m", 3)) == 0
     assert len(evaluate_result_multi(results["results"], "1m", 3)) == 0
 
@@ -1803,7 +1805,10 @@ def test_backtest_multi_pair_detail_simplified(
         "end_date": max_date,
     }
     results = backtesting.backtest(**backtest_conf)
-    assert len(evaluate_result_multi(results["results"], "1h", 1)) == 0
+    if use_detail:
+        assert len(evaluate_result_multi(results["results"], "1h", 1)) > 0
+    else:
+        assert len(evaluate_result_multi(results["results"], "1h", 1)) == 0
     assert len(evaluate_result_multi(results["results"], "5m", 1)) == 0
     assert len(evaluate_result_multi(results["results"], "1m", 1)) == 0
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1901,7 +1901,7 @@ def test_backtest_multi_pair_long_short_switch(
 
     if use_detail:
         # Backtest loop is called once per candle per pair
-        assert bl_spy.call_count == 1484
+        assert bl_spy.call_count == 1482
     else:
         assert bl_spy.call_count == 479
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1772,15 +1772,18 @@ def test_backtest_multi_pair_detail_simplified(
     if use_detail:
         # Backtest loop is called once per candle per pair
         # Exact numbers depend on trade state - but should be around 3_800
-        assert bl_spy.call_count > 3_350
-        assert bl_spy.call_count < 3_800
+        assert bl_spy.call_count > 2_250
+        assert bl_spy.call_count < 2_800
     else:
         assert bl_spy.call_count < 995
 
     # Make sure we have parallel trades
     assert len(evaluate_result_multi(results["results"], "1h", 2)) > 0
     # make sure we don't have trades with more than configured max_open_trades
+    # This must evaluate on detail timeframe - as we can have entries within the candle.
     assert len(evaluate_result_multi(results["results"], "1h", 3)) == 0
+    assert len(evaluate_result_multi(results["results"], "5m", 3)) == 0
+    assert len(evaluate_result_multi(results["results"], "1m", 3)) == 0
 
     # # Cached data correctly removed amounts
     offset = 1 if tres == 0 else 0
@@ -1800,6 +1803,8 @@ def test_backtest_multi_pair_detail_simplified(
     }
     results = backtesting.backtest(**backtest_conf)
     assert len(evaluate_result_multi(results["results"], "1h", 1)) == 0
+    assert len(evaluate_result_multi(results["results"], "5m", 1)) == 0
+    assert len(evaluate_result_multi(results["results"], "1m", 1)) == 0
 
 
 @pytest.mark.parametrize("use_detail", [True, False])

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1772,7 +1772,7 @@ def test_backtest_multi_pair_detail_simplified(
 
     if use_detail:
         # Backtest loop is called once per candle per pair
-        # Exact numbers depend on trade state - but should be around 3_800
+        # Exact numbers depend on trade state - but should be around 2_600
         assert bl_spy.call_count > 2_170
         assert bl_spy.call_count < 2_800
         assert len(evaluate_result_multi(results["results"], "1h", 3)) > 0

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -936,7 +936,7 @@ def test_backtest_one_detail(default_conf_usdt, mocker, testdatadir, use_detail)
 @pytest.mark.parametrize(
     "use_detail,exp_funding_fee, exp_ff_updates",
     [
-        (True, -0.018054162, 11),
+        (True, -0.018054162, 10),
         (False, -0.01780296, 6),
     ],
 )
@@ -998,7 +998,7 @@ def test_backtest_one_detail_futures(
     results = result["results"]
     assert not results.empty
     # Timeout settings from default_conf = entry: 10, exit: 30
-    assert len(results) == (5 if use_detail else 2)
+    assert len(results) == (4 if use_detail else 2)
 
     assert "orders" in results.columns
     data_pair = processed[pair]

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -866,6 +866,7 @@ def test_backtest_one_detail(default_conf_usdt, mocker, testdatadir, use_detail)
     backtesting = Backtesting(default_conf_usdt)
     backtesting._set_strategy(backtesting.strategylist[0])
     backtesting.strategy.populate_entry_trend = advise_entry
+    backtesting.strategy.ignore_buying_expired_candle_after = 59
     backtesting.strategy.custom_entry_price = custom_entry_price
     pair = "XRP/ETH"
     # Pick a timerange adapted to the pair we use to test

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -2145,7 +2145,6 @@ def test_Trade_object_idem():
         "bt_trades_open",
         "bt_trades_open_pp",
         "bt_open_open_trade_count",
-        "bt_open_open_trade_count_candle",
         "bt_total_profit",
         "from_json",
     )


### PR DESCRIPTION
## Summary

Improve backtesting accuracy with `--timeframe-detail`

closes  #11217

## Quick changelog

- Change execution logic for timeframe-detail to have a linear timeline (no timejumps)
- Add support for `ignore_buying_expired_candle_after` for backtesting (only in combination with `--timeframe-detail`)
- simulate code 


## What's new?

Using `--timeframe-detail` on an extreme example (all below pairs have the 10:00 candle with an entry signal) may lead to the following backtesting Trade sequence with 1 max_open_trades:

| Pair | Entry Time | Exit Time | Duration |
|------|------------|-----------| -------- |
| BTC/USDT | 2024-01-01 10:00:00 | 2021-01-01 10:05:00 | 5m |
| ETH/USDT | 2024-01-01 10:05:00 | 2021-01-01 10:15:00 | 10m |
| XRP/USDT | 2024-01-01 10:15:00 | 2021-01-01 10:30:00 | 15m |
| SOL/USDT | 2024-01-01 10:15:00 | 2021-01-01 11:05:00 | 50m |
| BTC/USDT | 2024-01-01 11:05:00 | 2021-01-01 12:00:00 | 55m |

Without timeframe-detail, this would look like:

| Pair | Entry Time | Exit Time | Duration |
|------|------------|-----------| -------- |
| BTC/USDT | 2024-01-01 10:00:00 | 2021-01-01 11:00:00 | 1h |
| BTC/USDT | 2024-01-01 11:00:00 | 2021-01-01 12:00:00 | 1h |


Previously - it would've looked similar to the "without timeframe-detail" case.
