### PR TITLE
CI: Bump joblib to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
     strategy:
       matrix:
         os: [ "windows-2022", "windows-2025" ]
-        python-version: ["3.11", "3.12", "3.13.6"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v5

--- a/requirements-freqai.txt
+++ b/requirements-freqai.txt
@@ -4,7 +4,7 @@
 
 # Required for freqai
 scikit-learn==1.7.1
-joblib==1.5.1
+joblib==1.5.2
 catboost==1.2.8; 'arm' not in platform_machine
 lightgbm==4.6.0
 xgboost==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jsonschema==4.25.1
 tabulate==0.9.0
 pycoingecko==3.2.0
 jinja2==3.1.6
-joblib==1.5.1
+joblib==1.5.2
 rich==14.1.0
 pyarrow==21.0.0; platform_machine != 'armv7l' and platform_machine != "aarch64"
 # TODO: downgrade for aarch64 until https://github.com/apache/arrow/issues/47229 is resolved


### PR DESCRIPTION
Pinning to 3.13.6 was a workaround for the loky bug

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
Bump joblib to latest version to fix a regression with 3.13.7
Run CI against 3.13.7 again.