### PR TITLE
Improve stoploss cancellation logic

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2387,6 +2387,8 @@ class FreqtradeBot(LoggingMixin):
                 self.strategy.ft_stoploss_adjust(
                     current_rate, trade, datetime.now(UTC), profit, 0, after_fill=True
                 )
+            if not trade.is_open:
+                self.cancel_stoploss_on_exchange(trade)
             # Updating wallets when order is closed
             self.wallets.update()
         return trade

--- a/tests/freqtradebot/test_integration.py
+++ b/tests/freqtradebot/test_integration.py
@@ -800,9 +800,13 @@ def test_dca_handle_similar_open_order(
     # Should Create a new exit order
     freqtrade.exchange.amount_to_contract_precision = MagicMock(return_value=2)
     freqtrade.strategy.adjust_trade_position = MagicMock(return_value=-2)
+    msg = r"Skipping cancelling stoploss on exchange for.*"
 
     mocker.patch(f"{EXMS}._dry_is_price_crossed", return_value=False)
+    assert not log_has_re(msg, caplog)
     freqtrade.process()
+    assert log_has_re(msg, caplog)
+
     trade = Trade.get_trades().first()
 
     assert trade.orders[-2].status == "closed"


### PR DESCRIPTION
## Summary

Enhance the stoploss cancellation process to prevent unnecessary early cancellations and ensure proper cancellation of stoploss orders when trades close.

closes #12528

## Quick changelog

- Avoid early cancellation of stoploss if not needed.
- Ensure stoploss is canceled on the exchange when a trade closes.
