### PR TITLE
Some improvements to backtest summary metrics

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -160,117 +160,144 @@ The most important in the backtesting is to understand the result.
 A backtesting result will look like that:
 
 ```
-================================================ BACKTESTING REPORT =================================================
-| Pair     | Trades |   Avg Profit % |   Tot Profit BTC |   Tot Profit % | Avg Duration |  Wins Draws Loss   Win%  |
-|----------+--------+----------------+------------------+----------------+--------------+--------------------------|
-| ADA/BTC  |     35 |          -0.11 |      -0.00019428 |          -1.94 | 4:35:00      |    14     0    21   40.0 |
-| ARK/BTC  |     11 |          -0.41 |      -0.00022647 |          -2.26 | 2:03:00      |     3     0     8   27.3 |
-| BTS/BTC  |     32 |           0.31 |       0.00048938 |           4.89 | 5:05:00      |    18     0    14   56.2 |
-| DASH/BTC |     13 |          -0.08 |      -0.00005343 |          -0.53 | 4:39:00      |     6     0     7   46.2 |
-| ENG/BTC  |     18 |           1.36 |       0.00122807 |          12.27 | 2:50:00      |     8     0    10   44.4 |
-| EOS/BTC  |     36 |           0.08 |       0.00015304 |           1.53 | 3:34:00      |    16     0    20   44.4 |
-| ETC/BTC  |     26 |           0.37 |       0.00047576 |           4.75 | 6:14:00      |    11     0    15   42.3 |
-| ETH/BTC  |     33 |           0.30 |       0.00049856 |           4.98 | 7:31:00      |    16     0    17   48.5 |
-| IOTA/BTC |     32 |           0.03 |       0.00005444 |           0.54 | 3:12:00      |    14     0    18   43.8 |
-| LSK/BTC  |     15 |           1.75 |       0.00131413 |          13.13 | 2:58:00      |     6     0     9   40.0 |
-| LTC/BTC  |     32 |          -0.04 |      -0.00006886 |          -0.69 | 4:49:00      |    11     0    21   34.4 |
-| NANO/BTC |     17 |           1.26 |       0.00107058 |          10.70 | 1:55:00      |    10     0     7   58.5 |
-| NEO/BTC  |     23 |           0.82 |       0.00094936 |           9.48 | 2:59:00      |    10     0    13   43.5 |
-| REQ/BTC  |      9 |           1.17 |       0.00052734 |           5.27 | 3:47:00      |     4     0     5   44.4 |
-| XLM/BTC  |     16 |           1.22 |       0.00097800 |           9.77 | 3:15:00      |     7     0     9   43.8 |
-| XMR/BTC  |     23 |          -0.18 |      -0.00020696 |          -2.07 | 5:30:00      |    12     0    11   52.2 |
-| XRP/BTC  |     35 |           0.66 |       0.00114897 |          11.48 | 3:49:00      |    12     0    23   34.3 |
-| ZEC/BTC  |     22 |          -0.46 |      -0.00050971 |          -5.09 | 2:22:00      |     7     0    15   31.8 |
-| TOTAL    |    429 |           0.36 |       0.00762792 |          76.20 | 4:12:00      |   186     0   243   43.4 |
-============================================= LEFT OPEN TRADES REPORT =============================================
-| Pair     |  Trades |   Avg Profit % |   Tot Profit BTC |   Tot Profit % | Avg Duration   |  Win Draw Loss Win% |
-|----------+---------+----------------+------------------+----------------+----------------+---------------------|
-| ADA/BTC  |       1 |           0.89 |       0.00004434 |           0.44 | 6:00:00        |    1    0    0  100 |
-| LTC/BTC  |       1 |           0.68 |       0.00003421 |           0.34 | 2:00:00        |    1    0    0  100 |
-| TOTAL    |       2 |           0.78 |       0.00007855 |           0.78 | 4:00:00        |    2    0    0  100 |
-==================== EXIT REASON STATS ====================
-| Exit Reason        |   Exits |  Wins |  Draws |  Losses |
-|--------------------+---------+-------+--------+---------|
-| trailing_stop_loss |     205 |   150 |      0 |      55 |
-| stop_loss          |     166 |     0 |      0 |     166 |
-| exit_signal        |      56 |    36 |      0 |      20 |
-| force_exit         |       2 |     0 |      0 |       2 |
-
-================== SUMMARY METRICS ==================
-| Metric                      | Value               |
-|-----------------------------+---------------------|
-| Backtesting from            | 2019-01-01 00:00:00 |
-| Backtesting to              | 2019-05-01 00:00:00 |
-| Trading Mode                | Spot                |
-| Max open trades             | 3                   |
-|                             |                     |
-| Total/Daily Avg Trades      | 429 / 3.575         |
-| Starting balance            | 0.01000000 BTC      |
-| Final balance               | 0.01762792 BTC      |
-| Absolute profit             | 0.00762792 BTC      |
-| Total profit %              | 76.2%               |
-| CAGR %                      | 460.87%             |
-| Sortino                     | 1.88                |
-| Sharpe                      | 2.97                |
-| Calmar                      | 6.29                |
-| SQN                         | 2.45                |
-| Profit factor               | 1.11                |
-| Expectancy (Ratio)          | -0.15 (-0.05)       |
-| Avg. stake amount           | 0.001      BTC      |
-| Total trade volume          | 0.429      BTC      |
-|                             |                     |
-| Long / Short                | 352 / 77            |
-| Total profit Long %         | 1250.58%            |
-| Total profit Short %        | -15.02%             |
-| Absolute profit Long        | 0.00838792 BTC      |
-| Absolute profit Short       | -0.00076 BTC        |
-|                             |                     |
-| Best Pair                   | LSK/BTC 26.26%      |
-| Worst Pair                  | ZEC/BTC -10.18%     |
-| Best Trade                  | LSK/BTC 4.25%       |
-| Worst Trade                 | ZEC/BTC -10.25%     |
-| Best day                    | 0.00076 BTC         |
-| Worst day                   | -0.00036 BTC        |
-| Days win/draw/lose          | 12 / 82 / 25        |
-| Avg. Duration Winners       | 4:23:00             |
-| Avg. Duration Loser         | 6:55:00             |
-| Max Consecutive Wins / Loss | 3 / 4               |
-| Rejected Entry signals      | 3089                |
-| Entry/Exit Timeouts         | 0 / 0               |
-| Canceled Trade Entries      | 34                  |
-| Canceled Entry Orders       | 123                 |
-| Replaced Entry Orders       | 89                  |
-|                             |                     |
-| Min balance                 | 0.00945123 BTC      |
-| Max balance                 | 0.01846651 BTC      |
-| Max % of account underwater | 25.19%              |
-| Absolute Drawdown (Account) | 13.33%              |
-| Drawdown                    | 0.0015 BTC          |
-| Drawdown high               | 0.0013 BTC          |
-| Drawdown low                | -0.0002 BTC         |
-| Drawdown Start              | 2019-02-15 14:10:00 |
-| Drawdown End                | 2019-04-11 18:15:00 |
-| Market change               | -5.88%              |
-=====================================================
+                                                  BACKTESTING REPORT
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃           Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ DOGE/USDT:USDT │    406 │         3.58 │        1453.700 │        72.68 │ 1 day, 19:30:00 │  176     0   230  43.3 │
+│  ADA/USDT:USDT │    480 │         2.17 │        1041.450 │        52.07 │ 1 day, 13:14:00 │  201     0   279  41.9 │
+│  SOL/USDT:USDT │    403 │         2.17 │         871.360 │        43.57 │ 1 day, 18:56:00 │  177     0   226  43.9 │
+│  XRP/USDT:USDT │    465 │         1.84 │         857.098 │        42.85 │ 1 day, 18:52:00 │  190     0   275  40.9 │
+│ AVAX/USDT:USDT │    406 │         2.27 │         849.555 │        42.48 │ 1 day, 16:17:00 │  181     0   225  44.6 │
+│  XLM/USDT:USDT │    508 │         1.61 │         817.847 │        40.89 │ 1 day, 14:51:00 │  206     0   302  40.6 │
+│  ETC/USDT:USDT │    490 │         1.51 │         737.908 │         36.9 │ 1 day, 13:18:00 │  201     0   289  41.0 │
+│  ETH/USDT:USDT │    468 │         1.58 │         734.632 │        36.73 │ 1 day, 19:18:00 │  202     0   266  43.2 │
+│  DOT/USDT:USDT │    415 │         1.61 │         665.423 │        33.27 │ 1 day, 16:29:00 │  182     0   233  43.9 │
+│  FIL/USDT:USDT │    375 │         1.63 │         597.045 │        29.85 │ 1 day, 17:06:00 │  152     0   223  40.5 │
+│  BCH/USDT:USDT │    494 │         1.05 │         517.877 │        25.89 │ 1 day, 17:26:00 │  190     0   304  38.5 │
+│  BTC/USDT:USDT │    247 │         1.78 │         418.177 │        20.91 │ 2 days, 6:16:00 │  120     0   127  48.6 │
+│  UNI/USDT:USDT │    417 │         0.99 │         405.739 │        20.29 │ 1 day, 16:22:00 │  170     0   247  40.8 │
+│  CRV/USDT:USDT │    444 │         0.91 │         402.472 │        20.12 │ 1 day, 11:32:00 │  155     0   289  34.9 │
+│ AAVE/USDT:USDT │    408 │         0.99 │         384.711 │        19.24 │ 1 day, 16:20:00 │  173     0   235  42.4 │
+│ NEAR/USDT:USDT │    400 │         0.74 │         291.283 │        14.56 │ 1 day, 16:15:00 │  177     0   223  44.2 │
+│ ATOM/USDT:USDT │    476 │         0.57 │         271.570 │        13.58 │ 1 day, 14:54:00 │  211     0   265  44.3 │
+│ LINK/USDT:USDT │    489 │          0.5 │         246.783 │        12.34 │ 1 day, 15:39:00 │  218     0   271  44.6 │
+│  LTC/USDT:USDT │    490 │         0.42 │         204.725 │        10.24 │ 1 day, 15:15:00 │  191     0   299  39.0 │
+│ ALGO/USDT:USDT │    492 │         0.24 │         116.689 │         5.83 │ 1 day, 11:29:00 │  184     0   308  37.4 │
+│          TOTAL │   8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
+└────────────────┴────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
+                                              LEFT OPEN TRADES REPORT
+┏━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃          Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃   Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ CRV/USDT:USDT │      1 │        -2.02 │          -2.017 │         -0.1 │ 1 day, 0:00:00 │    0     0     1     0 │
+│ ETH/USDT:USDT │      1 │        -2.09 │          -2.023 │         -0.1 │       12:00:00 │    0     0     1     0 │
+│ BCH/USDT:USDT │      1 │        -2.74 │          -2.736 │        -0.14 │       16:00:00 │    0     0     1     0 │
+│         TOTAL │      3 │        -2.28 │          -6.776 │        -0.34 │       17:20:00 │    0     0     3     0 │
+└───────────────┴────────┴──────────────┴─────────────────┴──────────────┴────────────────┴────────────────────────┘
+                                                  ENTER TAG STATS
+┏━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃   Enter Tag ┃ Entries ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│  enter_long │    4608 │         1.79 │        8174.064 │        408.7 │ 1 day, 22:03:00 │ 1909     0  2699  41.4 │
+│ enter_short │    4165 │         0.91 │        3711.981 │        185.6 │  1 day, 9:52:00 │ 1748     0  2417  42.0 │
+│       TOTAL │    8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
+└─────────────┴─────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
+                                                 EXIT REASON STATS
+┏━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Exit Reason ┃ Exits ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃     Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ exit_signal │  8229 │         0.99 │        8003.737 │       400.19 │  1 day, 15:48:00 │ 3354     0  4875  40.8 │
+│         roi │   303 │        23.77 │        7097.760 │       354.89 │ 2 days, 16:48:00 │  303     0     0   100 │
+│  force_exit │     3 │        -2.28 │          -6.776 │        -0.34 │         17:20:00 │    0     0     3     0 │
+│   stop_loss │   238 │       -13.74 │       -3208.676 │      -160.43 │   1 day, 1:14:00 │    0     0   238     0 │
+│       TOTAL │  8773 │         1.37 │       11886.045 │        594.3 │  1 day, 16:16:00 │ 3657     0  5116  41.7 │
+└─────────────┴───────┴──────────────┴─────────────────┴──────────────┴──────────────────┴────────────────────────┘
+                                                         MIXED TAG STATS
+┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃   Enter Tag ┃ Exit Reason ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃     Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│  enter_long │ exit_signal │   4570 │         2.01 │        9083.885 │       454.19 │  1 day, 22:07:00 │ 1909     0  2661  41.8 │
+│ enter_short │         roi │    303 │        23.77 │        7097.760 │       354.89 │ 2 days, 16:48:00 │  303     0     0   100 │
+│  enter_long │  force_exit │      3 │        -2.28 │          -6.776 │        -0.34 │         17:20:00 │    0     0     3     0 │
+│  enter_long │   stop_loss │     35 │       -26.37 │        -903.045 │       -45.15 │  1 day, 15:53:00 │    0     0    35     0 │
+│ enter_short │ exit_signal │   3659 │         -0.3 │       -1080.148 │       -54.01 │   1 day, 7:56:00 │ 1445     0  2214  39.5 │
+│ enter_short │   stop_loss │    203 │       -11.56 │       -2305.631 │      -115.28 │         22:42:00 │    0     0   203     0 │
+│       TOTAL │             │   8773 │         1.37 │       11886.045 │        594.3 │  1 day, 16:16:00 │ 3657     0  5116  41.7 │
+└─────────────┴─────────────┴────────┴──────────────┴─────────────────┴──────────────┴──────────────────┴────────────────────────┘
+                          SUMMARY METRICS
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Metric                        ┃ Value                           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Backtesting from              │ 2020-01-01 00:00:00             │
+│ Backtesting to                │ 2025-07-31 16:00:00             │
+│ Trading Mode                  │ Isolated Futures                │
+│ Max open trades               │ 20                              │
+│                               │                                 │
+│ Total/Daily Avg Trades        │ 8773 / 4.3                      │
+│ Starting balance              │ 2000 USDT                       │
+│ Final balance                 │ 13886.045 USDT                  │
+│ Absolute profit               │ 11886.045 USDT                  │
+│ Total profit %                │ 594.30%                         │
+│ CAGR %                        │ 41.49%                          │
+│ Sortino                       │ 28.95                           │
+│ Sharpe                        │ 7.21                            │
+│ Calmar                        │ 92.50                           │
+│ SQN                           │ 8.21                            │
+│ Profit factor                 │ 1.68                            │
+│ Expectancy (Ratio)            │ 1.35 (0.40)                     │
+│ Avg. daily profit             │ 5.832 USDT                      │
+│ Avg. stake amount             │ 98.376 USDT                     │
+│ Total trade volume            │ 2090483.493 USDT                │
+│                               │                                 │
+│ Long / Short trades           │ 4608 / 4165                     │
+│ Long / Short profit %         │ 408.70% / 185.60%               │
+│ Long / Short profit USDT      │ 8174.064 / 3711.981             │
+│                               │                                 │
+│ Best Pair                     │ DOGE/USDT:USDT 72.68%           │
+│ Worst Pair                    │ ALGO/USDT:USDT 5.83%            │
+│ Best trade                    │ DOGE/USDT:USDT 724.62%          │
+│ Worst trade                   │ UNI/USDT:USDT -34.76%           │
+│ Best day                      │ 782.575 USDT                    │
+│ Worst day                     │ -285.862 USDT                   │
+│ Days win/draw/lose            │ 767 / 270 / 1000                │
+│ Min/Max/Avg. Duration Winners │ 0d 00:00 / 23d 16:00 / 2d 14:13 │
+│ Min/Max/Avg. Duration Losers  │ 0d 00:00 / 12d 16:00 / 1d 00:35 │
+│ Max Consecutive Wins / Loss   │ 27 / 37                         │
+│ Rejected Entry signals        │ 0                               │
+│ Entry/Exit Timeouts           │ 0 / 0                           │
+│                               │                                 │
+│ Min balance                   │ 1993.526 USDT                   │
+│ Max balance                   │ 13941.454 USDT                  │
+│ Max % of account underwater   │ 10.17%                          │
+│ Absolute drawdown             │ 516.716 USDT (6.02%)            │
+│ Drawdown duration             │ 40 days 20:00:00                │
+│ Profit at drawdown start      │ 6579.085 USDT                   │
+│ Profit at drawdown end        │ 6062.369 USDT                   │
+│ Drawdown start                │ 2022-08-09 08:00:00             │
+│ Drawdown end                  │ 2022-09-19 04:00:00             │
+│ Market change                 │ 1011.30%                        │
+└───────────────────────────────┴─────────────────────────────────┘
 ```
 
 ### Backtesting report table
 
-The 1st table contains all trades the bot made, including "left open trades".
+The first table contains all trades the bot made, including "left open trades".
 
 The last line will give you the overall performance of your strategy,
 here:
 
 ```
-| TOTAL    |    429 |           0.36 |         152.41 |       0.00762792 |          76.20 | 4:12:00      |   186     0   243   43.4 |
+│          TOTAL │   8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
 ```
 
-The bot has made `429` trades for an average duration of `4:12:00`, with a performance of `76.20%` (profit), that means it has
-earned a total of `0.00762792 BTC` starting with a capital of 0.01 BTC.
+The bot has made `8773` trades for an average duration of `1 day, 16:16:00`, with a performance of `594.3%` (profit), that means it has
+earned a total of `11886.045 USDT` starting with a capital of 2000 USDT.
 
 The column `Avg Profit %` shows the average profit for all trades made.
 The column `Tot Profit %` shows instead the total profit % in relation to the starting balance.
-In the above results, we have a starting balance of 0.01 BTC and an absolute profit of 0.00762792 BTC - so the `Tot Profit %` will be `(0.00762792 / 0.01) * 100 ~= 76.2%`.
+
+In the above results, we have a starting balance of 2000 USDT and an absolute profit of 11886.045 USDT - so the `Tot Profit %` will be `(11886.045 / 2000) * 100 ~= 594.3%`.
 
 Your strategy performance is influenced by your entry strategy, your exit strategy, and also by the `minimal_roi` and `stop_loss` you have set.
 
@@ -286,86 +313,87 @@ On the other hand, if you set a too high `minimal_roi` like `"0":  0.55`
 (55%), there is almost no chance that the bot will ever reach this profit.
 Hence, keep in mind that your performance is an integral mix of all different elements of the strategy, your configuration, and the crypto-currency pairs you have set up.
 
-### Exit reasons table
-
-The 2nd table contains a recap of exit reasons.
-This table can tell you which area needs some additional work (e.g. all or many of the `exit_signal` trades are losses, so you should work on improving the exit signal, or consider disabling it).
-
 ### Left open trades table
 
-The 3rd table contains all trades the bot had to `force_exit` at the end of the backtesting period to present you the full picture.
+The second table contains all trades the bot had to `force_exit` at the end of the backtesting period to present you the full picture.
 This is necessary to simulate realistic behavior, since the backtest period has to end at some point, while realistically, you could leave the bot running forever.
 These trades are also included in the first table, but are also shown separately in this table for clarity.
+
+### Enter tag stats table
+
+The third table provides a breakdown of trades by their entry tags (e.g., `enter_long`, `enter_short`), showing the number of entries, average profit percentage, total profit in the stake currency, total profit percentage, average duration, and the number of wins, draws, and losses for each tag.
+
+### Exit reason stats table
+
+The fourth table contains a recap of exit reasons (e.g., `exit_signal`, `roi`, `stop_loss`, `force_exit`). This table can tell you which area needs additional work (e.g., if many `exit_signal` trades are losses, you should work on improving the exit signal or consider disabling it).
+
+### Mixed tag stats table
+
+The fifth table combines entry tags and exit reasons, providing a detailed view of how different entry tags performed with specific exit reasons. This can help identify which combinations of entry and exit strategies are most effective.
 
 ### Summary metrics
 
 The last element of the backtest report is the summary metrics table.
-It contains some useful key metrics about performance of your strategy on backtesting data.
+It contains key metrics about the performance of your strategy on backtesting data.
 
 ```
-================== SUMMARY METRICS ==================
-| Metric                      | Value               |
-|-----------------------------+---------------------|
-| Backtesting from            | 2019-01-01 00:00:00 |
-| Backtesting to              | 2019-05-01 00:00:00 |
-| Trading Mode                | Spot                |
-| Max open trades             | 3                   |
-|                             |                     |
-| Total/Daily Avg Trades      | 429 / 3.575         |
-| Starting balance            | 0.01000000 BTC      |
-| Final balance               | 0.01762792 BTC      |
-| Absolute profit             | 0.00762792 BTC      |
-| Total profit %              | 76.2%               |
-| CAGR %                      | 460.87%             |
-| Sortino                     | 1.88                |
-| Sharpe                      | 2.97                |
-| Calmar                      | 6.29                |
-| SQN                         | 2.45                |
-| Profit factor               | 1.11                |
-| Expectancy (Ratio)          | -0.15 (-0.05)       |
-| Avg. daily profit           | 0.0001     BTC      |
-| Avg. stake amount           | 0.001      BTC      |
-| Total trade volume          | 0.429      BTC      |
-|                             |                     |
-| Long / Short                | 352 / 77            |
-| Total profit Long %         | 1250.58%            |
-| Total profit Short %        | -15.02%             |
-| Absolute profit Long        | 0.00838792 BTC      |
-| Absolute profit Short       | -0.00076 BTC        |
-|                             |                     |
-| Best Pair                   | LSK/BTC 26.26%      |
-| Worst Pair                  | ZEC/BTC -10.18%     |
-| Best Trade                  | LSK/BTC 4.25%       |
-| Worst Trade                 | ZEC/BTC -10.25%     |
-| Best day                    | 0.00076 BTC         |
-| Worst day                   | -0.00036 BTC        |
-| Days win/draw/lose          | 12 / 82 / 25        |
-| Avg. Duration Winners       | 4:23:00             |
-| Avg. Duration Loser         | 6:55:00             |
-| Max Consecutive Wins / Loss | 3 / 4               |
-| Rejected Entry signals      | 3089                |
-| Entry/Exit Timeouts         | 0 / 0               |
-| Canceled Trade Entries      | 34                  |
-| Canceled Entry Orders       | 123                 |
-| Replaced Entry Orders       | 89                  |
-|                             |                     |
-| Min balance                 | 0.00945123 BTC      |
-| Max balance                 | 0.01846651 BTC      |
-| Max % of account underwater | 25.19%              |
-| Absolute Drawdown (Account) | 13.33%              |
-| Drawdown                    | 0.0015 BTC          |
-| Drawdown high               | 0.0013 BTC          |
-| Drawdown low                | -0.0002 BTC         |
-| Drawdown Start              | 2019-02-15 14:10:00 |
-| Drawdown End                | 2019-04-11 18:15:00 |
-| Market change               | -5.88%              |
-=====================================================
-
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Metric                        ┃ Value                           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Backtesting from              │ 2020-01-01 00:00:00             │
+│ Backtesting to                │ 2025-07-31 16:00:00             │
+│ Trading Mode                  │ Isolated Futures                │
+│ Max open trades               │ 20                              │
+│                               │                                 │
+│ Total/Daily Avg Trades        │ 8773 / 4.3                      │
+│ Starting balance              │ 2000 USDT                       │
+│ Final balance                 │ 13886.045 USDT                  │
+│ Absolute profit               │ 11886.045 USDT                  │
+│ Total profit %                │ 594.30%                         │
+│ CAGR %                        │ 41.49%                          │
+│ Sortino                       │ 28.95                           │
+│ Sharpe                        │ 7.21                            │
+│ Calmar                        │ 92.50                           │
+│ SQN                           │ 8.21                            │
+│ Profit factor                 │ 1.68                            │
+│ Expectancy (Ratio)            │ 1.35 (0.40)                     │
+│ Avg. daily profit             │ 5.832 USDT                      │
+│ Avg. stake amount             │ 98.376 USDT                     │
+│ Total trade volume            │ 2090483.493 USDT                │
+│                               │                                 │
+│ Long / Short trades           │ 4608 / 4165                     │
+│ Long / Short profit %         │ 408.70% / 185.60%               │
+│ Long / Short profit USDT      │ 8174.064 / 3711.981             │
+│                               │                                 │
+│ Best Pair                     │ DOGE/USDT:USDT 72.68%           │
+│ Worst Pair                    │ ALGO/USDT:USDT 5.83%            │
+│ Best trade                    │ DOGE/USDT:USDT 724.62%          │
+│ Worst trade                   │ UNI/USDT:USDT -34.76%           │
+│ Best day                      │ 782.575 USDT                    │
+│ Worst day                     │ -285.862 USDT                   │
+│ Days win/draw/lose            │ 767 / 270 / 1000                │
+│ Min/Max/Avg. Duration Winners │ 0d 00:00 / 23d 16:00 / 2d 14:13 │
+│ Min/Max/Avg. Duration Losers  │ 0d 00:00 / 12d 16:00 / 1d 00:35 │
+│ Max Consecutive Wins / Loss   │ 27 / 37                         │
+│ Rejected Entry signals        │ 0                               │
+│ Entry/Exit Timeouts           │ 0 / 0                           │
+│                               │                                 │
+│ Min balance                   │ 1993.526 USDT                   │
+│ Max balance                   │ 13941.454 USDT                  │
+│ Max % of account underwater   │ 10.17%                          │
+│ Absolute drawdown             │ 516.716 USDT (6.02%)            │
+│ Drawdown duration             │ 40 days 20:00:00                │
+│ Profit at drawdown start      │ 6579.085 USDT                   │
+│ Profit at drawdown end        │ 6062.369 USDT                   │
+│ Drawdown start                │ 2022-08-09 08:00:00             │
+│ Drawdown end                  │ 2022-09-19 04:00:00             │
+│ Market change                 │ 1011.30%                        │
+└───────────────────────────────┴─────────────────────────────────┘
 ```
 
 - `Backtesting from` / `Backtesting to`: Backtesting range (usually defined with the `--timerange` option).
-- `Max open trades`: Setting of `max_open_trades` (or `--max-open-trades`) - or number of pairs in the pairlist (whatever is lower).
 - `Trading Mode`: Spot or Futures trading.
+- `Max open trades`: Setting of `max_open_trades` (or `--max-open-trades`) - or number of pairs in the pairlist (whatever is lower).
 - `Total/Daily Avg Trades`: Identical to the total trades of the backtest output table / Total trades divided by the backtesting duration in days (this will give you information about how many trades to expect from the strategy).
 - `Starting balance`: Start balance - as given by dry-run-wallet (config or command line).
 - `Final balance`: Final balance - starting balance + absolute profit.
@@ -376,58 +404,71 @@ It contains some useful key metrics about performance of your strategy on backte
 - `Sharpe`: Annualized Sharpe ratio.
 - `Calmar`: Annualized Calmar ratio.
 - `SQN`: System Quality Number (SQN) - by Van Tharp.
-- `Profit factor`: profit / loss.
+- `Profit factor`: Sum of the profits of all winning trades divided by the sum of the losses of all losing trades.
 - `Expectancy (Ratio)`: Expectancy ratio, which is the average profit or loss per trade. A negative expectancy ratio means that your strategy is not profitable.
 - `Avg. daily profit`: Average profit per day, calculated as `(Total Profit / Backtest Days)`.
 - `Avg. stake amount`: Average stake amount, either `stake_amount` or the average when using dynamic stake amount.
 - `Total trade volume`: Volume generated on the exchange to reach the above profit.
-- `Best Pair` / `Worst Pair`: Best and worst performing pair (based on absolute profit), and it's corresponding `Tot Profit %`.
-- `Best Trade` / `Worst Trade`: Biggest single winning trade and biggest single losing trade.
+- `Long / Short trades`: Split long/short trade counts (only shown when short trades were made).
+- `Long / Short profit %`: Profit percentage for long and short trades (only shown when short trades were made).
+- `Long / Short profit USDT`: Profit in stake currency for long and short trades (only shown when short trades were made).
+- `Best Pair` / `Worst Pair`: Best and worst performing pair (based on total profit percentage), and its corresponding `Tot Profit %`.
+- `Best trade` / `Worst trade`: Biggest single winning trade and biggest single losing trade.
 - `Best day` / `Worst day`: Best and worst day based on daily profit.
-- `Days win/draw/lose`: Winning / Losing days (draws are usually days without closed trade).
-- `Avg. Duration Winners` / `Avg. Duration Loser`: Average durations for winning and losing trades.
+- `Days win/draw/lose`: Winning / Losing days (draws are usually days without closed trades).
+- `Min/Max/Avg. Duration Winners`: Minimum, maximum, and average durations for winning trades.
+- `Min/Max/Avg. Duration Losers`: Minimum, maximum, and average durations for losing trades.
 - `Max Consecutive Wins / Loss`: Maximum consecutive wins/losses in a row.
 - `Rejected Entry signals`: Trade entry signals that could not be acted upon due to `max_open_trades` being reached.
 - `Entry/Exit Timeouts`: Entry/exit orders which did not fill (only applicable if custom pricing is used).
-- `Canceled Trade Entries`: Number of trades that have been canceled by user request via `adjust_entry_price`.
-- `Canceled Entry Orders`: Number of entry orders that have been canceled by user request via `adjust_entry_price`.
-- `Replaced Entry Orders`: Number of entry orders that have been replaced by user request via `adjust_entry_price`.
 - `Min balance` / `Max balance`: Lowest and Highest Wallet balance during the backtest period.
-- `Max % of account underwater`: Maximum percentage your account has decreased from the top since the simulation started.
-Calculated as the maximum of `(Max Balance - Current Balance) / (Max Balance)`.
-- `Absolute Drawdown (Account)`: Maximum Account Drawdown experienced. Calculated as `(Absolute Drawdown) / (DrawdownHigh + startingBalance)`.
-- `Drawdown`: Maximum, absolute drawdown experienced. Difference between Drawdown High and Subsequent Low point.
-- `Drawdown high` / `Drawdown low`: Profit at the beginning and end of the largest drawdown period. A negative low value means initial capital lost.
-- `Drawdown Start` / `Drawdown End`: Start and end datetime for this largest drawdown (can also be visualized via the `plot-dataframe` sub-command).
-- `Market change`: Change of the market during the backtest period. Calculated as average of all pairs changes from the first to the last candle using the "close" column.
-- `Long / Short`: Split long/short values (Only shown when short trades were made).
-- `Total profit Long %` / `Absolute profit Long`: Profit long trades only (Only shown when short trades were made).
-- `Total profit Short %` / `Absolute profit Short`: Profit short trades only (Only shown when short trades were made).
+- `Max % of account underwater`: Maximum percentage your account has decreased from the top since the simulation started. Calculated as the maximum of `(Max Balance - Current Balance) / (Max Balance)`.
+- `Absolute drawdown`: Maximum absolute drawdown experienced, including percentage relative to the account calculated as `(Absolute Drawdown) / (DrawdownHigh + startingBalance)`..
+- `Drawdown duration`: Duration of the largest drawdown period.
+- `Profit at drawdown start` / `Profit at drawdown end`: Profit at the beginning and end of the largest drawdown period.
+- `Drawdown start` / `Drawdown end`: Start and end datetime for the largest drawdown (can also be visualized via the `plot-dataframe` sub-command).
+- `Market change`: Change of the market during the backtest period. Calculated as the average of all pairs' changes from the first to the last candle using the "close" column.
 
-### Daily / Weekly / Monthly breakdown
+### Daily / Weekly / Monthly / Yearly breakdown
 
-You can get an overview over daily / weekly or monthly results by using the `--breakdown <>` switch.
+You can get an overview over daily, weekly, monthly, or yearly results by using the `--breakdown <>` switch.
 
-To visualize daily and weekly breakdowns, you can use the following:
+To visualize monthly and yearly breakdowns, you can use the following:
 
 ``` bash
-freqtrade backtesting --strategy MyAwesomeStrategy --breakdown day week
+freqtrade backtesting --strategy MyAwesomeStrategy --breakdown month year
 ```
 
 ``` output
-======================== DAY BREAKDOWN =========================
-|        Day |   Tot Profit USDT |   Wins |   Draws |   Losses |
-|------------+-------------------+--------+---------+----------|
-| 03/07/2021 |           200.0   |      2 |       0 |        0 |
-| 04/07/2021 |           -50.31  |      0 |       0 |        2 |
-| 05/07/2021 |           220.611 |      3 |       2 |        0 |
-| 06/07/2021 |           150.974 |      3 |       0 |        2 |
-| 07/07/2021 |           -70.193 |      1 |       0 |        2 |
-| 08/07/2021 |           212.413 |      2 |       0 |        3 |
-
+                                 MONTH BREAKDOWN
+┏━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃      Month ┃ Trades ┃ Tot Profit USDT ┃ Profit Factor ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 31/01/2020 │     12 │          44.451 │          7.28 │   10     0     2  83.3 │
+│ 29/02/2020 │     30 │           45.41 │          2.36 │   17     0    13  56.7 │
+│ 31/03/2020 │     35 │         142.024 │          2.42 │   14     0    21  40.0 │
+│ 30/04/2020 │     67 │         -23.692 │          0.81 │   24     0    43  35.8 │
+...
+...
+│ 30/04/2025 │    203 │          -63.43 │          0.81 │   73     0   130  36.0 │
+│ 31/05/2025 │    142 │         104.675 │          1.28 │   59     0    83  41.5 │
+│ 30/06/2025 │    177 │          -1.014 │           1.0 │   85     0    92  48.0 │
+│ 31/07/2025 │    155 │         232.762 │           1.6 │   63     0    92  40.6 │
+└────────────┴────────┴─────────────────┴───────────────┴────────────────────────┘
+                                  YEAR BREAKDOWN
+┏━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃       Year ┃ Trades ┃ Tot Profit USDT ┃ Profit Factor ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 31/12/2020 │    896 │         868.889 │          1.46 │  351     0   545  39.2 │
+│ 31/12/2021 │   1778 │        4487.163 │          1.93 │  745     0  1033  41.9 │
+│ 31/12/2022 │   1736 │          938.27 │          1.27 │  698     0  1038  40.2 │
+│ 31/12/2023 │   1712 │        1677.126 │          1.68 │  670     0  1042  39.1 │
+│ 31/12/2024 │   1609 │        3198.424 │          2.22 │  773     0   836  48.0 │
+│ 31/12/2025 │   1042 │         716.174 │          1.33 │  420     0   622  40.3 │
+└────────────┴────────┴─────────────────┴───────────────┴────────────────────────┘
 ```
 
-The output will show a table containing the realized absolute Profit (in stake currency) for the given timeperiod, as well as wins, draws and losses that materialized (closed) on this day. Below that there will be a second table for the summarized values of weeks indicated by the date of the closing Sunday. The same would apply to a monthly breakdown indicated by the last day of the month.
+The output will display tables containing the realized absolute profit (in stake currency) for the selected period, along with additional statistics such as number of trades, profit factor, and distribution of wins, draws, and losses that materialized (closed) on this period.
 
 ### Backtest result caching
 
@@ -451,10 +492,10 @@ For this mode - `--notes "<notes>"` can be used to add notes to the backtest res
 The output file freqtrade produces is a zip file containing the following files:
 
 - The backtest report in json format
-- the market change data in feather format
-- a copy of the strategy file
-- a copy of the strategy parameters (if a parameter file was used)
-- a sanitized copy of the config file
+- The market change data in feather format
+- A copy of the strategy file
+- A copy of the strategy parameters (if a parameter file was used)
+- A sanitized copy of the config file
 
 This will ensure results are reproducible - under the assumption that the same data is available.
 
@@ -472,7 +513,7 @@ Since backtesting lacks some detailed information about what happens within a ca
 - Exit-signal is favored over Stoploss, because exit-signals are assumed to trigger on candle's open
 - ROI
   - Exits are compared to high - but the ROI value is used (e.g. ROI = 2%, high=5% - so the exit will be at 2%)
-  - Exits are never "below the candle", so a ROI of 2% may result in a exit at 2.4% if low was at 2.4% profit
+  - Exits are never "below the candle", so a ROI of 2% may result in an exit at 2.4% if low was at 2.4% profit
   - ROI entries which came into effect on the triggering candle (e.g. `120: 0.02` for 1h candles, from `60: 0.05`) will use the candle's open as exit rate
   - Force-exits caused by `<N>=-1` ROI entries use low as exit value, unless N falls on the candle open (e.g. `120: -1` for 1h candles)
 - Stoploss exits happen exactly at stoploss price, even if low was lower, but the loss will be `2 * fees` higher than the stoploss price
@@ -538,7 +579,7 @@ freqtrade backtesting --strategy AwesomeStrategy --timeframe 1h --timeframe-deta
 
 This will load 1h data (the main timeframe) as well as 5m data (detail timeframe) for the selected timerange.
 The strategy will be analyzed with the 1h timeframe.
-Candles where activity may take place (there's an active signal, the pair is in a trade) are  evaluated at the 5m timeframe.
+Candles where activity may take place (there's an active signal, the pair is in a trade) are evaluated at the 5m timeframe.
 This will allow for a more accurate simulation of intra-candle movements - and can lead to different results, especially on higher timeframes.
 
 Entries will generally still happen at the main candle's open, however freed trade slots may be freed earlier (if the exit signal is triggered on the 5m candle), which can then be used for a new trade of a different pair.
@@ -601,5 +642,5 @@ Detailed output for all strategies one after the other will be available, so mak
 
 ## Next step
 
-Great, your strategy is profitable. What if the bot can give your the optimal parameters to use for your strategy?
+Great, your strategy is profitable. What if the bot can give you the optimal parameters to use for your strategy?
 Your next step is to learn [how to find optimal parameters with Hyperopt](hyperopt.md)

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -160,124 +160,117 @@ The most important in the backtesting is to understand the result.
 A backtesting result will look like that:
 
 ```
-                                                  BACKTESTING REPORT
-┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃           Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
-┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ DOGE/USDT:USDT │    406 │         3.58 │        1453.700 │        72.68 │ 1 day, 19:30:00 │  176     0   230  43.3 │
-│  ADA/USDT:USDT │    480 │         2.17 │        1041.450 │        52.07 │ 1 day, 13:14:00 │  201     0   279  41.9 │
-│  SOL/USDT:USDT │    403 │         2.17 │         871.360 │        43.57 │ 1 day, 18:56:00 │  177     0   226  43.9 │
-│  XRP/USDT:USDT │    465 │         1.84 │         857.098 │        42.85 │ 1 day, 18:52:00 │  190     0   275  40.9 │
-│ AVAX/USDT:USDT │    406 │         2.27 │         849.555 │        42.48 │ 1 day, 16:17:00 │  181     0   225  44.6 │
-│  XLM/USDT:USDT │    508 │         1.61 │         817.847 │        40.89 │ 1 day, 14:51:00 │  206     0   302  40.6 │
-│  ETC/USDT:USDT │    490 │         1.51 │         737.908 │         36.9 │ 1 day, 13:18:00 │  201     0   289  41.0 │
-│  ETH/USDT:USDT │    468 │         1.58 │         734.632 │        36.73 │ 1 day, 19:18:00 │  202     0   266  43.2 │
-│  DOT/USDT:USDT │    415 │         1.61 │         665.423 │        33.27 │ 1 day, 16:29:00 │  182     0   233  43.9 │
-│  FIL/USDT:USDT │    375 │         1.63 │         597.045 │        29.85 │ 1 day, 17:06:00 │  152     0   223  40.5 │
-│  BCH/USDT:USDT │    494 │         1.05 │         517.877 │        25.89 │ 1 day, 17:26:00 │  190     0   304  38.5 │
-│  BTC/USDT:USDT │    247 │         1.78 │         418.177 │        20.91 │ 2 days, 6:16:00 │  120     0   127  48.6 │
-│  UNI/USDT:USDT │    417 │         0.99 │         405.739 │        20.29 │ 1 day, 16:22:00 │  170     0   247  40.8 │
-│  CRV/USDT:USDT │    444 │         0.91 │         402.472 │        20.12 │ 1 day, 11:32:00 │  155     0   289  34.9 │
-│ AAVE/USDT:USDT │    408 │         0.99 │         384.711 │        19.24 │ 1 day, 16:20:00 │  173     0   235  42.4 │
-│ NEAR/USDT:USDT │    400 │         0.74 │         291.283 │        14.56 │ 1 day, 16:15:00 │  177     0   223  44.2 │
-│ ATOM/USDT:USDT │    476 │         0.57 │         271.570 │        13.58 │ 1 day, 14:54:00 │  211     0   265  44.3 │
-│ LINK/USDT:USDT │    489 │          0.5 │         246.783 │        12.34 │ 1 day, 15:39:00 │  218     0   271  44.6 │
-│  LTC/USDT:USDT │    490 │         0.42 │         204.725 │        10.24 │ 1 day, 15:15:00 │  191     0   299  39.0 │
-│ ALGO/USDT:USDT │    492 │         0.24 │         116.689 │         5.83 │ 1 day, 11:29:00 │  184     0   308  37.4 │
-│          TOTAL │   8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
-└────────────────┴────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
-                                              LEFT OPEN TRADES REPORT
-┏━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃          Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃   Avg Duration ┃  Win  Draw  Loss  Win% ┃
-┡━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ CRV/USDT:USDT │      1 │        -2.02 │          -2.017 │         -0.1 │ 1 day, 0:00:00 │    0     0     1     0 │
-│ ETH/USDT:USDT │      1 │        -2.09 │          -2.023 │         -0.1 │       12:00:00 │    0     0     1     0 │
-│ BCH/USDT:USDT │      1 │        -2.74 │          -2.736 │        -0.14 │       16:00:00 │    0     0     1     0 │
-│         TOTAL │      3 │        -2.28 │          -6.776 │        -0.34 │       17:20:00 │    0     0     3     0 │
-└───────────────┴────────┴──────────────┴─────────────────┴──────────────┴────────────────┴────────────────────────┘
-                                                  ENTER TAG STATS
-┏━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃   Enter Tag ┃ Entries ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
-┡━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-│  enter_long │    4608 │         1.79 │        8174.064 │        408.7 │ 1 day, 22:03:00 │ 1909     0  2699  41.4 │
-│ enter_short │    4165 │         0.91 │        3711.981 │        185.6 │  1 day, 9:52:00 │ 1748     0  2417  42.0 │
-│       TOTAL │    8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
-└─────────────┴─────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
-                                                 EXIT REASON STATS
-┏━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Exit Reason ┃ Exits ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃     Avg Duration ┃  Win  Draw  Loss  Win% ┃
-┡━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ exit_signal │  8229 │         0.99 │        8003.737 │       400.19 │  1 day, 15:48:00 │ 3354     0  4875  40.8 │
-│         roi │   303 │        23.77 │        7097.760 │       354.89 │ 2 days, 16:48:00 │  303     0     0   100 │
-│  force_exit │     3 │        -2.28 │          -6.776 │        -0.34 │         17:20:00 │    0     0     3     0 │
-│   stop_loss │   238 │       -13.74 │       -3208.676 │      -160.43 │   1 day, 1:14:00 │    0     0   238     0 │
-│       TOTAL │  8773 │         1.37 │       11886.045 │        594.3 │  1 day, 16:16:00 │ 3657     0  5116  41.7 │
-└─────────────┴───────┴──────────────┴─────────────────┴──────────────┴──────────────────┴────────────────────────┘
-                                                         MIXED TAG STATS
-┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃   Enter Tag ┃ Exit Reason ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃     Avg Duration ┃  Win  Draw  Loss  Win% ┃
-┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-│  enter_long │ exit_signal │   4570 │         2.01 │        9083.885 │       454.19 │  1 day, 22:07:00 │ 1909     0  2661  41.8 │
-│ enter_short │         roi │    303 │        23.77 │        7097.760 │       354.89 │ 2 days, 16:48:00 │  303     0     0   100 │
-│  enter_long │  force_exit │      3 │        -2.28 │          -6.776 │        -0.34 │         17:20:00 │    0     0     3     0 │
-│  enter_long │   stop_loss │     35 │       -26.37 │        -903.045 │       -45.15 │  1 day, 15:53:00 │    0     0    35     0 │
-│ enter_short │ exit_signal │   3659 │         -0.3 │       -1080.148 │       -54.01 │   1 day, 7:56:00 │ 1445     0  2214  39.5 │
-│ enter_short │   stop_loss │    203 │       -11.56 │       -2305.631 │      -115.28 │         22:42:00 │    0     0   203     0 │
-│       TOTAL │             │   8773 │         1.37 │       11886.045 │        594.3 │  1 day, 16:16:00 │ 3657     0  5116  41.7 │
-└─────────────┴─────────────┴────────┴──────────────┴─────────────────┴──────────────┴──────────────────┴────────────────────────┘
-                          SUMMARY METRICS
+                                                 BACKTESTING REPORT                                                  
+┏━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃          Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ LTC/USDT:USDT │     16 │          1.0 │          56.176 │         5.62 │        16:16:00 │   16     0     0   100 │
+│ ETC/USDT:USDT │     12 │         0.72 │          30.936 │         3.09 │         9:55:00 │   11     0     1  91.7 │
+│ ETH/USDT:USDT │      8 │         0.66 │          17.864 │         1.79 │ 1 day, 13:55:00 │    7     0     1  87.5 │
+│ XLM/USDT:USDT │     10 │         0.31 │          11.054 │         1.11 │        12:08:00 │    9     0     1  90.0 │
+│ BTC/USDT:USDT │      8 │         0.21 │           7.289 │         0.73 │ 3 days, 1:24:00 │    6     0     2  75.0 │
+│ XRP/USDT:USDT │      9 │        -0.14 │          -7.261 │        -0.73 │        21:18:00 │    8     0     1  88.9 │
+│ DOT/USDT:USDT │      6 │         -0.4 │          -9.187 │        -0.92 │         5:35:00 │    4     0     2  66.7 │
+│ ADA/USDT:USDT │      8 │        -1.76 │         -52.098 │        -5.21 │        11:38:00 │    6     0     2  75.0 │
+│         TOTAL │     77 │         0.22 │          54.774 │         5.48 │        22:12:00 │   67     0    10  87.0 │
+└───────────────┴────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
+                                               LEFT OPEN TRADES REPORT                                                
+┏━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃          Pair ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃     Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ BTC/USDT:USDT │      1 │        -4.14 │          -9.930 │        -0.99 │ 17 days, 8:00:00 │    0     0     1     0 │
+│ ETC/USDT:USDT │      1 │        -4.24 │         -15.365 │        -1.54 │         10:40:00 │    0     0     1     0 │
+│ DOT/USDT:USDT │      1 │        -5.29 │         -19.125 │        -1.91 │         11:30:00 │    0     0     1     0 │
+│         TOTAL │      3 │        -4.56 │         -44.420 │        -4.44 │  6 days, 2:03:00 │    0     0     3     0 │
+└───────────────┴────────┴──────────────┴─────────────────┴──────────────┴──────────────────┴────────────────────────┘
+                                                ENTER TAG STATS                                                
+┏━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Enter Tag ┃ Entries ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃ Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│     OTHER │      77 │         0.22 │          54.774 │         5.48 │     22:12:00 │   67     0    10  87.0 │
+│     TOTAL │      77 │         0.22 │          54.774 │         5.48 │     22:12:00 │   67     0    10  87.0 │
+└───────────┴─────────┴──────────────┴─────────────────┴──────────────┴──────────────┴────────────────────────┘
+                                                EXIT REASON STATS                                                 
+┏━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Exit Reason ┃ Exits ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│         roi │    67 │         1.05 │         242.179 │        24.22 │        15:49:00 │   67     0     0   100 │
+│ exit_signal │     4 │        -2.23 │         -31.217 │        -3.12 │  1 day, 8:38:00 │    0     0     4     0 │
+│  force_exit │     3 │        -4.56 │         -44.420 │        -4.44 │ 6 days, 2:03:00 │    0     0     3     0 │
+│   stop_loss │     3 │       -10.14 │        -111.768 │       -11.18 │  1 day, 3:05:00 │    0     0     3     0 │
+│       TOTAL │    77 │         0.22 │          54.774 │         5.48 │        22:12:00 │   67     0    10  87.0 │
+└─────────────┴───────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
+                                                        MIXED TAG STATS                                                        
+┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Enter Tag ┃ Exit Reason ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃    Avg Duration ┃  Win  Draw  Loss  Win% ┃
+┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│           │         roi │     67 │         1.05 │         242.179 │        24.22 │        15:49:00 │   67     0     0   100 │
+│           │ exit_signal │      4 │        -2.23 │         -31.217 │        -3.12 │  1 day, 8:38:00 │    0     0     4     0 │
+│           │  force_exit │      3 │        -4.56 │         -44.420 │        -4.44 │ 6 days, 2:03:00 │    0     0     3     0 │
+│           │   stop_loss │      3 │       -10.14 │        -111.768 │       -11.18 │  1 day, 3:05:00 │    0     0     3     0 │
+│     TOTAL │             │     77 │         0.22 │          54.774 │         5.48 │        22:12:00 │   67     0    10  87.0 │
+└───────────┴─────────────┴────────┴──────────────┴─────────────────┴──────────────┴─────────────────┴────────────────────────┘
+                          SUMMARY METRICS                          
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Metric                        ┃ Value                           ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ Backtesting from              │ 2020-01-01 00:00:00             │
-│ Backtesting to                │ 2025-07-31 16:00:00             │
+│ Backtesting from              │ 2025-07-01 00:00:00             │
+│ Backtesting to                │ 2025-08-01 00:00:00             │
 │ Trading Mode                  │ Isolated Futures                │
-│ Max open trades               │ 20                              │
+│ Max open trades               │ 3                               │
 │                               │                                 │
-│ Total/Daily Avg Trades        │ 8773 / 4.3                      │
-│ Starting balance              │ 2000 USDT                       │
-│ Final balance                 │ 13886.045 USDT                  │
-│ Absolute profit               │ 11886.045 USDT                  │
-│ Total profit %                │ 594.30%                         │
-│ CAGR %                        │ 41.49%                          │
-│ Sortino                       │ 28.95                           │
-│ Sharpe                        │ 7.21                            │
-│ Calmar                        │ 92.50                           │
-│ SQN                           │ 8.21                            │
-│ Profit factor                 │ 1.68                            │
-│ Expectancy (Ratio)            │ 1.35 (0.40)                     │
-│ Avg. daily profit             │ 5.832 USDT                      │
-│ Avg. stake amount             │ 98.376 USDT                     │
-│ Total trade volume            │ 2090483.493 USDT                │
+│ Total/Daily Avg Trades        │ 77 / 2.48                       │
+│ Starting balance              │ 1000 USDT                       │
+│ Final balance                 │ 1054.774 USDT                   │
+│ Absolute profit               │ 54.774 USDT                     │
+│ Total profit %                │ 5.48%                           │
+│ CAGR %                        │ 87.36%                          │
+│ Sortino                       │ 2.48                            │
+│ Sharpe                        │ 3.75                            │
+│ Calmar                        │ 40.99                           │
+│ SQN                           │ 0.69                            │
+│ Profit factor                 │ 1.29                            │
+│ Expectancy (Ratio)            │ 0.71 (0.04)                     │
+│ Avg. daily profit             │ 1.767 USDT                      │
+│ Avg. stake amount             │ 345.016 USDT                    │
+│ Total trade volume            │ 53316.954 USDT                  │
 │                               │                                 │
-│ Long / Short trades           │ 4608 / 4165                     │
-│ Long / Short profit %         │ 408.70% / 185.60%               │
-│ Long / Short profit USDT      │ 8174.064 / 3711.981             │
+│ Long / Short trades           │ 67 / 10                         │
+│ Long / Short profit %         │ 8.94% / -3.47%                  │
+│ Long / Short profit USDT      │ 89.425 / -34.651                │
 │                               │                                 │
-│ Best Pair                     │ DOGE/USDT:USDT 72.68%           │
-│ Worst Pair                    │ ALGO/USDT:USDT 5.83%            │
-│ Best trade                    │ DOGE/USDT:USDT 724.62%          │
-│ Worst trade                   │ UNI/USDT:USDT -34.76%           │
-│ Best day                      │ 782.575 USDT                    │
-│ Worst day                     │ -285.862 USDT                   │
-│ Days win/draw/lose            │ 767 / 270 / 1000                │
-│ Min/Max/Avg. Duration Winners │ 0d 00:00 / 23d 16:00 / 2d 14:13 │
-│ Min/Max/Avg. Duration Losers  │ 0d 00:00 / 12d 16:00 / 1d 00:35 │
-│ Max Consecutive Wins / Loss   │ 27 / 37                         │
-│ Rejected Entry signals        │ 0                               │
+│ Best Pair                     │ LTC/USDT:USDT 5.62%             │
+│ Worst Pair                    │ ADA/USDT:USDT -5.21%            │
+│ Best trade                    │ ETC/USDT:USDT 2.00%             │
+│ Worst trade                   │ ADA/USDT:USDT -10.17%           │
+│ Best day                      │ 26.91 USDT                      │
+│ Worst day                     │ -47.741 USDT                    │
+│ Days win/draw/lose            │ 20 / 6 / 5                      │
+│ Min/Max/Avg. Duration Winners │ 0d 00:35 / 5d 18:15 / 0d 15:49  │
+│ Min/Max/Avg. Duration Losers  │ 0d 10:40 / 17d 08:00 / 2d 17:00 │
+│ Max Consecutive Wins / Loss   │ 36 / 3                          │
+│ Rejected Entry signals        │ 258                             │
 │ Entry/Exit Timeouts           │ 0 / 0                           │
 │                               │                                 │
-│ Min balance                   │ 1993.526 USDT                   │
-│ Max balance                   │ 13941.454 USDT                  │
-│ Max % of account underwater   │ 10.17%                          │
-│ Absolute drawdown             │ 516.716 USDT (6.02%)            │
-│ Drawdown duration             │ 40 days 20:00:00                │
-│ Profit at drawdown start      │ 6579.085 USDT                   │
-│ Profit at drawdown end        │ 6062.369 USDT                   │
-│ Drawdown start                │ 2022-08-09 08:00:00             │
-│ Drawdown end                  │ 2022-09-19 04:00:00             │
-│ Market change                 │ 1011.30%                        │
+│ Min balance                   │ 1003.168 USDT                   │
+│ Max balance                   │ 1149.421 USDT                   │
+│ Max % of account underwater   │ 8.23%                           │
+│ Absolute drawdown             │ 94.647 USDT (8.23%)             │
+│ Drawdown duration             │ 9 days 08:50:00                 │
+│ Profit at drawdown start      │ 149.421 USDT                    │
+│ Profit at drawdown end        │ 54.774 USDT                     │
+│ Drawdown start                │ 2025-07-22 15:10:00             │
+│ Drawdown end                  │ 2025-08-01 00:00:00             │
+│ Market change                 │ 30.51%                          │
 └───────────────────────────────┴─────────────────────────────────┘
+
+Backtested 2025-07-01 00:00:00 -> 2025-08-01 00:00:00 | Max open trades : 3
+                                                            STRATEGY SUMMARY                                                            
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
+┃       Strategy ┃ Trades ┃ Avg Profit % ┃ Tot Profit USDT ┃ Tot Profit % ┃ Avg Duration ┃  Win  Draw  Loss  Win% ┃           Drawdown ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
+│ SampleStrategy │     77 │         0.22 │          54.774 │         5.48 │     22:12:00 │   67     0    10  87.0 │ 94.647 USDT  8.23% │
+└────────────────┴────────┴──────────────┴─────────────────┴──────────────┴──────────────┴────────────────────────┴────────────────────┘
 ```
 
 ### Backtesting report table
@@ -288,16 +281,15 @@ The last line will give you the overall performance of your strategy,
 here:
 
 ```
-│          TOTAL │   8773 │         1.37 │       11886.045 │        594.3 │ 1 day, 16:16:00 │ 3657     0  5116  41.7 │
+│         TOTAL │     77 │         0.22 │          54.774 │         5.48 │        22:12:00 │   67     0    10  87.0 │
 ```
 
-The bot has made `8773` trades for an average duration of `1 day, 16:16:00`, with a performance of `594.3%` (profit), that means it has
-earned a total of `11886.045 USDT` starting with a capital of 2000 USDT.
+The bot has made `77` trades for an average duration of `22:12:00`, with a performance of `5.48%` (profit), that means it has earned a total of `54.774 USDT` starting with a capital of 1000 USDT.
 
 The column `Avg Profit %` shows the average profit for all trades made.
 The column `Tot Profit %` shows instead the total profit % in relation to the starting balance.
 
-In the above results, we have a starting balance of 2000 USDT and an absolute profit of 11886.045 USDT - so the `Tot Profit %` will be `(11886.045 / 2000) * 100 ~= 594.3%`.
+In the above results, we have a starting balance of 1000 USDT and an absolute profit of 54.774 USDT - so the `Tot Profit %` will be `(54.774 / 1000) * 100 ~= 5.48%`.
 
 Your strategy performance is influenced by your entry strategy, your exit strategy, and also by the `minimal_roi` and `stop_loss` you have set.
 
@@ -340,54 +332,50 @@ It contains key metrics about the performance of your strategy on backtesting da
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Metric                        ┃ Value                           ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ Backtesting from              │ 2020-01-01 00:00:00             │
-│ Backtesting to                │ 2025-07-31 16:00:00             │
+│ Backtesting from              │ 2025-07-01 00:00:00             │
+│ Backtesting to                │ 2025-08-01 00:00:00             │
 │ Trading Mode                  │ Isolated Futures                │
-│ Max open trades               │ 20                              │
+│ Max open trades               │ 3                               │
 │                               │                                 │
-│ Total/Daily Avg Trades        │ 8773 / 4.3                      │
-│ Starting balance              │ 2000 USDT                       │
-│ Final balance                 │ 13886.045 USDT                  │
-│ Absolute profit               │ 11886.045 USDT                  │
-│ Total profit %                │ 594.30%                         │
-│ CAGR %                        │ 41.49%                          │
-│ Sortino                       │ 28.95                           │
-│ Sharpe                        │ 7.21                            │
-│ Calmar                        │ 92.50                           │
-│ SQN                           │ 8.21                            │
-│ Profit factor                 │ 1.68                            │
-│ Expectancy (Ratio)            │ 1.35 (0.40)                     │
-│ Avg. daily profit             │ 5.832 USDT                      │
-│ Avg. stake amount             │ 98.376 USDT                     │
-│ Total trade volume            │ 2090483.493 USDT                │
+│ Total/Daily Avg Trades        │ 72 / 2.32                       │
+│ Starting balance              │ 1000 USDT                       │
+│ Final balance                 │ 1106.734 USDT                   │
+│ Absolute profit               │ 106.734 USDT                    │
+│ Total profit %                │ 10.67%                          │
+│ CAGR %                        │ 230.04%                         │
+│ Sortino                       │ 4.99                            │
+│ Sharpe                        │ 8.00                            │
+│ Calmar                        │ 77.76                           │
+│ SQN                           │ 1.52                            │
+│ Profit factor                 │ 1.79                            │
+│ Expectancy (Ratio)            │ 1.48 (0.07)                     │
+│ Avg. daily profit             │ 3.443 USDT                      │
+│ Avg. stake amount             │ 363.133 USDT                    │
+│ Total trade volume            │ 52466.174 USDT                  │
 │                               │                                 │
-│ Long / Short trades           │ 4608 / 4165                     │
-│ Long / Short profit %         │ 408.70% / 185.60%               │
-│ Long / Short profit USDT      │ 8174.064 / 3711.981             │
-│                               │                                 │
-│ Best Pair                     │ DOGE/USDT:USDT 72.68%           │
-│ Worst Pair                    │ ALGO/USDT:USDT 5.83%            │
-│ Best trade                    │ DOGE/USDT:USDT 724.62%          │
-│ Worst trade                   │ UNI/USDT:USDT -34.76%           │
-│ Best day                      │ 782.575 USDT                    │
-│ Worst day                     │ -285.862 USDT                   │
-│ Days win/draw/lose            │ 767 / 270 / 1000                │
-│ Min/Max/Avg. Duration Winners │ 0d 00:00 / 23d 16:00 / 2d 14:13 │
-│ Min/Max/Avg. Duration Losers  │ 0d 00:00 / 12d 16:00 / 1d 00:35 │
-│ Max Consecutive Wins / Loss   │ 27 / 37                         │
-│ Rejected Entry signals        │ 0                               │
+│ Best Pair                     │ LTC/USDT:USDT 4.48%             │
+│ Worst Pair                    │ ADA/USDT:USDT -1.78%            │
+│ Best trade                    │ ETC/USDT:USDT 2.00%             │
+│ Worst trade                   │ ADA/USDT:USDT -10.17%           │
+│ Best day                      │ 23.535 USDT                     │
+│ Worst day                     │ -49.813 USDT                    │
+│ Days win/draw/lose            │ 21 / 6 / 4                      │
+│ Min/Max/Avg. Duration Winners │ 0d 00:35 / 5d 18:15 / 0d 15:30  │
+│ Min/Max/Avg. Duration Losers  │ 0d 12:00 / 17d 08:00 / 3d 23:28 │
+│ Max Consecutive Wins / Loss   │ 58 / 4                          │
+│ Rejected Entry signals        │ 254                             │
 │ Entry/Exit Timeouts           │ 0 / 0                           │
 │                               │                                 │
-│ Min balance                   │ 1993.526 USDT                   │
-│ Max balance                   │ 13941.454 USDT                  │
-│ Max % of account underwater   │ 10.17%                          │
-│ Absolute drawdown             │ 516.716 USDT (6.02%)            │
-│ Drawdown duration             │ 40 days 20:00:00                │
-│ Profit at drawdown start      │ 6579.085 USDT                   │
-│ Profit at drawdown end        │ 6062.369 USDT                   │
-│ Drawdown start                │ 2022-08-09 08:00:00             │
-│ Drawdown end                  │ 2022-09-19 04:00:00             │
-│ Market change                 │ 1011.30%                        │
+│ Min balance                   │ 1003.168 USDT                   │
+│ Max balance                   │ 1209 USDT                       │
+│ Max % of account underwater   │ 8.46%                           │
+│ Absolute drawdown             │ 102.266 USDT (8.46%)            │
+│ Drawdown duration             │ 9 days 08:50:00                 │
+│ Profit at drawdown start      │ 209 USDT                        │
+│ Profit at drawdown end        │ 106.734 USDT                    │
+│ Drawdown start                │ 2025-07-22 15:10:00             │
+│ Drawdown end                  │ 2025-08-01 00:00:00             │
+│ Market change                 │ 30.51%                          │
 └───────────────────────────────┴─────────────────────────────────┘
 ```
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -408,6 +408,18 @@ jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace freqtrade/tem
 jupyter nbconvert --ClearOutputPreprocessor.enabled=True --to markdown freqtrade/templates/strategy_analysis_example.ipynb --stdout > docs/strategy_analysis_example.md
 ```
 
+## Backtest documentation results
+
+To generate backtest outputs, please use the following commands:
+
+``` bash
+freqtrade create-userdir --userdir user_data_bttest/
+freqtrade download-data --timerange 20250625-20250801 --config tests/testdata/config.tests.usdt.json --userdir user_data_bttest/ -t 5m
+
+freqtrade backtesting --config tests/testdata/config.tests.usdt.json -s SampleStrategy --userdir user_data_bttest/ --cache none --timerange 20250701-20250801
+```
+
+
 ## Continuous integration
 
 This documents some decisions taken for the CI Pipeline.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -413,7 +413,11 @@ jupyter nbconvert --ClearOutputPreprocessor.enabled=True --to markdown freqtrade
 To generate backtest outputs, please use the following commands:
 
 ``` bash
+# Assume a dedicated user directory for this output
 freqtrade create-userdir --userdir user_data_bttest/
+# set can_short = True
+sed -i "s/can_short: bool = False/can_short: bool = True/" user_data_bttest/strategies/sample_strategy.py
+
 freqtrade download-data --timerange 20250625-20250801 --config tests/testdata/config.tests.usdt.json --userdir user_data_bttest/ -t 5m
 
 freqtrade backtesting --config tests/testdata/config.tests.usdt.json -s SampleStrategy --userdir user_data_bttest/ --cache none --timerange 20250701-20250801

--- a/freqtrade/optimize/optimize_reports/optimize_reports.py
+++ b/freqtrade/optimize/optimize_reports/optimize_reports.py
@@ -627,6 +627,7 @@ def generate_strategy_stats(
         underwater = calculate_max_drawdown(
             results, value_col="profit_abs", starting_balance=start_balance, relative=True
         )
+        drawdown_duration = drawdown.low_date - drawdown.high_date
 
         strat_stats.update(
             {
@@ -637,6 +638,8 @@ def generate_strategy_stats(
                 "drawdown_start_ts": drawdown.high_date.timestamp() * 1000,
                 "drawdown_end": drawdown.low_date.strftime(DATETIME_PRINT_FORMAT),
                 "drawdown_end_ts": drawdown.low_date.timestamp() * 1000,
+                "drawdown_duration": drawdown_duration,
+                "drawdown_duration_s": drawdown_duration.total_seconds(),
                 "max_drawdown_low": drawdown.low_value,
                 "max_drawdown_high": drawdown.high_value,
             }

--- a/tests/testdata/config.tests.usdt.json
+++ b/tests/testdata/config.tests.usdt.json
@@ -1,10 +1,12 @@
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
     "max_open_trades": 3,
-    "stake_currency": "BTC",
-    "stake_amount": 0.05,
+    "stake_currency": "USDT",
+    "stake_amount": "unlimited",
     "tradable_balance_ratio": 0.99,
     "fiat_display_currency": "USD",
+    "trading_mode": "futures",
+    "margin_mode": "isolated",
     "timeframe": "5m",
     "dry_run": true,
     "cancel_open_orders_on_exit": false,
@@ -30,22 +32,22 @@
         "order_book_top": 1
     },
     "exchange": {
-        "name": "gate",
+        "name": "bybit",
         "key": "your_exchange_key",
         "secret": "your_exchange_secret",
         "ccxt_config": {},
         "ccxt_async_config": {},
         "pair_whitelist": [
-            "ETH/BTC",
-            "LTC/BTC",
-            "ETC/BTC",
-            "XLM/BTC",
-            "XRP/BTC",
-            "ADA/BTC",
-            "DOT/BTC"
+            "BTC/USDT:USDT",
+            "ETH/USDT:USDT",
+            "LTC/USDT:USDT",
+            "ETC/USDT:USDT",
+            "XLM/USDT:USDT",
+            "XRP/USDT:USDT",
+            "ADA/USDT:USDT",
+            "DOT/USDT:USDT"
         ],
         "pair_blacklist": [
-            "DOGE/BTC"
         ]
     },
     "pairlists": [


### PR DESCRIPTION
## Summary

 - Compacted Long/Short metrics and renamed them for better readability
 - Combined absolute and percentage drawdown into a single line
 - Added Drawdown duration to drawdown metrics
 - Renamed Drawdown high/low to more descriptive names