### PR TITLE
Set binance USDT stake amount to something useable

### DIFF
--- a/config_examples/config_binance.example.json
+++ b/config_examples/config_binance.example.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.freqtrade.io/schema.json",
     "max_open_trades": 3,
     "stake_currency": "USDT",
-    "stake_amount": 0.05,
+    "stake_amount": 20,
     "tradable_balance_ratio": 0.99,
     "fiat_display_currency": "USD",
     "timeframe": "5m",


### PR DESCRIPTION
The stake amount in the binance config example is set too low (0.05 USDT). This PR sets it to a more realistic amount of 20 USDT