### PR TITLE
Fix: Use correct enter_tag for notify_enter

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1219,7 +1219,7 @@ class FreqtradeBot(LoggingMixin):
             "trade_id": trade.id,
             "type": RPCMessageType.ENTRY_FILL if fill else RPCMessageType.ENTRY,
             "buy_tag": trade.enter_tag,
-            "enter_tag": trade.enter_tag,
+            "enter_tag": order.ft_order_tag,
             "exchange": trade.exchange.capitalize(),
             "pair": trade.pair,
             "leverage": trade.leverage if trade.leverage else None,


### PR DESCRIPTION
## Summary
The goal of this PR is to use the correct **enter_tag** on notify enter the latest **order_tag**.

## What's new?
Before the fix when using adjust trade position callback with a custom entry tag, the telegram notification was sending a wrong **enter_tag**, corresponding to the trade first **enter_tag** but not the latest position adjustment **order_tag**.

I find the naming a bit confusing, maybe a clarification would be needed between **enter tag** / **order tag** .
Replacing **enter_tag** by **trade_tag** or **trade_entrer_tag** ?