### PR TITLE
patch for issue 11642, fixing a false positive for lookahead-analysis

### DIFF
--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -155,7 +155,7 @@ class LookaheadAnalysisSubFunctions:
             )
         config["max_open_trades"] = -1
         logger.info(
-            f"forced pairs to -1 (same amount of max_open_trades as there are pairs)"
+            f"Forced max_open_trades to -1 (same amount as there are pairs)"
         )
 
         min_dry_run_wallet = 1000000000

--- a/freqtrade/optimize/analysis/lookahead_helpers.py
+++ b/freqtrade/optimize/analysis/lookahead_helpers.py
@@ -153,14 +153,10 @@ class LookaheadAnalysisSubFunctions:
             raise OperationalException(
                 "Targeted trade amount can't be smaller than minimum trade amount."
             )
-        if len(config["pairs"]) > config.get("max_open_trades", 0):
-            logger.info(
-                "Max_open_trades were less than amount of pairs "
-                "or defined in the strategy. "
-                "Set max_open_trades to amount of pairs "
-                "just to avoid false positives."
-            )
-            config["max_open_trades"] = len(config["pairs"])
+        config["max_open_trades"] = -1
+        logger.info(
+            f"forced pairs to -1 (same amount of max_open_trades as there are pairs)"
+        )
 
         min_dry_run_wallet = 1000000000
         if get_dry_run_wallet(config) < min_dry_run_wallet:


### PR DESCRIPTION
The bug that was pointed out in the issue https://github.com/freqtrade/freqtrade/issues/11642 came from a length of the list of just 1 but it states "all pairs of /USDT" which would be far more than the set 3

Before this it just checked length of pairs = 1 is smaller than amount of max_open_trades - nothing to adjust!

Now it just sets that value to -1 and forcing freqtrade to define the amount itself - not the command anymore.