### PR TITLE
fix binance futures candle type hardcoding for trades data

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -400,7 +400,7 @@ class Binance(Exchange):
                 since = max(since, listing_date)
 
             _, res = await download_archive_trades(
-                CandleType.SPOT,
+                CandleType.FUTURES if self.trading_mode == "futures" else CandleType.SPOT,
                 pair,
                 since_ms=since,
                 until_ms=until,


### PR DESCRIPTION
Downloading data from binance-futures using data.binance.vision always used the spot market dataset, regardless of the provided trading-mode in the config or CLI. 
```
freqtrade download-data --exchange binance --pairs BTC/USDT:USDT --timerange=20250101-20250102 -vv --timeframes 5m --trading-mode futures --erase

....
freqtrade.exchange.binance_public_data - DEBUG - download trades data from
binance: https://data.binance.vision/data/spot/daily/aggTrades/BTCUSDT/BTCUSDT-aggTrades-2025-01-01.zip
```
This skewed bot data as strategies still digested spot market data while trying to operate on futures.
