### PR TITLE
Allow warning messages when starting backtesting

### DIFF
--- a/freqtrade/mixins/logging_mixin.py
+++ b/freqtrade/mixins/logging_mixin.py
@@ -29,6 +29,7 @@ class LoggingMixin:
         :param force_show: If True, sends the message regardless of show_output value.
         :return: None.
         """
+
         @cached(cache=self._log_cache)
         def _log_once(message: str):
             logmethod(message)

--- a/freqtrade/mixins/logging_mixin.py
+++ b/freqtrade/mixins/logging_mixin.py
@@ -9,8 +9,8 @@ class LoggingMixin:
     Shows similar messages only once every `refresh_period`.
     """
 
-    # Disable INFO output when False
-    show_info_output = True
+    # Disable output completely
+    show_output = True
 
     def __init__(self, logger, refresh_period: int = 3600):
         """
@@ -35,10 +35,6 @@ class LoggingMixin:
 
         # Log as debug first
         self.logger.debug(message)
-
-        # Determine if this is an INFO level message
-        is_info_message = getattr(logmethod, "__name__", "") == "info"
-
-        # For INFO messages, respect show_info_output flag
-        if not is_info_message or self.show_info_output:
+        # Call hidden function.
+        if self.show_output:
             _log_once(message)

--- a/freqtrade/mixins/logging_mixin.py
+++ b/freqtrade/mixins/logging_mixin.py
@@ -9,8 +9,8 @@ class LoggingMixin:
     Shows similar messages only once every `refresh_period`.
     """
 
-    # Disable output completely
-    show_output = True
+    # Disable INFO output when False
+    show_info_output = True
 
     def __init__(self, logger, refresh_period: int = 3600):
         """
@@ -35,6 +35,10 @@ class LoggingMixin:
 
         # Log as debug first
         self.logger.debug(message)
-        # Call hidden function.
-        if self.show_output:
+
+        # Determine if this is an INFO level message
+        is_info_message = getattr(logmethod, "__name__", "") == "info"
+
+        # For INFO messages, respect show_info_output flag
+        if not is_info_message or self.show_info_output:
             _log_once(message)

--- a/freqtrade/mixins/logging_mixin.py
+++ b/freqtrade/mixins/logging_mixin.py
@@ -39,4 +39,3 @@ class LoggingMixin:
         # Call hidden function if show_output is True or force_show is True
         if self.show_output or force_show:
             _log_once(message)
-

--- a/freqtrade/mixins/logging_mixin.py
+++ b/freqtrade/mixins/logging_mixin.py
@@ -20,21 +20,23 @@ class LoggingMixin:
         self.refresh_period = refresh_period
         self._log_cache: TTLCache = TTLCache(maxsize=1024, ttl=self.refresh_period)
 
-    def log_once(self, message: str, logmethod: Callable) -> None:
+    def log_once(self, message: str, logmethod: Callable, force_show: bool = False) -> None:
         """
         Logs message - not more often than "refresh_period" to avoid log spamming
         Logs the log-message as debug as well to simplify debugging.
         :param message: String containing the message to be sent to the function.
         :param logmethod: Function that'll be called. Most likely `logger.info`.
+        :param force_show: If True, sends the message regardless of show_output value.
         :return: None.
         """
-
         @cached(cache=self._log_cache)
         def _log_once(message: str):
             logmethod(message)
 
         # Log as debug first
         self.logger.debug(message)
-        # Call hidden function.
-        if self.show_output:
+
+        # Call hidden function if show_output is True or force_show is True
+        if self.show_output or force_show:
             _log_once(message)
+

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -114,7 +114,7 @@ class Backtesting:
     """
 
     def __init__(self, config: Config, exchange: Exchange | None = None) -> None:
-        LoggingMixin.show_output = False
+        LoggingMixin.show_info_output = False
         self.config = config
         self.results: BacktestResultType = get_BacktestResultType_default()
         self.trade_id_counter: int = 0
@@ -235,7 +235,7 @@ class Backtesting:
 
     @staticmethod
     def cleanup():
-        LoggingMixin.show_output = True
+        LoggingMixin.show_info_output = True
         enable_database_use()
 
     def init_backtest_detail(self) -> None:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -114,7 +114,7 @@ class Backtesting:
     """
 
     def __init__(self, config: Config, exchange: Exchange | None = None) -> None:
-        LoggingMixin.show_info_output = False
+        LoggingMixin.show_output = False
         self.config = config
         self.results: BacktestResultType = get_BacktestResultType_default()
         self.trade_id_counter: int = 0
@@ -235,7 +235,7 @@ class Backtesting:
 
     @staticmethod
     def cleanup():
-        LoggingMixin.show_info_output = True
+        LoggingMixin.show_output = True
         enable_database_use()
 
     def init_backtest_detail(self) -> None:

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -237,11 +237,6 @@ class IPairList(LoggingMixin, ABC):
         :return: the list of pairs the user wants to trade without those unavailable or
         black_listed
         """
-
-        # Save show_output value and set it to True
-        prev_show_output = self.show_output
-        self.show_output = True
-
         markets = self._exchange.markets
         if not markets:
             raise OperationalException(
@@ -256,6 +251,7 @@ class IPairList(LoggingMixin, ABC):
                     f"Pair {pair} is not compatible with exchange "
                     f"{self._exchange.name}. Removing it from whitelist..",
                     logger.warning,
+                    True,
                 )
                 continue
 
@@ -263,6 +259,7 @@ class IPairList(LoggingMixin, ABC):
                 self.log_once(
                     f"Pair {pair} is not tradable with Freqtrade. Removing it from whitelist..",
                     logger.warning,
+                    True,
                 )
                 continue
 
@@ -271,19 +268,21 @@ class IPairList(LoggingMixin, ABC):
                     f"Pair {pair} is not compatible with your stake currency "
                     f"{self._config['stake_currency']}. Removing it from whitelist..",
                     logger.warning,
+                    True,
                 )
                 continue
 
             # Check if market is active
             market = markets[pair]
             if not market_is_active(market):
-                self.log_once(f"Ignoring {pair} from whitelist. Market is not active.", logger.info)
+                self.log_once(
+                    f"Ignoring {pair} from whitelist. Market is not active.",
+                    logger.info,
+                    True,
+                )
                 continue
             if pair not in sanitized_whitelist:
                 sanitized_whitelist.append(pair)
-
-        # Return show_output to its previous value
-        self.show_output = prev_show_output
 
         # We need to remove pairs that are unknown
         return sanitized_whitelist

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -237,6 +237,11 @@ class IPairList(LoggingMixin, ABC):
         :return: the list of pairs the user wants to trade without those unavailable or
         black_listed
         """
+
+        # Save show_output value and set it to True
+        prev_show_output = self.show_output
+        self.show_output = True
+
         markets = self._exchange.markets
         if not markets:
             raise OperationalException(
@@ -276,6 +281,9 @@ class IPairList(LoggingMixin, ABC):
                 continue
             if pair not in sanitized_whitelist:
                 sanitized_whitelist.append(pair)
+
+        # Return show_output to its previous value
+        self.show_output = prev_show_output
 
         # We need to remove pairs that are unknown
         return sanitized_whitelist


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

I spent over an hour going crazy, trying to figure out why SHIB wasn't appearing in my backtest results. Later, I discovered that SHIB is called 1000SHIB on Binance Futures... how could I have imagined that...? 😆

Well, after some research, I saw that freqtrade already checks if there's an incompatible pair in your pairlist, but for some reason, those warnings were disabled.

This PR fixes this, and now when you start backtesting, it warns you about these kinds of things to prevent you from going crazy...

![Screenshot_20250413_003959](https://github.com/user-attachments/assets/ac5adfce-c645-464f-8b09-f756b957e139)
