### PR TITLE
Allow NAN in Freqai datadrawer metadata

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -33,6 +33,8 @@ LABEL_PIPELINE = "label_pipeline"
 TRAINDF = "trained_df"
 METADATA = "metadata"
 
+METADATA_NUMBER_MODE = rapidjson.NM_NATIVE | rapidjson.NM_NAN
+
 
 class pair_info(TypedDict):
     model_filename: str
@@ -495,7 +497,7 @@ class FreqaiDataDrawer:
         dk.data["label_list"] = dk.label_list
 
         with (save_path / f"{dk.model_filename}_{METADATA}.json").open("w") as fp:
-            rapidjson.dump(dk.data, fp, default=self.np_encoder, number_mode=rapidjson.NM_NATIVE)
+            rapidjson.dump(dk.data, fp, default=self.np_encoder, number_mode=METADATA_NUMBER_MODE)
 
         return
 
@@ -526,7 +528,7 @@ class FreqaiDataDrawer:
         dk.data["label_list"] = dk.label_list
         # store the metadata
         with (save_path / f"{dk.model_filename}_{METADATA}.json").open("w") as fp:
-            rapidjson.dump(dk.data, fp, default=self.np_encoder, number_mode=rapidjson.NM_NATIVE)
+            rapidjson.dump(dk.data, fp, default=self.np_encoder, number_mode=METADATA_NUMBER_MODE)
 
         # save the pipelines to pickle files
         with (save_path / f"{dk.model_filename}_{FEATURE_PIPELINE}.pkl").open("wb") as fp:
@@ -563,7 +565,7 @@ class FreqaiDataDrawer:
         presaved backtesting (prediction file loading).
         """
         with (dk.data_path / f"{dk.model_filename}_{METADATA}.json").open("r") as fp:
-            dk.data = rapidjson.load(fp, number_mode=rapidjson.NM_NATIVE)
+            dk.data = rapidjson.load(fp, number_mode=METADATA_NUMBER_MODE)
             dk.training_features_list = dk.data["training_features_list"]
             dk.label_list = dk.data["label_list"]
 
@@ -587,7 +589,7 @@ class FreqaiDataDrawer:
             dk.label_pipeline = self.meta_data_dictionary[coin][LABEL_PIPELINE]
         else:
             with (dk.data_path / f"{dk.model_filename}_{METADATA}.json").open("r") as fp:
-                dk.data = rapidjson.load(fp, number_mode=rapidjson.NM_NATIVE)
+                dk.data = rapidjson.load(fp, number_mode=METADATA_NUMBER_MODE)
 
             with (dk.data_path / f"{dk.model_filename}_{FEATURE_PIPELINE}.pkl").open("rb") as fp:
                 dk.feature_pipeline = cloudpickle.load(fp)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Using a constant for aligned number mode with freqAI drawer.
This also adds support for NAN's - which also won't cause any issues as we save and load using the same method.

closes #11274 (or bugs similar to this).