### PR TITLE
Fix: Convert numpy types to native Python types in API response

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1300,7 +1300,7 @@ class RPC:
             raise RPCException("Edge is not enabled.")
         return self._freqtrade.edge.accepted_pairs()
 
-    @staticmethod
+@staticmethod
     def _convert_dataframe_to_dict(
         strategy: str,
         pair: str,
@@ -1309,6 +1309,9 @@ class RPC:
         last_analyzed: datetime,
         selected_cols: list[str] | None,
     ) -> dict[str, Any]:
+        """
+        Returns the current dataframe as a dict
+        """
         has_content = len(dataframe) != 0
         dataframe_columns = list(dataframe.columns)
         signals = {
@@ -1325,6 +1328,7 @@ class RPC:
                 dataframe = dataframe.loc[:, df_cols]
 
             dataframe.loc[:, "__date_ts"] = dataframe.loc[:, "date"].astype(int64) // 1000 // 1000
+
             # Move signal close to separate column when signal for easy plotting
             for sig_type in signals.keys():
                 if sig_type in dataframe.columns:
@@ -1342,6 +1346,10 @@ class RPC:
 
             dataframe = dataframe.replace({inf: None, -inf: None, nan: None})
 
+            # Convert numpy values to Python native types
+            values = dataframe.values.tolist()
+            values = [[int(x) if isinstance(x, int64) else x for x in row] for row in values]
+
         res = {
             "pair": pair,
             "timeframe": timeframe,
@@ -1349,7 +1357,7 @@ class RPC:
             "strategy": strategy,
             "all_columns": dataframe_columns,
             "columns": list(dataframe.columns),
-            "data": dataframe.values.tolist(),
+            "data": values if has_content else [],  # Use our converted values here
             "length": len(dataframe),
             "buy_signals": signals["enter_long"],  # Deprecated
             "sell_signals": signals["exit_long"],  # Deprecated

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1357,7 +1357,7 @@ class RPC:
             "strategy": strategy,
             "all_columns": dataframe_columns,
             "columns": list(dataframe.columns),
-            "data": values if has_content else [],  
+            "data": values if has_content else [],
             "length": len(dataframe),
             "buy_signals": signals["enter_long"],  # Deprecated
             "sell_signals": signals["exit_long"],  # Deprecated

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1300,7 +1300,7 @@ class RPC:
             raise RPCException("Edge is not enabled.")
         return self._freqtrade.edge.accepted_pairs()
 
-@staticmethod
+    @staticmethod
     def _convert_dataframe_to_dict(
         strategy: str,
         pair: str,
@@ -1357,7 +1357,7 @@ class RPC:
             "strategy": strategy,
             "all_columns": dataframe_columns,
             "columns": list(dataframe.columns),
-            "data": values if has_content else [],  # Use our converted values here
+            "data": values if has_content else [],  
             "length": len(dataframe),
             "buy_signals": signals["enter_long"],  # Deprecated
             "sell_signals": signals["exit_long"],  # Deprecated


### PR DESCRIPTION
## Problem
The FastAPI endpoints were failing with a `PydanticSerializationError` when returning DataFrame data containing numpy types (specifically `numpy.int64`). This occurred when trying to view candle data in FreqUI, as Pydantic is unable to serialize numpy's integer types directly.

Error that generated PR:
```
2025-01-28 19:19:38,226 - uvicorn.error - ERROR - Exception in ASGI application
Traceback (most recent call last):
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/uvicorn/proto
cols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/uvicorn/middl
eware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/appli
cations.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/app
lications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/mid
dleware/errors.py", line 187, in __call__
    raise exc
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/mid
dleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/mid
dleware/cors.py", line 93, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/mid
dleware/cors.py", line 144, in simple_response
    await self.app(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/mid
dleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/_ex
ception_handler.py", line 53, in wrapped_app
    raise exc
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/_ex
ception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/rou
ting.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/rou
ting.py", line 735, in app
    await route.handle(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/rou
ting.py", line 288, in handle
    await self.app(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/rou
ting.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/_ex
ception_handler.py", line 53, in wrapped_app
    raise exc
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/_ex
ception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/rou
ting.py", line 73, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/routi
ng.py", line 327, in app
    content = await serialize_response(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/routi
ng.py", line 181, in serialize_response
    return field.serialize(
           ^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/_comp
at.py", line 151, in serialize
    return self._type_adapter.dump_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File 
"/home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/pydantic/type
_adapter.py", line 527, in dump_python
    return self.serializer.to_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize 
unknown type: <class 'numpy.int64'>
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/uvicorn/pr │
│ otocols/http/h11_impl.py:403 in run_asgi                                     │
│                                                                              │
│   402 │   │   try:                                                           │
│ ❱ 403 │   │   │   result = await app(  # type: ignore[func-returns-value]    │
│   404 │   │   │   │   self.scope, self.receive, self.send                    │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/uvicorn/mi │
│ ddleware/proxy_headers.py:60 in __call__                                     │
│                                                                              │
│    59 │   │                                                                  │
│ ❱  60 │   │   return await self.app(scope, receive, send)                    │
│    61                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/ap │
│ plications.py:1054 in __call__                                               │
│                                                                              │
│   1053 │   │   │   scope["root_path"] = self.root_path                       │
│ ❱ 1054 │   │   await super().__call__(scope, receive, send)                  │
│   1055                                                                       │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ applications.py:113 in __call__                                              │
│                                                                              │
│   112 │   │   │   self.middleware_stack = self.build_middleware_stack()      │
│ ❱ 113 │   │   await self.middleware_stack(scope, receive, send)              │
│   114                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ middleware/errors.py:187 in __call__                                         │
│                                                                              │
│   186 │   │   │   # to optionally raise the error within the test case.      │
│ ❱ 187 │   │   │   raise exc                                                  │
│   188                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ middleware/errors.py:165 in __call__                                         │
│                                                                              │
│   164 │   │   try:                                                           │
│ ❱ 165 │   │   │   await self.app(scope, receive, _send)                      │
│   166 │   │   except Exception as exc:                                       │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ middleware/cors.py:93 in __call__                                            │
│                                                                              │
│    92 │   │                                                                  │
│ ❱  93 │   │   await self.simple_response(scope, receive, send, request_heade │
│    94                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ middleware/cors.py:144 in simple_response                                    │
│                                                                              │
│   143 │   │   send = functools.partial(self.send, send=send, request_headers │
│ ❱ 144 │   │   await self.app(scope, receive, send)                           │
│   145                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ middleware/exceptions.py:62 in __call__                                      │
│                                                                              │
│   61 │   │                                                                   │
│ ❱ 62 │   │   await wrap_app_handling_exceptions(self.app, conn)(scope, recei │
│   63                                                                         │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ _exception_handler.py:53 in wrapped_app                                      │
│                                                                              │
│   52 │   │   │   if handler is None:                                         │
│ ❱ 53 │   │   │   │   raise exc                                               │
│   54                                                                         │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ _exception_handler.py:42 in wrapped_app                                      │
│                                                                              │
│   41 │   │   try:                                                            │
│ ❱ 42 │   │   │   await app(scope, receive, sender)                           │
│   43 │   │   except Exception as exc:                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ routing.py:715 in __call__                                                   │
│                                                                              │
│   714 │   │   """                                                            │
│ ❱ 715 │   │   await self.middleware_stack(scope, receive, send)              │
│   716                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ routing.py:735 in app                                                        │
│                                                                              │
│   734 │   │   │   │   scope.update(child_scope)                              │
│ ❱ 735 │   │   │   │   await route.handle(scope, receive, send)               │
│   736 │   │   │   │   return                                                 │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ routing.py:288 in handle                                                     │
│                                                                              │
│   287 │   │   else:                                                          │
│ ❱ 288 │   │   │   await self.app(scope, receive, send)                       │
│   289                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ routing.py:76 in app                                                         │
│                                                                              │
│    75 │   │                                                                  │
│ ❱  76 │   │   await wrap_app_handling_exceptions(app, request)(scope, receiv │
│    77                                                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ _exception_handler.py:53 in wrapped_app                                      │
│                                                                              │
│   52 │   │   │   if handler is None:                                         │
│ ❱ 53 │   │   │   │   raise exc                                               │
│   54                                                                         │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ _exception_handler.py:42 in wrapped_app                                      │
│                                                                              │
│   41 │   │   try:                                                            │
│ ❱ 42 │   │   │   await app(scope, receive, sender)                           │
│   43 │   │   except Exception as exc:                                        │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/starlette/ │
│ routing.py:73 in app                                                         │
│                                                                              │
│    72 │   │   async def app(scope: Scope, receive: Receive, send: Send) -> N │
│ ❱  73 │   │   │   response = await f(request)                                │
│    74 │   │   │   await response(scope, receive, send)                       │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/ro │
│ uting.py:327 in app                                                          │
│                                                                              │
│    326 │   │   │   │   │   │   │   )                                         │
│ ❱  327 │   │   │   │   │   │   content = await serialize_response(           │
│    328 │   │   │   │   │   │   │   field=response_field,                     │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/ro │
│ uting.py:181 in serialize_response                                           │
│                                                                              │
│    180 │   │   if hasattr(field, "serialize"):                               │
│ ❱  181 │   │   │   return field.serialize(                                   │
│    182 │   │   │   │   value,                                                │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/fastapi/_c │
│ ompat.py:151 in serialize                                                    │
│                                                                              │
│   150 │   │   │   # self._type_adapter.validate_python(value)                │
│ ❱ 151 │   │   │   return self._type_adapter.dump_python(                     │
│   152 │   │   │   │   value,                                                 │
│                                                                              │
│ /home/smarm/freqqav4/freqtrade/.venv/lib/python3.12/site-packages/pydantic/t │
│ ype_adapter.py:527 in dump_python                                            │
│                                                                              │
│   526 │   │   """                                                            │
│ ❱ 527 │   │   return self.serializer.to_python(                              │
│   528 │   │   │   instance,                                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
PydanticSerializationError: Unable to serialize unknown type: <class 
'numpy.int64'>
```


## Solution
Modified the `_convert_dataframe_to_dict` method in `freqtrade/rpc/rpc.py` to explicitly convert numpy types to Python native types before serialization. This is done by converting the DataFrame values to a list and ensuring any `numpy.int64` values are cast to Python `int`.

## Impact
- Fixes candle data display in FreqUI
- No impact on trading functionality
- Minor performance overhead from type conversion, but only affects API responses
