### PR TITLE
fix: allow dict be convertible in env file

### DIFF
--- a/freqtrade/configuration/environment_vars.py
+++ b/freqtrade/configuration/environment_vars.py
@@ -25,8 +25,8 @@ def _get_var_typed(val):
             # try to convert from json
             try:
                 value = rapidjson.loads(val)
-                # Limited to lists for now
-                if isinstance(value, list):
+                # Limited to lists and dicts for now
+                if isinstance(value, (list, dict)):
                     return value
             except rapidjson.JSONDecodeError:
                 pass


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

allow dict be convertible in env file

Solve the issue: #11852

## Quick changelog

- add dict as convertible env config

## What's new?

Apart from list, allow dict to be convertible to enable setting of ccxt_config in env file