### PR TITLE
Add tests for coupling of `AVAILABLE_CLI_OPTIONS`, `ARGS_*`, and `Arguments`

### DIFF
--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -21,6 +21,8 @@ ARGS_COMMON = [
     "user_data_dir",
 ]
 
+ARGS_MAIN = ["version_main"]
+
 ARGS_STRATEGY = [
     "strategy",
     "strategy_path",
@@ -347,7 +349,7 @@ class Arguments:
         self.parser = ArgumentParser(
             prog="freqtrade", description="Free, open source crypto trading bot"
         )
-        self._build_args(optionlist=["version_main"], parser=self.parser)
+        self._build_args(optionlist=ARGS_MAIN, parser=self.parser)
 
         from freqtrade.commands import (
             start_analysis_entries_exits,

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -34,6 +34,21 @@ def test_available_cli_options():
         )
 
 
+def test_arguments_match_available_cli_options(monkeypatch):
+    """All entries in AVAILABLE_CLI_OPTIONS are used in argument parsing."""
+    parsed_options = set()
+    actual_build_args = Arguments._build_args
+
+    def build_args_monitor(self, optionlist, parser):
+        parsed_options.update(optionlist)
+        return actual_build_args(self, optionlist=optionlist, parser=parser)
+
+    monkeypatch.setattr(Arguments, "_build_args", build_args_monitor)
+    # this will result in a parser being built so we can check the arguments used
+    Arguments([]).get_parsed_arg()
+    assert parsed_options == set(AVAILABLE_CLI_OPTIONS)
+
+
 # Parse common command-line-arguments. Used for all tools
 def test_parse_args_none() -> None:
     arguments = Arguments(["trade"])

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -7,16 +7,19 @@ import pytest
 
 from freqtrade.commands import Arguments, arguments
 from freqtrade.commands.cli_options import (
+    AVAILABLE_CLI_OPTIONS,
     check_int_nonzero,
     check_int_positive,
-    AVAILABLE_CLI_OPTIONS,
 )
 from tests.conftest import CURRENT_TEST_STRATEGY
 
 
 def test_available_cli_options():
-    """AVAILABLE_CLI_OPTIONS has keys that are the union of the values in all ARGS_* - required by CLI"""
-    # each of the ARGS_* lists has a list of members which is assumed to also be in AVAILABLE_CLI_OPTIONS
+    """
+    AVAILABLE_CLI_OPTIONS has keys that are the union of the values in all ARGS_* - required by CLI
+    each of the ARGS_* lists has a list of members which is assumed to also
+    be in AVAILABLE_CLI_OPTIONS
+    """
     args_union = {
         arg
         for variable, value in vars(arguments).items()
@@ -30,7 +33,8 @@ def test_available_cli_options():
         pytest.fail(
             "variables around command line arguments not kept in sync:\n"
             f" * args only in some ARGS_* list but not AVAILABLE_CLI_OPTIONS: {only_in_all_args}\n"
-            f" * args only in AVAILABLE_CLI_OPTIONS but not some ARGS_* list: {only_in_command_args}"
+            " * args only in AVAILABLE_CLI_OPTIONS but not some ARGS_* list: "
+            f"{only_in_command_args}"
         )
 
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -5,9 +5,33 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from freqtrade.commands import Arguments
-from freqtrade.commands.cli_options import check_int_nonzero, check_int_positive
+from freqtrade.commands import Arguments, arguments
+from freqtrade.commands.cli_options import (
+    check_int_nonzero,
+    check_int_positive,
+    AVAILABLE_CLI_OPTIONS,
+)
 from tests.conftest import CURRENT_TEST_STRATEGY
+
+
+def test_available_cli_options():
+    """AVAILABLE_CLI_OPTIONS has keys that are the union of the values in all ARGS_* - required by CLI"""
+    # each of the ARGS_* lists has a list of members which is assumed to also be in AVAILABLE_CLI_OPTIONS
+    args_union = {
+        arg
+        for variable, value in vars(arguments).items()
+        if variable.startswith("ARGS_")
+        for arg in value
+    }
+    expected_options = set(AVAILABLE_CLI_OPTIONS)
+    only_in_command_args = expected_options.difference(args_union)
+    only_in_all_args = args_union.difference(expected_options)
+    if only_in_all_args or only_in_command_args:
+        pytest.fail(
+            "variables around command line arguments not kept in sync:\n"
+            f" * args only in some ARGS_* list but not AVAILABLE_CLI_OPTIONS: {only_in_all_args}\n"
+            f" * args only in AVAILABLE_CLI_OPTIONS but not some ARGS_* list: {only_in_command_args}"
+        )
 
 
 # Parse common command-line-arguments. Used for all tools


### PR DESCRIPTION
## Summary

Added tests to avoid things falling out of sync which might have resulted in dead code, bugs, or tripped up developers.

## Quick changelog

- Add tests for coupling of `AVAILABLE_CLI_OPTIONS`, `ARGS_*`, and `Arguments`

## What's new?

Helps thing stay in sync:
 * _new_: if something is in `AVAILABLE_CLI_OPTIONS` but not used in `Arguments` then it will be raised in a test
 * _new:_ if something is in `AVAILABLE_CLI_OPTIONS` but not some `ARGS_*` then it will be raised in a test
 * _improved:_ if something is in some `ARGS_*` but not `AVAILABLE_CLI_OPTIONS` then it will raised in a test, which previously might have evaded testing