### PR TITLE
improve `_parse_args`

### DIFF
--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -311,8 +311,6 @@ class Arguments:
         # (see https://bugs.python.org/issue16399)
         # Allow no-config for certain commands (like downloading / plotting)
         if "config" in parsed_arg and parsed_arg.config is None:
-            conf_required = "command" in parsed_arg and parsed_arg.command in NO_CONF_REQURIED
-
             if "user_data_dir" in parsed_arg and parsed_arg.user_data_dir is not None:
                 user_dir = parsed_arg.user_data_dir
             else:
@@ -325,7 +323,10 @@ class Arguments:
             else:
                 # Else use "config.json".
                 cfgfile = Path.cwd() / DEFAULT_CONFIG
-                if cfgfile.is_file() or not conf_required:
+                conf_required = (
+                    "command" in parsed_arg and parsed_arg.command not in NO_CONF_REQURIED
+                )
+                if cfgfile.is_file() or conf_required:
                     parsed_arg.config = [DEFAULT_CONFIG]
 
         return parsed_arg


### PR DESCRIPTION
This pr moves the definition of `conf_required` closer to its usage, and changed :

```python
conf_required = "command" in parsed_arg and parsed_arg.command in NO_CONF_REQURIED
```

to 

```python
conf_required = (
                    "command" in parsed_arg and parsed_arg.command not in NO_CONF_REQURIED
                )
```

