### PR TITLE
Add coincurve for faster ECDSA signing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ ta-lib==0.6.8
 technical==1.5.3
 
 ccxt==4.5.14
+# for fast ECDSA signatures/verification
+coincurve==21.0.0
 cryptography==46.0.3
 aiohttp==3.13.2
 SQLAlchemy==2.0.44

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ft-pandas-ta==0.3.16
 ta-lib==0.6.8
 technical==1.5.3
 
-ccxt==4.5.14
+ccxt==4.5.16
 # for fast ECDSA signatures/verification
 coincurve==21.0.0
 cryptography==46.0.3


### PR DESCRIPTION
## Summary

Introduce coincurve as dependency to enhance the performance of ECDSA signing - as supported by ccxt