### PR TITLE
fix hyperopt repeated parameters between batches

### DIFF
--- a/freqtrade/optimize/hyperopt/hyperopt.py
+++ b/freqtrade/optimize/hyperopt/hyperopt.py
@@ -206,9 +206,8 @@ class Hyperopt:
                 asked_non_tried.append(asked_new)
             i += 1
         if len(asked_non_tried) < n_points:
-            logger.warning(
-                "duplicate params detected. Please check if search space is not too small!"
-            )
+            if self.count_skipped_epochs == 0:
+                logger.warning("Duplicate params detected. Maybe your search space is too small?")
             self.count_skipped_epochs += n_points - len(asked_non_tried)
 
         return asked_non_tried, [False for _ in range(len(asked_non_tried))]

--- a/freqtrade/optimize/hyperopt/hyperopt.py
+++ b/freqtrade/optimize/hyperopt/hyperopt.py
@@ -22,7 +22,7 @@ from freqtrade.enums import HyperoptState
 from freqtrade.exceptions import OperationalException
 from freqtrade.misc import file_dump_json, plural
 from freqtrade.optimize.hyperopt.hyperopt_logger import logging_mp_handle, logging_mp_setup
-from freqtrade.optimize.hyperopt.hyperopt_optimizer import HyperOptimizer
+from freqtrade.optimize.hyperopt.hyperopt_optimizer import INITIAL_POINTS, HyperOptimizer
 from freqtrade.optimize.hyperopt.hyperopt_output import HyperoptOutput
 from freqtrade.optimize.hyperopt_tools import (
     HyperoptStateContainer,
@@ -33,9 +33,6 @@ from freqtrade.util import get_progress_tracker
 
 
 logger = logging.getLogger(__name__)
-
-
-INITIAL_POINTS = 30
 
 
 log_queue: Any

--- a/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
+++ b/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
@@ -45,6 +45,7 @@ from freqtrade.util.dry_run_wallet import get_dry_run_wallet
 
 logger = logging.getLogger(__name__)
 
+INITIAL_POINTS = 30
 
 MAX_LOSS = 100000  # just a big enough number to be bad result in loss optimization
 
@@ -425,7 +426,16 @@ class HyperOptimizer:
                 raise OperationalException(f"Optuna Sampler {o_sampler} not supported.")
             with warnings.catch_warnings():
                 warnings.filterwarnings(action="ignore", category=ExperimentalWarning)
-                sampler = optuna_samplers_dict[o_sampler](seed=random_state)
+                if o_sampler in ["NSGAIIISampler", "NSGAIISampler"]:
+                    sampler = optuna_samplers_dict[o_sampler](
+                        seed=random_state, population_size=INITIAL_POINTS
+                    )
+                elif o_sampler in ["GPSampler", "TPESampler", "CmaEsSampler"]:
+                    sampler = optuna_samplers_dict[o_sampler](
+                        seed=random_state, n_startup_trials=INITIAL_POINTS
+                    )
+                else:
+                    sampler = optuna_samplers_dict[o_sampler](seed=random_state)
         else:
             sampler = o_sampler
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #_repeated parameters between batches__

## Quick changelog

- change get_asked_points function
- add check_optuna_asked_points function

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Will check if optuna.trial.params are already asked in the past. If yes, will skip evaluating that trial.
I added also a warning in case asked params are same.
I'm testing now this change to see how many times I receive repeated params warning for buy sell stoploss roi and then for protections only.
In case there are many warnings, we need to ask for more points - similar with the original version....