### PR TITLE
Fix ShuffleFilter behavior in backtesting

### DIFF
--- a/docs/commands/backtesting.md
+++ b/docs/commands/backtesting.md
@@ -49,7 +49,7 @@ options:
                         backtesting down by a considerable amount, but will
                         include configured protections
   --enable-dynamic-pairlist
-                        Enables dynamic pairlisting in backtesting. The
+                        Enables dynamic pairlist refreshes in backtesting. The
                         pairlist will be generated for each new candle if
                         you're using a pairlist handler that supports this
                         feature, for example, ShuffleFilter.

--- a/docs/commands/backtesting.md
+++ b/docs/commands/backtesting.md
@@ -10,6 +10,7 @@ usage: freqtrade backtesting [-h] [-v] [--no-color] [--logfile FILE] [-V]
                              [--stake-amount STAKE_AMOUNT] [--fee FLOAT]
                              [-p PAIRS [PAIRS ...]] [--eps]
                              [--enable-protections]
+                             [--enable-dynamic-pairlist]
                              [--dry-run-wallet DRY_RUN_WALLET]
                              [--timeframe-detail TIMEFRAME_DETAIL]
                              [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
@@ -44,9 +45,14 @@ options:
                         Allow buying the same pair multiple times (position
                         stacking).
   --enable-protections, --enableprotections
-                        Enable protections for backtesting.Will slow
+                        Enable protections for backtesting. Will slow
                         backtesting down by a considerable amount, but will
                         include configured protections
+  --enable-dynamic-pairlist
+                        Enables dynamic pairlisting in backtesting. The
+                        pairlist will be generated for each new candle if
+                        you're using a pairlist handler that supports this
+                        feature, for example, ShuffleFilter.
   --dry-run-wallet DRY_RUN_WALLET, --starting-balance DRY_RUN_WALLET
                         Starting balance, used for backtesting / hyperopt and
                         dry-runs.

--- a/docs/commands/hyperopt.md
+++ b/docs/commands/hyperopt.md
@@ -44,7 +44,7 @@ options:
                         Allow buying the same pair multiple times (position
                         stacking).
   --enable-protections, --enableprotections
-                        Enable protections for backtesting.Will slow
+                        Enable protections for backtesting. Will slow
                         backtesting down by a considerable amount, but will
                         include configured protections
   --dry-run-wallet DRY_RUN_WALLET, --starting-balance DRY_RUN_WALLET

--- a/docs/commands/lookahead-analysis.md
+++ b/docs/commands/lookahead-analysis.md
@@ -48,7 +48,7 @@ options:
                         backtesting down by a considerable amount, but will
                         include configured protections
   --enable-dynamic-pairlist
-                        Enables dynamic pairlisting in backtesting. The
+                        Enables dynamic pairlist refreshes in backtesting. The
                         pairlist will be generated for each new candle if
                         you're using a pairlist handler that supports this
                         feature, for example, ShuffleFilter.

--- a/docs/commands/lookahead-analysis.md
+++ b/docs/commands/lookahead-analysis.md
@@ -11,6 +11,7 @@ usage: freqtrade lookahead-analysis [-h] [-v] [--no-color] [--logfile FILE]
                                     [--stake-amount STAKE_AMOUNT]
                                     [--fee FLOAT] [-p PAIRS [PAIRS ...]]
                                     [--enable-protections]
+                                    [--enable-dynamic-pairlist]
                                     [--dry-run-wallet DRY_RUN_WALLET]
                                     [--timeframe-detail TIMEFRAME_DETAIL]
                                     [--strategy-list STRATEGY_LIST [STRATEGY_LIST ...]]
@@ -43,9 +44,14 @@ options:
                         Limit command to these pairs. Pairs are space-
                         separated.
   --enable-protections, --enableprotections
-                        Enable protections for backtesting.Will slow
+                        Enable protections for backtesting. Will slow
                         backtesting down by a considerable amount, but will
                         include configured protections
+  --enable-dynamic-pairlist
+                        Enables dynamic pairlisting in backtesting. The
+                        pairlist will be generated for each new candle if
+                        you're using a pairlist handler that supports this
+                        feature, for example, ShuffleFilter.
   --dry-run-wallet DRY_RUN_WALLET, --starting-balance DRY_RUN_WALLET
                         Starting balance, used for backtesting / hyperopt and
                         dry-runs.

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -49,6 +49,7 @@ ARGS_BACKTEST = [
     *ARGS_COMMON_OPTIMIZE,
     "position_stacking",
     "enable_protections",
+    "enable_dynamic_pairlist",
     "dry_run_wallet",
     "timeframe_detail",
     "strategy_list",

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -184,9 +184,17 @@ AVAILABLE_CLI_OPTIONS = {
     "enable_protections": Arg(
         "--enable-protections",
         "--enableprotections",
-        help="Enable protections for backtesting."
+        help="Enable protections for backtesting. "
         "Will slow backtesting down by a considerable amount, but will include "
         "configured protections",
+        action="store_true",
+        default=False,
+    ),
+    "enable_dynamic_pairlist": Arg(
+        "--enable-dynamic-pairlist",
+        help="Enables dynamic pairlisting in backtesting. "
+        "The pairlist will be generated for each new candle if you're using a "
+        "pairlist handler that supports this feature, for example, ShuffleFilter.",
         action="store_true",
         default=False,
     ),

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -192,7 +192,7 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "enable_dynamic_pairlist": Arg(
         "--enable-dynamic-pairlist",
-        help="Enables dynamic pairlisting in backtesting. "
+        help="Enables dynamic pairlist refreshes in backtesting. "
         "The pairlist will be generated for each new candle if you're using a "
         "pairlist handler that supports this feature, for example, ShuffleFilter.",
         action="store_true",

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -256,7 +256,13 @@ class Configuration:
         self._args_to_config(
             config,
             argname="enable_protections",
-            logstring="Parameter --enable-protections detected, enabling Protections. ...",
+            logstring="Parameter --enable-protections detected, enabling Protections ...",
+        )
+
+        self._args_to_config(
+            config,
+            argname="enable_dynamic_pairlist",
+            logstring="Parameter --enable-dynamic-pairlist detected, enabling dynamic pairlist ...",
         )
 
         if self.args.get("max_open_trades"):

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -173,7 +173,7 @@ class Backtesting:
         self.disable_database_use()
         self.init_backtest_detail()
         self.pairlists = PairListManager(self.exchange, self.config, self.dataprovider)
-        self.dinamic_pairlist = False
+        self.dynamic_pairlist = False
         self._validate_pairlists_for_backtesting()
 
         self.dataprovider.add_pairlisthandler(self.pairlists)
@@ -228,7 +228,7 @@ class Backtesting:
             )
 
         if "ShuffleFilter" in self.pairlists.name_list:
-            self.dinamic_pairlist = True
+            self.dynamic_pairlist = True
 
     def log_once(self, msg: str) -> None:
         """
@@ -1587,7 +1587,7 @@ class Backtesting:
             # Loop for each main candle.
             self.check_abort()
 
-            if self.dinamic_pairlist:
+            if self.dynamic_pairlist:
                 self.pairlists.refresh_pairlist()
                 pairs = self.pairlists.whitelist
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1587,7 +1587,7 @@ class Backtesting:
             # Loop for each main candle.
             self.check_abort()
 
-            if self.dynamic_pairlist:
+            if self.dynamic_pairlist and self.pairlists:
                 self.pairlists.refresh_pairlist()
                 pairs = self.pairlists.whitelist
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -173,7 +173,6 @@ class Backtesting:
         self.disable_database_use()
         self.init_backtest_detail()
         self.pairlists = PairListManager(self.exchange, self.config, self.dataprovider)
-        self.dynamic_pairlist = False
         self._validate_pairlists_for_backtesting()
 
         self.dataprovider.add_pairlisthandler(self.pairlists)
@@ -212,6 +211,7 @@ class Backtesting:
         self._can_short = self.trading_mode != TradingMode.SPOT
         self._position_stacking: bool = self.config.get("position_stacking", False)
         self.enable_protections: bool = self.config.get("enable_protections", False)
+        self.dynamic_pairlist: bool = self.config.get("enable_dynamic_pairlist", False)
         migrate_data(config, self.exchange)
 
         self.init_backtest()
@@ -226,9 +226,6 @@ class Backtesting:
             raise OperationalException(
                 "PrecisionFilter not allowed for backtesting multiple strategies."
             )
-
-        if "ShuffleFilter" in self.pairlists.name_list:
-            self.dynamic_pairlist = True
 
     def log_once(self, msg: str) -> None:
         """

--- a/freqtrade/plugins/pairlist/ShuffleFilter.py
+++ b/freqtrade/plugins/pairlist/ShuffleFilter.py
@@ -93,6 +93,8 @@ class ShuffleFilter(IPairList):
             return pairlist_new
         # Shuffle is done inplace
         self._random.shuffle(pairlist)
-        self.__pairlist_cache[pairlist_bef] = pairlist
+
+        if self._config.get("runmode") in (RunMode.LIVE, RunMode.DRY_RUN):
+            self.__pairlist_cache[pairlist_bef] = pairlist
 
         return pairlist

--- a/freqtrade/plugins/pairlist/StaticPairList.py
+++ b/freqtrade/plugins/pairlist/StaticPairList.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 
 from cachetools import LRUCache
 
-from freqtrade.enums.runmode import RunMode
+from freqtrade.enums import RunMode
 from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 
@@ -25,7 +25,8 @@ class StaticPairList(IPairList):
         super().__init__(*args, **kwargs)
 
         self._allow_inactive = self._pairlistconfig.get("allow_inactive", False)
-        self._pair_cache: LRUCache = LRUCache(maxsize=1)
+        # Pair cache - only used for optimize modes
+        self._bt_pair_cache: LRUCache = LRUCache(maxsize=1)
 
     @property
     def needstickers(self) -> bool:
@@ -64,7 +65,7 @@ class StaticPairList(IPairList):
         :param tickers: Tickers (from exchange.get_tickers). May be cached.
         :return: List of pairs
         """
-        pairlist = self._pair_cache.get("pairlist")
+        pairlist = self._bt_pair_cache.get("pairlist")
 
         if not pairlist:
             wl = self.verify_whitelist(
@@ -78,7 +79,7 @@ class StaticPairList(IPairList):
                 pairlist = self._whitelist_for_active_markets(wl)
 
             if self._config["runmode"] in (RunMode.BACKTEST, RunMode.HYPEROPT):
-                self._pair_cache["pairlist"] = pairlist.copy()
+                self._bt_pair_cache["pairlist"] = pairlist.copy()
 
         return pairlist
 

--- a/freqtrade/plugins/pairlist/StaticPairList.py
+++ b/freqtrade/plugins/pairlist/StaticPairList.py
@@ -7,6 +7,9 @@ Provides pair white list as it configured in config
 import logging
 from copy import deepcopy
 
+from cachetools import LRUCache
+
+from freqtrade.enums.runmode import RunMode
 from freqtrade.exchange.exchange_types import Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 
@@ -22,6 +25,7 @@ class StaticPairList(IPairList):
         super().__init__(*args, **kwargs)
 
         self._allow_inactive = self._pairlistconfig.get("allow_inactive", False)
+        self._pair_cache: LRUCache = LRUCache(maxsize=1)
 
     @property
     def needstickers(self) -> bool:
@@ -60,15 +64,23 @@ class StaticPairList(IPairList):
         :param tickers: Tickers (from exchange.get_tickers). May be cached.
         :return: List of pairs
         """
-        wl = self.verify_whitelist(
-            self._config["exchange"]["pair_whitelist"], logger.info, keep_invalid=True
-        )
-        if self._allow_inactive:
-            return wl
-        else:
-            # Avoid implicit filtering of "verify_whitelist" to keep
-            # proper warnings in the log
-            return self._whitelist_for_active_markets(wl)
+        pairlist = self._pair_cache.get("pairlist")
+
+        if not pairlist:
+            wl = self.verify_whitelist(
+                self._config["exchange"]["pair_whitelist"], logger.info, keep_invalid=True
+            )
+            if self._allow_inactive:
+                pairlist = wl
+            else:
+                # Avoid implicit filtering of "verify_whitelist" to keep
+                # proper warnings in the log
+                pairlist = self._whitelist_for_active_markets(wl)
+
+            if self._config["runmode"] in (RunMode.BACKTEST, RunMode.HYPEROPT):
+                self._pair_cache["pairlist"] = pairlist.copy()
+
+        return pairlist
 
     def filter_pairlist(self, pairlist: list[str], tickers: Tickers) -> list[str]:
         """

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -157,16 +157,17 @@ class PairListManager(LoggingMixin):
         :param logmethod: Function that'll be called, `logger.info` or `logger.warning`.
         :return: pairlist - blacklisted pairs
         """
-        try:
-            blacklist = self.expanded_blacklist
-        except ValueError as err:
-            logger.error(f"Pair blacklist contains an invalid Wildcard: {err}")
-            return []
-        log_once = partial(self.log_once, logmethod=logmethod)
-        for pair in pairlist.copy():
-            if pair in blacklist:
-                log_once(f"Pair {pair} in your blacklist. Removing it from whitelist...")
-                pairlist.remove(pair)
+        if self._blacklist:
+            try:
+                blacklist = self.expanded_blacklist
+            except ValueError as err:
+                logger.error(f"Pair blacklist contains an invalid Wildcard: {err}")
+                return []
+            log_once = partial(self.log_once, logmethod=logmethod)
+            for pair in pairlist.copy():
+                if pair in blacklist:
+                    log_once(f"Pair {pair} in your blacklist. Removing it from whitelist...")
+                    pairlist.remove(pair)
         return pairlist
 
     def verify_whitelist(

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -5,7 +5,7 @@ PairList manager class
 import logging
 from functools import partial
 
-from cachetools import TTLCache, cached
+from cachetools import LRUCache, TTLCache, cached
 
 from freqtrade.constants import Config, ListPairsWithTimeframes
 from freqtrade.data.dataprovider import DataProvider
@@ -56,6 +56,7 @@ class PairListManager(LoggingMixin):
             )
 
         self._check_backtest()
+        self._not_expiring_cache: LRUCache = LRUCache(maxsize=1)
 
         refresh_period = config.get("pairlist_refresh_period", 3600)
         LoggingMixin.__init__(self, logger, refresh_period)
@@ -109,7 +110,15 @@ class PairListManager(LoggingMixin):
     @property
     def expanded_blacklist(self) -> list[str]:
         """The expanded blacklist (including wildcard expansion)"""
-        return expand_pairlist(self._blacklist, self._exchange.get_markets().keys())
+        eblacklist = self._not_expiring_cache.get("eblacklist")
+
+        if not eblacklist:
+            eblacklist = expand_pairlist(self._blacklist, self._exchange.get_markets().keys())
+
+            if self._config["runmode"] in (RunMode.BACKTEST, RunMode.HYPEROPT):
+                self._not_expiring_cache["eblacklist"] = eblacklist.copy()
+
+        return eblacklist
 
     @property
     def name_list(self) -> list[str]:

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -27,7 +27,7 @@ from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename, 
 from freqtrade.optimize.backtesting import Backtesting
 from freqtrade.persistence import LocalTrade, Trade
 from freqtrade.resolvers import StrategyResolver
-from freqtrade.util.datetime_helpers import dt_utc
+from freqtrade.util import dt_now, dt_utc
 from tests.conftest import (
     CURRENT_TEST_STRATEGY,
     EXMS,
@@ -2720,9 +2720,10 @@ def test_get_backtest_metadata_filename():
 @pytest.mark.parametrize("dynamic_pairlist", [True, False])
 def test_time_pair_generator_refresh_pairlist(mocker, default_conf, dynamic_pairlist):
     patch_exchange(mocker)
+    default_conf["enable_dynamic_pairlist"] = dynamic_pairlist
     backtesting = Backtesting(default_conf)
     backtesting._set_strategy(backtesting.strategylist[0])
-    backtesting.dynamic_pairlist = dynamic_pairlist
+    assert backtesting.dynamic_pairlist == dynamic_pairlist
 
     refresh_mock = mocker.patch(
         "freqtrade.plugins.pairlistmanager.PairListManager.refresh_pairlist"
@@ -2746,16 +2747,17 @@ def test_time_pair_generator_refresh_pairlist(mocker, default_conf, dynamic_pair
 @pytest.mark.parametrize("dynamic_pairlist", [True, False])
 def test_time_pair_generator_open_trades_first(mocker, default_conf, dynamic_pairlist):
     patch_exchange(mocker)
+    default_conf["enable_dynamic_pairlist"] = dynamic_pairlist
     backtesting = Backtesting(default_conf)
     backtesting._set_strategy(backtesting.strategylist[0])
-    backtesting.dynamic_pairlist = dynamic_pairlist
+    assert backtesting.dynamic_pairlist == dynamic_pairlist
 
     pairs = ["XRP/BTC", "LTC/BTC", "NEO/BTC", "ETH/BTC"]
 
     # Simulate open trades
     trades = [
-        LocalTrade(pair="XRP/BTC", open_date=datetime.now(tz=UTC), amount=1, open_rate=1),
-        LocalTrade(pair="NEO/BTC", open_date=datetime.now(tz=UTC), amount=1, open_rate=1),
+        LocalTrade(pair="XRP/BTC", open_date=dt_now(), amount=1, open_rate=1),
+        LocalTrade(pair="NEO/BTC", open_date=dt_now(), amount=1, open_rate=1),
     ]
     LocalTrade.bt_trades_open = trades
     LocalTrade.bt_trades_open_pp = {


### PR DESCRIPTION
## What's new?

Added the ability to use a dynamic pairlist in backtesting by setting self.dynamic_pairlist to True. 
This allows ShuffleFilter to randomize the pair list on each new candle, which is the expected behavior. 
Using this will significantly increase backtest execution time, but I think this is also expected when using a dynamic pairlist.
