### PR TITLE
Fix calc_profit_ratio

### DIFF
--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -1181,7 +1181,7 @@ class LocalTrade:
         """
         Calculates the profit as ratio (including fee).
         :param rate: rate to compare with.
-        :param amount: Amount to use for the calculation. Falls back to self.amount if not set.
+        :param amount: Amount to use for the calculation. Falls back to trade.amount if not set.
         :param open_rate: open_rate to use. Defaults to self.open_rate if not provided.
         :return: profit ratio as float
         """

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -1190,11 +1190,10 @@ class LocalTrade:
         if (amount is None) and (open_rate is None):
             open_trade_value = self.open_trade_value
         else:
-            if amount is None:
-                amount = self.amount
-            if open_rate is None:
-                open_rate = self.open_rate
-            open_trade_value = self._calc_open_trade_value(amount, open_rate)
+            # Fall back to trade.amount and self.open_rate if necessary
+            open_trade_value = self._calc_open_trade_value(
+                amount or self.amount, open_rate or self.open_rate
+            )
 
         if open_trade_value == 0.0:
             return 0.0

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -1181,15 +1181,19 @@ class LocalTrade:
         """
         Calculates the profit as ratio (including fee).
         :param rate: rate to compare with.
-        :param amount: Amount to use for the calculation. Falls back to trade.amount if not set.
+        :param amount: Amount to use for the calculation. Falls back to self.amount if not set.
         :param open_rate: open_rate to use. Defaults to self.open_rate if not provided.
         :return: profit ratio as float
         """
         close_trade_value = self.calc_close_trade_value(rate, amount)
 
-        if amount is None or open_rate is None:
+        if (amount is None) and (open_rate is None):
             open_trade_value = self.open_trade_value
         else:
+            if amount is None:
+                amount = self.amount
+            if open_rate is None:
+                open_rate = self.open_rate
             open_trade_value = self._calc_open_trade_value(amount, open_rate)
 
         if open_trade_value == 0.0:

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -1528,6 +1528,25 @@ def test_handle_trade(
     assert trade.close_date is not None
     assert trade.exit_reason == "sell_signal1"
 
+    correct_profit_ratio = trade.calc_profit_ratio(
+        rate=trade.close_rate, amount=trade.amount, open_rate=trade.open_rate
+    )
+    profit_ratio_1 = trade.calc_profit_ratio(rate=trade.close_rate, open_rate=trade.open_rate)
+    profit_ratio_2 = trade.calc_profit_ratio(
+        rate=trade.close_rate, open_rate=trade.open_rate * 1.02
+    )
+    profit_ratio_3 = trade.calc_profit_ratio(rate=trade.close_rate, amount=trade.amount)
+    profit_ratio_4 = trade.calc_profit_ratio(rate=trade.close_rate)
+    profit_ratio_5 = trade.calc_profit_ratio(
+        rate=trade.close_rate, amount=trade.amount, open_rate=trade.open_rate * 1.02
+    )
+    assert correct_profit_ratio == close_profit
+    assert correct_profit_ratio == profit_ratio_1
+    assert correct_profit_ratio != profit_ratio_2
+    assert correct_profit_ratio == profit_ratio_3
+    assert correct_profit_ratio == profit_ratio_4
+    assert correct_profit_ratio != profit_ratio_5
+
 
 @pytest.mark.parametrize("is_short", [False, True])
 def test_handle_overlapping_signals(
@@ -5729,7 +5748,7 @@ def test_position_adjust2(mocker, default_conf_usdt, fee) -> None:
 @pytest.mark.parametrize(
     "data",
     [
-        # tuple 1 - side amount, price
+        # tuple 1 - side, amount, price
         # tuple 2 - amount, open_rate, stake_amount, cumulative_profit, realized_profit, rel_profit
         (
             (("buy", 100, 10), (100.0, 10.0, 1000.0, 0.0, None, None)),


### PR DESCRIPTION
## Summary

Fix calc_profit_ratio to behave correctly when only either one of amount and open rate is None

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

In the description of the function
```
:param amount: Amount to use for the calculation. Falls back to self.amount if not set.
:param open_rate: open_rate to use. Defaults to self.open_rate if not provided.
```
So we can safely assume that when their value isn't given, they will use the current trade's data. But in reality, if we only supply one of them, let's say I do this
```
marked_up_rate = trade.open_rate * 1.3
new_current_profit = trade.calc_profit_ratio(rate=current_rate, open_rate=marked_up_rate)
```
I would expect the bot to fill the amount with trade.amount since I don't supply any to the function, and then calculate the new profif % using the supplied open rate, but it's not. When either one of them is None, the bot will use the original open_trade_value, ignoring the supplied open_rate.

It should only use the original open_trade_value only when both open_rate and amount aren't specified. When only one isn't specified, use the fallback to calculate new open_trade_value