### PR TITLE
Add support for bitget futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ hesitate to read the source code and understand the mechanism of this bot.
 Please read the [exchange specific notes](docs/exchanges.md) to learn about eventual, special configurations needed for each exchange.
 
 - [X] [Binance](https://www.binance.com/)
-- [X] [Bitmart](https://bitmart.com/)
 - [X] [BingX](https://bingx.com/invite/0EM9RX)
+- [X] [Bitget](https://www.bitget.com/)
+- [X] [Bitmart](https://bitmart.com/)
 - [X] [Bybit](https://bybit.com/)
 - [X] [Gate.io](https://www.gate.io/ref/6266643)
 - [X] [HTX](https://www.htx.com/)
@@ -41,6 +42,7 @@ Please read the [exchange specific notes](docs/exchanges.md) to learn about even
 ### Supported Futures Exchanges (experimental)
 
 - [X] [Binance](https://www.binance.com/)
+- [X] [Bitget](https://www.bitget.com/)
 - [X] [Gate.io](https://www.gate.io/ref/6266643)
 - [X] [Hyperliquid](https://hyperliquid.xyz/) (A decentralized exchange, or DEX)
 - [X] [OKX](https://okx.com/)

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -487,3 +487,5 @@ For example, to test the order type `FOK` with Kraken, and modify candle limit t
 
 !!! Warning
     Please make sure to fully understand the impacts of these settings before modifying them.
+    Using `_ft_has_params` overrides may lead to unexpected behavior, and may even break your bot. 
+    We will not be able to provide support for issues caused by custom settings in `_ft_has_params`.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -355,6 +355,12 @@ Bitget supports [time_in_force](configuration.md#understand-order_time_in_force)
     Bitget supports `stoploss_on_exchange` and can use both stop-loss-market and stop-loss-limit orders. It provides great advantages, so we recommend to benefit from it.
     You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to decide which type of stoploss shall be used.
 
+### Bitget Futures
+
+Futures trading on bitget is supported for isolated futures mode.
+
+On startup, freqtrade will set the position mode to "One-way Mode" for the whole (sub)account. This avoids making this call over and over again (slowing down bot operations), but means that manual changes to this setting may result in exceptions and errors.
+
 ## Hyperliquid
 
 !!! Tip "Stoploss on Exchange"

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -298,7 +298,14 @@ Without these permissions, the bot will not start correctly and show errors like
 
 Bybit supports [time_in_force](configuration.md#understand-order_time_in_force) with settings "GTC" (good till cancelled), "FOK" (full-or-cancel), "IOC" (immediate-or-cancel) and "PO" (Post only) settings.
 
-Futures trading on bybit is currently supported for isolated futures mode.
+!!! Warning "Unified accounts"
+    Freqtrade assumes accounts to be dedicated to the bot.
+    We therefore recommend the usage of one subaccount per bot. This is especially important when using unified accounts.  
+    Other configurations (multiple bots on one account, manual non-bot trades on the bot account) are not supported and may lead to unexpected behavior.
+
+### Bybit Futures
+
+Futures trading on bybit is supported for isolated futures mode.
 
 On startup, freqtrade will set the position mode to "One-way Mode" for the whole (sub)account. This avoids making this call over and over again (slowing down bot operations), but means that manual changes to this setting may result in exceptions and errors.
 
@@ -312,10 +319,6 @@ API Keys for live futures trading must have the following permissions:
 
 We do strongly recommend to limit all API keys to the IP you're going to use it from.
 
-!!! Warning "Unified accounts"
-    Freqtrade assumes accounts to be dedicated to the bot.
-    We therefore recommend the usage of one subaccount per bot. This is especially important when using unified accounts.  
-    Other configurations (multiple bots on one account, manual non-bot trades on the bot account) are not supported and may lead to unexpected behavior.
 
 ## Bitmart
 

--- a/docs/includes/exchange-features.md
+++ b/docs/includes/exchange-features.md
@@ -5,6 +5,8 @@
 | [Binance](exchanges.md#binance) | futures | isolated, cross | market, limit |
 | [Bingx](exchanges.md#bingx) | spot | | market, limit |
 | [Bitmart](exchanges.md#bitmart) | spot | | ❌ (not supported) |
+| [Bitget](exchanges.md#bitget) | spot | | market, limit |
+| [Bitget](exchanges.md#bitget) | futures | isolated | market, limit |
 | [Bybit](exchanges.md#bybit) | spot | | ❌ (not supported) |
 | [Bybit](exchanges.md#bybit) | futures | isolated | market, limit |
 | [Gate.io](exchanges.md#gateio) | spot | | limit |

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Please read the [exchange specific notes](exchanges.md) to learn about eventual,
 
 - [X] [Binance](https://www.binance.com/)
 - [X] [BingX](https://bingx.com/invite/0EM9RX)
+- [X] [Bitget](https://www.bitget.com/)
 - [X] [Bitmart](https://bitmart.com/)
 - [X] [Bybit](https://bybit.com/)
 - [X] [Gate.io](https://www.gate.io/ref/6266643)
@@ -52,6 +53,7 @@ Please read the [exchange specific notes](exchanges.md) to learn about eventual,
 ### Supported Futures Exchanges (experimental)
 
 - [X] [Binance](https://www.binance.com/)
+- [X] [Bitget](https://www.bitget.com/)
 - [X] [Bybit](https://bybit.com/)
 - [X] [Gate.io](https://www.gate.io/ref/6266643)
 - [X] [Hyperliquid](https://hyperliquid.xyz/) (A decentralized exchange, or DEX)

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -21,13 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class Bitget(Exchange):
-    """
-    Bitget exchange class. Contains adjustments needed for Freqtrade to work
-    with this exchange.
-
-    Please note that this exchange is not included in the list of exchanges
-    officially supported by the Freqtrade development team. So some features
-    may still not work as expected.
+    """Bitget exchange class.
+    Contains adjustments needed for Freqtrade to work with this exchange.
     """
 
     _ft_has: FtHas = {

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -40,6 +40,7 @@ class Bitget(Exchange):
     }
     _ft_has_futures: FtHas = {
         "mark_ohlcv_timeframe": "4h",
+        "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
     }
 
     _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -40,6 +40,7 @@ class Bitget(Exchange):
     }
     _ft_has_futures: FtHas = {
         "mark_ohlcv_timeframe": "4h",
+        "funding_fee_candle_limit": 100,
         "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
     }
 

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -41,6 +41,12 @@ class Bitget(Exchange):
         "mark_ohlcv_timeframe": "4h",
     }
 
+    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
+        (TradingMode.SPOT, MarginMode.NONE),
+        (TradingMode.FUTURES, MarginMode.ISOLATED),
+        # (TradingMode.FUTURES, MarginMode.CROSS),
+    ]
+
     def ohlcv_candle_limit(
         self, timeframe: str, candle_type: CandleType, since_ms: int | None = None
     ) -> int:

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -234,5 +234,5 @@ class Bitget(Exchange):
             )
         else:
             raise OperationalException(
-                "Freqtrade only supports isolated futures for leverage trading"
+                "Freqtrade currently only supports isolated futures for bitget"
             )

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -232,8 +232,8 @@ class Bitget(Exchange):
         if self.trading_mode == TradingMode.FUTURES and self.margin_mode == MarginMode.ISOLATED:
             position_direction = -1 if is_short else 1
 
-            return wallet_balance - (amount * open_rate * position_direction) / amount * (
-                mm_ratio + taker_fee_rate - position_direction
+            return (wallet_balance - (amount * open_rate * position_direction)) / (
+                amount * (mm_ratio + taker_fee_rate - position_direction)
             )
         else:
             raise OperationalException(

--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -29,6 +29,7 @@ class Bitget(Exchange):
         "stoploss_on_exchange": True,
         "stop_price_param": "stopPrice",
         "stop_price_prop": "stopPrice",
+        "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
         "stoploss_order_types": {"limit": "limit", "market": "market"},
         "ohlcv_candle_limit": 200,  # 200 for historical candles, 1000 for recent ones.
         "order_time_in_force": ["GTC", "FOK", "IOC", "PO"],
@@ -36,7 +37,6 @@ class Bitget(Exchange):
     _ft_has_futures: FtHas = {
         "mark_ohlcv_timeframe": "4h",
         "funding_fee_candle_limit": 100,
-        "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
     }
 
     _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -57,6 +57,7 @@ SUPPORTED_EXCHANGES = [
     "binance",
     "bingx",
     "bitmart",
+    "bitget",
     "bybit",
     "gate",
     "htx",

--- a/tests/exchange/test_bitget.py
+++ b/tests/exchange/test_bitget.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from freqtrade.enums import CandleType
+from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import RetryableOrderError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.util import dt_now, dt_ts
@@ -120,3 +120,18 @@ def test_bitget_ohlcv_candle_limit(mocker, default_conf_usdt):
         assert exch.ohlcv_candle_limit(timeframe, CandleType.FUTURES, start_time) == length
         assert exch.ohlcv_candle_limit(timeframe, CandleType.MARK, start_time) == length
         assert exch.ohlcv_candle_limit(timeframe, CandleType.FUNDING_RATE, start_time) == 200
+
+
+def test_additional_exchange_init_bitget(default_conf, mocker):
+    default_conf["dry_run"] = False
+    default_conf["trading_mode"] = TradingMode.FUTURES
+    default_conf["margin_mode"] = MarginMode.ISOLATED
+    api_mock = MagicMock()
+    api_mock.set_position_mode = MagicMock(return_value={})
+
+    get_patched_exchange(mocker, default_conf, exchange="bitget", api_mock=api_mock)
+    assert api_mock.set_position_mode.call_count == 1
+
+    ccxt_exceptionhandlers(
+        mocker, default_conf, api_mock, "bitget", "additional_exchange_init", "set_position_mode"
+    )

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -5942,7 +5942,7 @@ def test_get_max_leverage_futures(default_conf, mocker, leverage_tiers):
     assert exchange.get_max_leverage("TIA/USDT:USDT", 130.008) == 40
 
 
-@pytest.mark.parametrize("exchange_name", ["binance", "kraken", "gate", "okx", "bybit"])
+@pytest.mark.parametrize("exchange_name", ["binance", "kraken", "gate", "okx", "bybit", "bitget"])
 def test__get_params(mocker, default_conf, exchange_name):
     api_mock = MagicMock()
     mocker.patch(f"{EXMS}.exchange_has", return_value=True)
@@ -5965,6 +5965,9 @@ def test__get_params(mocker, default_conf, exchange_name):
 
     if exchange_name == "bybit":
         params2["position_idx"] = 0
+
+    if exchange_name == "bitget":
+        params2["marginMode"] = "isolated"
 
     assert (
         exchange._get_params(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -5942,32 +5942,32 @@ def test_get_max_leverage_futures(default_conf, mocker, leverage_tiers):
     assert exchange.get_max_leverage("TIA/USDT:USDT", 130.008) == 40
 
 
-@pytest.mark.parametrize("exchange_name", ["binance", "kraken", "gate", "okx", "bybit", "bitget"])
-def test__get_params(mocker, default_conf, exchange_name):
+@pytest.mark.parametrize(
+    "exchange_name, add_params_spot, add_params_futures",
+    [
+        ("binance", {}, {}),
+        ("kraken", {}, {"leverage": 3.0}),
+        ("gate", {}, {}),
+        ("okx", {}, {"tdMode": "isolated", "posSide": "net"}),
+        ("bybit", {}, {"position_idx": 0}),
+        ("bitget", {}, {"marginMode": "isolated"}),
+    ],
+)
+def test__get_params(mocker, default_conf, exchange_name, add_params_spot, add_params_futures):
     api_mock = MagicMock()
     mocker.patch(f"{EXMS}.exchange_has", return_value=True)
     exchange = get_patched_exchange(mocker, default_conf, api_mock, exchange=exchange_name)
     exchange._params = {"test": True}
 
     params1 = {"test": True}
-    params2 = {
+    params1.update(add_params_spot)
+
+    params_fut = {
         "test": True,
         "timeInForce": "IOC",
         "reduceOnly": True,
     }
-
-    if exchange_name == "kraken":
-        params2["leverage"] = 3.0
-
-    if exchange_name == "okx":
-        params2["tdMode"] = "isolated"
-        params2["posSide"] = "net"
-
-    if exchange_name == "bybit":
-        params2["position_idx"] = 0
-
-    if exchange_name == "bitget":
-        params2["marginMode"] = "isolated"
+    params_fut.update(add_params_futures)
 
     assert (
         exchange._get_params(
@@ -6015,7 +6015,7 @@ def test__get_params(mocker, default_conf, exchange_name):
             time_in_force="IOC",
             leverage=3.0,
         )
-        == params2
+        == params_fut
     )
 
 

--- a/tests/exchange_online/conftest.py
+++ b/tests/exchange_online/conftest.py
@@ -422,6 +422,10 @@ EXCHANGES = {
         "hasQuoteVolume": True,
         "timeframe": "1h",
         "candle_count": 1000,
+        "futures": True,
+        "futures_pair": "BTC/USDT:USDT",
+        "leverage_tiers_public": True,
+        "leverage_in_spot_market": True,
     },
     "coinex": {
         "pair": "BTC/USDT",


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Add support for bitget isolated futures trading 
Add bitget as supported exchange

closes #12234
closes #12046
closes #8294
