### PR TITLE
fix: order_by_id always true

### DIFF
--- a/ft_client/freqtrade_client/ft_rest_client.py
+++ b/ft_client/freqtrade_client/ft_rest_client.py
@@ -268,8 +268,8 @@ class FtRestClient:
             params["limit"] = limit
         if offset:
             params["offset"] = offset
-        if order_by_id:
-            params["order_by_id"] = True
+        if not order_by_id:
+            params["order_by_id"] = False
         return self._get("trades", params)
 
     def list_open_trades_custom_data(self, key=None, limit=100, offset=0):


### PR DESCRIPTION
# Pull Request Template

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->

## Summary

<!-- Explain in one sentence the goal of this PR -->
Optimize trades history API parameter handling by removing redundant default parameter.

## Quick changelog

- Removed redundant `order_by_id=True` parameter from trades API call
- Simplified parameter logic by only including non-default values

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->

This PR simplifies the parameter handling in the `trades()` method by:
1. Removing the redundant inclusion of `order_by_id=True` since it's the default behavior
2. Only including the parameter when it differs from the default (`False`)
3. Making the code more maintainable by reducing unnecessary parameter passing

The change maintains all existing functionality while making the code cleaner:
- When `order_by_id=True` (default): No parameter is sent
- When `order_by_id=False`: Parameter is included as `False`