### PR TITLE
Display profit factor per pair in backtesting reports

### DIFF
--- a/freqtrade/optimize/optimize_reports/bt_output.py
+++ b/freqtrade/optimize/optimize_reports/bt_output.py
@@ -30,6 +30,7 @@ def _get_line_header(
         f"Tot Profit {stake_currency}",
         "Tot Profit %",
         "Avg Duration",
+        "Profit Factor",
         "Win  Draw  Loss  Win%",
     ]
 
@@ -63,6 +64,7 @@ def text_table_bt_results(
             f"{t['profit_total_abs']:.{decimals_per_coin(stake_currency)}f}",
             t["profit_total_pct"],
             t["duration_avg"],
+            round(t["profit_factor"], 2) if "profit_factor" in t else "N/A",
             generate_wins_draws_losses(t["wins"], t["draws"], t["losses"]),
         ]
         for t in pair_results
@@ -114,6 +116,7 @@ def text_table_tags(
             f"{t['profit_total_abs']:.{decimals_per_coin(stake_currency)}f}",
             t["profit_total_pct"],
             t.get("duration_avg"),
+            round(t["profit_factor"], 2) if "profit_factor" in t else "N/A",
             generate_wins_draws_losses(t["wins"], t["draws"], t["losses"]),
         ]
         for t in tag_results
@@ -156,10 +159,16 @@ def text_table_strategy(strategy_results, stake_currency: str, title: str):
     :param strategy_results: Dict of <Strategyname: DataFrame> containing results for all strategies
     :param stake_currency: stake-currency - used to correctly name headers
     """
-    headers = _get_line_header("Strategy", stake_currency, "Trades")
-    # _get_line_header() is also used for per-pair summary. Per-pair drawdown is mostly useless
-    # therefore we slip this column in only for strategy summary here.
-    headers.append("Drawdown")
+    headers = [
+        "Strategy",
+        "Trades",
+        "Avg Profit %",
+        f"Tot Profit {stake_currency}",
+        "Tot Profit %",
+        "Avg Duration",
+        "Win  Draw  Loss  Win%",
+        "Drawdown",
+    ]
 
     # Align drawdown string on the center two space separator.
     if "max_drawdown_account" in strategy_results[0]:

--- a/freqtrade/optimize/optimize_reports/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports/optimize_reports.py
@@ -78,6 +78,9 @@ def _generate_result_line(
     profit_sum = result["profit_ratio"].sum()
     # (end-capital - starting capital) / starting capital
     profit_total = result["profit_abs"].sum() / starting_balance
+    winning_profit = result.loc[result["profit_abs"] > 0, "profit_abs"].sum()
+    losing_profit = result.loc[result["profit_abs"] < 0, "profit_abs"].sum()
+    profit_factor = winning_profit / abs(losing_profit) if losing_profit else 0.0
 
     return {
         "key": first_column,
@@ -102,6 +105,7 @@ def _generate_result_line(
         # 'duration_min': str(timedelta(
         #                     minutes=round(result['trade_duration'].min()))
         #                     ) if not result.empty else '0:00',
+        "profit_factor": round(profit_factor, 8),
         "wins": len(result[result["profit_abs"] > 0]),
         "draws": len(result[result["profit_abs"] == 0]),
         "losses": len(result[result["profit_abs"] < 0]),


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## What's new?

The profit factor is now displayed for each pair and for each tag.
I think it's a metric that helps a lot to understand how your strategy performs for each pair or for the different entries you have tagged.
