### PR TITLE
Switch from Coveralls to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         os: [ "ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15" , "windows-2022", "windows-2025" ]
         python-version: ["3.11", "3.12", "3.13"]
-    permissions:
-      id-token: write
 
     steps:
     - uses: actions/checkout@v5
@@ -79,7 +77,8 @@ jobs:
     - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
       if: (runner.os == 'Linux' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04')
       with:
-        use_oidc: true
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Cleanup codecov dirty state files
       if: (runner.os == 'Linux' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         pytest --random-order --cov=freqtrade --cov=freqtrade_client --cov-config=.coveragerc
 
     - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+      if: (runner.os == 'Linux' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04')
       with:
         use_oidc: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
       with:
         use_oidc: true
 
+    - name: Cleanup codecov dirty state files
+      if: (runner.os == 'Linux' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04')
+      run: |
+        # See https://github.com/codecov/codecov-action/issues/1851
+        rm -rf codecov codecov.SHA256SUM codecov.SHA256SUM.sig
+
     - name: Run json schema extract
       # This should be kept before the repository check to ensure that the schema is up-to-date
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         os: [ "ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15" , "windows-2022", "windows-2025" ]
         python-version: ["3.11", "3.12", "3.13"]
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v5
@@ -74,15 +76,9 @@ jobs:
       run: |
         pytest --random-order --cov=freqtrade --cov=freqtrade_client --cov-config=.coveragerc
 
-    - name: Coveralls
-      if: (runner.os == 'Linux' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04')
-      env:
-        # Coveralls token. Not used as secret due to github not providing secrets to forked repositories
-        COVERALLS_REPO_TOKEN: 6D1m0xupS3FgutfuGao8keFf9Hc0FpIXu
-      run: |
-        # Allow failure for coveralls
-        uv pip install coveralls
-        coveralls || true
+    - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+      with:
+        use_oidc: true
 
     - name: Run json schema extract
       # This should be kept before the repository check to ensure that the schema is up-to-date


### PR DESCRIPTION
## Summary

Switch the code coverage reporting service from Coveralls to Codecov.

## Quick changelog

- Removed Coveralls integration.
- Added Codecov action for coverage reporting.

## What's new?

This change improves the code coverage reporting process by utilizing Codecov, which offers better integration and features compared to Coveralls (and more importantly, more uptime). 
The new setup ensures that coverage reports are generated and uploaded during CI runs.

