### PR TITLE
fix: remove spaces from rename_dict/rename_dict_old in BaseReinforcementLearningModel

### DIFF
--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -318,13 +318,13 @@ class BaseReinforcementLearningModel(IFreqaiModel):
         rename_dict = {
             "%-raw_open": "open",
             "%-raw_low": "low",
-            "%-raw_high": " high",
+            "%-raw_high": "high",
             "%-raw_close": "close",
         }
         rename_dict_old = {
             f"%-{pair}raw_open_{tf}": "open",
             f"%-{pair}raw_low_{tf}": "low",
-            f"%-{pair}raw_high_{tf}": " high",
+            f"%-{pair}raw_high_{tf}": "high",
             f"%-{pair}raw_close_{tf}": "close",
         }
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

In the RL environment, an error occurs when accessing the 'high' property of the self.prices DataFrame object. This is simply a typing issue, so submit a simple fix.

## Quick changelog

- Remove spaces from rename_dict/rename_dict_old in BaseReinforcementLearningModel.
