### PR TITLE
fix(okx): correct PriceType.MARK and PriceType.INDEX mapping

### DIFF
--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -41,8 +41,8 @@ class Okx(Exchange):
         "stop_price_type_field": "slTriggerPxType",
         "stop_price_type_value_mapping": {
             PriceType.LAST: "last",
-            PriceType.MARK: "index",
-            PriceType.INDEX: "mark",
+            PriceType.MARK: "mark",
+            PriceType.INDEX: "index",
         },
         "stoploss_blocks_assets": False,
         "ws_enabled": True,

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import ccxt
 import pytest
 
-from freqtrade.enums import CandleType, MarginMode, PriceType, TradingMode
+from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import RetryableOrderError, TemporaryError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import timeframe_to_minutes
@@ -679,26 +679,6 @@ def test__get_stop_params_okx(mocker, default_conf):
 
     assert params["tdMode"] == "isolated"
     assert params["posSide"] == "net"
-
-
-def test_okx_stop_price_type_mapping(mocker, default_conf):
-    """
-    Test that OKX stop_price_type_value_mapping correctly maps PriceType values.
-    PriceType.MARK should map to "mark", PriceType.INDEX should map to "index".
-    """
-    default_conf["trading_mode"] = "futures"
-    default_conf["margin_mode"] = "isolated"
-    exchange = get_patched_exchange(mocker, default_conf, exchange="okx")
-
-    # Verify the mapping is correct
-    mapping = exchange._ft_has.get("stop_price_type_value_mapping", {})
-
-    assert mapping.get(PriceType.LAST) == "last"
-    assert mapping.get(PriceType.MARK) == "mark"
-    assert mapping.get(PriceType.INDEX) == "index"
-
-    # Verify stop_price_type_field is set correctly
-    assert exchange._ft_has.get("stop_price_type_field") == "slTriggerPxType"
 
 
 def test_fetch_orders_okx(default_conf, mocker, limit_order):

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import ccxt
 import pytest
 
-from freqtrade.enums import CandleType, MarginMode, TradingMode
+from freqtrade.enums import CandleType, MarginMode, PriceType, TradingMode
 from freqtrade.exceptions import RetryableOrderError, TemporaryError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import timeframe_to_minutes
@@ -679,6 +679,26 @@ def test__get_stop_params_okx(mocker, default_conf):
 
     assert params["tdMode"] == "isolated"
     assert params["posSide"] == "net"
+
+
+def test_okx_stop_price_type_mapping(mocker, default_conf):
+    """
+    Test that OKX stop_price_type_value_mapping correctly maps PriceType values.
+    PriceType.MARK should map to "mark", PriceType.INDEX should map to "index".
+    """
+    default_conf["trading_mode"] = "futures"
+    default_conf["margin_mode"] = "isolated"
+    exchange = get_patched_exchange(mocker, default_conf, exchange="okx")
+
+    # Verify the mapping is correct
+    mapping = exchange._ft_has.get("stop_price_type_value_mapping", {})
+
+    assert mapping.get(PriceType.LAST) == "last"
+    assert mapping.get(PriceType.MARK) == "mark"
+    assert mapping.get(PriceType.INDEX) == "index"
+
+    # Verify stop_price_type_field is set correctly
+    assert exchange._ft_has.get("stop_price_type_field") == "slTriggerPxType"
 
 
 def test_fetch_orders_okx(default_conf, mocker, limit_order):


### PR DESCRIPTION
## Summary
Fixed incorrect mapping of `PriceType.MARK` and `PriceType.INDEX` in OKX exchange configuration.

## Changes
The `stop_price_type_value_mapping` had swapped values:
- `PriceType.MARK` was incorrectly mapped to `"index"`
- `PriceType.INDEX` was incorrectly mapped to `"mark"`

This fix corrects the mapping so that:
- `PriceType.MARK` → `"mark"`
- `PriceType.INDEX` → `"index"`

## Impact
This bug could cause stoploss orders on OKX futures to use the wrong price type for triggering.

## Testing
- All existing OKX unit tests pass (21/21)
- pre-commit checks pass