### PR TITLE
fix: Allow users to override the exchange check for FreqAI incase the…

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1461,6 +1461,11 @@
           "type": "boolean",
           "default": false
         },
+        "override_exchange_check": {
+          "description": "Override the exchange check to force FreqAI to use exchangesthat may not have enough historic data. Turn this to True if you know your FreqAI model and strategy do not require historical data.",
+          "type": "boolean",
+          "default": false
+        },
         "feature_parameters": {
           "description": "The parameters used to engineer the feature set",
           "type": "object",

--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1462,7 +1462,7 @@
           "default": false
         },
         "override_exchange_check": {
-          "description": "Override the exchange check to force FreqAI to use exchangesthat may not have enough historic data. Turn this to True if you know your FreqAI model and strategy do not require historical data.",
+          "description": "Override the exchange check to force FreqAI to use exchanges that may not have enough historic data. Turn this to True if you know your FreqAI model and strategy do not require historical data.",
           "type": "boolean",
           "default": false
         },

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -1142,6 +1142,15 @@ CONF_SCHEMA = {
                     "type": "boolean",
                     "default": False,
                 },
+                "override_exchange_check": {
+                    "description": (
+                        "Override the exchange check to force FreqAI to use exchanges"
+                        "that may not have enough historic data. Turn this to True if "
+                        "you know your FreqAI model and strategy do not require historical data."
+                    ),
+                    "type": "boolean",
+                    "default": False,
+                },
                 "feature_parameters": {
                     "description": "The parameters used to engineer the feature set",
                     "type": "object",

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -1144,7 +1144,7 @@ CONF_SCHEMA = {
                 },
                 "override_exchange_check": {
                     "description": (
-                        "Override the exchange check to force FreqAI to use exchanges"
+                        "Override the exchange check to force FreqAI to use exchanges "
                         "that may not have enough historic data. Turn this to True if "
                         "you know your FreqAI model and strategy do not require historical data."
                     ),

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -832,7 +832,8 @@ class Exchange:
 
     def validate_freqai(self, config: Config) -> None:
         freqai_enabled = config.get("freqai", {}).get("enabled", False)
-        if freqai_enabled and not self._ft_has["ohlcv_has_history"]:
+        override = config.get("freqai", {}).get("override_exchange_checks", False)
+        if not override and freqai_enabled and not self._ft_has["ohlcv_has_history"]:
             raise ConfigurationError(
                 f"Historic OHLCV data not available for {self.name}. Can't use freqAI."
             )

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -837,6 +837,11 @@ class Exchange:
             raise ConfigurationError(
                 f"Historic OHLCV data not available for {self.name}. Can't use freqAI."
             )
+        elif override and freqai_enabled and not self._ft_has["ohlcv_has_history"]:
+            logger.warning(
+                "Overriding exchange checks for freqAI. Make sure that your exchange supports "
+                "fetching historic OHLCV data, otherwise freqAI will not work."
+            )
 
     def validate_required_startup_candles(self, startup_candles: int, timeframe: str) -> int:
         """


### PR DESCRIPTION
Currently, any exchange that doesn't provide enough historical data is blocked from FreqAI usage. 

However, there are some cases where a user may use FreqAI without needing historical data. In this case, we let the user make the conscious choice to override the exchange check.
