### PR TITLE
improve strategy loading with huge strategy libraries

### DIFF
--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -148,6 +148,9 @@ class IResolver:
                 logger.debug("Ignoring broken symlink %s", entry)
                 continue
             module_path = entry.resolve()
+            if entry.read_text().find(f"class {object_name}(") == -1:
+                logger.debug(f"Skipping {module_path} as it does not contain class {object_name}")
+                continue
 
             if obj := next(cls._get_valid_object(module_path, object_name), None):
                 obj[0].__file__ = str(entry)

--- a/freqtrade/resolvers/iresolver.py
+++ b/freqtrade/resolvers/iresolver.py
@@ -149,7 +149,7 @@ class IResolver:
                 continue
             module_path = entry.resolve()
             if entry.read_text().find(f"class {object_name}(") == -1:
-                logger.debug(f"Skipping {module_path} as it does not contain class {object_name}")
+                logger.debug(f"Skipping {module_path} as it does not contain class {object_name}.")
                 continue
 
             if obj := next(cls._get_valid_object(module_path, object_name), None):

--- a/tests/strategy/test_strategy_loading.py
+++ b/tests/strategy/test_strategy_loading.py
@@ -96,6 +96,16 @@ def test_load_strategy_invalid_directory(caplog, default_conf, tmp_path):
     assert log_has_re(r"Path .*" + r"some.*path.*" + r".* does not exist", caplog)
 
 
+def test_load_strategy_skip_other_files(caplog, default_conf, tmp_path):
+    default_conf["user_data_dir"] = tmp_path
+    caplog.set_level(logging.DEBUG)
+
+    s = StrategyResolver._load_strategy("StrategyTestV3", config=default_conf)
+    assert isinstance(s, IStrategy)
+
+    assert log_has_re(r"Skipping .* as it does not contain class StrategyTestV3\.", caplog)
+
+
 def test_load_not_found_strategy(default_conf, tmp_path):
     default_conf["user_data_dir"] = tmp_path
     default_conf["strategy"] = "NotFoundStrategy"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

improve strategy loading with huge strategy libraries by skiping non-matching strategies.
This can greatly improve startup - as well as memory footprint - as only the searched strategy is actually loaded.

Prior behavior loaded all strategies (alphabetically) until the right strategy is found - which can cause huge libraries to be loaded into memory (never to be unloaded).