### PR TITLE
make sure the strat's startup count don't get replaced

### DIFF
--- a/freqtrade/optimize/analysis/recursive.py
+++ b/freqtrade/optimize/analysis/recursive.py
@@ -39,6 +39,7 @@ class RecursiveAnalysis(BaseAnalysis):
         self.dict_recursive: dict[str, Any] = dict()
 
         self.pair_to_used: str | None = None
+        self._strat_scc: int | None = None
 
     # For recursive bias check
     # analyzes two data frames with processed indicators and shows differences between them.
@@ -151,7 +152,8 @@ class RecursiveAnalysis(BaseAnalysis):
         backtesting._set_strategy(backtesting.strategylist[0])
 
         strat = backtesting.strategy
-        self._strat_scc = strat.startup_candle_count
+        if self._strat_scc is None:
+            self._strat_scc = strat.startup_candle_count
 
         if self._strat_scc < 1:
             raise ConfigurationError(


### PR DESCRIPTION
Let's say my strat use startup of 999 as defined in the strategy. Then on my recursive test command, I give this `--startup-candle 499 1999 2999 3999`

Current process
- Test recursive using strat's startup candle count. Save the number to self._strat_scc.
- Test recursive using supplied other numbers supplied in command. Save the numbers to self._strat_scc.

This will lead to this
`┃      Indicators ┃       499 ┃ 999 ┃     1999 ┃     2999 ┃     3999 (from strategy) ┃`

Fixed process
- Test recursive using strat's startup candle count. Save the number to self._strat_scc.
- Test recursive using supplied other numbers supplied in command, if any. Don't save the numbers to self._strat_scc.

This is the right header
`┃      Indicators ┃       499 ┃ 999 (from strategy) ┃     1999 ┃     2999 ┃     3999 ┃`