### PR TITLE
Fixed the take of a low or high price for the profit calculation for exits

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -1429,18 +1429,12 @@ class IStrategy(ABC, HyperStrategyMixin):
         :return: List of exit reasons - or empty list.
         """
         exits: list[ExitCheckTuple] = []
-        current_rate = rate
-        current_profit = trade.calc_profit_ratio(current_rate)
-        current_profit_best = current_profit
-        if low is not None or high is not None:
-            # Set current rate to high for backtesting ROI exits
-            current_rate_best = (low if trade.is_short else high) or rate
-            current_profit_best = trade.calc_profit_ratio(current_rate_best)
+        current_profit = trade.calc_profit_ratio(rate)
 
-        trade.adjust_min_max_rates(high or current_rate, low or current_rate)
+        trade.adjust_min_max_rates(high or rate, low or rate)
 
         stoplossflag = self.ft_stoploss_reached(
-            current_rate=current_rate,
+            current_rate=rate,
             trade=trade,
             current_time=current_time,
             current_profit=current_profit,
@@ -1451,7 +1445,7 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         # if enter signal and ignore_roi is set, we don't need to evaluate min_roi.
         roi_reached = not (enter and self.ignore_roi_if_entry_signal) and self.min_roi_reached(
-            trade=trade, current_profit=current_profit_best, current_time=current_time
+            trade=trade, current_profit=current_profit, current_time=current_time
         )
 
         exit_signal = ExitType.NONE
@@ -1465,7 +1459,7 @@ class IStrategy(ABC, HyperStrategyMixin):
                     pair=trade.pair,
                     trade=trade,
                     current_time=current_time,
-                    current_rate=current_rate,
+                    current_rate=rate,
                     current_profit=current_profit,
                 )
                 if reason_cust:

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -455,6 +455,47 @@ def test_min_roi_reached_custom_roi(default_conf, fee) -> None:
     assert strategy.custom_roi.call_count == 10
 
 
+def test_should_exit_by_roi_with_funding(default_conf, fee) -> None:
+    strategy = StrategyResolver.load_strategy(default_conf)
+
+    curr_rate = 1
+    funding_amount = -0.1
+    profit = 0.05
+    trade = Trade(
+        pair="ETH/USDT:USDT",
+        stake_amount=0.01,
+        amount=curr_rate,
+        open_date=dt_now() - timedelta(hours=1),
+        fee_open=fee.return_value,
+        fee_close=fee.return_value,
+        exchange="binance",
+        open_rate=curr_rate,
+        leverage=5.0,
+        funding_fees=funding_amount,
+        trading_mode="futures",
+        stop_loss=0.0001,
+    )
+    strategy.custom_roi = MagicMock(side_effect=lambda: profit)
+    strategy.use_custom_roi = True
+    now = dt_now()
+
+    res = strategy.should_exit(trade, curr_rate, now, enter=False, exit_=False, low=None, high=None)
+    assert not res
+    assert trade.calc_profit_ratio(curr_rate) < 0  # Check that the funding has an influence
+
+    res = strategy.should_exit(trade, curr_rate + funding_amount, now, enter=False, exit_=False, low=None, high=None)
+    assert not res
+
+    res = strategy.should_exit(trade, curr_rate - funding_amount + profit, now, enter=False, exit_=False, low=None,
+                               high=None)
+    assert res == [ExitCheckTuple(exit_type=ExitType.ROI)]
+
+    # Check that low and high during backtest don't have an influence on the exit signal
+    res = strategy.should_exit(trade, curr_rate, now, enter=False, exit_=False, low=curr_rate * 0.9,
+                               high=curr_rate - funding_amount + profit)
+    assert not res
+
+
 @pytest.mark.parametrize(
     "profit,adjusted,expected,liq,trailing,custom,profit2,adjusted2,expected2,custom_stop",
     [

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -483,16 +483,32 @@ def test_should_exit_by_roi_with_funding(default_conf, fee) -> None:
     assert not res
     assert trade.calc_profit_ratio(curr_rate) < 0  # Check that the funding has an influence
 
-    res = strategy.should_exit(trade, curr_rate + funding_amount, now, enter=False, exit_=False, low=None, high=None)
+    res = strategy.should_exit(
+        trade, curr_rate + funding_amount, now, enter=False, exit_=False, low=None, high=None
+    )
     assert not res
 
-    res = strategy.should_exit(trade, curr_rate - funding_amount + profit, now, enter=False, exit_=False, low=None,
-                               high=None)
+    res = strategy.should_exit(
+        trade,
+        curr_rate - funding_amount + profit,
+        now,
+        enter=False,
+        exit_=False,
+        low=None,
+        high=None,
+    )
     assert res == [ExitCheckTuple(exit_type=ExitType.ROI)]
 
     # Check that low and high during backtest don't have an influence on the exit signal
-    res = strategy.should_exit(trade, curr_rate, now, enter=False, exit_=False, low=curr_rate * 0.9,
-                               high=curr_rate - funding_amount + profit)
+    res = strategy.should_exit(
+        trade,
+        curr_rate,
+        now,
+        enter=False,
+        exit_=False,
+        low=curr_rate * 0.9,
+        high=curr_rate - funding_amount + profit,
+    )
     assert not res
 
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the [issue](https://discord.com/channels/700048804539400213/702584639063064586/1425922720012697601) when during backtest can be unexpected negative profit with ROI signal due to funding rates.

## Quick changelog
- Wrote tests to check that candle low and high during backtest don't have an influence on the exit signal
- Changed (removed) buggy logic of should_exit

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Sorry one more time for my low quality code. I am sure that you will redo it and just one string of my code will left like in [this pr ](https://github.com/freqtrade/freqtrade/pull/12201). But it will be easier to explain my idea via a code again.

I just changed first time this string like `current_rate_best = (low if trade.is_short else current_rate) or rate` and my tests worked, but after that I made an assumption that all related logic in the function is excessive. At least all strategy tests are working and backtests results look fine now on the real data for me:
<img width="1471" height="658" alt="изображение" src="https://github.com/user-attachments/assets/b280a74c-f079-40e5-aede-e165958b7e3c" />
I am sure that I broke some logic, because there were reasons why you tried to took into consideration low and highs, that I just didn't understand as newbie.

P.S: But if my pr is generally correct, looks like, that I should redo all my backtests results now. 
