### PR TITLE
add np.NAN to strategy updater conversion (which worked in 1.x but not in 2.x anymore)

### DIFF
--- a/freqtrade/strategy/strategyupdater.py
+++ b/freqtrade/strategy/strategyupdater.py
@@ -46,6 +46,7 @@ class StrategyUpdater:
             "aliases": set(),
             "replacements": [
                 ("NaN", "nan"),
+                ("NAN", "nan"),
             ],
         }
     }


### PR DESCRIPTION
Added the conversion of np.NAN to np.nan since it worked on 1.x but not on 2.x anymore.
(now freqtrade pushes errors on any np.NAN)

Source:
https://numpy.org/doc/2.0/reference/constants.html NaN and NAN are aliases of nan.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

np.NAN => np.nan conversion
since people on github used that, one more case to the heap.