### PR TITLE
Fix continual learning pytorch

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -763,6 +763,8 @@ class IFreqaiModel(ABC):
             init_model = None
         else:
             init_model = self.dd.model_dictionary[pair]
+            # Set "fresh" tb_logger - the one in model_dictionary has the writer closed.
+            init_model.tb_logger = self.tb_logger
 
         return init_model
 


### PR DESCRIPTION
tb_logger get's closed after training.
So we need to re-assign the new one, otherwise pickling fails.

closes #10034

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

tb_logger is the object that's stale - causing pickle errors.
reassigning the "fresh" tb_logger instance when reusing the model fixes this bug.

closes #10034

## Quick changelog

- reassing tb_logger


### Reproduction of the problem 

Running a simple backtest with continual-learning = true (in combination with tensorboard, or not explicitly disabling tensorboard) causes the following exception - on the 2nd model that's saved (the first model does still work).

```
2025-03-11 19:54:19,862 - freqtrade.freqai.freqai_interface - INFO - Saving backtest model to disk.
2025-03-11 19:54:19,875 - freqtrade - ERROR - Fatal exception!
Traceback (most recent call last):
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/main.py", line 47, in main
    return_code = args["func"](args)
                  ^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/commands/optimize_commands.py", line 61, in start_backtesting
    backtesting.start()
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/optimize/backtesting.py", line 1773, in start
    min_date, max_date = self.backtest_one_strategy(strat, data, timerange)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/optimize/backtesting.py", line 1682, in backtest_one_strategy
    preprocessed = self.strategy.advise_all_indicators(data)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/strategy/interface.py", line 1683, in advise_all_indicators
    pair: self.advise_indicators(pair_data.copy(), {"pair": pair}).copy()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/strategy/interface.py", line 1737, in advise_indicators
    return self.populate_indicators(dataframe, metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/xmatt/userdirs/issue_11474/strategies/issue_11474.py", line 233, in populate_indicators
    dataframe = self.freqai.start(dataframe, metadata, self)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/freqai/freqai_interface.py", line 161, in start
    dk = self.start_backtesting(dataframe, metadata, self.dk, strategy)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/freqai/freqai_interface.py", line 385, in start_backtesting
    self.dd.save_data(self.model, pair, dk)
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/freqai/data_drawer.py", line 523, in save_data
    model.save(save_path / f"{dk.model_filename}_model.zip")
  File "/home/xmatt/devel/cryptos/freqtrade/freqtrade/freqai/torch/PyTorchModelTrainer.py", line 172, in save
    torch.save(
  File "/home/xmatt/.pyenv/versions/3.12.7/envs/trade_3127/lib/python3.12/site-packages/torch/serialization.py", line 944, in save
    _save(
  File "/home/xmatt/.pyenv/versions/3.12.7/envs/trade_3127/lib/python3.12/site-packages/torch/serialization.py", line 1190, in _save
    pickler.dump(obj)
TypeError: cannot pickle '_thread.lock' object
```

<details><summary>Reproduction</summary>
<p>

In a fresh user_directory: 

```
freqtrade download-data 20240101- --userdir --userdir userdir_11474/  -t 5m

freqtrade backtesting --timerange 20250101-20250105 --userdir userdir_11474/ -s FreqaiExampleStrategy --strategy-path freqtrade/templates  --freqaimodel PyTorchTransformerRegressor --timeframe 5m --cache none

```

Config: 
(`userdir_11474/config.json`)
```
{
    "$schema": "https://schema.freqtrade.io/schema.json",
    "max_open_trades": 500,
    "stake_currency": "USDT",
    "stake_amount": 50,
    "tradable_balance_ratio": 0.99,
    "fiat_display_currency": "USD",
    "dry_run": true,
    "dry_run_wallet": 10000,
    "cancel_open_orders_on_exit": false,
    "trading_mode": "futures",
    "margin_mode": "isolated",
    "unfilledtimeout": {
        "entry": 10,
        "exit": 10,
        "exit_timeout_count": 0,
        "unit": "minutes"
    },
    "entry_pricing": {
        "price_side": "same",
        "use_order_book": true,
        "order_book_top": 1,
        "price_last_balance": 0.0,
        "check_depth_of_market": {
            "enabled": false,
            "bids_to_ask_delta": 1
        }
    },
    "exit_pricing": {
        "price_side": "same",
        "use_order_book": true,
        "order_book_top": 1
    },
    "exchange": {
        "name": "binance",
        "key": "",
        "secret": "",
        "ccxt_config": {},
        "ccxt_async_config": {},
        "pair_whitelist": [
            "BTC/USDT",
            "ETH/USDT",
            "BTC/USDT:USDT",
            "ETH/USDT:USDT"
        ],
        "pair_blacklist": [
            "BNB/.*"
        ]
    },
    "pairlists": [
        {
            "method": "StaticPairList",
            "pairs": [
                "BTC/USDT",
                "ETH/USDT"
            ]
        }
    ],
    "freqai": {
        "enabled": true,
        "purge_old_models": 2,
        "train_period_days": 15,
        "backtest_period_days": 1,
        "live_retrain_hours": 0,
        "continual_learning": true,
        "save_backtest_models": true,
        "identifier": "unique-id",
        "activate_tensorboard": true,
        "feature_parameters": {
            "include_timeframes": [
//                "15m",
//                "1h"
            ],
            "include_corr_pairlist": [
                "BTC/USDT:USDT",
                "ETH/USDT:USDT"
            ],
            "label_period_candles": 20,
            "include_shifted_candles": 2,
            "DI_threshold": 0.9,
            "weight_factor": 0.9,
            "principal_component_analysis": false,
            "use_SVM_to_remove_outliers": true,
            "indicator_periods_candles": [
                10,
                20
            ],
            "plot_feature_importances": 0
        },
        "data_split_parameters": {
            "test_size": 0.33,
            "random_state": 1
        },
        "model_training_parameters": {}
    }
}

```


</p>
</details> 
