### PR TITLE
Add `scipy-stubs` as dev dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: mypy
         exclude: build_helpers
         additional_dependencies:
+          - scipy-stubs==1.15.3.0
           - types-cachetools==6.0.0.20250525
           - types-filelock==3.2.7
           - types-requests==2.32.4.20250611

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
       - id: mypy
         exclude: build_helpers
         additional_dependencies:
-          - scipy-stubs==1.15.3.0
           - types-cachetools==6.0.0.20250525
           - types-filelock==3.2.7
           - types-requests==2.32.4.20250611
           - types-tabulate==0.9.0.20241207
           - types-python-dateutil==2.9.0.20250516
+          - scipy-stubs==1.15.3.0
           - SQLAlchemy==2.0.41
         # stages: [push]
 

--- a/build_helpers/pre_commit_update.py
+++ b/build_helpers/pre_commit_update.py
@@ -16,10 +16,12 @@ with require_dev.open("r") as rfile:
 with require.open("r") as rfile:
     requirements.extend(rfile.readlines())
 
-# Extract types only
-type_reqs = [
-    r.strip("\n") for r in requirements if r.startswith("types-") or r.startswith("SQLAlchemy")
-]
+# Extract relevant types only
+supported = ("types-", "SQLAlchemy", "scipy-stubs")
+
+# Find relevant dependencies
+# Only keep the first part of the line up to the first space
+type_reqs = [r.strip("\n").split()[0] for r in requirements if r.startswith(supported)]
 
 with pre_commit_file.open("r") as file:
     f = yaml.load(file, Loader=yaml.SafeLoader)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ develop = [
   "pytest-xdist",
   "pytest",
   "ruff",
+  "scipy-stubs",
   "time-machine",
   "types-cachetools",
   "types-filelock",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,7 @@ time-machine==2.16.0
 nbconvert==7.16.6
 
 # mypy types
+scipy-stubs==1.15.3.0  # keep in sync with `scipy` in `requirements-hyperopt.txt`
 types-cachetools==6.0.0.20250525
 types-filelock==3.2.7
 types-requests==2.32.4.20250611


### PR DESCRIPTION
This adds [`scipy-stubs`](https://github.com/scipy/scipy-stubs) as an optional development dependency. It can help quite a bit with IDE supports, such as autocompletion and introspection. It requires no configuration, no mypy plugins, and there's no runtime impact.  So even if you don't care about typing annotations, you'll basically improve DX for free :)
Scipy-stubs does not have `scipy` as hard requirement, so the impact it has on the runtime of pre-commit and CI will be minimal.