### PR TITLE
Fix backtesting exception when no data is available for a pair

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1425,7 +1425,7 @@ class Backtesting:
             # Row is treated as "current incomplete candle".
             # entry / exit signals are shifted by 1 to compensate for this.
             row = data[pair][row_index]
-        except IndexError:
+        except (IndexError, KeyError):
             # missing Data for one pair at the end.
             # Warnings for this are shown during data loading
             return None

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -126,6 +126,7 @@ class Backtesting:
 
         self.config["dry_run"] = True
         self.price_pair_prec: dict[str, Series] = {}
+        self.available_pairs: list[str] = []
         self.run_ids: dict[str, str] = {}
         self.strategylist: list[IStrategy] = []
         self.all_bt_content: dict[str, BacktestContentType] = {}
@@ -176,7 +177,8 @@ class Backtesting:
         self._validate_pairlists_for_backtesting()
 
         self.dataprovider.add_pairlisthandler(self.pairlists)
-        self.pairlists.refresh_pairlist()
+        self.dynamic_pairlist: bool = self.config.get("enable_dynamic_pairlist", False)
+        self.pairlists.refresh_pairlist(only_first=self.dynamic_pairlist)
 
         if len(self.pairlists.whitelist) == 0:
             raise OperationalException("No pair in whitelist.")
@@ -211,7 +213,6 @@ class Backtesting:
         self._can_short = self.trading_mode != TradingMode.SPOT
         self._position_stacking: bool = self.config.get("position_stacking", False)
         self.enable_protections: bool = self.config.get("enable_protections", False)
-        self.dynamic_pairlist: bool = self.config.get("enable_dynamic_pairlist", False)
         migrate_data(config, self.exchange)
 
         self.init_backtest()
@@ -335,10 +336,12 @@ class Backtesting:
         self.progress.set_new_value(1)
         self._load_bt_data_detail()
         self.price_pair_prec = {}
+
         for pair in self.pairlists.whitelist:
             if pair in data:
                 # Load price precision logic
                 self.price_pair_prec[pair] = get_tick_size_over_time(data[pair])
+                self.available_pairs.append(pair)
         return data, self.timerange
 
     def _load_bt_data_detail(self) -> None:
@@ -1425,7 +1428,7 @@ class Backtesting:
             # Row is treated as "current incomplete candle".
             # entry / exit signals are shifted by 1 to compensate for this.
             row = data[pair][row_index]
-        except (IndexError, KeyError):
+        except IndexError:
             # missing Data for one pair at the end.
             # Warnings for this are shown during data loading
             return None
@@ -1587,7 +1590,7 @@ class Backtesting:
             self.check_abort()
 
             if self.dynamic_pairlist and self.pairlists:
-                self.pairlists.refresh_pairlist()
+                self.pairlists.refresh_pairlist(pairs=self.available_pairs)
                 pairs = self.pairlists.whitelist
 
             # Reset open trade count for this candle

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -2772,7 +2772,7 @@ def test_time_pair_generator_open_trades_first(mocker, default_conf, dynamic_pai
     dummy_row = (end_date, 1.0, 1.1, 0.9, 1.0, 0, 0, 0, 0, None, None)
     data = {pair: [dummy_row] for pair in pairs}
 
-    def mock_refresh(self):
+    def mock_refresh(self, **kwargs):
         # Simulate shuffle
         self._whitelist = pairs[::-1]  # ['ETH/BTC', 'NEO/BTC', 'LTC/BTC', 'XRP/BTC']
 


### PR DESCRIPTION
[backtest_exception_log.txt](https://github.com/user-attachments/files/23582077/backtest_exception_log.txt)

This exception occurs when there is no data available for a pair in the pairlist within the specified time range.