### PR TITLE
Improve price precision logic and add significant digits calculation

### DIFF
--- a/freqtrade/data/btanalysis/__init__.py
+++ b/freqtrade/data/btanalysis/__init__.py
@@ -25,6 +25,7 @@ from .bt_fileutils import (
     trade_list_to_dataframe,
     update_backtest_metadata,
 )
+from .historic_precision import get_significant_digits_over_time
 from .trade_parallelism import (
     analyze_trade_parallelism,
     evaluate_result_multi,

--- a/freqtrade/data/btanalysis/__init__.py
+++ b/freqtrade/data/btanalysis/__init__.py
@@ -25,7 +25,7 @@ from .bt_fileutils import (
     trade_list_to_dataframe,
     update_backtest_metadata,
 )
-from .historic_precision import get_significant_digits_over_time
+from .historic_precision import get_tick_size_over_time
 from .trade_parallelism import (
     analyze_trade_parallelism,
     evaluate_result_multi,

--- a/freqtrade/data/btanalysis/historic_precision.py
+++ b/freqtrade/data/btanalysis/historic_precision.py
@@ -19,7 +19,7 @@ def get_significant_digits_over_time(candles: DataFrame) -> Series:
 
     candles1 = candles.set_index("date", drop=True)
     # Group by month and calculate the average number of significant digits
-    monthly_count_avg1 = candles1["max_count"].resample("ME").max()
+    monthly_count_avg1 = candles1["max_count"].resample("MS").max()
     # monthly_open_count_avg
     # convert monthly_open_count_avg from 5.0 to 0.00001, 4.0 to 0.0001, ...
     monthly_open_count_avg = 1 / 10**monthly_count_avg1

--- a/freqtrade/data/btanalysis/historic_precision.py
+++ b/freqtrade/data/btanalysis/historic_precision.py
@@ -1,0 +1,27 @@
+from pandas import DataFrame, Series
+
+
+def get_significant_digits_over_time(candles: DataFrame) -> Series:
+    """
+    Calculate the number of significant digits for candles over time.
+    It's using the Monthly maximum of the number of significant digits for each month.
+    :param candles: DataFrame with OHLCV data
+    :return: Series with the average number of significant digits for each month
+    """
+    # count the number of significant digits for the open and close prices
+    for col in ["open", "high", "low", "close"]:
+        candles[f"{col}_count"] = (
+            candles[col].round(14).astype(str).str.extract(r"\.(\d*[1-9])")[0].str.len()
+        )
+    candles["max_count"] = candles[["open_count", "close_count", "high_count", "low_count"]].max(
+        axis=1
+    )
+
+    candles1 = candles.set_index("date", drop=True)
+    # Group by month and calculate the average number of significant digits
+    monthly_count_avg1 = candles1["max_count"].resample("ME").max()
+    # monthly_open_count_avg
+    # convert monthly_open_count_avg from 5.0 to 0.00001, 4.0 to 0.0001, ...
+    monthly_open_count_avg = 1 / 10**monthly_count_avg1
+
+    return monthly_open_count_avg

--- a/freqtrade/data/btanalysis/historic_precision.py
+++ b/freqtrade/data/btanalysis/historic_precision.py
@@ -1,7 +1,7 @@
 from pandas import DataFrame, Series
 
 
-def get_significant_digits_over_time(candles: DataFrame) -> Series:
+def get_tick_size_over_time(candles: DataFrame) -> Series:
     """
     Calculate the number of significant digits for candles over time.
     It's using the Monthly maximum of the number of significant digits for each month.

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -18,7 +18,7 @@ from freqtrade.constants import DATETIME_PRINT_FORMAT, Config, IntOrInf, LongSho
 from freqtrade.data import history
 from freqtrade.data.btanalysis import (
     find_existing_backtest_stats,
-    get_significant_digits_over_time,
+    get_tick_size_over_time,
     trade_list_to_dataframe,
 )
 from freqtrade.data.converter import trim_dataframe, trim_dataframes
@@ -323,7 +323,8 @@ class Backtesting:
         self.price_pair_prec = {}
         for pair in self.pairlists.whitelist:
             if pair in data:
-                self.price_pair_prec[pair] = get_significant_digits_over_time(data[pair])
+                # Load price precision logic
+                self.price_pair_prec[pair] = get_tick_size_over_time(data[pair])
         return data, self.timerange
 
     def _load_bt_data_detail(self) -> None:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -394,7 +394,7 @@ class Backtesting:
         else:
             self.futures_data = {}
 
-    def get_pair_precision(self, pair: str, current_time: datetime) -> tuple[float, int]:
+    def get_pair_precision(self, pair: str, current_time: datetime) -> tuple[float | None, int]:
         """
         Get pair precision at that moment in time
         :param pair: Pair to get precision for

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -322,7 +322,8 @@ class Backtesting:
         self._load_bt_data_detail()
         self.price_pair_prec = {}
         for pair in self.pairlists.whitelist:
-            self.price_pair_prec[pair] = get_significant_digits_over_time(data[pair])
+            if pair in data:
+                self.price_pair_prec[pair] = get_significant_digits_over_time(data[pair])
         return data, self.timerange
 
     def _load_bt_data_detail(self) -> None:
@@ -403,9 +404,9 @@ class Backtesting:
         if precision_series is not None:
             precision = precision_series.asof(current_time)
 
-        if not isnan(precision):
-            # Force tick size if we define the precision
-            return precision, TICK_SIZE
+            if not isnan(precision):
+                # Force tick size if we define the precision
+                return precision, TICK_SIZE
         return self.exchange.get_precision_price(pair), self.exchange.precision_mode_price
 
     def disable_database_use(self):

--- a/tests/data/test_historic_precision.py
+++ b/tests/data/test_historic_precision.py
@@ -1,0 +1,92 @@
+# pragma pylint: disable=missing-docstring, C0103
+
+from datetime import timezone
+
+import pandas as pd
+from numpy import nan
+from pandas import DataFrame, Timestamp
+
+from freqtrade.data.btanalysis.historic_precision import get_significant_digits_over_time
+
+
+def test_get_significant_digits_over_time():
+    """
+    Test the get_significant_digits_over_time function with predefined data
+    """
+    # Create test dataframe with different levels of precision
+    data = {
+        "date": [
+            Timestamp("2020-01-01 00:00:00", tz=timezone.utc),
+            Timestamp("2020-01-02 00:00:00", tz=timezone.utc),
+            Timestamp("2020-01-03 00:00:00", tz=timezone.utc),
+            Timestamp("2020-01-15 00:00:00", tz=timezone.utc),
+            Timestamp("2020-01-16 00:00:00", tz=timezone.utc),
+            Timestamp("2020-01-31 00:00:00", tz=timezone.utc),
+            Timestamp("2020-02-01 00:00:00", tz=timezone.utc),
+            Timestamp("2020-02-15 00:00:00", tz=timezone.utc),
+            Timestamp("2020-03-15 00:00:00", tz=timezone.utc),
+        ],
+        "open": [1.23456, 1.234, 1.23, 1.2, 1.23456, 1.234, 2.3456, 2.34, 2.34],
+        "high": [1.23457, 1.235, 1.24, 1.3, 1.23456, 1.235, 2.3457, 2.34, 2.34],
+        "low": [1.23455, 1.233, 1.22, 1.1, 1.23456, 1.233, 2.3455, 2.34, 2.34],
+        "close": [1.23456, 1.234, 1.23, 1.2, 1.23456, 1.234, 2.3456, 2.34, 2.34],
+        "volume": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    }
+
+    candles = DataFrame(data)
+
+    # Calculate significant digits
+    result = get_significant_digits_over_time(candles)
+
+    # Check that the result is a pandas Series
+    assert isinstance(result, pd.Series)
+
+    # Check that we have three months of data (Jan, Feb and March 2020 )
+    assert len(result) == 3
+
+    # Before
+    assert result.asof("2019-01-01 00:00:00+00:00") is nan
+    # January should have 5 significant digits (based on 1.23456789 being the most precise value)
+    # which should be converted to 0.00001
+
+    assert result.asof("2020-01-01 00:00:00+00:00") == 0.00001
+    assert result.asof("2020-01-01 00:00:00+00:00") == 0.00001
+    assert result.asof("2020-02-25 00:00:00+00:00") == 0.0001
+    assert result.asof("2020-03-25 00:00:00+00:00") == 0.01
+    assert result.asof("2020-04-01 00:00:00+00:00") == 0.01
+    # Value far past the last date should be the last value
+    assert result.asof("2025-04-01 00:00:00+00:00") == 0.01
+
+    assert result.iloc[0] == 0.00001
+
+
+def test_get_significant_digits_over_time_real_data(testdatadir):
+    """
+    Test the get_significant_digits_over_time function with real data from the testdatadir
+    """
+    from freqtrade.data.history import load_pair_history
+
+    # Load some test data from the testdata directory
+    pair = "UNITTEST/BTC"
+    timeframe = "1m"
+
+    candles = load_pair_history(
+        datadir=testdatadir,
+        pair=pair,
+        timeframe=timeframe,
+    )
+
+    # Make sure we have test data
+    assert not candles.empty, "No test data found, cannot run test"
+
+    # Calculate significant digits
+    result = get_significant_digits_over_time(candles)
+
+    assert isinstance(result, pd.Series)
+
+    # Verify that all values are between 0 and 1 (valid precision values)
+    assert all(result > 0)
+    assert all(result < 1)
+
+    assert all(result <= 0.0001)
+    assert all(result >= 0.00000001)

--- a/tests/data/test_historic_precision.py
+++ b/tests/data/test_historic_precision.py
@@ -6,12 +6,12 @@ import pandas as pd
 from numpy import nan
 from pandas import DataFrame, Timestamp
 
-from freqtrade.data.btanalysis.historic_precision import get_significant_digits_over_time
+from freqtrade.data.btanalysis.historic_precision import get_tick_size_over_time
 
 
-def test_get_significant_digits_over_time():
+def test_get_tick_size_over_time():
     """
-    Test the get_significant_digits_over_time function with predefined data
+    Test the get_tick_size_over_time function with predefined data
     """
     # Create test dataframe with different levels of precision
     data = {
@@ -36,7 +36,7 @@ def test_get_significant_digits_over_time():
     candles = DataFrame(data)
 
     # Calculate significant digits
-    result = get_significant_digits_over_time(candles)
+    result = get_tick_size_over_time(candles)
 
     # Check that the result is a pandas Series
     assert isinstance(result, pd.Series)
@@ -60,9 +60,9 @@ def test_get_significant_digits_over_time():
     assert result.iloc[0] == 0.00001
 
 
-def test_get_significant_digits_over_time_real_data(testdatadir):
+def test_get_tick_size_over_time_real_data(testdatadir):
     """
-    Test the get_significant_digits_over_time function with real data from the testdatadir
+    Test the get_tick_size_over_time function with real data from the testdatadir
     """
     from freqtrade.data.history import load_pair_history
 
@@ -80,7 +80,7 @@ def test_get_significant_digits_over_time_real_data(testdatadir):
     assert not candles.empty, "No test data found, cannot run test"
 
     # Calculate significant digits
-    result = get_significant_digits_over_time(candles)
+    result = get_tick_size_over_time(candles)
 
     assert isinstance(result, pd.Series)
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -22,6 +22,7 @@ from freqtrade.data.history import get_timerange
 from freqtrade.enums import CandleType, ExitType, RunMode
 from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.exchange import timeframe_to_next_date, timeframe_to_prev_date
+from freqtrade.exchange.exchange_utils import DECIMAL_PLACES, TICK_SIZE
 from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename, get_strategy_run_id
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.persistence import LocalTrade, Trade
@@ -346,6 +347,29 @@ def test_data_to_dataframe_bt(default_conf, mocker, testdatadir) -> None:
 
     processed2 = strategy.advise_all_indicators(data)
     assert processed["UNITTEST/BTC"].equals(processed2["UNITTEST/BTC"])
+
+
+def test_get_pair_precision_bt(default_conf, mocker) -> None:
+    patch_exchange(mocker)
+    default_conf["timeframe"] = "30m"
+    backtesting = Backtesting(default_conf)
+    backtesting._set_strategy(backtesting.strategylist[0])
+    pair = "UNITTEST/BTC"
+    backtesting.pairlists._whitelist = [pair]
+    ex_mock = mocker.patch(f"{EXMS}.get_precision_price", return_value=1e-5)
+    data, timerange = backtesting.load_bt_data()
+    assert data
+
+    assert backtesting.get_pair_precision(pair, dt_utc(2018, 1, 1)) == (1e-8, TICK_SIZE)
+    assert ex_mock.call_count == 0
+    assert backtesting.get_pair_precision(pair, dt_utc(2017, 12, 15)) == (1e-8, TICK_SIZE)
+    assert ex_mock.call_count == 0
+
+    # Fallback to exchange logic
+    assert backtesting.get_pair_precision(pair, dt_utc(2017, 1, 15)) == (1e-5, DECIMAL_PLACES)
+    assert ex_mock.call_count == 1
+    assert backtesting.get_pair_precision("ETH/BTC", dt_utc(2017, 1, 15)) == (1e-5, DECIMAL_PLACES)
+    assert ex_mock.call_count == 2
 
 
 def test_backtest_abort(default_conf, mocker, testdatadir) -> None:


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->
Use existing data to calculate historic price precision - taking the maximum available decimals per month.

This WILL modify backtest results over longer periods of time - but will improve results as we no longer round prices to "today's" precision - but to the proper precision.

Closes #11203

## Quick changelog

- Add "historic precision" calculation
- apply this historic precision logic to backtesting