### PR TITLE
Introduced the fetching of funding for all pairs by default.

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2686,6 +2686,19 @@ class Exchange:
                 (pair, timeframe, c_type), copy=False
             )
 
+        if self.trading_mode == TradingMode.FUTURES and self._config.get("runmode") in TRADE_MODES and hasattr(
+                self, 'fetchan_funding_rates'):
+            pair_names = set(pair for pair, _, _ in pair_list)
+
+            # It's important to fetch all at once for performance and avoid rate limiting
+            current_fundings = self.fetch_funding_rates(list(pair_names))
+
+            if current_fundings and results_df:
+                for pair_info, dataframe in results_df.items():
+                    pair_name = pair_info[0]
+                    dataframe.loc[dataframe.index[-1], 'funding_rate'] = current_fundings.get(pair_name, {}).get(
+                        'fundingRate', 0.0)
+
         return results_df
 
     def refresh_ohlcv_with_cache(


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

When I tried to implement funding fetching in my strategy, I haven't found good place to do it. The place that I found was `get_entry_signal`, but it works per pair and I got a lot of errors like `freqtrade.strategy.interface - WARNING - Outdated history for pair METAX/USDT:USDT. Last tick is 18 minutes old`, because the fetching of funding per pair is not so quick task. Also, I got rate limiting errors. 

After the fix of the commit I haven't got any problems during a day in dry-run and successfully used funding indicator in my `populate_indicators` that includes the data of old funding from the @informative too. 

I think, you will move the code to better place and when I started to write test I saw, there is not good general approach to work with funding like that in your tests and probably a few existing tests should be rewritten to move some common parts related to fundings to conftest.py etc. So, I think, that interfaces and test design should be confirmed by you before test implementation of pushed functionality. 
