### PR TITLE
Bump ccxt to 4.4.95

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ft-pandas-ta==0.3.15
 ta-lib==0.5.5
 technical==1.5.1
 
-ccxt==4.4.94
+ccxt==4.4.95
 cryptography==45.0.5
 aiohttp==3.12.14
 SQLAlchemy==2.0.41


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

Bump ccxt to 4.4.95 - which improves rate-limits for hyperliquid significantly.