### PR TITLE
Fix telegram profit stats when fiat_display_currency is not set

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1044,12 +1044,15 @@ class Telegram(RPCHandler):
         else:
             # Message to display
             if stats["closed_trade_count"] > 0:
+                fiat_closed_trades = (
+                    f"∙ `{fmt_coin(profit_closed_fiat, fiat_disp_cur)}`\n" if fiat_disp_cur else ""
+                )
                 markdown_msg = (
                     "*ROI:* Closed trades\n"
                     f"∙ `{fmt_coin(profit_closed_coin, stake_cur)} "
                     f"({profit_closed_ratio_mean:.2%}) "
                     f"({profit_closed_percent} \N{GREEK CAPITAL LETTER SIGMA}%)`\n"
-                    f"∙ `{fmt_coin(profit_closed_fiat, fiat_disp_cur)}`\n"
+                    f"{fiat_closed_trades}"
                 )
             else:
                 markdown_msg = "`No closed trade` \n"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

When you don't set fiat_display_currency because you don't want to convert profit to fiat, Telegram's profit statistics display an unnecessary row where the profit converted to fiat was displayed. This PR fixes this.
