### PR TITLE
fix: Ensure pipelines that modify feature set are supported for fast backtesting

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -493,7 +493,7 @@ class FreqaiDataDrawer:
 
         dk.data["data_path"] = str(dk.data_path)
         dk.data["model_filename"] = str(dk.model_filename)
-        dk.data["training_features_list"] = list(dk.data_dictionary["train_features"].columns)
+        dk.data["training_features_list"] = dk.training_features_list
         dk.data["label_list"] = dk.label_list
 
         with (save_path / f"{dk.model_filename}_{METADATA}.json").open("w") as fp:

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -514,12 +514,7 @@ class IFreqaiModel(ABC):
                    current coin/bot loop
         """
 
-        if "training_features_list_raw" in dk.data:
-            feature_list = dk.data["training_features_list_raw"]
-        else:
-            feature_list = dk.data["training_features_list"]
-
-        if dk.training_features_list != feature_list:
+        if dk.training_features_list != dk.data["training_features_list"]:
             raise OperationalException(
                 "Trying to access pretrained model with `identifier` "
                 "but found different features furnished by current strategy. "


### PR DESCRIPTION
Users who use backtest + save_backtest_models: false + feature modification data pipeline (e.g. PCA), will run into issues due to how the features are saved in `save_metadata`. 

This PR fixes it, and addresses #12078 #12066 .