### PR TITLE
Update exchanges.md - clarify Hyperliquid docs on subaccounts usage

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -407,11 +407,11 @@ To use these with Freqtrade, you will need to use the following configuration pa
 ``` json
 "exchange": {
     "name": "hyperliquid",
-    "walletAddress": "your_master_wallet_address", // Your master wallet address (not API wallet address and not vault/subaccount address).
-    "privateKey": "your_api_private_key", // API wallet private key (see https://app.hyperliquid.xyz/API). You'll only need private key, API wallet address is not needed.
+    "walletAddress": "your_master_wallet_address", // Your master wallet address (not the API wallet address and not the vault/subaccount address).
+    "privateKey": "your_api_private_key", // API wallet private key (see https://app.hyperliquid.xyz/API). You'll only need the private key.
     "ccxt_config": {
         "options": {
-            "vaultAddress": "your_vault_address", // Optional, only if you want to use a vault OR...
+            "vaultAddress": "your_vault_address", // Optional, only if you want to use a vault ...
             "subAccountAddress": "your_subaccount_address" // OR optional, only if you want to use a subaccount
         }
     },
@@ -420,6 +420,9 @@ To use these with Freqtrade, you will need to use the following configuration pa
 ```
 
 Your balance and trades will now be used from your vault / subaccount - and no longer from your main account.
+
+!!! Note
+    You can only use either a vault or a subaccount - not both at the same time.
 
 ### Historic Hyperliquid data
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -407,11 +407,12 @@ To use these with Freqtrade, you will need to use the following configuration pa
 ``` json
 "exchange": {
     "name": "hyperliquid",
-    "walletAddress": "your_vault_address",  // Vault or subaccount address
-    "privateKey": "your_api_private_key",
+    "walletAddress": "your_master_wallet_address", // Your master wallet address (not API wallet address and not vault/subaccount address).
+    "privateKey": "your_api_private_key", // API wallet private key (see https://app.hyperliquid.xyz/API). You'll only need private key, API wallet address is not needed.
     "ccxt_config": {
         "options": {
-            "vaultAddress": "your_vault_address" // Optional, only if you want to use a vault or subaccount
+            "vaultAddress": "your_vault_address", // Optional, only if you want to use a vault OR...
+            "subAccountAddress": "your_subaccount_address" // OR optional, only if you want to use a subaccount
         }
     },
     // ...


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

No AI used. Only painful process of try, fail, continue until works.

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: Documentation was unclear on how to use subaccounts from Hyperliquid with freqtrade and ccxt.

## Quick changelog

- Update Hyperliquid docs on subaccounts usage.

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->

I digged in [ccxt docs here](https://docs.ccxt.com/#/exchanges/hyperliquid), found mentions of `subAccountAddress`. Tried to use it in freqtrade `ccxt_config` prop, and it worked. I wanted to clarify those nuances in freqtrade docs for the future generations.
