### PR TITLE
Fix IndexError in fetch_positions for Hyperliquid when no pair specified

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -1834,9 +1834,9 @@ class Exchange:
         if self._config["dry_run"] or self.trading_mode != TradingMode.FUTURES:
             return []
         try:
-            symbols = []
+            symbols = None
             if pair:
-                symbols.append(pair)
+                symbols = [pair]
             positions: list[CcxtPosition] = self._api.fetch_positions(symbols)
             self._log_exchange_response("fetch_positions", positions)
             return positions


### PR DESCRIPTION
## Summary

Fix IndexError crash in fetch_positions() when initializing wallets on Hyperliquid exchange.

## Quick changelog

- Changed fetch_positions to pass None instead of empty list when no specific pair is requested
- Fixes compatibility with Hyperliquid CCXT implementation that expects None for all positions

## What's new?

When fetch_positions() is called without a specific pair parameter, the code was passing an empty list [] to the CCXT API. For Hyperliquid exchange, this causes an IndexError because the exchange's implementation attempts to access symbols[0] without checking if the list is empty.

The CCXT standard is to pass None (not an empty list) when requesting all positions. This change aligns the code with the CCXT API convention and prevents the crash on Hyperliquid during wallet initialization.

Error that was occurring:
```
IndexError: list index out of range
  at /root/freqtrade/.venv/lib/python3.11/site-packages/ccxt/hyperliquid.py:3051
  market = self.market(symbols[0])
```
