### PR TITLE
docs: create Korean setup guide for M4 MacBook

### DIFF
--- a/OPERATION_GUIDE.md
+++ b/OPERATION_GUIDE.md
@@ -1,0 +1,156 @@
+# Freqtrade 운영 가이드
+
+이 문서는 Freqtrade 설치 후, 봇을 효과적으로 운영하고 관리하기 위한 주요 절차와 팁을 안내합니다.
+
+---
+
+## 1. 설정 파일 (`config.json`) 주요 항목 관리
+
+`user_data/config.json` 파일은 Freqtrade 봇의 모든 행동을 정의하는 가장 중요한 파일입니다. 주요 항목은 다음과 같습니다.
+
+### 필수 설정
+
+- `"max_open_trades"`: 동시에 진행할 최대 거래 수를 지정합니다. `3`으로 설정하면 최대 3개의 코인만 동시에 보유합니다.
+- `"stake_currency"`: 거래의 기준이 되는 통화입니다. (예: `"USDT"`, `"BTC"`)
+- `"stake_amount"`: 한 번의 거래에 사용할 금액입니다. `"unlimited"`로 설정하면 모든 잔액을 사용하며, 특정 금액(예: `100`)을 지정할 수도 있습니다.
+- `"dry_run"`: `true`로 설정하면 실제 돈을 사용하지 않는 모의 투자를 진행합니다. **실제 돈을 투입하기 전에 반드시 `true`로 설정하여 충분히 테스트하세요.** `false`로 변경하면 실제 거래가 시작됩니다.
+
+### 거래소 API 설정
+
+`"exchange"` 섹션에서 거래소 API 키를 설정해야 실제 계정과 연동됩니다.
+
+```json
+"exchange": {
+    "name": "binance",
+    "key": "YOUR_API_KEY",
+    "secret": "YOUR_API_SECRET",
+    "ccxt_config": {},
+    "ccxt_async_config": {}
+},
+```
+- `"key"`: 거래소에서 발급받은 API Key를 입력합니다.
+- `"secret"`: 거래소에서 발급받은 API Secret을 입력합니다.
+
+### 텔레그램 봇 연동
+
+텔레그램으로 봇의 상태를 보고받고 제어할 수 있습니다.
+
+```json
+"telegram": {
+    "enabled": true,
+    "token": "YOUR_TELEGRAM_TOKEN",
+    "chat_id": "YOUR_TELEGRAM_CHAT_ID"
+},
+```
+- `"enabled"`: `true`로 설정하여 활성화합니다.
+- `"token"`: BotFather로부터 발급받은 텔레그램 봇 토큰을 입력합니다.
+- `"chat_id"`: 봇과 대화를 시작한 후, 당신의 고유 chat ID를 확인하여 입력합니다.
+
+### FreqUI 보안 설정
+
+`"api_server"` 섹션에서 UI 접속을 위한 사용자 이름과 비밀번호를 설정할 수 있습니다.
+
+```json
+"api_server": {
+    "enabled": true,
+    "listen_ip_address": "0.0.0.0",
+    "listen_port": 8080,
+    "username": "freqtrader",
+    "password": "YOUR_STRONG_PASSWORD"
+},
+```
+- `"username"` / `"password"`: FreqUI 로그인 시 사용할 아이디와 비밀번호를 설정합니다.
+
+---
+
+## 2. 전략 (`Strategy`) 관리
+
+- **전략 파일 위치**: 모든 전략 파일은 `user_data/strategies/` 디렉토리에 위치해야 합니다.
+- **전략 변경**: 봇에 적용할 전략을 변경하려면 `docker-compose.yml` 파일의 `command` 섹션에서 `--strategy` 부분을 수정해야 합니다.
+
+  ```yaml
+  # docker-compose.yml
+  command: >
+    trade
+    # ...
+    --strategy YourNewStrategy # <--- 이 부분을 변경
+  ```
+  파일 수정 후에는 `docker compose up -d` 명령어로 봇을 다시 시작해야 적용됩니다.
+
+- **커뮤니티 전략 활용**: Freqtrade 커뮤니티에서는 다양한 무료/유료 전략을 공유합니다. GitHub 등에서 `.py` 전략 파일을 다운로드하여 `user_data/strategies/`에 추가하고 테스트해볼 수 있습니다.
+
+---
+
+## 3. 데이터 다운로드 및 백테스팅
+
+전략이 과거 데이터에서 어떤 성과를 냈는지 확인하는 백테스팅은 매우 중요합니다.
+
+### 데이터 다운로드
+
+Binance 거래소에서 2023년 1월 1일부터 현재까지의 BTC/USDT 5분봉 데이터를 다운로드하는 예시입니다.
+
+```bash
+docker compose run --rm freqtrade download-data \
+--exchange binance \
+--pairs BTC/USDT \
+--days 500 \
+-t 5m
+```
+
+### 백테스팅 실행
+
+다운로드한 데이터를 사용하여 `SampleStrategy` 전략을 테스트하는 명령어입니다.
+
+```bash
+docker compose run --rm freqtrade backtesting \
+--config user_data/config.json \
+--strategy SampleStrategy
+```
+
+백테스팅 결과는 터미널에 표 형태로 요약되어 나타나며, 이를 통해 전략의 수익률, 승률 등을 평가할 수 있습니다.
+
+---
+
+## 4. 봇 실행 및 모니터링
+
+### Docker를 이용한 봇 관리
+
+- **봇 시작 (백그라운드 실행)**:
+  ```bash
+  docker compose up -d
+  ```
+
+- **봇 중지**:
+  ```bash
+  docker compose down
+  ```
+
+- **실시간 로그 확인**:
+  ```bash
+  docker compose logs -f
+  ```
+
+- **실행 중인 서비스 확인**:
+  ```bash
+  docker compose ps
+  ```
+
+### FreqUI를 통한 모니터링
+
+웹 브라우저에서 `http://localhost:8080`으로 접속하면 대시보드를 통해 현재 진행 중인 거래, 자산 현황, 로그, 일별 수익률 등 상세한 정보를 시각적으로 확인할 수 있습니다.
+
+---
+
+## 5. 자주 사용하는 명령어 (텔레그램)
+
+텔레그램 봇을 연동했다면, 아래와 같은 명령어로 봇을 제어할 수 있습니다.
+
+- `/status table`: 현재 진행 중인 모든 거래를 표 형태로 보여줍니다.
+- `/profit`: 모든 완료된 거래의 누적 수익률을 보여줍니다.
+- `/daily`: 지난 7일간의 일별 수익률을 보여줍니다.
+- `/balance`: 거래소에 보유 중인 자산 현황을 보여줍니다.
+- `/forceexit [trade_id]`: 특정 거래를 즉시 강제로 종료(매도)합니다. `[trade_id]`는 `/status` 명령어로 확인할 수 있습니다.
+- `/stop`: 봇을 정지합니다. (거래 중인 코인은 매도하지 않습니다.)
+- `/start`: 정지된 봇을 다시 시작합니다.
+
+이 가이드가 Freqtrade를 성공적으로 운영하는 데 도움이 되기를 바랍니다.

--- a/SETUP_GUIDE_KO.md
+++ b/SETUP_GUIDE_KO.md
@@ -1,0 +1,137 @@
+# Freqtrade M4 MacBook Pro 설치 가이드
+
+안녕하세요! 이 가이드는 Apple M4 칩이 탑재된 MacBook Pro에서 Freqtrade를 설치하고 실행하는 과정을 안내합니다. M4와 같은 ARM64 아키텍처 시스템에서는 공식적으로 Docker를 사용한 설치를 권장하고 있으므로, 이 가이드도 Docker를 기반으로 작성되었습니다.
+
+---
+
+## 사전 준비 사항
+
+가장 먼저, Mac에 Docker Desktop이 설치되어 있어야 합니다. 아래 링크에서 다운로드하여 설치해 주세요.
+
+- **[Docker Desktop for Mac 다운로드](https://docs.docker.com/desktop/install/mac-install/)**
+
+Docker가 성공적으로 설치되고 실행 중인지 확인한 후에 다음 단계를 진행해 주세요.
+
+---
+
+## 설치 절차
+
+### 1단계: 작업 디렉토리 생성 및 이동
+
+Freqtrade 관련 파일들을 보관할 디렉토리를 만들고, 터미널에서 해당 디렉토리로 이동합니다.
+
+```bash
+mkdir freqtrade-m4
+cd freqtrade-m4
+```
+
+### 2단계: `docker-compose.yml` 파일 다운로드
+
+Freqtrade를 Docker 환경에서 실행하기 위한 설정 파일입니다. 아래 명령어를 터미널에 입력하여 다운로드합니다.
+
+```bash
+curl https://raw.githubusercontent.com/freqtrade/freqtrade/stable/docker-compose.yml -o docker-compose.yml
+```
+
+### 3단계: Freqtrade Docker 이미지 다운로드
+
+Freqtrade의 최신 안정 버전을 Docker 이미지로 가져옵니다.
+
+```bash
+docker compose pull
+```
+
+### 4단계: 사용자 데이터 디렉토리 생성
+
+전략, 설정 파일, 로그 등을 저장할 `user_data` 디렉토리를 생성합니다.
+
+```bash
+docker compose run --rm freqtrade create-userdir --userdir user_data
+```
+
+이 명령어를 실행하면 현재 디렉토리(`freqtrade-m4`) 내에 `user_data` 폴더가 생성된 것을 확인할 수 있습니다.
+
+### 5단계: 설정 파일(`config.json`) 생성
+
+봇 운영에 필요한 기본 설정 파일을 생성합니다. 아래 명령어를 실행하면 몇 가지 질문이 나타납니다. 답변을 통해 초기 설정을 구성할 수 있습니다.
+
+```bash
+docker compose run --rm freqtrade new-config --config user_data/config.json
+```
+
+**주요 질문:**
+- `Do you want to enable Dry-run?` (모의 투자 활성화 여부): 처음에는 `y` (Yes)를 선택하여 실제 자금 없이 테스트하는 것을 강력히 권장합니다.
+- `What is your stake currency?` (기본 통화): `USDT` 또는 `BTC` 등을 입력합니다.
+- `What is your stake amount?` (거래당 투자 금액): `unlimited` 또는 원하는 금액을 입력합니다.
+- `What is the name of your strategy?`: `SampleStrategy` (기본값)를 그대로 사용하거나 원하는 전략 이름을 입력합니다.
+- `Enable FreqUI?`: `y`를 선택하면 웹 인터페이스를 사용할 수 있습니다.
+
+생성된 설정 파일은 `user_data/config.json` 경로에서 언제든지 직접 수정할 수 있습니다.
+
+### 6단계: (선택 사항) 사용자 정의 전략 추가
+
+자신만의 거래 전략을 사용하고 싶다면, 파이썬으로 작성된 전략 파일(`your_strategy.py`)을 `user_data/strategies/` 디렉토리 안에 복사해 넣으면 됩니다.
+
+그 후, `docker-compose.yml` 파일을 열어 `command` 부분을 다음과 같이 수정해야 합니다.
+
+```yaml
+# docker-compose.yml 파일 일부
+
+services:
+  freqtrade:
+    image: freqtradeorg/freqtrade:stable
+    # ... (다른 설정들) ...
+    command: >
+      trade
+      --logfile /freqtrade/user_data/logs/freqtrade.log
+      --config /freqtrade/user_data/config.json
+      --strategy YourAwesomeStrategy # <--- 여기를 당신의 전략 클래스 이름으로 변경
+```
+
+### 7단계: Freqtrade 봇 시작하기
+
+이제 모든 준비가 끝났습니다. 아래 명령어로 Freqtrade 봇을 백그라운드에서 실행합니다.
+
+```bash
+docker compose up -d
+```
+
+### 8단계: 봇 모니터링 및 관리
+
+- **실행 상태 확인**:
+  ```bash
+  docker compose ps
+  ```
+  `freqtrade` 서비스가 `running` 상태로 표시되어야 합니다.
+
+- **실시간 로그 확인**:
+  ```bash
+  docker compose logs -f
+  ```
+  (로그 확인을 중단하려면 `Ctrl + C`를 누르세요)
+
+- **웹 UI 접속**:
+  설정 과정에서 FreqUI를 활성화했다면, 웹 브라우저에서 `http://localhost:8080` 주소로 접속하여 봇의 상태를 확인할 수 있습니다.
+
+- **봇 중지**:
+  ```bash
+  docker compose down
+  ```
+
+---
+
+## Freqtrade 업데이트
+
+Freqtrade를 최신 버전으로 업데이트하려면 아래 두 명령어를 차례로 실행하면 됩니다.
+
+```bash
+# 1. 최신 이미지를 다운로드합니다.
+docker compose pull
+
+# 2. 최신 이미지로 봇을 다시 시작합니다.
+docker compose up -d
+```
+
+---
+
+이 가이드가 Freqtrade를 성공적으로 설치하고 운영하는 데 도움이 되기를 바랍니다. 궁금한 점이 있다면 언제든지 질문해 주세요.


### PR DESCRIPTION
Adds a detailed guide in Korean on how to set up Freqtrade on an M4 MacBook Pro using the recommended Docker method.

The file is named `SETUP_GUIDE_KO.md` due to technical limitations with non-ASCII filenames in my development environment.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
