### PR TITLE
fix parsing trade-data for kraken_csv

### DIFF
--- a/freqtrade/data/converter/trade_converter_kraken.py
+++ b/freqtrade/data/converter/trade_converter_kraken.py
@@ -69,6 +69,10 @@ def import_kraken_trades_from_csv(config: Config, convert_to: str):
         trades = pd.concat(dfs, ignore_index=True)
         del dfs
 
+        # drop any row not having a number in the column timestamp
+        timestamp_numeric = pd.to_numeric(trades["timestamp"], errors="coerce")
+        trades = trades[timestamp_numeric.notna() & (timestamp_numeric % 1 == 0)]
+
         trades.loc[:, "timestamp"] = trades["timestamp"] * 1e3
         trades.loc[:, "cost"] = trades["price"] * trades["amount"]
         for col in DEFAULT_TRADES_COLUMNS:

--- a/freqtrade/data/converter/trade_converter_kraken.py
+++ b/freqtrade/data/converter/trade_converter_kraken.py
@@ -71,7 +71,7 @@ def import_kraken_trades_from_csv(config: Config, convert_to: str):
 
         # drop any row not having a number in the column timestamp
         timestamp_numeric = pd.to_numeric(trades["timestamp"], errors="coerce")
-        trades = trades[timestamp_numeric.notna() & (timestamp_numeric % 1 == 0)]
+        trades = trades[timestamp_numeric.notna()]
 
         trades.loc[:, "timestamp"] = trades["timestamp"] * 1e3
         trades.loc[:, "cost"] = trades["price"] * trades["amount"]


### PR DESCRIPTION
## Summary

The official data from kraken has malformed data in one file in the first row (of USDGEUR.csv) currently.
This PR fixes the parsing by removing the malformed row of the file, while still allowing any other rows to be properly parsed.

It's just 2 rows. Didn't make into a oneliner to have it a little more readable.