### PR TITLE
Update installation.md for older Raspberry Pi 2

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ OS Specific steps are listed first, the common section below is necessary for al
 
 
     ```bash
-    sudo apt-get install python3-venv libatlas-base-dev cmake curl
+    sudo apt-get install python3-venv libatlas-base-dev cmake curl libffi-dev
     # Use piwheels.org to speed up installation
     sudo echo "[global]\nextra-index-url=https://www.piwheels.org/simple" > tee /etc/pip.conf
 


### PR DESCRIPTION
I got the following error on Pi 2 (using Debian Bookworm armhf arch)
```
...
            running bdist_wheel
            running build
            running build_py
            creating build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/lock.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/backend_ctypes.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/_imp_emulation.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/model.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/ffiplatform.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/setuptools_ext.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/error.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/vengine_gen.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/api.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/__init__.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/recompiler.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/cffi_opcode.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/pkgconfig.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/verifier.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/cparser.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/_shimmed_dist_utils.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/commontypes.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/vengine_cpy.py -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/_cffi_include.h -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/parse_c_type.h -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/_embedding.h -> build/lib.linux-armv7l-cpython-311/cffi
            copying src/cffi/_cffi_errors.h -> build/lib.linux-armv7l-cpython-311/cffi
            running build_ext
            building '_cffi_backend' extension
            creating build/temp.linux-armv7l-cpython-311/src/c
            arm-linux-gnueabihf-gcc -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/freqtrade/.venv/include -I/usr/include/python3.11 -c src/c/_cffi_backend.c -o build/temp.linux-armv7l-cpython-311/src/c/_cffi_backend.o
            src/c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
               15 | #include <ffi.h>
                  |          ^~~~~~~
            compilation terminated.
            error: command '/usr/bin/arm-linux-gnueabihf-gcc' failed with exit code 1
            [end of output]
      
        note: This error originates from a subprocess, and is likely not a problem with pip.
        ERROR: Failed building wheel for cffi
      Failed to build cffi
      ERROR: Failed to build installable wheels for some pyproject.toml based projects (cffi)
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× pip subprocess to install build dependencies did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Failed installing dependencies
```

It can be Easily solved by installing libffi-dev before hand

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: installing freqtrade on Raspberry Pi 2

## Quick changelog

- Adding missed dependency (libffi-dev)

## What's new?

Fixing error `error: command '/usr/bin/arm-linux-gnueabihf-gcc' failed with exit code 1`
