### PR TITLE
feat(exchange): add Coinmate exchange support

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -11,6 +11,7 @@ from freqtrade.exchange.bitmart import Bitmart
 from freqtrade.exchange.bitpanda import Bitpanda
 from freqtrade.exchange.bitvavo import Bitvavo
 from freqtrade.exchange.bybit import Bybit
+from freqtrade.exchange.coinmate import Coinmate
 from freqtrade.exchange.cryptocom import Cryptocom
 from freqtrade.exchange.exchange_utils import (
     ROUND_DOWN,

--- a/freqtrade/exchange/coinmate.py
+++ b/freqtrade/exchange/coinmate.py
@@ -1,0 +1,121 @@
+"""Coinmate exchange subclass"""
+
+import logging
+from typing import Dict
+
+from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+logger = logging.getLogger(__name__)
+
+
+class Coinmate(Exchange):
+    """
+    Coinmate exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+    
+    Coinmate is a Czech cryptocurrency exchange supporting spot trading only.
+    Rate limit: 100 requests/minute.
+    """
+
+    _ft_has: FtHas = {
+        # Core trading features
+        "stoploss_on_exchange": False,  # No stop-loss support on exchange
+        "order_time_in_force": ["GTC"],  # Good Till Cancelled only
+        "trades_pagination": "id",
+        "trades_pagination_arg": "fromId",
+        "trades_has_history": True,
+        
+        # Order book features  
+        "l2_limit_range": [1, 10, 50, 100],  # Supported order book depths
+        "l2_limit_range_required": False,
+        
+        # Market data features
+        "ohlcv_candle_limit": None,  # No OHLCV support
+        "ohlcv_has_history": False,
+        
+        # Rate limiting
+        "ccxt_futures_name": "swap",  # Required by base class
+    }
+
+    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
+        # Coinmate only supports spot trading
+        (TradingMode.SPOT, MarginMode.NONE),
+    ]
+
+    @property
+    def _ccxt_config(self) -> Dict:
+        """Configure CCXT parameters for Coinmate"""
+        config = super()._ccxt_config
+        config.update({
+            "uid": self._api_key_headers.get("uid", ""),
+            "rateLimit": 600,  # 100 requests/minute
+            "enableRateLimit": True,
+            "options": {
+                "adjustForTimeDifference": True,
+                "recvWindow": 10000,
+            }
+        })
+        return config
+
+    def validate_ordertypes(self, order_types: Dict) -> None:
+        """Validate order types for Coinmate. Supports market and limit orders."""
+        super().validate_ordertypes(order_types)
+        
+        # Coinmate supports both market and limit orders
+        valid_order_types = ['market', 'limit']
+        
+        for order_type in ['entry', 'exit']:
+            if order_types.get(order_type) not in valid_order_types:
+                raise OperationalException(
+                    f"Coinmate only supports 'market' and 'limit' orders for {order_type}. "
+                    f"Got: {order_types.get(order_type)}"
+                )
+        
+        # Stoploss orders are not supported on exchange
+        if order_types.get("stoploss_on_exchange"):
+            raise OperationalException(
+                "Coinmate does not support stoploss orders on exchange. "
+                "Please set 'stoploss_on_exchange': false in your configuration."
+            )
+
+    def validate_trading_mode_and_margin_mode(
+        self, 
+        trading_mode: TradingMode, 
+        margin_mode: MarginMode
+    ) -> None:
+        """Validate trading mode and margin mode. Only spot trading supported."""
+        if trading_mode != TradingMode.SPOT:
+            raise OperationalException(
+                f"Trading mode '{trading_mode.value}' is not supported by Coinmate. "
+                "Only spot trading is available."
+            )
+        
+        if margin_mode != MarginMode.NONE:
+            raise OperationalException(
+                f"Margin mode '{margin_mode.value}' is not supported by Coinmate. "
+                "Only 'none' margin mode is available for spot trading."
+            )
+
+    def validate_config(self, config) -> None:
+        """Validate Coinmate configuration. UID is required."""
+        super().validate_config(config)
+        
+        # Coinmate requires UID for authentication
+        exchange_config = config.get('exchange', {})
+        if not exchange_config.get('uid'):
+            raise OperationalException(
+                "Coinmate requires 'uid' parameter in exchange configuration."
+            )
+
+    def get_fee(self, symbol: str, type: str = '', side: str = '', amount: float = 1,
+                price: float = 1, taker_or_maker: str = 'maker') -> float:
+        """Get trading fee for Coinmate. Falls back to 0.35% if API unavailable."""
+        try:
+            return super().get_fee(symbol, type, side, amount, price, taker_or_maker)
+        except Exception:
+            # Fallback to default Coinmate fees if not available from API
+            # Coinmate standard fees: 0.35% maker, 0.35% taker
+            return 0.0035

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -58,6 +58,7 @@ SUPPORTED_EXCHANGES = [
     "bingx",
     "bitmart",
     "bybit",
+    "coinmate",
     "gate",
     "htx",
     "hyperliquid",

--- a/tests/exchange/test_coinmate.py
+++ b/tests/exchange/test_coinmate.py
@@ -1,0 +1,164 @@
+import pytest
+from unittest.mock import MagicMock
+
+from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange import Coinmate
+from tests.conftest import get_patched_exchange
+
+
+def test_coinmate_exchange_initialization(default_conf, mocker):
+    """Test that Coinmate exchange initializes correctly"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    assert isinstance(exchange, Coinmate)
+    assert exchange.name == "Coinmate"
+    assert exchange.id == "coinmate"
+    
+
+def test_coinmate_supported_features(default_conf, mocker):
+    """Test that Coinmate reports correct supported features"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Features that should be supported per requirements
+    assert exchange.exchange_has("fetchOrder")
+    assert exchange.exchange_has("fetchOpenOrders")
+    assert exchange.exchange_has("fetchMyTrades")
+    assert exchange.exchange_has("cancelOrder")
+    assert exchange.exchange_has("createOrder")
+    assert exchange.exchange_has("fetchBalance")
+    assert exchange.exchange_has("fetchTicker")
+    assert exchange.exchange_has("fetchOrderBook")
+    assert exchange.exchange_has("fetchTrades")
+    assert exchange.exchange_has("fetchMarkets")
+    
+    # Features that are not supported
+    assert not exchange.exchange_has("fetchOHLCV")
+    assert not exchange._ft_has["stoploss_on_exchange"]
+
+
+def test_coinmate_trading_mode_spot_only(default_conf, mocker):
+    """Test that only spot trading is supported"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    supported_modes = exchange._supported_trading_mode_margin_pairs
+    assert len(supported_modes) == 1
+    assert supported_modes[0] == (TradingMode.SPOT, MarginMode.NONE)
+
+
+def test_coinmate_validate_trading_mode_spot_valid(default_conf, mocker):
+    """Test that spot trading mode validation passes"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Should not raise exception
+    exchange.validate_trading_mode_and_margin_mode(TradingMode.SPOT, MarginMode.NONE)
+
+
+def test_coinmate_validate_trading_mode_futures_invalid(default_conf, mocker):
+    """Test that futures trading mode is rejected"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    with pytest.raises(OperationalException, match="Trading mode 'futures' is not supported"):
+        exchange.validate_trading_mode_and_margin_mode(TradingMode.FUTURES, MarginMode.ISOLATED)
+
+
+def test_coinmate_validate_ordertypes_valid(default_conf, mocker):
+    """Test that valid order types are accepted"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Should not raise exception for market orders
+    order_types = {"entry": "market", "exit": "market", "stoploss": "market", "stoploss_on_exchange": False}
+    exchange.validate_ordertypes(order_types)
+    
+    # Should not raise exception for limit orders
+    order_types = {"entry": "limit", "exit": "limit", "stoploss": "limit", "stoploss_on_exchange": False}
+    exchange.validate_ordertypes(order_types)
+
+
+def test_coinmate_validate_ordertypes_invalid(default_conf, mocker):
+    """Test that invalid order types are rejected"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Should reject unsupported order types
+    order_types = {"entry": "stop", "exit": "market"}
+    with pytest.raises(OperationalException, match="Coinmate only supports 'market' and 'limit' orders"):
+        exchange.validate_ordertypes(order_types)
+
+
+def test_coinmate_validate_stoploss_on_exchange_rejected(default_conf, mocker):
+    """Test that stoploss on exchange is rejected"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    order_types = {"entry": "market", "exit": "market", "stoploss_on_exchange": True}
+    with pytest.raises(OperationalException, match="Coinmate does not support stoploss orders on exchange"):
+        exchange.validate_ordertypes(order_types)
+
+
+def test_coinmate_validate_config_uid_required(default_conf, mocker):
+    """Test that UID is required in configuration"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Should raise exception when UID is missing
+    config_without_uid = {"exchange": {"name": "coinmate", "key": "test", "secret": "test"}}
+    with pytest.raises(OperationalException, match="Coinmate requires 'uid' parameter"):
+        exchange.validate_config(config_without_uid)
+    
+    # Should not raise exception when UID is present
+    config_with_uid = {"exchange": {"name": "coinmate", "key": "test", "secret": "test", "uid": "123"}}
+    exchange.validate_config(config_with_uid)  # Should not raise
+
+
+def test_coinmate_rate_limiting_config(default_conf, mocker):
+    """Test that rate limiting is properly configured"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    ccxt_config = exchange._ccxt_config
+    assert ccxt_config["rateLimit"] == 600  # 100 requests/minute = 600ms between requests
+    assert ccxt_config["enableRateLimit"] is True
+
+
+def test_coinmate_get_fee_fallback(default_conf, mocker):
+    """Test that fee calculation falls back to default when API unavailable"""
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    # Mock the parent get_fee to raise exception
+    mocker.patch.object(exchange, 'get_fee', side_effect=Exception("API unavailable"))
+    
+    # Should fall back to default fee (0.35%)
+    fee = exchange.get_fee("BTC/CZK", "limit", "buy", 1, 25000, "maker")
+    assert fee == 0.0035
+
+
+def test_coinmate_ccxt_config_uid(default_conf, mocker):
+    """Test that UID is properly passed to CCXT config"""
+    default_conf["exchange"]["uid"] = "test123"
+    api_mock = MagicMock()
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, id="coinmate")
+    
+    ccxt_config = exchange._ccxt_config
+    assert ccxt_config["uid"] == "test123"
+
+
+def test_coinmate_ft_has_configuration():
+    """Test that _ft_has is properly configured for Coinmate requirements"""
+    exchange = Coinmate(config={}, validate=False)
+    
+    # Test rate limiting configuration
+    assert exchange._ft_has["l2_limit_range"] == [1, 10, 50, 100]
+    assert exchange._ft_has["stoploss_on_exchange"] is False
+    assert exchange._ft_has["order_time_in_force"] == ["GTC"]
+    assert exchange._ft_has["trades_pagination"] == "id"
+    assert exchange._ft_has["trades_pagination_arg"] == "fromId"
+    assert exchange._ft_has["trades_has_history"] is True
+    assert exchange._ft_has["ohlcv_candle_limit"] is None  # No OHLCV support


### PR DESCRIPTION
## Summary

Add support for Coinmate cryptocurrency exchange with spot trading.

## Quick changelog

- Add Coinmate exchange class with spot trading
- Configure rate limiting (100 req/min)
- Add UID validation requirement
- Support market and limit orders
- Add unit tests

## What's new?

This PR adds support for the Coinmate exchange, a Czech exchange that supports spot trading.

**Features:**
- Spot trading only - rejects futures/margin trading modes
- Rate limiting: 600ms between requests (100 requests/minute)
- Authentication: requires UID parameter along with API key and secret
- Order types: market and limit orders
- No stop-loss on exchange (not supported by Coinmate)

**Implementation:**
- Extends base `Exchange` class
- Validates trading modes and order types
- Configures CCXT parameters for Coinmate
- Unit tests cover main functionality

**Files Modified:**
- `freqtrade/exchange/coinmate.py` - Exchange implementation
- `freqtrade/exchange/__init__.py` - Added import
- `freqtrade/exchange/common.py` - Added to supported exchanges
- `tests/exchange/test_coinmate.py` - Unit tests