### PR TITLE
Fix config["log_config"] use so it doesn't break during deepcopy/backtesting

### DIFF
--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -123,7 +123,7 @@ def _add_formatter(log_config: dict[str, Any], format_name: str, format_: str):
 
 def _create_log_config(config: Config) -> dict[str, Any]:
     # Get log_config from user config or use default
-    log_config = config.get("log_config", deepcopy(FT_LOGGING_CONFIG))
+    log_config = deepcopy(config.get("log_config", FT_LOGGING_CONFIG))
 
     if logfile := config.get("logfile"):
         s = logfile.split(":")


### PR DESCRIPTION
The issue was that `logging.config.dictConfig(log_config)` ends up modifying the dictionary in place and including non-picklable items such as an RLock which blows up pickling during backtesting as it was referred to by the `strategy.config`.

With this in place, you can put your log config (e.g. copy `FT_LOGGING_CONFIG`) into "log_config" of your `config.json`.