### PR TITLE
restructure CI to reliably fail the build step if other ch…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,10 +275,7 @@ jobs:
   # Notify only once - when CI completes (and after deploy) in case it's successful
   notify-complete:
     needs: [
-      tests,
-      docs-check,
-      mypy-version-check,
-      pre-commit,
+      build,
       build-linux-online
     ]
     runs-on: ubuntu-22.04
@@ -308,7 +305,12 @@ jobs:
   build:
     if: always()
     name: "Build"
-    needs: [ tests, docs-check, mypy-version-check, pre-commit ]
+    needs: [
+      tests,
+      docs-check,
+      mypy-version-check,
+      pre-commit,
+    ]
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,11 +306,18 @@ jobs:
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
 
   build:
+    if: always()
     name: "Build"
     needs: [ tests, docs-check, mypy-version-check, pre-commit ]
     runs-on: ubuntu-22.04
 
     steps:
+
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}
+
     - uses: actions/checkout@v5
       with:
         persist-credentials: false
@@ -405,10 +412,7 @@ jobs:
   docker-build:
     name: "Docker Build and Deploy"
     needs: [
-      tests,
-      docs-check,
-      mypy-version-check,
-      pre-commit
+     build,
     ]
     if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'release') && github.repository == 'freqtrade/freqtrade'
     uses: ./.github/workflows/docker-build.yml


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary
 restructure CI to reliably fail the build step if other steps failed.

This improves the reliability of "only allow merge if ci passes" - as we have a reliable point to block on.
