### PR TITLE
Work around os.fork deprecation

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -18,7 +18,12 @@ from freqtrade.commands import Arguments
 from freqtrade.constants import DOCS_LINK
 from freqtrade.exceptions import ConfigurationError, FreqtradeException, OperationalException
 from freqtrade.loggers import setup_logging_pre
-from freqtrade.system import asyncio_setup, gc_set_threshold, print_version_info
+from freqtrade.system import (
+    asyncio_setup,
+    gc_set_threshold,
+    print_version_info,
+    set_mp_start_method,
+)
 
 
 logger = logging.getLogger("freqtrade")
@@ -44,6 +49,7 @@ def main(sysargv: list[str] | None = None) -> None:
         elif "func" in args:
             logger.info(f"freqtrade {__version__}")
             gc_set_threshold()
+            set_mp_start_method()
             return_code = args["func"](args)
         else:
             # No subcommand was issued.

--- a/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
+++ b/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
@@ -7,7 +7,7 @@ import logging
 import sys
 import warnings
 from datetime import UTC, datetime
-from multiprocessing import Manager
+from multiprocessing import Manager, get_all_start_methods, set_start_method
 from pathlib import Path
 from typing import Any
 
@@ -125,6 +125,12 @@ class HyperOptimizer:
         local_queue must be a global and passed to the child process via inheritance.
         """
         global log_queue
+        try:
+            sms = get_all_start_methods()
+            if "forkserver" in sms:
+                set_start_method("forkserver")
+        except RuntimeError:
+            pass  # start method has already been set
         m = Manager()
         log_queue = m.Queue()
         logger.info(f"manager queue {type(log_queue)}")

--- a/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
+++ b/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
@@ -7,7 +7,7 @@ import logging
 import sys
 import warnings
 from datetime import UTC, datetime
-from multiprocessing import Manager, get_all_start_methods, set_start_method
+from multiprocessing import Manager
 from pathlib import Path
 from typing import Any
 
@@ -125,12 +125,6 @@ class HyperOptimizer:
         local_queue must be a global and passed to the child process via inheritance.
         """
         global log_queue
-        try:
-            sms = get_all_start_methods()
-            if "forkserver" in sms:
-                set_start_method("forkserver")
-        except RuntimeError:
-            pass  # start method has already been set
         m = Manager()
         log_queue = m.Queue()
         logger.info(f"manager queue {type(log_queue)}")

--- a/freqtrade/system/__init__.py
+++ b/freqtrade/system/__init__.py
@@ -2,7 +2,8 @@
 
 from freqtrade.system.asyncio_config import asyncio_setup
 from freqtrade.system.gc_setup import gc_set_threshold
+from freqtrade.system.set_mp_start_method import set_mp_start_method
 from freqtrade.system.version_info import print_version_info
 
 
-__all__ = ["asyncio_setup", "gc_set_threshold", "print_version_info"]
+__all__ = ["asyncio_setup", "gc_set_threshold", "print_version_info", "set_mp_start_method"]

--- a/freqtrade/system/set_mp_start_method.py
+++ b/freqtrade/system/set_mp_start_method.py
@@ -1,0 +1,14 @@
+from multiprocessing import get_all_start_methods, get_start_method, set_start_method
+
+
+def set_mp_start_method():
+    """
+    Set multiprocessing start method to not be fork.
+    forkserver will become the default in 3.14 - and is deprecated in 3.13
+    """
+    try:
+        sms = get_all_start_methods()
+        if "forkserver" in sms and get_start_method(True) is None:
+            set_start_method("forkserver")
+    except RuntimeError:
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ hyperopt = [
 freqai = [
   "scikit-learn",
   "joblib",
-  'catboost; platform_machine != "aarch64"',
+  'catboost; platform_machine != "arm"',
   "lightgbm",
   "xgboost",
   "tensorboard",

--- a/tests/commands/test_startup_time.py
+++ b/tests/commands/test_startup_time.py
@@ -4,7 +4,7 @@ import time
 from tests.conftest import is_arm, is_mac
 
 
-MAXIMUM_STARTUP_TIME = 0.7 if is_mac() and not is_arm() else 0.5
+MAXIMUM_STARTUP_TIME = 0.7 if is_mac() and not is_arm(True) else 0.5
 
 
 def test_startup_time():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from freqtrade.exchange import Exchange, timeframe_to_minutes, timeframe_to_seco
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import LocalTrade, Order, Trade, init_db
 from freqtrade.resolvers import ExchangeResolver
+from freqtrade.system import set_mp_start_method
 from freqtrade.util import dt_now, dt_ts
 from freqtrade.worker import Worker
 from tests.conftest_trades import (
@@ -498,6 +499,15 @@ def create_mock_trades_usdt(fee, is_short: bool | None = False, use_db: bool = T
 @pytest.fixture(autouse=True)
 def patch_gc(mocker) -> None:
     mocker.patch("freqtrade.main.gc_set_threshold")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fixture_set_mp_start_method():
+    """
+    Patch multiprocessing start mode globally
+    Auto-used, runs once per session.
+    """
+    set_mp_start_method()
 
 
 def is_arm(include_aarch64: bool = False) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -500,9 +500,11 @@ def patch_gc(mocker) -> None:
     mocker.patch("freqtrade.main.gc_set_threshold")
 
 
-def is_arm() -> bool:
+def is_arm(include_aarch64: bool = False) -> bool:
     machine = platform.machine()
-    return "arm" in machine or "aarch64" in machine
+    if include_aarch64:
+        return "aarch64" in machine or "arm" in machine
+    return "arm" in machine
 
 
 def is_mac() -> bool:

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -143,6 +143,7 @@ def test_extract_data_and_train_model_Standard(
         ("CatboostClassifierMultiTarget", "freqai_test_multimodel_classifier_strat"),
     ],
 )
+@pytest.mark.filterwarnings(r"ignore:.*__sklearn_tags__.*:DeprecationWarning")
 def test_extract_data_and_train_model_MultiTargets(mocker, freqai_conf, model, strat):
     can_run_model(model)
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

multiprocessing itself raises a deprecation warning in 3.13.
We can work around this by setting the default to forkServer - which will become the default in 3.14 anyway.

Also enables catboost installation and tests on aarch64.
