### PR TITLE
Fix drawdown calculation when maximum drawdown happens on the first trade

### DIFF
--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -201,13 +201,11 @@ def calculate_max_drawdown(
         if relative
         else max_drawdown_df["drawdown"].idxmin()
     )
-    if idxmin == 0:
-        raise ValueError("No losing trade, therefore no drawdown.")
-    high_date = profit_results.loc[max_drawdown_df.iloc[:idxmin]["high_value"].idxmax(), date_col]
+
+    high_idx = max_drawdown_df.iloc[:idxmin+1]["high_value"].idxmax()
+    high_date = profit_results.loc[high_idx, date_col]
     low_date = profit_results.loc[idxmin, date_col]
-    high_val = max_drawdown_df.loc[
-        max_drawdown_df.iloc[:idxmin]["high_value"].idxmax(), "cumulative"
-    ]
+    high_val = max_drawdown_df.loc[high_idx, "cumulative"]
     low_val = max_drawdown_df.loc[idxmin, "cumulative"]
     max_drawdown_rel = max_drawdown_df.loc[idxmin, "drawdown_relative"]
 

--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -202,7 +202,7 @@ def calculate_max_drawdown(
         else max_drawdown_df["drawdown"].idxmin()
     )
 
-    high_idx = max_drawdown_df.iloc[:idxmin+1]["high_value"].idxmax()
+    high_idx = max_drawdown_df.iloc[: idxmin + 1]["high_value"].idxmax()
     high_date = profit_results.loc[high_idx, date_col]
     low_date = profit_results.loc[idxmin, date_col]
     high_val = max_drawdown_df.loc[high_idx, "cumulative"]

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -562,8 +562,9 @@ def test_calculate_max_drawdown2():
     assert pytest.approx(drawdown.relative_account_drawdown) == 0.32129575
 
     df = DataFrame(zip(values[:5], dates[:5], strict=False), columns=["profit", "open_date"])
-    with pytest.raises(ValueError, match="No losing trade, therefore no drawdown."):
-        calculate_max_drawdown(df, date_col="open_date", value_col="profit")
+    # No losing trade ...
+    drawdown = calculate_max_drawdown(df, date_col="open_date", value_col="profit")
+    assert drawdown.drawdown_abs == 0.0
 
     df1 = DataFrame(zip(values[:5], dates[:5], strict=False), columns=["profit", "open_date"])
     df1.loc[:, "profit"] = df1["profit"] * -1


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

This fixes the incorrect drawdown calculation when the maximum drawdown happens on the first trade.
