### PR TITLE
Add Numpy2.0 np.NaN => np.nan conversion to strategy_updater

### DIFF
--- a/tests/test_strategy_updater.py
+++ b/tests/test_strategy_updater.py
@@ -42,8 +42,10 @@ def test_strategy_updater_methods(default_conf, caplog) -> None:
     instance_strategy_updater = StrategyUpdater()
     modified_code1 = instance_strategy_updater.update_code(
         """
+import numpy as np
 class testClass(IStrategy):
     def populate_buy_trend():
+        some_variable = np.NaN
         pass
     def populate_sell_trend():
         pass
@@ -62,6 +64,7 @@ class testClass(IStrategy):
     assert "check_exit_timeout" in modified_code1
     assert "custom_exit" in modified_code1
     assert "INTERFACE_VERSION = 3" in modified_code1
+    assert "np.nan" in modified_code1
 
 
 def test_strategy_updater_params(default_conf, caplog) -> None:


### PR DESCRIPTION
## Summary

Numpy2.0 changes np.NaN to np.nan which causes errors while trying to load a strategy.
This PR  automatically adjusts it to the new version while providing the possibility to add more conversions.
It includes aliases of the imports too.