### PR TITLE
Fix the type of the fit_live_predictions_candles field in the config …

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1417,8 +1417,7 @@
         },
         "fit_live_predictions_candles": {
           "description": "Number of historical candles to use for computing target (label) statistics from prediction data, instead of from the training dataset.",
-          "type": "boolean",
-          "default": false
+          "type": "integer"
         },
         "data_kitchen_thread_count": {
           "description": "Designate the number of threads you want to use for data processing (outlier methods, normalization, etc.).",

--- a/freqtrade/configuration/config_schema.py
+++ b/freqtrade/configuration/config_schema.py
@@ -1027,7 +1027,6 @@ CONF_SCHEMA = {
                         "statistics from prediction data, instead of from the training dataset."
                     ),
                     "type": "integer",
-                    "default": 0,
                 },
                 "data_kitchen_thread_count": {
                     "description": (

--- a/freqtrade/configuration/config_schema.py
+++ b/freqtrade/configuration/config_schema.py
@@ -1026,8 +1026,8 @@ CONF_SCHEMA = {
                         "Number of historical candles to use for computing target (label) "
                         "statistics from prediction data, instead of from the training dataset."
                     ),
-                    "type": "boolean",
-                    "default": False,
+                    "type": "integer",
+                    "default": 0,
                 },
                 "data_kitchen_thread_count": {
                     "description": (


### PR DESCRIPTION
When I download the data I get an error:
freqtrade.configuration.config_validation - CRITICAL - Invalid configuration. Reason: 24 is not of type 'boolean'

Failed validating 'type' in schema['properties']['freqai']['properties']['fit_live_predictions_candles']:
    {'description': 'Number of historical candles to use for computing '
                    'target (label) statistics from prediction data, '
                    'instead of from the training dataset.',
     'type': 'boolean',
     'default': False}
On instance['freqai']['fit_live_predictions_candles']:
    24
  
  The data type should be a numeric type

