### PR TITLE
Fix drawdown calculation when there are no winning trades

### DIFF
--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -118,7 +118,7 @@ def _calc_drawdown_series(
 ) -> pd.DataFrame:
     max_drawdown_df = pd.DataFrame()
     max_drawdown_df["cumulative"] = profit_results[value_col].cumsum()
-    max_drawdown_df["high_value"] = max_drawdown_df["cumulative"].cummax()
+    max_drawdown_df["high_value"] = np.maximum(0, max_drawdown_df["cumulative"].cummax())
     max_drawdown_df["drawdown"] = max_drawdown_df["cumulative"] - max_drawdown_df["high_value"]
     max_drawdown_df["date"] = profit_results.loc[:, date_col]
     if starting_balance:

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -569,7 +569,7 @@ def test_calculate_max_drawdown2():
     df1.loc[:, "profit"] = df1["profit"] * -1
     # No winning trade ...
     drawdown = calculate_max_drawdown(df1, date_col="open_date", value_col="profit")
-    assert drawdown.drawdown_abs == 0.043965
+    assert drawdown.drawdown_abs == 0.055545
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This fixes the incorrect drawdown calculation when there are no winning trades.

An example of the bug can be seen here: https://github.com/freqtrade/freqtrade/pull/11561#issuecomment-2768109300
