### PR TITLE
add leverage to min/max stake calculation in adjust_trade_position

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -765,7 +765,9 @@ class FreqtradeBot(LoggingMixin):
         min_exit_stake = self.exchange.get_min_pair_stake_amount(
             trade.pair, current_exit_rate, self.strategy.stoploss, trade.leverage
         )
-        max_entry_stake = self.exchange.get_max_pair_stake_amount(trade.pair, current_entry_rate, trade.leverage)
+        max_entry_stake = self.exchange.get_max_pair_stake_amount(
+            trade.pair, current_entry_rate, trade.leverage
+        )
         stake_available = self.wallets.get_available_stake_amount()
         logger.debug(f"Calling adjust_trade_position for pair {trade.pair}")
         stake_amount, order_tag = self.strategy._adjust_trade_position_internal(

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -760,12 +760,12 @@ class FreqtradeBot(LoggingMixin):
         current_exit_profit = trade.calc_profit_ratio(current_exit_rate)
 
         min_entry_stake = self.exchange.get_min_pair_stake_amount(
-            trade.pair, current_entry_rate, 0.0
+            trade.pair, current_entry_rate, 0.0, trade.leverage
         )
         min_exit_stake = self.exchange.get_min_pair_stake_amount(
-            trade.pair, current_exit_rate, self.strategy.stoploss
+            trade.pair, current_exit_rate, self.strategy.stoploss, trade.leverage
         )
-        max_entry_stake = self.exchange.get_max_pair_stake_amount(trade.pair, current_entry_rate)
+        max_entry_stake = self.exchange.get_max_pair_stake_amount(trade.pair, current_entry_rate, trade.leverage)
         stake_available = self.wallets.get_available_stake_amount()
         logger.debug(f"Calling adjust_trade_position for pair {trade.pair}")
         stake_amount, order_tag = self.strategy._adjust_trade_position_internal(


### PR DESCRIPTION
## Summary

Current min/max stake given at adjust_trade_position doesn't include leverage, which make the value wrong for those using leverage, especially on pairs with high min limit, such as BTC
