### PR TITLE
Fix binance futures stoploss Order handling

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -17,7 +17,7 @@ from freqtrade.exchange.binance_public_data import (
     download_archive_trades,
 )
 from freqtrade.exchange.common import retrier
-from freqtrade.exchange.exchange_types import FtHas, Tickers
+from freqtrade.exchange.exchange_types import CcxtOrder, FtHas, Tickers
 from freqtrade.exchange.exchange_utils_timeframe import timeframe_to_msecs
 from freqtrade.misc import deep_merge_dicts, json_load
 from freqtrade.util import FtTTLCache
@@ -144,6 +144,20 @@ class Binance(Exchange):
 
         except ccxt.BaseError as e:
             raise OperationalException(e) from e
+
+    def fetch_stoploss_order(
+        self, order_id: str, pair: str, params: dict | None = None
+    ) -> CcxtOrder:
+        if self.trading_mode == TradingMode.FUTURES:
+            params = params or {}
+            params.update({"stop": True})
+        return self.fetch_order(order_id, pair, params)
+
+    def cancel_stoploss_order(self, order_id: str, pair: str, params: dict | None = None) -> dict:
+        if self.trading_mode == TradingMode.FUTURES:
+            params = params or {}
+            params.update({"stop": True})
+        return self.cancel_order(order_id=order_id, pair=pair, params=params)
 
     def get_historic_ohlcv(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ft-pandas-ta==0.3.16
 ta-lib==0.6.8
 technical==1.5.3
 
-ccxt==4.5.26
+ccxt==4.5.27
 cryptography==46.0.3
 aiohttp==3.13.2
 SQLAlchemy==2.0.44


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary
Fix support for binance algo orders

Unfortunately, this will not yet work, as we're waiting for a fix release by ccxt.
this fix will _only_ work with the currently unrelease 4.5.27 - and will not reliably work on ccxt 4.5.26 or lower.

closes #12610 