### PR TITLE
Fix log format when using --logfile

### DIFF
--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -40,14 +40,11 @@ def setup_logging_pre() -> None:
     logging handlers after the real initialization, because we don't know which
     ones the user desires beforehand.
     """
-    rh = FtRichHandler(console=error_console)
-    rh.setFormatter(Formatter("%(message)s"))
     logging.basicConfig(
         level=logging.INFO,
         format=LOGFORMAT,
         handlers=[
             # FTStdErrStreamHandler(),
-            rh,
             bufferHandler,
         ],
     )
@@ -121,6 +118,10 @@ def setup_logging(config: Config) -> None:
                 )
             handler_rf.setFormatter(Formatter(LOGFORMAT))
             logging.root.addHandler(handler_rf)
+    else:
+        rh = FtRichHandler(console=error_console)
+        rh.setFormatter(Formatter("%(message)s"))
+        logging.root.addHandler(rh)
 
     logging.root.setLevel(logging.INFO if verbosity < 1 else logging.DEBUG)
     set_loggers(verbosity, config.get("api_server", {}).get("verbosity", "info"))


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This PR fixes an issue with incorrect logs when using the `--logfile` argument.

Solve the issue: #11477

## Quick changelog

- Fix log format when using --logfile

## What's new?

When using the `--logfile journald` argument, there are duplicated logs produced both `journald` and `rich` log handlers (with the latter producing  log lines splitted across multiple lines).
This PR ensure the `rich` handler is only used in the default case.

Here are the log output seen from journald when running freqtrade with the following command:

```
freqtrade trade --sd-notify --logfile journald --no-color
```

Viewing logs with

```
journalctl -o cat -fu freqtrade
```

#### Before

Here we can see all lines produced by the `rich` handler starting with a date.

![image](https://github.com/user-attachments/assets/f9e6e572-f409-40ed-9bd2-a2339a701d3f)

### After

![image](https://github.com/user-attachments/assets/49bc0e57-ae65-4dc7-b864-17f1a65e1fb3)

