### PR TITLE
fix: display pair information in message

### DIFF
--- a/freqtrade/optimize/analysis/lookahead.py
+++ b/freqtrade/optimize/analysis/lookahead.py
@@ -235,7 +235,7 @@ class LookaheadAnalysis(BaseAnalysis):
                 return None
             if "force_exit" in result_row["exit_reason"]:
                 logger.info(
-                    "found force-exit in pair: {result_row['pair']}, "
+                    f"found force-exit in pair: {result_row['pair']}, "
                     f"timerange:{result_row['open_date']}-{result_row['close_date']}, "
                     f"idx: {idx}, skipping this one to avoid a false-positive."
                 )


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
This small PR evaluates and displays the pair information in message.

## Quick changelog

- display pair information in message

## What's new?

