### PR TITLE
Fix 'Can't pickle: import of module failed' when modules are defined …

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -109,6 +109,9 @@ class IResolver:
                 if enum_failed:
                     return iter([None])
 
+            # fix "Can't pickle: import of module failed" when modules are defined in user_data/freqaimodels
+            sys.modules[module_name] = module
+
             def is_valid_class(obj):
                 try:
                     return (


### PR DESCRIPTION
…in user_data/freqaimodels

## Summary

Fix 'Can't pickle: import of module failed' when modules are defined in user_data/freqaimodels.

## Quick changelog
- just bugfix

Didn't make an issue out of it.
Basically, the problem is when using PyTorch model defined in `user_data/freqaimodels` to backtest, it raised when `torch.save` was called to save model checkpoint due to pickle could not import the module of the PyTorch model. 
This one line solve it by adding the dynamic loaded module into the `sys.modules`.
Solution reference: https://stackoverflow.com/questions/74841508/cant-pickle-class-import-of-module-failed