### PR TITLE
drop support for macos x64 PyTorch

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -258,6 +258,8 @@ freqtrade trade --config config_examples/config_freqai.example.json --strategy F
     We do provide an explicit docker-compose file for this in `docker/docker-compose-freqai.yml` - which can be used via `docker compose -f docker/docker-compose-freqai.yml run ...` - or can be copied to replace the original docker file.
     This docker-compose file also contains a (disabled) section to enable GPU resources within docker containers. This obviously assumes the system has GPU resources available.
 
+    PyTorch dropped support for macOS x64 (intel based Apple devices) in version 2.3. Subsequently, freqtrade also dropped support for PyTorch on this platform.
+
 ### Structure
 
 #### Model

--- a/requirements-freqai-rl.txt
+++ b/requirements-freqai-rl.txt
@@ -2,7 +2,6 @@
 -r requirements-freqai.txt
 
 # Required for freqai-rl
-torch==2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
 torch==2.6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
 gymnasium==0.29.1
 # SB3 >=2.5.0 depends on torch 2.3.0 - which implies it dropped support x86 macos


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Pytorch dropped support for intel based macs with version 2.3.
Considering the latest supported version now has a critical vulnerability (CVE-2024-7804), we should drop support for it as well.



## Quick changelog

- Drop support for pytorch on intel based Macs