### PR TITLE
Enhance dry-run stoploss functionality

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -104,6 +104,7 @@ from freqtrade.misc import (
     deep_merge_dicts,
     file_dump_json,
     file_load_json,
+    safe_value_fallback,
     safe_value_fallback2,
 )
 from freqtrade.util import FtTTLCache, PeriodicCache, dt_from_ts, dt_now
@@ -1292,7 +1293,7 @@ class Exchange:
             pair = order["symbol"]
             if not orderbook and self.exchange_has("fetchL2OrderBook"):
                 orderbook = self.fetch_l2_order_book(pair, 20)
-            price = order[self._ft_has["stop_price_prop"]]
+            price = safe_value_fallback(order, self._ft_has["stop_price_prop"], "price")
             crossed = self._dry_is_price_crossed(
                 pair, order["side"], price, orderbook, is_stop=True
             )

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1254,13 +1254,14 @@ class Exchange:
         limit: float,
         orderbook: OrderBook | None = None,
         offset: float = 0.0,
+        is_stop: bool = False,
     ) -> bool:
         if not self.exchange_has("fetchL2OrderBook"):
             return True
         if not orderbook:
             orderbook = self.fetch_l2_order_book(pair, 1)
         try:
-            if side == "buy":
+            if (side == "buy" and not is_stop) or (side == "sell" and is_stop):
                 price = orderbook["asks"][0][0]
                 if limit * (1 - offset) >= price:
                     return True

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1119,6 +1119,7 @@ class Exchange:
         leverage: float,
         params: dict | None = None,
         stop_loss: bool = False,
+        stop_price: float | None = None,
     ) -> CcxtOrder:
         now = dt_now()
         order_id = f"dry_run_{side}_{pair}_{now.timestamp()}"
@@ -1145,7 +1146,7 @@ class Exchange:
         }
         if stop_loss:
             dry_order["info"] = {"stopPrice": dry_order["price"]}
-            dry_order[self._ft_has["stop_price_prop"]] = dry_order["price"]
+            dry_order[self._ft_has["stop_price_prop"]] = stop_price or dry_order["price"]
             # Workaround to avoid filling stoploss orders immediately
             dry_order["ft_order_type"] = "stoploss"
         orderbook: OrderBook | None = None
@@ -1517,8 +1518,9 @@ class Exchange:
                 ordertype,
                 side,
                 amount,
-                stop_price_norm,
+                limit_rate or stop_price_norm,
                 stop_loss=True,
+                stop_price=stop_price_norm,
                 leverage=leverage,
             )
             return dry_order

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1257,7 +1257,8 @@ class Exchange:
         is_stop: bool = False,
     ) -> bool:
         if not self.exchange_has("fetchL2OrderBook"):
-            return True
+            # True unless checking a stoploss order
+            return not is_stop
         if not orderbook:
             orderbook = self.fetch_l2_order_book(pair, 1)
         try:

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -157,7 +157,8 @@ def test_create_stoploss_order_dry_run_binance(default_conf, mocker):
     assert "type" in order
 
     assert order["type"] == order_type
-    assert order["price"] == 220
+    assert order["price"] == 217.8
+    assert order["stopPrice"] == 220
     assert order["amount"] == 1
 
 

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1187,7 +1187,7 @@ def test__dry_is_price_crossed_without_orderbook_support(default_conf, mocker):
         (False, False, "sell", 1.0, "open", None, 0, None),
     ],
 )
-def test_check_dry_limit_order_filled_parametrized(
+def test_check_dry_limit_order_filled(
     default_conf,
     mocker,
     crossed,

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1173,7 +1173,10 @@ def test__dry_is_price_crossed_without_orderbook_support(default_conf, mocker):
     exchange.fetch_l2_order_book = MagicMock()
     mocker.patch(f"{EXMS}.exchange_has", return_value=False)
     assert exchange._dry_is_price_crossed("LTC/USDT", "buy", 1.0)
+    assert exchange._dry_is_price_crossed("LTC/USDT", "sell", 1.0)
     assert exchange.fetch_l2_order_book.call_count == 0
+    assert not exchange._dry_is_price_crossed("LTC/USDT", "buy", 1.0, is_stop=True)
+    assert not exchange._dry_is_price_crossed("LTC/USDT", "sell", 1.0, is_stop=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/exchange/test_htx.py
+++ b/tests/exchange/test_htx.py
@@ -123,7 +123,8 @@ def test_create_stoploss_order_dry_run_htx(default_conf, mocker):
     assert "type" in order
 
     assert order["type"] == order_type
-    assert order["price"] == 220
+    assert order["price"] == 217.8
+    assert order["stopPrice"] == 220
     assert order["amount"] == 1
 
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Improve handling of "stoploss on exchange" orders in dry-run mode to ensure they fill on their own instead of falling back to regular stoploss logic.


## Quick changelog

- Improved dry-run stoploss on exchange logic
- Adjusted tests