### PR TITLE
Feature startentry rpc api command

### DIFF
--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -414,6 +414,16 @@ class ForceExitPayload(BaseModel):
     amount: float | None = None
 
 
+class StartEntryPayload(BaseModel):
+    max_open_trades: int = 1
+
+    @model_validator(mode="after")
+    def validate_max_open_trades(self):
+        if self.max_open_trades <= 0:
+            raise ValueError("max_open_trades must be over 0 in a start entry context")
+        return self
+
+
 class BlacklistPayload(BaseModel):
     blacklist: list[str]
 

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -44,6 +44,7 @@ from freqtrade.rpc.api_server.api_schemas import (
     Profit,
     ResultMsg,
     ShowConfig,
+    StartEntryPayload,
     Stats,
     StatusMsg,
     StrategyListResponse,
@@ -326,6 +327,11 @@ def stop(rpc: RPC = Depends(get_rpc)):
 @router.post("/stopbuy", response_model=StatusMsg, tags=["botcontrol"])
 def stop_buy(rpc: RPC = Depends(get_rpc)):
     return rpc._rpc_stopentry()
+
+
+@router.post("/startentry", response_model=StatusMsg, tags=["trading"])
+def start_entry(payload: StartEntryPayload, rpc: RPC = Depends(get_rpc)):
+    return rpc._rpc_startentry(payload.max_open_trades)
 
 
 @router.post("/reload_config", response_model=StatusMsg, tags=["botcontrol"])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -860,6 +860,29 @@ class RPC:
 
         return {"status": "No more entries will occur from now. Run /reload_config to reset."}
 
+    def _rpc_startentry(self, max_open_trades: int) -> dict[str, str]:
+        """
+        Handler to start entries, according to specified max_open_trades.
+        """
+        if self._freqtrade.state == State.RUNNING:
+            self._freqtrade.config["max_open_trades"] = max_open_trades
+            self._freqtrade.strategy.max_open_trades = max_open_trades
+
+        open_trades_count = Trade.get_open_trade_count()
+
+        if open_trades_count >= max_open_trades:
+            message = (
+                f"All trade slots are currently in use. New entries will occur only "
+                f"after some trades are closed. "
+                f"Open trades: {open_trades_count}, Maximum allowed open trades: {max_open_trades}."
+            )
+        else:
+            message = (
+                f"New entries are allowed. Current maximum open trades is set to {max_open_trades}."
+            )
+
+        return {"status": message}
+
     def _rpc_reload_trade_from_exchange(self, trade_id: int) -> dict[str, str]:
         """
         Handler for reload_trade_from_exchange.


### PR DESCRIPTION
## Summary

The goal of the PR is to create a new **/startentry** RPC/API route allowing users to restart trading after /stopentry call or with an initial max_open_trades set to 0 in config.

## Quick changelog

- add StartEntryPayload to api schema
- add _rpc_startentry function to rpc
- add startentry route to api
- add test_api_startentry to validate startentry route behaviour

## What's new?
**/startentry** RPC/API route

This will allow users to start the bot in a stopentry mode (max_open_trades=0), then trigger begining of trading using the
**/startentry** call.

