### PR TITLE
allow loading logging from config

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -542,6 +542,10 @@
       "description": "Edge configuration.",
       "$ref": "#/definitions/edge"
     },
+    "log_config": {
+      "description": "Logging configuration.",
+      "$ref": "#/definitions/logging"
+    },
     "freqai": {
       "description": "FreqAI configuration.",
       "$ref": "#/definitions/freqai"
@@ -1271,6 +1275,30 @@
       "required": [
         "process_throttle_secs",
         "allowed_risk"
+      ]
+    },
+    "logging": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "number",
+          "const": 1
+        },
+        "formatters": {
+          "type": "object"
+        },
+        "handlers": {
+          "type": "object"
+        },
+        "root": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "version",
+        "formatters",
+        "handlers",
+        "root"
       ]
     },
     "external_message_consumer": {

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -248,7 +248,6 @@ If this section is left out, freqtrade will provide no output (in the non-config
 
 On many Linux systems the bot can be configured to send its log messages to `syslog` or `journald` system services. Logging to a remote `syslog` server is also available on Windows. The special values for the `--logfile` command line option can be used for this.
 
-
 ### Logging to syslog
 
 To send Freqtrade log messages to a local or remote `syslog` service use the `"log_config"` setup option to configure logging.
@@ -268,7 +267,7 @@ To send Freqtrade log messages to a local or remote `syslog` service use the `"l
       "syslog": {
          "class": "logging.handlers.SysLogHandler",
           "formatter": "syslog_fmt",
-          // Use one of the other options above as adress instead? 
+          // Use one of the other options above as address instead? 
           "address": "/dev/log"
       }
     },
@@ -283,6 +282,8 @@ To send Freqtrade log messages to a local or remote `syslog` service use the `"l
   }
 }
 ```
+
+[Additional log-handlers](#advanced-logging) may need to be configured to for example also have log output in the console.
 
 #### Syslog usage
 
@@ -369,6 +370,8 @@ To send Freqtrade log messages to `journald` system service, add the following c
   }
 }
 ```
+
+[Additional log-handlers](#advanced-logging) may need to be configured to for example also have log output in the console.
 
 Log messages are send to `journald` with the `user` facility. So you can see them with the following commands:
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -275,4 +275,4 @@ On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice vers
 ??? Info "Deprecated - command line option"
     To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
 
-    * `--logfile journald` -- send log messages to `journald`.
+    `--logfile journald` -- send log messages to `journald`.

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -232,9 +232,36 @@ $RepeatedMsgReduction on
 
 This needs the `cysystemd` python package installed as dependency (`pip install cysystemd`), which is not available on Windows. Hence, the whole journald logging functionality is not available for a bot running on Windows.
 
-To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
+To send Freqtrade log messages to `journald` system service, add the following configuration snippet to your configuration.
 
-* `--logfile journald` -- send log messages to `journald`.
+``` json
+{
+  // ...
+  "log_config": {
+    "version": 1,
+    "formatters": {
+      "journald_fmt": {
+        "format": "%(name)s - %(levelname)s - %(message)s"
+      }
+    },
+    "handlers": {
+      // Other handlers? 
+      "journald": {
+         "class": "cysystemd.journal.JournaldLogHandler",
+          "formatter": "journald_fmt",
+      }
+    },
+    "root": {
+      "handlers": [
+        // .. 
+        "journald",
+        
+      ]
+    }
+
+  }
+}
+```
 
 Log messages are send to `journald` with the `user` facility. So you can see them with the following commands:
 
@@ -244,3 +271,8 @@ Log messages are send to `journald` with the `user` facility. So you can see the
 There are many other options in the `journalctl` utility to filter the messages, see manual pages for this utility.
 
 On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfile syslog` or `--logfile journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
+
+??? Info "Deprecated - command line option"
+    To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
+
+    * `--logfile journald` -- send log messages to `journald`.

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -188,7 +188,66 @@ as the watchdog.
 
 ## Advanced Logging
 
+Freqtrade uses the default logging module provided by python.
+Python allows for extensive [logging configuration](https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig) in this regards - way more than what can be covered here.
+
+Default logging (Colored terminal output) is setup by default if no `log_config` is provided.
+Using `--logfile logfile.log` will enable the RotatingFileHandler.
+If you're not content with the log format - or with the default settings provided for the RotatingFileHandler, you can customize logging to your liking.
+
+The default configuration looks roughly like the below - with the file handler being provided - but not enabled.
+
+``` json hl_lines="5-7 13-16 27"
+{
+  "log_config": {
+      "version": 1,
+      "formatters": {
+          "basic": {
+              "format": "%(message)s"
+          },
+          "standard": {
+              "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+          }
+      },
+      "handlers": {
+          "console": {
+              "class": "freqtrade.loggers.ft_rich_handler.FtRichHandler",
+              "formatter": "basic"
+          },
+          "file": {
+              "class": "logging.handlers.RotatingFileHandler",
+              "formatter": "standard",
+              // "filename": "someRandomLogFile.log",
+              "maxBytes": 10485760,
+              "backupCount": 10
+          }
+      },
+      "root": {
+          "handlers": [
+              "console",
+              // "file"
+          ],
+          "level": "INFO",
+      }
+  }
+}
+```
+
+!!! Note highlighted lines
+    Highlighted lines in the above code-block define the Rich handler and belong together.
+    The formatter "standard" and "file" will belong to the FileHandler.
+
+Each handler must use one of the defined formatters (by name) - and it's class must be available and a valid logging class.
+To actually use a handler - it must be in the "handlers" section inside the "root" segment.
+If this section is left out, freqtrade will provide no output (in the non-configured handler, anyway).
+
+!!! Tip "Explicit log configuration"
+    We recommend to extract the logging configuration from your main configuration, and provide it to your bot via [multiple configuration files](configuration.md#multiple-configuration-files) functionality. This will avoid unnecessary code duplication.
+
+---
+
 On many Linux systems the bot can be configured to send its log messages to `syslog` or `journald` system services. Logging to a remote `syslog` server is also available on Windows. The special values for the `--logfile` command line option can be used for this.
+
 
 ### Logging to syslog
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -192,26 +192,47 @@ On many Linux systems the bot can be configured to send its log messages to `sys
 
 ### Logging to syslog
 
-To send Freqtrade log messages to a local or remote `syslog` service use the `--logfile` command line option with the value in the following format:
+To send Freqtrade log messages to a local or remote `syslog` service use the `"log_config"` setup option to configure logging.
 
-* `--logfile syslog:<syslog_address>` -- send log messages to `syslog` service using the `<syslog_address>` as the syslog address.
+``` json
+{
+  // ...
+  "log_config": {
+    "version": 1,
+    "formatters": {
+      "syslog_fmt": {
+        "format": "%(name)s - %(levelname)s - %(message)s"
+      }
+    },
+    "handlers": {
+      // Other handlers? 
+      "syslog": {
+         "class": "logging.handlers.SysLogHandler",
+          "formatter": "syslog_fmt",
+          // Use one of the other options above as adress instead? 
+          "address": "/dev/log"
+      }
+    },
+    "root": {
+      "handlers": [
+        // other handlers
+        "syslog",
+        
+      ]
+    }
 
-The syslog address can be either a Unix domain socket (socket filename) or a UDP socket specification, consisting of IP address and UDP port, separated by the `:` character.
+  }
+}
+```
 
-So, the following are the examples of possible usages:
-
-* `--logfile syslog:/dev/log` -- log to syslog (rsyslog) using the `/dev/log` socket, suitable for most systems.
-* `--logfile syslog` -- same as above, the shortcut for `/dev/log`.
-* `--logfile syslog:/var/run/syslog` -- log to syslog (rsyslog) using the `/var/run/syslog` socket. Use this on MacOS.
-* `--logfile syslog:localhost:514` -- log to local syslog using UDP socket, if it listens on port 514.
-* `--logfile syslog:<ip>:514` -- log to remote syslog at IP address and port 514. This may be used on Windows for remote logging to an external syslog server.
+#### Syslog usage
 
 Log messages are send to `syslog` with the `user` facility. So you can see them with the following commands:
 
-* `tail -f /var/log/user`, or 
+* `tail -f /var/log/user`, or
 * install a comprehensive graphical viewer (for instance, 'Log File Viewer' for Ubuntu).
 
-On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfile syslog` or `--logfile journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
+On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both syslog or journald can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
 
 For `rsyslog` the messages from the bot can be redirected into a separate dedicated log file. To achieve this, add
 
@@ -227,6 +248,33 @@ For `syslog` (`rsyslog`), the reduction mode can be switched on. This will reduc
 # Filter duplicated messages
 $RepeatedMsgReduction on
 ```
+
+#### Syslog addressing
+
+The syslog address can be either a Unix domain socket (socket filename) or a UDP socket specification, consisting of IP address and UDP port, separated by the `:` character.
+
+
+So, the following are the examples of possible addresses:
+
+* `"address": "/dev/log"` -- log to syslog (rsyslog) using the `/dev/log` socket, suitable for most systems.
+* `"address": "/var/run/syslog"` -- log to syslog (rsyslog) using the `/var/run/syslog` socket. Use this on MacOS.
+* `"address": "localhost:514"` -- log to local syslog using UDP socket, if it listens on port 514.
+* `"address": "<ip>:514"` -- log to remote syslog at IP address and port 514. This may be used on Windows for remote logging to an external syslog server.
+
+
+??? Info "Deprecated - configure syslog via command line"
+
+  `--logfile syslog:<syslog_address>` -- send log messages to `syslog` service using the `<syslog_address>` as the syslog address.
+
+  The syslog address can be either a Unix domain socket (socket filename) or a UDP socket specification, consisting of IP address and UDP port, separated by the `:` character.
+
+  So, the following are the examples of possible usages:
+
+  * `--logfile syslog:/dev/log` -- log to syslog (rsyslog) using the `/dev/log` socket, suitable for most systems.
+  * `--logfile syslog` -- same as above, the shortcut for `/dev/log`.
+  * `--logfile syslog:/var/run/syslog` -- log to syslog (rsyslog) using the `/var/run/syslog` socket. Use this on MacOS.
+  * `--logfile syslog:localhost:514` -- log to local syslog using UDP socket, if it listens on port 514.
+  * `--logfile syslog:<ip>:514` -- log to remote syslog at IP address and port 514. This may be used on Windows for remote logging to an external syslog server.
 
 ### Logging to journald
 
@@ -272,7 +320,7 @@ There are many other options in the `journalctl` utility to filter the messages,
 
 On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice versa), so both `--logfile syslog` or `--logfile journald` can be used and the messages be viewed with both `journalctl` and a syslog viewer utility. You can combine this in any way which suites you better.
 
-??? Info "Deprecated - command line option"
+??? Info "Deprecated - configure journald via command line"
     To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
 
     `--logfile journald` -- send log messages to `journald`.

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -233,7 +233,7 @@ The default configuration looks roughly like the below - with the file handler b
 }
 ```
 
-!!! Note highlighted lines
+!!! Note "highlighted lines"
     Highlighted lines in the above code-block define the Rich handler and belong together.
     The formatter "standard" and "file" will belong to the FileHandler.
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -386,3 +386,46 @@ On many systems `syslog` (`rsyslog`) fetches data from `journald` (and vice vers
     To send Freqtrade log messages to `journald` system service use the `--logfile` command line option with the value in the following format:
 
     `--logfile journald` -- send log messages to `journald`.
+
+### Log format as JSON
+
+You can also configure the default output stream to use JSON format instead.
+The "fmt_dict" attribute defines the keys for the json output - as well as the [python logging LogRecord attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes).
+
+The below configuration will change the default output to JSON. The same formatter could however also be used in combination with the `RotatingFileHandler`.
+We recommend to keep one format in human readable form.
+
+``` json
+{
+  // ...
+  "log_config": {
+    "version": 1,
+    "formatters": {
+       "json": {
+          "()": "freqtrade.loggers.json_formatter.JsonFormatter",
+          "fmt_dict": {
+              "timestamp": "asctime",
+              "level": "levelname",
+              "logger": "name",
+              "message": "message"
+          }
+      }
+    },
+    "handlers": {
+      // Other handlers? 
+      "jsonStream": {
+          "class": "logging.StreamHandler",
+          "formatter": "json"
+      }
+    },
+    "root": {
+      "handlers": [
+        // .. 
+        "jsonStream",
+        
+      ]
+    }
+
+  }
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,6 +282,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `dataformat_ohlcv` | Data format to use to store historical candle (OHLCV) data. <br> *Defaults to `feather`*. <br> **Datatype:** String
 | `dataformat_trades` | Data format to use to store historical trades data. <br> *Defaults to `feather`*. <br> **Datatype:** String
 | `reduce_df_footprint` | Recast all numeric columns to float32/int32, with the objective of reducing ram/disk usage (and decreasing train/inference timing in FreqAI). (Currently only affects FreqAI use-cases) <br> **Datatype:** Boolean. <br> Default: `False`.
+| `log_config` | Dictionary containing the log config for python logging. [more info](advanced-setup.md#advanced-logging) <br> **Datatype:** dict. <br> Default: `FtRichHandler`
 
 ### Parameters in the strategy
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -88,3 +88,8 @@ Setting protections from the configuration via `"protections": [],` has been rem
 Using hdf5 as data storage has been deprecated in 2024.12 and was removed in 2025.1. We recommend switching to the feather data format.
 
 Please use the [`convert-data` subcommand](data-download.md#sub-command-convert-data) to convert your existing data to one of the supported formats before updating.
+
+## Configuring advanced logging via config
+
+Configuring syslog and journald via `--logfile systemd` and `--logfile journald` respectively has been deprecated in 2025.3.
+Please use configuration based [log setup](advanced-setup.md#advanced-logging) instead.

--- a/freqtrade/configuration/config_schema.py
+++ b/freqtrade/configuration/config_schema.py
@@ -891,7 +891,10 @@ CONF_SCHEMA = {
                     # based on logging.config documentation
                     # "additionalProperties": {
                     #     "type": "object",
-                    #     "properties": {"format": {"type": "string"}, "datefmt": {"type": "string"}},
+                    #     "properties": {
+                    #         "format": {"type": "string"},
+                    #         "datefmt": {"type": "string"},
+                    #     },
                     #     "required": ["format"],
                     # },
                 },

--- a/freqtrade/configuration/config_schema.py
+++ b/freqtrade/configuration/config_schema.py
@@ -425,6 +425,10 @@ CONF_SCHEMA = {
             "description": "Edge configuration.",
             "$ref": "#/definitions/edge",
         },
+        "log_config": {
+            "description": "Logging configuration.",
+            "$ref": "#/definitions/logging",
+        },
         "freqai": {
             "description": "FreqAI configuration.",
             "$ref": "#/definitions/freqai",
@@ -876,6 +880,16 @@ CONF_SCHEMA = {
                 "remove_pumps": {"type": "boolean"},
             },
             "required": ["process_throttle_secs", "allowed_risk"],
+        },
+        "logging": {
+            "type": "object",
+            "properties": {
+                "version": {"type": "number", "const": 1},
+                "formatters": {"type": "object"},
+                "handlers": {"type": "object"},
+                "root": {"type": "object"},
+            },
+            "required": ["version", "formatters", "handlers", "root"],
         },
         "external_message_consumer": {
             "description": "Configuration for external message consumer.",

--- a/freqtrade/configuration/config_schema.py
+++ b/freqtrade/configuration/config_schema.py
@@ -885,7 +885,16 @@ CONF_SCHEMA = {
             "type": "object",
             "properties": {
                 "version": {"type": "number", "const": 1},
-                "formatters": {"type": "object"},
+                "formatters": {
+                    "type": "object",
+                    # In theory the below, but can be more flexible
+                    # based on logging.config documentation
+                    # "additionalProperties": {
+                    #     "type": "object",
+                    #     "properties": {"format": {"type": "string"}, "datefmt": {"type": "string"}},
+                    #     "required": ["format"],
+                    # },
+                },
                 "handlers": {"type": "object"},
                 "root": {"type": "object"},
             },

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -101,6 +101,11 @@ def _add_root_handler(log_config: dict[str, Any], handler_name: str):
         log_config["root"]["handlers"].append(handler_name)
 
 
+def _add_formatter(log_config: dict[str, Any], format_name: str, format: str):
+    if format_name not in log_config["formatters"]:
+        log_config["formatters"][format_name] = {"format": format}
+
+
 def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
     log_config = config.get("log_config", FT_LOGGING_CONFIG.copy())
@@ -114,11 +119,8 @@ def _create_log_config(config: Config) -> dict[str, Any]:
                 "formatter": "syslog_format",
                 "address": (s[1], int(s[2])) if len(s) > 2 else s[1] if len(s) > 1 else "/dev/log",
             }
-            # Add the syslog formatter if not already present
-            if "syslog_format" not in log_config["formatters"]:
-                log_config["formatters"]["syslog_format"] = {
-                    "format": "%(name)s - %(levelname)s - %(message)s"
-                }
+
+            _add_formatter(log_config, "syslog_format", "%(name)s - %(levelname)s - %(message)s")
             _add_root_handler(log_config, "syslog")
 
         elif s[0] == "journald":  # pragma: no cover
@@ -136,11 +138,8 @@ def _create_log_config(config: Config) -> dict[str, Any]:
                 "class": "cysystemd.journal.JournaldLogHandler",
                 "formatter": "journald_format",
             }
-            # Add the journald formatter if not already present
-            if "journald_format" not in log_config["formatters"]:
-                log_config["formatters"]["journald_format"] = {
-                    "format": "%(name)s - %(levelname)s - %(message)s"
-                }
+
+            _add_formatter(log_config, "journald_format", "%(name)s - %(levelname)s - %(message)s")
             _add_root_handler(log_config, "journald")
 
         else:

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import logging.config
+import os
 from copy import deepcopy
 from logging import Formatter
 from pathlib import Path
@@ -197,7 +198,7 @@ def setup_logging(config: Config) -> None:
     Process -v/--verbose, --logfile options
     """
     verbosity = config["verbosity"]
-    if not config.get("ft_tests_skip_logging"):
+    if os.environ.get("PYTEST_VERSION") is None or config.get("ft_tests_force_logging"):
         log_config = _create_log_config(config)
         _set_log_levels(
             log_config, verbosity, config.get("api_server", {}).get("verbosity", "info")

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -53,7 +53,7 @@ def setup_logging_pre() -> None:
     )
 
 
-logging_config = {
+FT_LOGGING_CONFIG = {
     "version": 1,
     # "incremental": True,
     # "disable_existing_loggers": False,
@@ -99,7 +99,7 @@ logging_config = {
 
 def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
-    log_config = config.get("log_config", logging_config.copy())
+    log_config = config.get("log_config", FT_LOGGING_CONFIG.copy())
 
     logfile = config.get("logfile")
 

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -1,4 +1,6 @@
 import logging
+import logging.config
+from copy import deepcopy
 from logging import Formatter
 from pathlib import Path
 from typing import Any
@@ -120,7 +122,7 @@ def _add_formatter(log_config: dict[str, Any], format_name: str, format_: str):
 
 def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
-    log_config = config.get("log_config", FT_LOGGING_CONFIG.copy())
+    log_config = config.get("log_config", deepcopy(FT_LOGGING_CONFIG))
 
     if logfile := config.get("logfile"):
         s = logfile.split(":")

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -197,14 +197,17 @@ def setup_logging(config: Config) -> None:
     Process -v/--verbose, --logfile options
     """
     verbosity = config["verbosity"]
+    if not config.get("ft_tests_skip_logging"):
+        log_config = _create_log_config(config)
+        _set_log_levels(
+            log_config, verbosity, config.get("api_server", {}).get("verbosity", "info")
+        )
 
-    log_config = _create_log_config(config)
-    _set_log_levels(log_config, verbosity, config.get("api_server", {}).get("verbosity", "info"))
-
-    logging.config.dictConfig(log_config)
+        logging.config.dictConfig(log_config)
 
     # Add buffer handler to root logger
-    logging.root.addHandler(bufferHandler)
+    if bufferHandler not in logging.root.handlers:
+        logging.root.addHandler(bufferHandler)
 
     # Set color system for console output
     if config.get("print_colorized", True):

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -69,12 +69,6 @@ FT_LOGGING_CONFIG = {
             "formatter": "basic",
         },
     },
-    "loggers": {
-        "freqtrade": {
-            "level": "INFO",
-            "propagate": True,
-        },
-    },
     "root": {
         "handlers": [
             "console",
@@ -83,6 +77,14 @@ FT_LOGGING_CONFIG = {
         "level": "INFO",
     },
 }
+
+
+def _set_loggers(log_config: dict[str, Any]) -> None:
+    if "loggers" not in log_config:
+        log_config["loggers"] = {}
+
+    if "freqtrade" not in log_config["loggers"]:
+        log_config["loggers"]["freqtrade"] = {"level": "INFO", "propagate": True}
 
 
 def _add_root_handler(log_config: dict[str, Any], handler_name: str):
@@ -164,7 +166,7 @@ def _create_log_config(config: Config) -> dict[str, Any]:
                     "non-root user, delete and recreate the directories you need, and then try "
                     "again."
                 )
-
+    _set_loggers(log_config)
     return log_config
 
 
@@ -172,10 +174,7 @@ def setup_logging(config: Config) -> None:
     """
     Process -v/--verbose, --logfile options
     """
-    verbosity = config["verbosity"]
-
     log_config = _create_log_config(config)
-    print(log_config)
     logging.config.dictConfig(log_config)
 
     # Add buffer handler to root logger
@@ -189,6 +188,7 @@ def setup_logging(config: Config) -> None:
     logging.info("Logfile configured")
 
     # Set verbosity levels
+    verbosity = config["verbosity"]
     logging.root.setLevel(logging.INFO if verbosity < 1 else logging.DEBUG)
     set_loggers(verbosity, config.get("api_server", {}).get("verbosity", "info"))
 

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from logging import Formatter
-from logging.handlers import RotatingFileHandler, SysLogHandler
 from pathlib import Path
+from typing import Any
 
 from freqtrade.constants import Config
 from freqtrade.exceptions import OperationalException
@@ -97,13 +97,7 @@ logging_config = {
 }
 
 
-def setup_logging(config: Config) -> None:
-    """
-    Process -v/--verbose, --logfile options
-    """
-    # Log level
-    verbosity = config["verbosity"]
-
+def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
     log_config = config.get("log_config", logging_config.copy())
 
@@ -182,6 +176,17 @@ def setup_logging(config: Config) -> None:
                     "non-root user, delete and recreate the directories you need, and then try "
                     "again."
                 )
+    return log_config
+
+
+def setup_logging(config: Config) -> None:
+    """
+    Process -v/--verbose, --logfile options
+    """
+    # Log level
+    verbosity = config["verbosity"]
+
+    log_config = _create_log_config(config)
 
     # Apply the configuration
     logging.config.dictConfig(log_config)

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -92,9 +92,9 @@ def _add_root_handler(log_config: dict[str, Any], handler_name: str):
         log_config["root"]["handlers"].append(handler_name)
 
 
-def _add_formatter(log_config: dict[str, Any], format_name: str, format: str):
+def _add_formatter(log_config: dict[str, Any], format_name: str, format_: str):
     if format_name not in log_config["formatters"]:
-        log_config["formatters"][format_name] = {"format": format}
+        log_config["formatters"][format_name] = {"format": format_}
 
 
 def _create_log_config(config: Config) -> dict[str, Any]:

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -140,6 +140,10 @@ def _create_log_config(config: Config) -> dict[str, Any]:
 
         elif s[0] == "journald":  # pragma: no cover
             # Check if we have the module available
+            logger.warning(
+                "DEPRECATED: Configuring Journald logging via command line is deprecated."
+                "Please use the log_config option in the configuration file instead."
+            )
             try:
                 from cysystemd.journal import JournaldLogHandler  # noqa: F401
             except ImportError:

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -53,18 +53,63 @@ def setup_logging_pre() -> None:
     )
 
 
+logging_config = {
+    "version": 1,
+    # "incremental": True,
+    # "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(message)s"},
+        "standard": {
+            "format": LOGFORMAT,
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "freqtrade.loggers.ft_rich_handler.FtRichHandler",
+            "console": error_console,
+            "formatter": "basic",
+            # "class": "logging.StreamHandler",
+            # "formatter": "standard",
+            # "stream": "ext://sys.stdout",
+        },
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "standard",
+            "filename": "whatever.log",
+            "maxBytes": 1024 * 1024 * 10,  # 10Mb
+            "backupCount": 10,
+        },
+    },
+    "loggers": {
+        "freqtrade": {
+            #     "handlers": ["console", "file"],
+            "level": "INFO",
+            "propagate": True,
+        },
+    },
+    "root": {
+        "handlers": ["console", "file"],
+        "level": "INFO",
+    },
+}
+
+
 def setup_logging(config: Config) -> None:
     """
     Process -v/--verbose, --logfile options
     """
     # Log level
     verbosity = config["verbosity"]
+
+    logging.config.dictConfig(logging_config)
+
     logging.root.addHandler(bufferHandler)
     if config.get("print_colorized", True):
         logger.info("Enabling colorized output.")
         error_console._color_system = error_console._detect_color_system()
 
     logfile = config.get("logfile")
+    logging.info("Logfile configured")
 
     if logfile:
         s = logfile.split(":")

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -128,6 +128,10 @@ def _create_log_config(config: Config) -> dict[str, Any]:
     if logfile := config.get("logfile"):
         s = logfile.split(":")
         if s[0] == "syslog":
+            logger.warning(
+                "DEPRECATED: Configuring syslog logging via command line is deprecated."
+                "Please use the log_config option in the configuration file instead."
+            )
             # Add syslog handler to the config
             log_config["handlers"]["syslog"] = {
                 "class": "logging.handlers.SysLogHandler",

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -184,16 +184,15 @@ def setup_logging(config: Config) -> None:
     """
     Process -v/--verbose, --logfile options
     """
-    # Log level
     verbosity = config["verbosity"]
 
     log_config = _create_log_config(config)
 
-    # Apply the configuration
     logging.config.dictConfig(log_config)
 
     # Add buffer handler to root logger
     logging.root.addHandler(bufferHandler)
+
     # Set color system for console output
     if config.get("print_colorized", True):
         logger.info("Enabling colorized output.")

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -96,11 +96,16 @@ FT_LOGGING_CONFIG = {
 }
 
 
+def _add_root_handler(log_config: dict[str, Any], handler_name: str):
+    if handler_name not in log_config["root"]["handlers"]:
+        log_config["root"]["handlers"].append(handler_name)
+
+
 def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
     log_config = config.get("log_config", FT_LOGGING_CONFIG.copy())
 
-    # Dynamically update any FtRichHandler with the error_console
+    # Dynamically update any FtRichHandler with the proper console object
     for handler_config in log_config.get("handlers", {}).values():
         if handler_config.get("class") == "freqtrade.loggers.ft_rich_handler.FtRichHandler":
             handler_config["console"] = error_console
@@ -119,9 +124,7 @@ def _create_log_config(config: Config) -> dict[str, Any]:
                 log_config["formatters"]["syslog_format"] = {
                     "format": "%(name)s - %(levelname)s - %(message)s"
                 }
-            # Add handler to root
-            if "syslog" not in log_config["root"]["handlers"]:
-                log_config["root"]["handlers"].append("syslog")
+            _add_root_handler(log_config, "syslog")
 
         elif s[0] == "journald":  # pragma: no cover
             # Check if we have the module available
@@ -143,9 +146,7 @@ def _create_log_config(config: Config) -> dict[str, Any]:
                 log_config["formatters"]["journald_format"] = {
                     "format": "%(name)s - %(levelname)s - %(message)s"
                 }
-            # Add handler to root
-            if "journald" not in log_config["root"]["handlers"]:
-                log_config["root"]["handlers"].append("journald")
+            _add_root_handler(log_config, "journald")
 
         else:
             # Regular file logging

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -67,21 +67,10 @@ FT_LOGGING_CONFIG = {
         "console": {
             "class": "freqtrade.loggers.ft_rich_handler.FtRichHandler",
             "formatter": "basic",
-            # "class": "logging.StreamHandler",
-            # "formatter": "standard",
-            # "stream": "ext://sys.stdout",
         },
-        # "file": {
-        #     "class": "logging.handlers.RotatingFileHandler",
-        #     "formatter": "standard",
-        #     "filename": "whatever.log",
-        #     "maxBytes": 1024 * 1024 * 10,  # 10Mb
-        #     "backupCount": 10,
-        # },
     },
     "loggers": {
         "freqtrade": {
-            #     "handlers": ["console", "file"],
             "level": "INFO",
             "propagate": True,
         },
@@ -186,7 +175,7 @@ def setup_logging(config: Config) -> None:
     verbosity = config["verbosity"]
 
     log_config = _create_log_config(config)
-
+    print(log_config)
     logging.config.dictConfig(log_config)
 
     # Add buffer handler to root logger

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -66,7 +66,6 @@ FT_LOGGING_CONFIG = {
     "handlers": {
         "console": {
             "class": "freqtrade.loggers.ft_rich_handler.FtRichHandler",
-            "console": error_console,
             "formatter": "basic",
             # "class": "logging.StreamHandler",
             # "formatter": "standard",
@@ -101,9 +100,12 @@ def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
     log_config = config.get("log_config", FT_LOGGING_CONFIG.copy())
 
-    logfile = config.get("logfile")
+    # Dynamically update any FtRichHandler with the error_console
+    for handler_config in log_config.get("handlers", {}).values():
+        if handler_config.get("class") == "freqtrade.loggers.ft_rich_handler.FtRichHandler":
+            handler_config["console"] = error_console
 
-    if logfile:
+    if logfile := config.get("logfile"):
         s = logfile.split(":")
         if s[0] == "syslog":
             # Add syslog handler to the config

--- a/freqtrade/loggers/json_formatter.py
+++ b/freqtrade/loggers/json_formatter.py
@@ -13,11 +13,20 @@ class JsonFormatter(logging.Formatter):
 
     def __init__(
         self,
-        fmt_dict: dict = None,
+        fmt_dict: dict | None = None,
         time_format: str = "%Y-%m-%dT%H:%M:%S",
         msec_format: str = "%s.%03dZ",
     ):
-        self.fmt_dict = fmt_dict if fmt_dict is not None else {"message": "message"}
+        self.fmt_dict = (
+            fmt_dict
+            if fmt_dict is not None
+            else {
+                "timestamp": "asctime",
+                "level": "levelname",
+                "logger": "name",
+                "message": "message",
+            }
+        )
         self.default_time_format = time_format
         self.default_msec_format = msec_format
         self.datefmt = None
@@ -28,7 +37,10 @@ class JsonFormatter(logging.Formatter):
         """
         return "asctime" in self.fmt_dict.values()
 
-    def formatMessage(self, record) -> dict:
+    def formatMessage(self, record) -> str:
+        raise NotImplementedError()
+
+    def formatMessageDict(self, record) -> dict:
         """
         Return a dictionary of the relevant LogRecord attributes instead of a string.
         KeyError is raised if an unknown attribute is provided in the fmt_dict.
@@ -45,7 +57,7 @@ class JsonFormatter(logging.Formatter):
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
 
-        message_dict = self.formatMessage(record)
+        message_dict = self.formatMessageDict(record)
 
         if record.exc_info:
             # Cache the traceback text to avoid converting it multiple times

--- a/freqtrade/loggers/json_formatter.py
+++ b/freqtrade/loggers/json_formatter.py
@@ -1,0 +1,63 @@
+import json
+import logging
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    Formatter that outputs JSON strings after parsing the LogRecord.
+
+    @param dict fmt_dict: Key: logging format attribute pairs. Defaults to {"message": "message"}.
+    @param str time_format: time.strftime() format string. Default: "%Y-%m-%dT%H:%M:%S"
+    @param str msec_format: Microsecond formatting. Appended at the end. Default: "%s.%03dZ"
+    """
+
+    def __init__(
+        self,
+        fmt_dict: dict = None,
+        time_format: str = "%Y-%m-%dT%H:%M:%S",
+        msec_format: str = "%s.%03dZ",
+    ):
+        print(fmt_dict)
+        self.fmt_dict = fmt_dict if fmt_dict is not None else {"message": "message"}
+        self.default_time_format = time_format
+        self.default_msec_format = msec_format
+        self.datefmt = None
+
+    def usesTime(self) -> bool:
+        """
+        Look for the attribute in the format dict values instead of the fmt string.
+        """
+        return "asctime" in self.fmt_dict.values()
+
+    def formatMessage(self, record) -> dict:
+        """
+        Return a dictionary of the relevant LogRecord attributes instead of a string.
+        KeyError is raised if an unknown attribute is provided in the fmt_dict.
+        """
+        return {fmt_key: record.__dict__[fmt_val] for fmt_key, fmt_val in self.fmt_dict.items()}
+
+    def format(self, record) -> str:
+        """
+        Mostly the same as the parent's class method, the difference being that a dict is
+        manipulated and dumped as JSON instead of a string.
+        """
+        record.message = record.getMessage()
+
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+
+        message_dict = self.formatMessage(record)
+
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            message_dict["exc_info"] = record.exc_text
+
+        if record.stack_info:
+            message_dict["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(message_dict, default=str)

--- a/freqtrade/loggers/json_formatter.py
+++ b/freqtrade/loggers/json_formatter.py
@@ -17,7 +17,6 @@ class JsonFormatter(logging.Formatter):
         time_format: str = "%Y-%m-%dT%H:%M:%S",
         msec_format: str = "%s.%03dZ",
     ):
-        print(fmt_dict)
         self.fmt_dict = fmt_dict if fmt_dict is not None else {"message": "message"}
         self.default_time_format = time_format
         self.default_msec_format = msec_format

--- a/freqtrade/loggers/set_log_levels.py
+++ b/freqtrade/loggers/set_log_levels.py
@@ -4,25 +4,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def set_loggers(verbosity: int = 0, api_verbosity: str = "info") -> None:
-    """
-    Set the logging level for third party libraries
-    :param verbosity: Verbosity level. amount of `-v` passed to the command line
-    :return: None
-    """
-    for logger_name in ("requests", "urllib3", "httpcore"):
-        logging.getLogger(logger_name).setLevel(logging.INFO if verbosity <= 1 else logging.DEBUG)
-    logging.getLogger("ccxt.base.exchange").setLevel(
-        logging.INFO if verbosity <= 2 else logging.DEBUG
-    )
-    logging.getLogger("telegram").setLevel(logging.INFO)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    logging.getLogger("werkzeug").setLevel(
-        logging.ERROR if api_verbosity == "error" else logging.INFO
-    )
-
-
 __BIAS_TESTER_LOGGERS = [
     "freqtrade.resolvers",
     "freqtrade.strategy.hyper",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -549,6 +549,14 @@ def user_dir(mocker, tmp_path) -> Path:
     return user_dir
 
 
+@pytest.fixture()
+def keep_log_config_loggers(mocker):
+    # Mock the _handle_existing_loggers function to prevent it from disabling all loggers.
+    # This is necessary to keep all loggers active, and avoid random failures if
+    # this file is ran before the test_rest_client file.
+    mocker.patch("logging.config._handle_existing_loggers")
+
+
 @pytest.fixture(autouse=True)
 def patch_coingecko(mocker) -> None:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -644,7 +644,6 @@ def get_default_conf(testdatadir):
         "trading_mode": "spot",
         "margin_mode": "",
         "candle_type_def": CandleType.SPOT,
-        "ft_tests_skip_logging": True,
     }
     return configuration
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -644,6 +644,7 @@ def get_default_conf(testdatadir):
         "trading_mode": "spot",
         "margin_mode": "",
         "candle_type_def": CandleType.SPOT,
+        "ft_tests_skip_logging": True,
     }
     return configuration
 

--- a/tests/exchange_online/test_ccxt_ws_compat.py
+++ b/tests/exchange_online/test_ccxt_ws_compat.py
@@ -12,7 +12,6 @@ import pytest
 
 from freqtrade.enums import CandleType
 from freqtrade.exchange.exchange_utils import timeframe_to_prev_date
-from freqtrade.loggers.set_log_levels import set_loggers
 from freqtrade.util.datetime_helpers import dt_now
 from tests.conftest import log_has_re
 from tests.exchange_online.conftest import EXCHANGE_WS_FIXTURE_TYPE
@@ -50,7 +49,6 @@ class TestCCXTExchangeWs:
         assert res[pair_tf] is not None
         df1 = res[pair_tf]
         caplog.set_level(logging.DEBUG)
-        set_loggers(1)
         assert df1.iloc[-1]["date"] == curr_candle
 
         # Wait until the next candle (might be up to 1 minute).

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -614,6 +614,7 @@ def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:
     assert log_has("Verbosity set to 3", caplog)
 
 
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_logfile(default_conf, mocker, tmp_path):
     default_conf["ft_tests_force_logging"] = True
     patched_configuration_load_config_file(mocker, default_conf)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -603,7 +603,7 @@ def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:
     patched_configuration_load_config_file(mocker, default_conf)
 
     # Prevent setting loggers
-    mocker.patch("freqtrade.loggers.set_loggers", MagicMock)
+    mocker.patch("freqtrade.loggers.logging.config.dictConfig", MagicMock)
     arglist = ["trade", "-vvv"]
     args = Arguments(arglist).get_parsed_arg()
 
@@ -615,6 +615,7 @@ def test_cli_verbose_with_params(default_conf, mocker, caplog) -> None:
 
 
 def test_set_logfile(default_conf, mocker, tmp_path):
+    default_conf["ft_tests_force_logging"] = True
     patched_configuration_load_config_file(mocker, default_conf)
     f = tmp_path / "test_file.log"
     assert not f.is_file()

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -16,6 +16,7 @@ from freqtrade.loggers.set_log_levels import (
 )
 
 
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_loggers() -> None:
     # Reset Logging to Debug, otherwise this fails randomly as it's set globally
     logging.getLogger("requests").setLevel(logging.DEBUG)
@@ -62,6 +63,7 @@ def test_set_loggers() -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_loggers_syslog():
     logger = logging.getLogger()
     orig_handlers = logger.handlers
@@ -87,6 +89,7 @@ def test_set_loggers_syslog():
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_loggers_Filehandler(tmp_path):
     logger = logging.getLogger()
     orig_handlers = logger.handlers
@@ -114,6 +117,7 @@ def test_set_loggers_Filehandler(tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_loggers_Filehandler_without_permission(tmp_path):
     logger = logging.getLogger()
     orig_handlers = logger.handlers
@@ -138,7 +142,8 @@ def test_set_loggers_Filehandler_without_permission(tmp_path):
 
 
 @pytest.mark.skip(reason="systemd is not installed on every system, so we're not testing this.")
-def test_set_loggers_journald(mocker):
+@pytest.mark.usefixtures("keep_log_config_loggers")
+def test_set_loggers_journald():
     logger = logging.getLogger()
     orig_handlers = logger.handlers
     logger.handlers = []
@@ -158,6 +163,7 @@ def test_set_loggers_journald(mocker):
     logger.handlers = orig_handlers
 
 
+@pytest.mark.usefixtures("keep_log_config_loggers")
 def test_set_loggers_journald_importerror(import_fails):
     logger = logging.getLogger()
     orig_handlers = logger.handlers

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -7,7 +7,6 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.loggers import (
     FTBufferingHandler,
     FtRichHandler,
-    set_loggers,
     setup_logging,
     setup_logging_pre,
 )
@@ -27,8 +26,11 @@ def test_set_loggers() -> None:
     previous_value1 = logging.getLogger("requests").level
     previous_value2 = logging.getLogger("ccxt.base.exchange").level
     previous_value3 = logging.getLogger("telegram").level
-
-    set_loggers()
+    config = {
+        "verbosity": 1,
+        "ft_tests_force_logging": True,
+    }
+    setup_logging(config)
 
     value1 = logging.getLogger("requests").level
     assert previous_value1 is not value1
@@ -41,15 +43,17 @@ def test_set_loggers() -> None:
     value3 = logging.getLogger("telegram").level
     assert previous_value3 is not value3
     assert value3 is logging.INFO
-
-    set_loggers(verbosity=2)
+    config["verbosity"] = 2
+    setup_logging(config)
 
     assert logging.getLogger("requests").level is logging.DEBUG
     assert logging.getLogger("ccxt.base.exchange").level is logging.INFO
     assert logging.getLogger("telegram").level is logging.INFO
     assert logging.getLogger("werkzeug").level is logging.INFO
 
-    set_loggers(verbosity=3, api_verbosity="error")
+    config["verbosity"] = 3
+    config["api_server"] = {"verbosity": "error"}
+    setup_logging(config)
 
     assert logging.getLogger("requests").level is logging.DEBUG
     assert logging.getLogger("ccxt.base.exchange").level is logging.DEBUG
@@ -64,6 +68,7 @@ def test_set_loggers_syslog():
     logger.handlers = []
 
     config = {
+        "ft_tests_force_logging": True,
         "verbosity": 2,
         "logfile": "syslog:/dev/log",
     }
@@ -88,6 +93,7 @@ def test_set_loggers_Filehandler(tmp_path):
     logger.handlers = []
     logfile = tmp_path / "logs/ft_logfile.log"
     config = {
+        "ft_tests_force_logging": True,
         "verbosity": 2,
         "logfile": str(logfile),
     }
@@ -117,6 +123,7 @@ def test_set_loggers_Filehandler_without_permission(tmp_path):
         tmp_path.chmod(0o400)
         logfile = tmp_path / "logs/ft_logfile.log"
         config = {
+            "ft_tests_force_logging": True,
             "verbosity": 2,
             "logfile": str(logfile),
         }
@@ -137,6 +144,7 @@ def test_set_loggers_journald(mocker):
     logger.handlers = []
 
     config = {
+        "ft_tests_force_logging": True,
         "verbosity": 2,
         "logfile": "journald",
     }
@@ -156,6 +164,7 @@ def test_set_loggers_journald_importerror(import_fails):
     logger.handlers = []
 
     config = {
+        "ft_tests_force_logging": True,
         "verbosity": 2,
         "logfile": "journald",
     }


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Improved advanced logging configuration - allowing way more flexibility in how logging is configured.

convenience functions to log to file (e.g. `--logfile user_data/logs/logfile.log`) will remain - but for more advanced usecases,  log_config can be customized to everyone's liking.

closes: #11147
replaces #11372

## Quick changelog

- add `log_config` configuration key which will be used to configure logging.
- deprecate `--logfile syslog` in favor of the new log_config setup
- deprecate `--logfile journald` in favor of the new log_config setup
- provide documentation for default setup
- JSON formatter for dynamic json log format output