### PR TITLE
Bump ccxt version to 4.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ft-pandas-ta==0.3.15
 ta-lib==0.6.5
 technical==1.5.2
 
-ccxt==4.5.1
+ccxt==4.5.2
 cryptography==45.0.6
 aiohttp==3.12.15
 SQLAlchemy==2.0.43


### PR DESCRIPTION
Update the ccxt dependency to version 4.5.2 to incorporate the latest features and fixes.