### PR TITLE
Fix: Add missing space in exit_pricing JSON formatting

### DIFF
--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -34,8 +34,7 @@
             "bids_to_ask_delta": 1
         }
     },
-    "exit_pricing":{
-        "price_side": "same",
+        "exit_pricing": {        "price_side": "same",
         "use_order_book": true,
         "order_book_top": 1
     },


### PR DESCRIPTION
Fixes #12539

Added space between colon and opening brace in exit_pricing block for consistent JSON formatting style.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
