### PR TITLE
feat: explicitly manage db sessions for custom_data

### DIFF
--- a/freqtrade/persistence/custom_data.py
+++ b/freqtrade/persistence/custom_data.py
@@ -169,7 +169,7 @@ class CustomDataWrapper:
             raise
 
     @staticmethod
-    def set_custom_data(trade_id: int, key: str, value: Any) -> None:
+    def set_custom_data(trade_id: int, key: str, value: Any) -> None:  # noqa: C901, RUF100
         value_type = type(value).__name__
 
         if value_type not in CustomDataWrapper.unserialized_types:

--- a/freqtrade/persistence/custom_data.py
+++ b/freqtrade/persistence/custom_data.py
@@ -119,7 +119,9 @@ class CustomDataWrapper:
     @staticmethod
     def delete_custom_data(trade_id: int) -> None:
         try:
-            _CustomData.session.query(_CustomData).filter(_CustomData.ft_trade_id == trade_id).delete()
+            _CustomData.session.query(_CustomData).filter(
+                _CustomData.ft_trade_id == trade_id
+            ).delete()
             _CustomData.session.commit()
         except Exception as e:
             logger.error(f"Error deleting custom data: {e}")


### PR DESCRIPTION
## Summary

Fix database connection pool exhaustion by properly closing SQLAlchemy sessions in custom_data.py

## Quick changelog

- Add proper session cleanup in all database methods in custom_data.py
- Implement robust error handling with try/except/finally blocks
- Ensure sessions are closed even when exceptions occur
- Add transaction management with commit/rollback where needed

## What's new?

This PR addresses an issue where database connections were not being properly closed after use in the custom_data.py module, leading to connection pool exhaustion. The error manifested as "QueuePool limit of size 5 overflow 10 reached, connection timed out" and resulted in "idle in transaction" connections accumulating in the database.

The changes include:

1. __Improved session management in all database methods:__

   - `get_custom_data`: Now properly closes the session after retrieving data
   - `set_custom_data`: Now properly closes the session after saving data
   - `delete_custom_data`: Now properly closes the session after deleting data
   - `query_cd`: Now properly closes the session after querying data

2. __Enhanced error handling:__

   - Added try/except/finally blocks to ensure sessions are closed even when exceptions occur
   - Added proper transaction management with commit/rollback
   - Added error logging to help with debugging

3. __Better resource management:__

   - Created copies of query results before closing sessions to prevent accessing closed sessions
   - Ensured proper cleanup in all code paths

These changes maintain all existing functionality while adding proper resource management to prevent connection leaks. This should resolve issues with database connection pool exhaustion during high-traffic periods or long-running operations.

The fix is particularly important for strategies that make heavy use of custom data storage, as they were most affected by this issue.
