### PR TITLE
refactor(freqai): cleanup some FreqAI models

### DIFF
--- a/docs/freqai-feature-engineering.md
+++ b/docs/freqai-feature-engineering.md
@@ -186,7 +186,7 @@ In total, the number of features the user of the presented example strategy has 
 
 ### Gain finer control over `feature_engineering_*` functions with `metadata`
 
-All `feature_engineering_*` and `set_freqai_targets()` functions are passed a `metadata` dictionary which contains information about the `pair`, `tf` (timeframe), and `period` that FreqAI is automating for feature building. As such, a user can use `metadata` inside `feature_engineering_*` functions as criteria for blocking/reserving features for certain timeframes, periods, pairs etc.
+All `feature_engineering_*` and `set_freqai_targets()` functions are passed a `metadata` dictionary, which contains information about the `pair`, `tf` (timeframe), and `period` that FreqAI is automating for feature building. As such, a user can use `metadata` inside `feature_engineering_*` functions as criteria for blocking/reserving features for certain timeframes, periods, pairs etc.
 
 ```python
 def feature_engineering_expand_all(self, dataframe: DataFrame, period, metadata, **kwargs) -> DataFrame:

--- a/freqtrade/freqai/prediction_models/LightGBMClassifier.py
+++ b/freqtrade/freqai/prediction_models/LightGBMClassifier.py
@@ -28,9 +28,13 @@ class LightGBMClassifier(BaseClassifierModel):
         :param dk: The datakitchen object for the current coin/model
         """
 
+        X = data_dictionary["train_features"].to_numpy()
+        y = data_dictionary["train_labels"].to_numpy()[:, 0]
+        sample_weight = data_dictionary["train_weights"]
+
         if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) == 0:
             eval_set = None
-            test_weights = None
+            eval_weights = None
         else:
             eval_set = [
                 (
@@ -38,10 +42,7 @@ class LightGBMClassifier(BaseClassifierModel):
                     data_dictionary["test_labels"].to_numpy()[:, 0],
                 )
             ]
-            test_weights = data_dictionary["test_weights"]
-        X = data_dictionary["train_features"].to_numpy()
-        y = data_dictionary["train_labels"].to_numpy()[:, 0]
-        train_weights = data_dictionary["train_weights"]
+            eval_weights = [data_dictionary["test_weights"]]
 
         init_model = self.get_init_model(dk.pair)
 
@@ -50,8 +51,8 @@ class LightGBMClassifier(BaseClassifierModel):
             X=X,
             y=y,
             eval_set=eval_set,
-            sample_weight=train_weights,
-            eval_sample_weight=[test_weights],
+            sample_weight=sample_weight,
+            eval_sample_weight=eval_weights,
             init_model=init_model,
         )
 

--- a/freqtrade/freqai/prediction_models/LightGBMRegressor.py
+++ b/freqtrade/freqai/prediction_models/LightGBMRegressor.py
@@ -28,15 +28,16 @@ class LightGBMRegressor(BaseRegressionModel):
         :param dk: The datakitchen object for the current coin/model
         """
 
+        X = data_dictionary["train_features"]
+        y = data_dictionary["train_labels"]
+        sample_weight = data_dictionary["train_weights"]
+
         if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) == 0:
             eval_set = None
             eval_weights = None
         else:
             eval_set = [(data_dictionary["test_features"], data_dictionary["test_labels"])]
-            eval_weights = data_dictionary["test_weights"]
-        X = data_dictionary["train_features"]
-        y = data_dictionary["train_labels"]
-        train_weights = data_dictionary["train_weights"]
+            eval_weights = [data_dictionary["test_weights"]]
 
         init_model = self.get_init_model(dk.pair)
 
@@ -46,8 +47,8 @@ class LightGBMRegressor(BaseRegressionModel):
             X=X,
             y=y,
             eval_set=eval_set,
-            sample_weight=train_weights,
-            eval_sample_weight=[eval_weights],
+            sample_weight=sample_weight,
+            eval_sample_weight=eval_weights,
             init_model=init_model,
         )
 

--- a/freqtrade/freqai/prediction_models/XGBoostClassifier.py
+++ b/freqtrade/freqai/prediction_models/XGBoostClassifier.py
@@ -43,6 +43,7 @@ class XGBoostClassifier(BaseClassifierModel):
 
         if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) == 0:
             eval_set = None
+            eval_weights = None
         else:
             test_features = data_dictionary["test_features"].to_numpy()
             test_labels = data_dictionary["test_labels"].to_numpy()[:, 0]
@@ -51,6 +52,7 @@ class XGBoostClassifier(BaseClassifierModel):
                 test_labels = pd.Series(le.transform(test_labels), dtype="int64")
 
             eval_set = [(test_features, test_labels)]
+            eval_weights = [data_dictionary["test_weights"]]
 
         train_weights = data_dictionary["train_weights"]
 
@@ -58,7 +60,14 @@ class XGBoostClassifier(BaseClassifierModel):
 
         model = XGBClassifier(**self.model_training_parameters)
 
-        model.fit(X=X, y=y, eval_set=eval_set, sample_weight=train_weights, xgb_model=init_model)
+        model.fit(
+            X=X,
+            y=y,
+            eval_set=eval_set,
+            sample_weight=train_weights,
+            sample_weight_eval_set=eval_weights,
+            xgb_model=init_model,
+        )
 
         return model
 

--- a/freqtrade/freqai/prediction_models/XGBoostRFClassifier.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRFClassifier.py
@@ -43,6 +43,7 @@ class XGBoostRFClassifier(BaseClassifierModel):
 
         if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) == 0:
             eval_set = None
+            eval_weights = None
         else:
             test_features = data_dictionary["test_features"].to_numpy()
             test_labels = data_dictionary["test_labels"].to_numpy()[:, 0]
@@ -51,6 +52,7 @@ class XGBoostRFClassifier(BaseClassifierModel):
                 test_labels = pd.Series(le.transform(test_labels), dtype="int64")
 
             eval_set = [(test_features, test_labels)]
+            eval_weights = [data_dictionary["test_weights"]]
 
         train_weights = data_dictionary["train_weights"]
 
@@ -58,7 +60,14 @@ class XGBoostRFClassifier(BaseClassifierModel):
 
         model = XGBRFClassifier(**self.model_training_parameters)
 
-        model.fit(X=X, y=y, eval_set=eval_set, sample_weight=train_weights, xgb_model=init_model)
+        model.fit(
+            X=X,
+            y=y,
+            eval_set=eval_set,
+            sample_weight=train_weights,
+            sample_weight_eval_set=eval_weights,
+            xgb_model=init_model,
+        )
 
         return model
 

--- a/freqtrade/freqai/prediction_models/XGBoostRegressor.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRegressor.py
@@ -37,7 +37,7 @@ class XGBoostRegressor(BaseRegressionModel):
             eval_weights = None
         else:
             eval_set = [(data_dictionary["test_features"], data_dictionary["test_labels"]), (X, y)]
-            eval_weights = [data_dictionary["test_weights"], data_dictionary["train_weights"]]
+            eval_weights = [data_dictionary["test_weights"]]
 
         sample_weight = data_dictionary["train_weights"]
 

--- a/freqtrade/freqai/prediction_models/XGBoostRegressor.py
+++ b/freqtrade/freqai/prediction_models/XGBoostRegressor.py
@@ -36,7 +36,7 @@ class XGBoostRegressor(BaseRegressionModel):
             eval_set = None
             eval_weights = None
         else:
-            eval_set = [(data_dictionary["test_features"], data_dictionary["test_labels"]), (X, y)]
+            eval_set = [(data_dictionary["test_features"], data_dictionary["test_labels"])]
             eval_weights = [data_dictionary["test_weights"]]
 
         sample_weight = data_dictionary["train_weights"]


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary and changelog

<!-- Explain in one sentence the goal of this PR -->

* XGBoostRFClassifier, XGBoostClassifier: use test set weights at training (https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.fit)
* XGBoostRegressor: remove the train sets and weights from the eval sets and weights
* LightBGM*: align variables namespace, align `eval_weights` data structure type at variable affectation, no functional changes
