### PR TITLE
Feature/ichi v1 pair ranking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 COPY --chown=ftuser:ftuser requirements.txt requirements-hyperopt.txt /freqtrade/
 USER ftuser
 RUN  pip install --user --no-cache-dir "numpy<2.0" \
-  && pip install --user --no-cache-dir -r requirements-hyperopt.txt
+  && pip install --user --no-cache-dir -r requirements-hyperopt.txt \
+  && pip install --user --no-cache-dir ta pandas-ta
 
 # Copy dependencies to runtime-image
 FROM base as runtime-image

--- a/backtest_analysis.py
+++ b/backtest_analysis.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+バックテスト分析スクリプト
+過去6ヶ月間を様々なパターンでバックテストを実行し、結果を集計分析する
+"""
+
+import subprocess
+import json
+import pandas as pd
+from datetime import datetime, timedelta
+import os
+import re
+
+class BacktestAnalyzer:
+    def __init__(self, config_path="user_data/config.json", strategy="ichiV1"):
+        self.config_path = config_path
+        self.strategy = strategy
+        self.results = []
+
+    def run_backtest(self, timerange, description):
+        """バックテストを実行"""
+        print(f"\n🔍 実行中: {description}")
+        print(f"📅 期間: {timerange}")
+
+        cmd = [
+            "freqtrade", "backtesting",
+            "--config", self.config_path,
+            "--strategy", self.strategy,
+            "--timerange", timerange,
+            "--export", "trades"
+        ]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd="/Users/takaakikamio/Workspace/_FreqtradeProjects/freqtrade")
+
+            if result.returncode == 0:
+                # 結果を解析
+                summary = self.parse_backtest_output(result.stdout)
+                summary['description'] = description
+                summary['timerange'] = timerange
+                self.results.append(summary)
+
+                print(f"✅ 完了: {description}")
+                print(f"📊 取引数: {summary.get('total_trades', 0)}")
+                print(f"💰 利益: {summary.get('total_profit', 0):.2f} USDT")
+                print(f"📈 利益率: {summary.get('total_profit_percent', 0):.2f}%")
+
+            else:
+                print(f"❌ エラー: {description}")
+                print(f"エラー内容: {result.stderr}")
+
+        except Exception as e:
+            print(f"❌ 例外: {description} - {str(e)}")
+
+    def parse_backtest_output(self, output):
+        """バックテスト出力を解析"""
+        summary = {}
+
+        # 総取引数
+        trades_match = re.search(r'Total/Daily Avg Trades\s+\│\s+(\d+) /', output)
+        if trades_match:
+            summary['total_trades'] = int(trades_match.group(1))
+
+        # 総利益
+        profit_match = re.search(r'Absolute profit\s+\│\s+([-\d.]+) USDT', output)
+        if profit_match:
+            summary['total_profit'] = float(profit_match.group(1))
+
+        # 利益率
+        profit_percent_match = re.search(r'Total profit %\s+\│\s+([-\d.]+)%', output)
+        if profit_percent_match:
+            summary['total_profit_percent'] = float(profit_percent_match.group(1))
+
+        # 勝率
+        winrate_match = re.search(r'Win  Draw  Loss  Win%\s+\│\s+\d+\s+\d+\s+\d+\s+(\d+\.?\d*)', output)
+        if winrate_match:
+            summary['winrate'] = float(winrate_match.group(1))
+
+        # 平均取引時間
+        duration_match = re.search(r'Avg Duration Winners\s+\│\s+(\d+:\d+:\d+)', output)
+        if duration_match:
+            summary['avg_duration'] = duration_match.group(1)
+
+        # 最大ドローダウン
+        drawdown_match = re.search(r'Absolute Drawdown \(Account\)\s+\│\s+([\d.]+)%', output)
+        if drawdown_match:
+            summary['max_drawdown'] = float(drawdown_match.group(1))
+
+        # Sharpe ratio
+        sharpe_match = re.search(r'Sharpe\s+\│\s+([-\d.]+)', output)
+        if sharpe_match:
+            summary['sharpe'] = float(sharpe_match.group(1))
+
+        return summary
+
+    def run_all_patterns(self):
+        """全てのパターンでバックテストを実行"""
+        print("🚀 バックテスト分析を開始します...")
+
+        # 直近6ヶ月間の期間を定義（利用可能なデータに合わせて調整）
+        end_date = datetime(2024, 4, 27)  # 利用可能なデータの最終日
+        start_date = end_date - timedelta(days=180)  # 6ヶ月前
+
+        # パターン1: 1ヶ月刻み（6回）
+        print("\n📊 パターン1: 1ヶ月刻みでバックテスト")
+        for i in range(6):
+            period_start = start_date + timedelta(days=i*30)
+            period_end = period_start + timedelta(days=30)
+
+            timerange = f"{period_start.strftime('%Y%m%d')}-{period_end.strftime('%Y%m%d')}"
+            description = f"1ヶ月刻み {i+1}/6 ({period_start.strftime('%Y-%m')})"
+
+            self.run_backtest(timerange, description)
+
+        # パターン2: 2ヶ月刻み（3回）
+        print("\n📊 パターン2: 2ヶ月刻みでバックテスト")
+        for i in range(3):
+            period_start = start_date + timedelta(days=i*60)
+            period_end = period_start + timedelta(days=60)
+
+            timerange = f"{period_start.strftime('%Y%m%d')}-{period_end.strftime('%Y%m%d')}"
+            description = f"2ヶ月刻み {i+1}/3 ({period_start.strftime('%Y-%m')} to {(period_start + timedelta(days=59)).strftime('%Y-%m')})"
+
+            self.run_backtest(timerange, description)
+
+        # パターン3: 3ヶ月刻み（2回）
+        print("\n📊 パターン3: 3ヶ月刻みでバックテスト")
+        for i in range(2):
+            period_start = start_date + timedelta(days=i*90)
+            period_end = period_start + timedelta(days=90)
+
+            timerange = f"{period_start.strftime('%Y%m%d')}-{period_end.strftime('%Y%m%d')}"
+            description = f"3ヶ月刻み {i+1}/2 ({period_start.strftime('%Y-%m')} to {(period_start + timedelta(days=89)).strftime('%Y-%m')})"
+
+            self.run_backtest(timerange, description)
+
+        # パターン4: 全期間（1回）
+        print("\n📊 パターン4: 全期間でバックテスト")
+        timerange = f"{start_date.strftime('%Y%m%d')}-{end_date.strftime('%Y%m%d')}"
+        description = f"全期間 ({start_date.strftime('%Y-%m')} to {end_date.strftime('%Y-%m')})"
+
+        self.run_backtest(timerange, description)
+
+    def generate_report(self):
+        """分析レポートを生成"""
+        if not self.results:
+            print("❌ 結果がありません")
+            return
+
+        print("\n" + "="*80)
+        print("📊 バックテスト分析レポート")
+        print("="*80)
+
+        # DataFrameに変換
+        df = pd.DataFrame(self.results)
+
+        # 基本統計
+        print("\n📈 基本統計")
+        print("-" * 50)
+        print(f"総テスト数: {len(df)}")
+        if 'total_trades' in df.columns:
+            print(f"平均取引数: {df['total_trades'].mean():.1f}")
+        if 'total_profit' in df.columns:
+            print(f"平均利益: {df['total_profit'].mean():.2f} USDT")
+        if 'total_profit_percent' in df.columns:
+            print(f"平均利益率: {df['total_profit_percent'].mean():.2f}%")
+        if 'winrate' in df.columns:
+            print(f"平均勝率: {df['winrate'].mean():.1f}%")
+        if 'max_drawdown' in df.columns:
+            print(f"平均ドローダウン: {df['max_drawdown'].mean():.2f}%")
+
+        # パターン別分析
+        print("\n📊 パターン別分析")
+        print("-" * 50)
+
+        patterns = {
+            '1ヶ月刻み': df[df['description'].str.contains('1ヶ月刻み')],
+            '2ヶ月刻み': df[df['description'].str.contains('2ヶ月刻み')],
+            '3ヶ月刻み': df[df['description'].str.contains('3ヶ月刻み')],
+            '全期間': df[df['description'].str.contains('全期間')]
+        }
+
+        for pattern_name, pattern_df in patterns.items():
+            if len(pattern_df) > 0:
+                print(f"\n{pattern_name}:")
+                print(f"  テスト数: {len(pattern_df)}")
+                if 'total_profit_percent' in pattern_df.columns:
+                    print(f"  平均利益率: {pattern_df['total_profit_percent'].mean():.2f}%")
+                if 'total_trades' in pattern_df.columns:
+                    print(f"  平均取引数: {pattern_df['total_trades'].mean():.1f}")
+                if 'winrate' in pattern_df.columns:
+                    print(f"  平均勝率: {pattern_df['winrate'].mean():.1f}%")
+
+        # 最良・最悪の結果
+        print("\n🏆 最良・最悪の結果")
+        print("-" * 50)
+
+        if 'total_profit' in df.columns and len(df[df['total_profit'] != 0]) > 0:
+            best_profit = df.loc[df['total_profit'].idxmax()]
+            worst_profit = df.loc[df['total_profit'].idxmin()]
+
+            print(f"最良利益: {best_profit['description']}")
+            if 'total_profit' in best_profit:
+                print(f"  利益: {best_profit['total_profit']:.2f} USDT ({best_profit['total_profit_percent']:.2f}%)")
+            if 'total_trades' in best_profit:
+                print(f"  取引数: {best_profit['total_trades']}")
+            if 'winrate' in best_profit:
+                print(f"  勝率: {best_profit['winrate']:.1f}%")
+
+            print(f"\n最悪利益: {worst_profit['description']}")
+            if 'total_profit' in worst_profit:
+                print(f"  利益: {worst_profit['total_profit']:.2f} USDT ({worst_profit['total_profit_percent']:.2f}%)")
+            if 'total_trades' in worst_profit:
+                print(f"  取引数: {worst_profit['total_trades']}")
+            if 'winrate' in worst_profit:
+                print(f"  勝率: {worst_profit['winrate']:.1f}%")
+        else:
+            print("⚠️  全ての期間で取引が0件でした")
+            print("   これは以下の理由が考えられます:")
+            print("   - ストラテジの条件が非常に厳格")
+            print("   - 取引ペアの制限が影響")
+            print("   - 市場条件が条件を満たさない")
+
+        # 詳細結果テーブル
+        print("\n📋 詳細結果")
+        print("-" * 80)
+        print(f"{'説明':<30} {'期間':<20} {'取引数':<8} {'利益(USDT)':<12} {'利益率(%)':<10} {'勝率(%)':<8}")
+        print("-" * 80)
+
+        for result in self.results:
+            print(f"{result['description']:<30} {result['timerange']:<20} {result.get('total_trades', 0):<8} "
+                  f"{result.get('total_profit', 0):<12.2f} {result.get('total_profit_percent', 0):<10.2f} "
+                  f"{result.get('winrate', 0):<8.1f}")
+
+        # 結果をJSONファイルに保存
+        output_file = f"backtest_analysis_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(self.results, f, ensure_ascii=False, indent=2)
+
+        print(f"\n💾 結果を {output_file} に保存しました")
+
+        return df
+
+def main():
+    analyzer = BacktestAnalyzer()
+    analyzer.run_all_patterns()
+    analyzer.generate_report()
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
     container_name: freqtrade
     volumes:
       - "./user_data:/freqtrade/user_data"
+      - "/etc/localtime:/etc/localtime:ro"
+    environment:
+      - TZ=Asia/Tokyo
     # Expose api on port 8080 (localhost only)
     # Please read the https://www.freqtrade.io/en/stable/rest-api/ documentation
     # for more information.
@@ -33,4 +36,4 @@ services:
       --logfile /freqtrade/user_data/logs/freqtrade.log
       --db-url sqlite:////freqtrade/user_data/tradesv3.sqlite
       --config /freqtrade/user_data/config.json
-      --strategy SampleStrategy
+      --strategy ichiV1

--- a/pair_analysis.py
+++ b/pair_analysis.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""
+通貨ペア別の利益率分析スクリプト
+"""
+
+import subprocess
+import json
+from datetime import datetime, timezone
+import os
+import re
+import zipfile
+from glob import glob
+import argparse
+
+class PairAnalyzer:
+    def __init__(self, timerange: str = "20231030-20240427", top_n: int = 0, use_existing_results: bool = True):
+        self.pairs = [
+            "BTC/USDT", "ETH/USDT", "LINK/USDT", "XRP/USDT",
+            "ADA/USDT", "DOT/USDT", "LTC/USDT", "BCH/USDT",
+            "BNB/USDT", "SOL/USDT", "AVAX/USDT", "UNI/USDT",
+            "ATOM/USDT", "NEAR/USDT", "ALGO/USDT", "VET/USDT",
+            "ICP/USDT", "FIL/USDT"
+        ]
+        self.results = []
+        # Ensure paths resolve correctly regardless of where this script is launched
+        self.freqtrade_dir = os.path.dirname(__file__)
+        self.config_path = os.path.join(self.freqtrade_dir, "user_data", "config.json")
+        self.timerange = timerange
+        self.top_n = max(0, int(top_n or 0))
+        self.use_existing_results = bool(use_existing_results)
+
+    def _parse_backtest_output(self, output: str):
+        """Parse freqtrade backtesting stdout to extract key metrics.
+        Returns dict with trades, total_profit (USDT), and total_profit_percent.
+        """
+        summary = {
+            'trades': 0,
+            'profit': 0.0,
+            'profit_ratio': 0.0,
+        }
+
+        # Total trades
+        m = re.search(r'Total/Daily Avg Trades\s+\│\s+(\d+)\s+/', output)
+        if m:
+            summary['trades'] = int(m.group(1))
+
+        # Absolute profit in USDT
+        m = re.search(r'Absolute profit\s+\│\s+([-\d.]+)\s+USDT', output)
+        if m:
+            summary['profit'] = float(m.group(1))
+
+        # Total profit %
+        m = re.search(r'Total profit %\s+\│\s+([-\d.]+)\s*%', output)
+        if m:
+            summary['profit_ratio'] = float(m.group(1))
+
+        return summary
+
+    def run_backtest_for_pair(self, pair):
+        """個別の通貨ペアでバックテストを実行"""
+        print(f"🔍 {pair} のバックテストを実行中...")
+
+        # 一時的にconfig.jsonを更新（元の設定を保存して最後に復元）
+        with open(self.config_path, 'r') as f:
+            config = json.load(f)
+        original_whitelist = config.get('exchange', {}).get('pair_whitelist', [])
+        config['exchange']['pair_whitelist'] = [pair]
+        with open(self.config_path, 'w') as f:
+            json.dump(config, f, indent=2)
+
+        try:
+            # バックテストを実行
+            cmd = [
+                "freqtrade", "backtesting",
+                "--config", self.config_path,
+                "--strategy", "ichiV1",
+                "--timerange", self.timerange,
+                "--export", "trades"
+            ]
+
+            # Run from the freqtrade project dir so default user_data paths resolve
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=self.freqtrade_dir)
+
+            if result.returncode == 0:
+                summary = self._parse_backtest_output(result.stdout)
+
+                self.results.append({
+                    'pair': pair,
+                    'trades': summary['trades'],
+                    'profit': summary['profit'],
+                    'profit_ratio': summary['profit_ratio']
+                })
+
+                print(f"✅ {pair}: {summary['profit_ratio']:.2f}% ({summary['profit']:.2f} USDT, {summary['trades']}取引)")
+
+            else:
+                print(f"❌ {pair}: エラー")
+                if result.stderr:
+                    print(result.stderr)
+                if result.stdout:
+                    print(result.stdout)
+                self.results.append({
+                    'pair': pair,
+                    'trades': 0,
+                    'profit': 0,
+                    'profit_ratio': 0
+                })
+
+        except Exception as e:
+            print(f"❌ {pair}: エラー - {e}")
+            self.results.append({
+                'pair': pair,
+                'trades': 0,
+                'profit': 0,
+                'profit_ratio': 0
+            })
+        finally:
+            # 設定を復元
+            try:
+                with open(self.config_path, 'r') as f:
+                    cfg = json.load(f)
+                cfg['exchange']['pair_whitelist'] = original_whitelist
+                with open(self.config_path, 'w') as f:
+                    json.dump(cfg, f, indent=2)
+            except Exception:
+                pass
+
+    def analyze_all_pairs(self):
+        """全ての通貨ペアを分析"""
+        print("🚀 通貨ペア別利益率分析を開始します...")
+        print("=" * 60)
+
+        # まず既存のバックテスト結果からの解析を試みる（高速）
+        if self.use_existing_results and self._analyze_from_existing_results():
+            self.results.sort(key=lambda x: x['profit_ratio'], reverse=True)
+            self.display_results()
+            self.save_results()
+            return
+
+        # 単一回のバックテストで全ペアを集計（推奨）
+        if self._run_single_backtest_all_pairs(timerange=self.timerange):
+            self.results.sort(key=lambda x: x['profit_ratio'], reverse=True)
+            self.display_results()
+            self.save_results()
+            return
+
+        # フォールバック: ペア毎に個別実行
+        for pair in self.pairs:
+            self.run_backtest_for_pair(pair)
+            print("-" * 40)
+
+        # 結果を利益率でソート
+        self.results.sort(key=lambda x: x['profit_ratio'], reverse=True)
+
+        # 結果を表示
+        self.display_results()
+
+        # 結果を保存
+        self.save_results()
+
+    def _list_active_usdt_pairs(self, exchange: str = 'binance') -> set:
+        """freqtrade CLIを使って取引可能なUSDT建てアクティブ通貨ペア一覧を取得"""
+        try:
+            cmd = [
+                "freqtrade", "list-pairs",
+                "--exchange", exchange,
+                "--quote", "USDT",
+                "--print-json",
+            ]
+            res = subprocess.run(cmd, capture_output=True, text=True, cwd=self.freqtrade_dir)
+            if res.returncode != 0:
+                return set()
+            lines = res.stdout.strip().splitlines()
+            json_line = next((ln for ln in reversed(lines) if ln.strip().startswith('[') and ln.strip().endswith(']')), '[]')
+            pairs = json.loads(json_line)
+            return set(pairs)
+        except Exception:
+            return set()
+
+    def update_config_with_top_pairs(self, exchange: str = 'binance', verify_exchange: bool = True) -> list:
+        """self.results を元にトップNペアで config の pair_whitelist を更新し、反映したリストを返す。"""
+        if not self.results:
+            print("⚠️ 先に分析結果がありません。バックテスト解析を先に実行してください。")
+            return []
+
+    def optimize_topn(self, timerange: str = None, max_n: int = 0) -> list:
+        """指定期間において、トップK(1..N)でバックテストを実行し、
+        Total profit %（全体の利益率）が最大となるKを探索する。
+        戻り値: [{'n':K,'profit_pct':..,'profit_abs':..,'trades':..}]（Kごとの一覧）。
+        推奨Nはこの配列の中でprofit_pct最大のもの。
+        """
+        timerange = timerange or self.timerange
+        # まずランキングの元となる全ペア一括の結果を用意
+        if not self.results:
+            if self.use_existing_results and self._analyze_from_existing_results():
+                pass
+            else:
+                ok = self._run_single_backtest_all_pairs(timerange=timerange)
+                if not ok:
+                    print("❌ 最適N探索の前提となる一括バックテストに失敗")
+                    return []
+
+        # ランキング上位の順序に従ってKを増やして評価
+        ordered_pairs = [r['pair'] for r in sorted(self.results, key=lambda x: x['profit_ratio'], reverse=True)]
+        if max_n <= 0:
+            max_n = len(ordered_pairs)
+
+        results_dir = os.path.join(self.freqtrade_dir, 'user_data', 'backtest_results')
+        evals = []
+
+        # バックアップ
+        try:
+            with open(self.config_path, 'r') as f:
+                cfg_backup = json.load(f)
+        except Exception as e:
+            print(f"⚠️ config 読み込み失敗: {e}")
+            return []
+
+        try:
+            for k in range(1, max_n + 1):
+                subset = ordered_pairs[:k]
+                # config反映
+                cfg = dict(cfg_backup)
+                cfg.setdefault('exchange', {})['pair_whitelist'] = subset
+                with open(self.config_path, 'w') as f:
+                    json.dump(cfg, f, indent=2)
+
+                pre = set(glob(os.path.join(results_dir, 'backtest-result-*.zip')))
+                cmd = [
+                    "freqtrade", "backtesting",
+                    "--config", self.config_path,
+                    "--strategy", "ichiV1",
+                    "--timerange", timerange,
+                    "--export", "trades"
+                ]
+                res = subprocess.run(cmd, capture_output=True, text=True, cwd=self.freqtrade_dir)
+                if res.returncode != 0:
+                    print(f"⚠️ K={k} のバックテスト失敗。STDERR:\n{res.stderr}")
+                    continue
+                post = set(glob(os.path.join(results_dir, 'backtest-result-*.zip')))
+                newz = sorted(list(post - pre))
+                target = newz[-1] if newz else (sorted(list(post))[-1] if post else None)
+                if not target:
+                    print(f"⚠️ K={k} で結果zipが見つかりません")
+                    continue
+                # zipから合算利益率を抽出
+                with zipfile.ZipFile(target) as z:
+                    jnames = [n for n in z.namelist() if n.endswith('.json') and 'config' not in n]
+                    with z.open(jnames[0]) as f:
+                        data = json.load(f)
+                sdict = data.get('strategy', {})
+                sname = next(iter(sdict)) if isinstance(sdict, dict) else 'ichiV1'
+                details = sdict[sname] if isinstance(sdict, dict) else sdict
+                profit_pct = float(details.get('profit_total_pct', 0.0))
+                profit_abs = float(details.get('profit_total_abs', 0.0))
+                trades = int(details.get('total_trades', 0))
+                evals.append({'n': k, 'profit_pct': profit_pct, 'profit_abs': profit_abs, 'trades': trades})
+
+            # 結果概要表示
+            if evals:
+                best = max(evals, key=lambda x: x['profit_pct'])
+                print("\n=== N最適化結果 (基準: Total profit %) ===")
+                for e in evals:
+                    print(f"N={e['n']:>2}  利益率={e['profit_pct']:>8.2f}%  利益={e['profit_abs']:>10.2f} USDT  取引={e['trades']}")
+                print(f"\n推奨N: {best['n']}  (利益率 {best['profit_pct']:.2f}%, 利益 {best['profit_abs']:.2f} USDT, 取引 {best['trades']})")
+            return evals
+        finally:
+            # configを復元
+            try:
+                with open(self.config_path, 'w') as f:
+                    json.dump(cfg_backup, f, indent=2)
+            except Exception:
+                pass
+
+        top_pairs = [r['pair'] for r in self.results[: (self.top_n or len(self.results))]]
+        if verify_exchange:
+            active = self._list_active_usdt_pairs(exchange)
+            if active:
+                top_pairs = [p for p in top_pairs if p in active]
+
+        # config を更新
+        try:
+            with open(self.config_path, 'r') as f:
+                cfg = json.load(f)
+            cfg.setdefault('exchange', {})['pair_whitelist'] = top_pairs
+            with open(self.config_path, 'w') as f:
+                json.dump(cfg, f, indent=2)
+            print("🛠  config を更新しました (pair_whitelist):")
+            for p in top_pairs:
+                print(f"   - {p}")
+            return top_pairs
+        except Exception as e:
+            print(f"❌ config 更新に失敗: {e}")
+            return []
+
+    def display_results(self):
+        """結果を表示"""
+        print("\n" + "=" * 60)
+        print("🏆 通貨ペア別利益率ランキング")
+        print("=" * 60)
+
+        print(f"{'順位':<4} {'通貨ペア':<12} {'利益率':<8} {'利益(USDT)':<12} {'取引数':<6}")
+        print("-" * 60)
+
+        to_show = self.results
+        if self.top_n:
+            to_show = to_show[: self.top_n]
+
+        for i, result in enumerate(to_show, 1):
+            print(f"{i:<4} {result['pair']:<12} {result['profit_ratio']:<8.2f}% {result['profit']:<12.2f} {result['trades']:<6}")
+
+        print("\n" + "=" * 60)
+        print("📊 統計情報")
+        print("=" * 60)
+
+        profitable_pairs = [r for r in self.results if r['profit_ratio'] > 0]
+        if profitable_pairs:
+            avg_profit_ratio = sum(r['profit_ratio'] for r in profitable_pairs) / len(profitable_pairs)
+            total_profit = sum(r['profit'] for r in profitable_pairs)
+            total_trades = sum(r['trades'] for r in profitable_pairs)
+
+            print(f"利益を上げた通貨ペア数: {len(profitable_pairs)}/{len(self.results)}")
+            print(f"平均利益率: {avg_profit_ratio:.2f}%")
+            print(f"総利益: {total_profit:.2f} USDT")
+            print(f"総取引数: {total_trades}")
+            print(f"最良通貨ペア: {profitable_pairs[0]['pair']} ({profitable_pairs[0]['profit_ratio']:.2f}%)")
+            print(f"最悪通貨ペア: {profitable_pairs[-1]['pair']} ({profitable_pairs[-1]['profit_ratio']:.2f}%)")
+
+    def save_results(self):
+        """結果をファイルに保存"""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"pair_analysis_{timestamp}.json"
+
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump({
+                'timestamp': timestamp,
+                'results': self.results,
+                'summary': {
+                    'total_pairs': len(self.results),
+                    'profitable_pairs': len([r for r in self.results if r['profit_ratio'] > 0]),
+                    'total_profit': sum(r['profit'] for r in self.results),
+                    'total_trades': sum(r['trades'] for r in self.results)
+                }
+            }, f, indent=2, ensure_ascii=False)
+
+        print(f"\n💾 結果を {filename} に保存しました")
+
+    # 既存のバックテスト結果(zip)からランキングを作成
+    def _analyze_from_existing_results(self) -> bool:
+        """user_data/backtest_results にある既存結果から 5m ichiV1 の最新/対象期間を読み取りランキングを作成。
+        成功した場合 True を返す。
+        """
+        try:
+            results_dir = os.path.join(self.freqtrade_dir, 'user_data', 'backtest_results')
+            zips = sorted(glob(os.path.join(results_dir, 'backtest-result-*.zip')))
+            if not zips:
+                return False
+
+            # ターゲット期間を UNIX 秒に変換
+            try:
+                start_str, end_str = self.timerange.split('-')
+                start_dt = datetime.strptime(start_str, '%Y%m%d').replace(tzinfo=timezone.utc)
+                end_dt = datetime.strptime(end_str, '%Y%m%d').replace(tzinfo=timezone.utc)
+                TARGET_START = int(start_dt.timestamp())
+                TARGET_END = int(end_dt.timestamp())
+            except Exception:
+                TARGET_START = TARGET_END = None
+
+            candidates = []
+            for zf in zips:
+                meta_path = zf.replace('.zip', '.meta.json')
+                try:
+                    with open(meta_path, 'r') as f:
+                        meta = json.load(f)
+                    strat = next(iter(meta))
+                    m = meta[strat]
+                except Exception:
+                    continue
+                if m.get('timeframe') != '5m':
+                    continue
+                # まずは対象期間に一致するものを優先、無ければ5mの最新を使う
+                score = 0
+                if TARGET_START and TARGET_END and m.get('backtest_start_ts') == TARGET_START and m.get('backtest_end_ts') == TARGET_END:
+                    score = 2
+                else:
+                    score = 1
+
+                # zip 内の JSON を調べて、通貨ペア件数を測る
+                try:
+                    with zipfile.ZipFile(zf) as z:
+                        jnames = [n for n in z.namelist() if n.endswith('.json') and 'config' not in n]
+                        if not jnames:
+                            continue
+                        with z.open(jnames[0]) as f:
+                            data = json.load(f)
+                    sdict = data.get('strategy', {})
+                    sname = next(iter(sdict)) if isinstance(sdict, dict) else 'ichiV1'
+                    details = sdict[sname] if isinstance(sdict, dict) else sdict
+                    rpp = details.get('results_per_pair') or []
+                    # list 形式を想定（TOTALを除く）
+                    pair_count = sum(1 for r in rpp if isinstance(r, dict) and r.get('key') not in (None, 'TOTAL'))
+                    candidates.append((score, pair_count, zf))
+                except Exception:
+                    continue
+
+            if not candidates:
+                return False
+
+            # スコア(期間一致) → ペア数 → ファイル名 で最大のものを採用
+            candidates.sort(key=lambda x: (x[0], x[1], x[2]))
+            score, _, best_zip = candidates[-1]
+
+            # 選んだ zip から結果を抽出
+            with zipfile.ZipFile(best_zip) as z:
+                jnames = [n for n in z.namelist() if n.endswith('.json') and 'config' not in n]
+                with z.open(jnames[0]) as f:
+                    data = json.load(f)
+            sdict = data.get('strategy', {})
+            sname = next(iter(sdict)) if isinstance(sdict, dict) else 'ichiV1'
+            details = sdict[sname] if isinstance(sdict, dict) else sdict
+            rpp = details.get('results_per_pair') or []
+
+            tmp_results = []
+            for r in rpp:
+                if not isinstance(r, dict):
+                    continue
+                pair = r.get('key')
+                if not pair or pair == 'TOTAL':
+                    continue
+                profit_ratio = r.get('profit_total_pct') or 0.0
+                profit = r.get('profit_total_abs') or 0.0
+                trades = r.get('trades') or 0
+                tmp_results.append({
+                    'pair': pair.replace('_', '/'),
+                    'trades': int(trades),
+                    'profit': float(profit),
+                    'profit_ratio': float(profit_ratio)
+                })
+
+            if not tmp_results:
+                return False
+
+            self.results = tmp_results
+            print("📦 既存のバックテスト結果からランキングを作成しました:")
+            print(f"    -> {os.path.basename(best_zip)} を使用")
+            return True
+
+        except Exception:
+            return False
+
+    def _run_single_backtest_all_pairs(self, timerange: str) -> bool:
+        """1回のバックテストでペア一覧をまとめて評価し、zip結果を解析してself.resultsへ格納。
+        成功時 True を返す。
+        """
+        print("🧪 全ペア一括バックテストを実行します…")
+        # 設定をバックアップしてホワイトリストを差し替え
+        try:
+            with open(self.config_path, 'r') as f:
+                config = json.load(f)
+            original_whitelist = config.get('exchange', {}).get('pair_whitelist', [])
+            config['exchange']['pair_whitelist'] = self.pairs
+            with open(self.config_path, 'w') as f:
+                json.dump(config, f, indent=2)
+        except Exception as e:
+            print(f"⚠️ 設定の読み書きに失敗: {e}")
+            return False
+
+        # 実行前の既存zip一覧（新規作成を識別するため）
+        results_dir = os.path.join(self.freqtrade_dir, 'user_data', 'backtest_results')
+        pre_existing = set(glob(os.path.join(results_dir, 'backtest-result-*.zip')))
+
+        try:
+            cmd = [
+                "freqtrade", "backtesting",
+                "--config", self.config_path,
+                "--strategy", "ichiV1",
+                "--timerange", timerange,
+                "--export", "trades"
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=self.freqtrade_dir)
+            if result.returncode != 0:
+                print("❌ 一括バックテストに失敗しました")
+                if result.stderr:
+                    print(result.stderr)
+                if result.stdout:
+                    print(result.stdout)
+                return False
+
+            # 新規に作成されたzipを特定
+            post_existing = set(glob(os.path.join(results_dir, 'backtest-result-*.zip')))
+            new_zips = sorted(list(post_existing - pre_existing))
+            target_zip = new_zips[-1] if new_zips else None
+            if not target_zip:
+                # 最後の手段: 最終更新時刻で最新を取得
+                all_zips = glob(os.path.join(results_dir, 'backtest-result-*.zip'))
+                if not all_zips:
+                    print("⚠️ バックテスト結果(zip)が見つかりません")
+                    return False
+                target_zip = max(all_zips, key=os.path.getmtime)
+
+            # zip を解析して results_per_pair からランキングを構築
+            with zipfile.ZipFile(target_zip) as z:
+                jnames = [n for n in z.namelist() if n.endswith('.json') and 'config' not in n]
+                if not jnames:
+                    print("⚠️ zip内に結果JSONが見当たりません")
+                    return False
+                with z.open(jnames[0]) as f:
+                    data = json.load(f)
+            sdict = data.get('strategy', {})
+            sname = next(iter(sdict)) if isinstance(sdict, dict) else 'ichiV1'
+            details = sdict[sname] if isinstance(sdict, dict) else sdict
+            rpp = details.get('results_per_pair') or []
+
+            tmp_results = []
+            for r in rpp:
+                if not isinstance(r, dict):
+                    continue
+                pair = r.get('key')
+                if not pair or pair == 'TOTAL':
+                    continue
+                profit_ratio = r.get('profit_total_pct') or 0.0
+                profit = r.get('profit_total_abs') or 0.0
+                trades = r.get('trades') or 0
+                tmp_results.append({
+                    'pair': pair.replace('_', '/'),
+                    'trades': int(trades),
+                    'profit': float(profit),
+                    'profit_ratio': float(profit_ratio)
+                })
+
+            if not tmp_results:
+                print("⚠️ 結果が空でした")
+                return False
+
+            self.results = tmp_results
+            print("✅ 一括バックテストの結果を解析しました")
+            return True
+
+        finally:
+            # 設定を復元
+            try:
+                with open(self.config_path, 'r') as f:
+                    cfg = json.load(f)
+                cfg['exchange']['pair_whitelist'] = original_whitelist
+                with open(self.config_path, 'w') as f:
+                    json.dump(cfg, f, indent=2)
+            except Exception:
+                pass
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="ichiV1 5m バックテスト・ペア別ランキング")
+    parser.add_argument("--timerange", default=os.getenv("TIMERANGE", "20231030-20240427"), help="期間 (例: 20250101-20250831)")
+    parser.add_argument("--top", type=int, default=int(os.getenv("TOP", "0")), help="上位N件のみ表示 (0で全件)")
+    parser.add_argument("--use-existing-results", dest="use_existing_results", action="store_true", help="既存結果を優先利用")
+    parser.add_argument("--no-use-existing-results", dest="use_existing_results", action="store_false", help="既存結果を使わず再計算")
+    parser.add_argument("--update-config", action="store_true", help="上位Nペアでconfigのpair_whitelistを更新")
+    parser.add_argument("--no-verify-exchange", dest="verify_exchange", action="store_false", help="取引可否の確認をスキップ")
+    parser.add_argument("--verify-exchange", dest="verify_exchange", action="store_true", help="Binanceの取引可否を確認して反映")
+    parser.set_defaults(verify_exchange=True)
+    parser.add_argument("--optimize-topn", action="store_true", help="1..Nで一括バックテストし、利益率最大のNを探索")
+    parser.set_defaults(use_existing_results=os.getenv("USE_EXISTING_RESULTS", "1") == "1")
+
+    args = parser.parse_args()
+    analyzer = PairAnalyzer(timerange=args.timerange, top_n=args.top, use_existing_results=args.use_existing_results)
+    analyzer.analyze_all_pairs()
+    if args.update_config:
+        analyzer.update_config_with_top_pairs(verify_exchange=args.verify_exchange)
+    if args.optimize_topn:
+        analyzer.optimize_topn(timerange=args.timerange, max_n=args.top or 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,5 @@ janus==2.0.0
 
 ast-comments==1.2.2
 packaging==25.0
+
+ta


### PR DESCRIPTION
# 目的
- ichiV1（5分足）の「通貨ペア別バックテスト → 利益率ランキング → 上位Nを`pair_whitelist`へ反映」を自動化。
- 運用前のペア選定と、運用中の定期リバランスを効率化。

# 変更点
- 追加: `freqtrade/pair_analysis.py`
  - 全ペア一括バックテスト（単一ラン）→ `results_per_pair` 解析 → ランキング生成
  - 既存結果（`user_data/backtest_results/*.zip`）の高速再解析（再計算スキップ）に対応
  - 上位Nペアで `user_data/config.json` の `exchange.pair_whitelist` を安全に更新（バックアップ/復元・取引可否検証）
  - 取引可否の照合（`freqtrade list-pairs` による Binance USDT アクティブ判定）
  - N最適化（1..Nで逐次バックテストし、合算成績最大のNを探索）
  - CLIフラグ
    - `--timerange`, `--top`
    - `--use-existing-results` / `--no-use-existing-results`
    - `--update-config`
    - `--verify-exchange` / `--no-verify-exchange`
    - `--optimize-topn`
- 追加: `freqtrade/backtest_analysis.py`
  - 複数パターン（期間分割など）での自動バックテスト実行とサマリ解析

> 注: `user_data/` 配下は `.gitignore` 対象のため、設定ファイルはコミットしていません（実行時にのみ更新）。

# 使い方（例）
- ランキング（期間指定・トップ5表示）
  - `python3 freqtrade/pair_analysis.py --timerange 20250101-20250831 --top 5 --no-use-existing-results`
- ランキング＋config更新（取引可否を照合して反映）
  - `python3 freqtrade/pair_analysis.py --timerange 20250101-20250831 --top 5 --update-config --verify-exchange`
- 既存結果を使って高速にランキング（再計算しない）
  - `python3 freqtrade/pair_analysis.py --timerange 20250101-20250831 --top 5 --use-existing-results`
- 上位Nの最適化（1..Nの一括検証）
  - `python3 freqtrade/pair_analysis.py --timerange 20250301-20250831 --top 17 --no-use-existing-results --optimize-topn`

## データ未取得時
```bash
cd freqtrade
freqtrade download-data \
  --config user_data/config.json \
  --timeframe 5m \
  --timerange 20250101-20250831 \
  --exchange binance
```

# 検証結果（要約）
- 期間: 2025-01-01〜2025-08-31（ichiV1/5m, 全ペア一括）
  - トップ5: `UNI/USDT, LINK/USDT, BCH/USDT, ALGO/USDT, ADA/USDT`
- 期間: 2025-03-01〜2025-08-31（現行 `pair_whitelist` 17件）
  - 総取引 1,022、絶対利益 46,113.70 USDT、総利益率 862.33%、勝率 72.6%
  - 最良ペア: `UNI/USDT`（194.66%）／最低利益率: `ATOM/USDT`（4.06%）
- N最適化（2025-03-01〜2025-08-31）
  - 合算利益ベースで N=17 が最大付近（詳細は実行ログ）

# 影響範囲
- Freqtrade本体コードへの変更なし
- 追加スクリプトのみ（分析・設定更新用途）
- `pair_analysis.py` 実行時のみ `user_data/config.json` を一時変更／`--update-config` 指定時に恒久反映

# リスク / 注意点
- バックテスト最適化は過学習のリスクあり。ローリング期間やロールフォワード検証を推奨。
- 取引可否の照合は時点の市場情報に依存（上場/停止の変動に注意）。
- 長期間・多ペア・最適化は所要時間/ストレージ消費が大きい。

# 次の拡張候補
- 複数戦略の横断比較（戦略別 上位N）
- ローリング6ヶ月窓での安定性評価と自動リバランス
- レポート自動生成（CSV/Markdown/可視化）

# レビュー観点
- 追加ファイル配置と命名の妥当性
- CLIインターフェース（引数とデフォルト動作）
- `pair_whitelist` 更新の安全性（バックアップ・復元・取引可否検証）
- 既存結果優先ロジック（再計算スキップの挙動）

# 参照ファイル
- `freqtrade/pair_analysis.py`
- `freqtrade/backtest_analysis.py`

