### PR TITLE
Add price parameter to force-exit API

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2081,7 +2081,12 @@ class FreqtradeBot(LoggingMixin):
         ):
             exit_type = "stoploss"
 
-        order_type = ordertype or self.strategy.order_types[exit_type]
+        order_type = (
+            (ordertype or self.strategy.order_types[exit_type])
+            if exit_check.exit_type != ExitType.EMERGENCY_EXIT
+            else self.strategy.order_types.get("emergency_exit", "market")
+        )
+
         # set custom_exit_price if available
         proposed_limit_rate = limit
         custom_exit_price = limit
@@ -2103,10 +2108,6 @@ class FreqtradeBot(LoggingMixin):
 
         # First cancelling stoploss on exchange ...
         trade = self.cancel_stoploss_on_exchange(trade, allow_nonblocking=True)
-
-        if exit_check.exit_type == ExitType.EMERGENCY_EXIT:
-            # Emergency exits (default to market!)
-            order_type = self.strategy.order_types.get("emergency_exit", "market")
 
         amount = self._safe_exit_amount(trade, trade.pair, sub_trade_amt or trade.amount)
         time_in_force = self.strategy.order_time_in_force["exit"]

--- a/freqtrade/rpc/api_server/api_schemas.py
+++ b/freqtrade/rpc/api_server/api_schemas.py
@@ -426,6 +426,7 @@ class ForceExitPayload(BaseModel):
     tradeid: str | int
     ordertype: OrderTypeValues | None = None
     amount: float | None = None
+    price: float | None = None
 
 
 class BlacklistPayload(BaseModel):

--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -92,7 +92,8 @@ logger = logging.getLogger(__name__)
 # 2.42: Add /pair_history endpoint with live data
 # 2.43: Add /profit_all endpoint
 # 2.44: Add candle_types parameter to download-data endpoint
-API_VERSION = 2.44
+# 2.45: Add price to forceexit endpoint
+API_VERSION = 2.45
 
 # Public API, requires no auth.
 router_public = APIRouter()
@@ -325,7 +326,9 @@ def force_entry(payload: ForceEnterPayload, rpc: RPC = Depends(get_rpc)):
 @router.post("/forcesell", response_model=ResultMsg, tags=["trading"])
 def forceexit(payload: ForceExitPayload, rpc: RPC = Depends(get_rpc)):
     ordertype = payload.ordertype.value if payload.ordertype else None
-    return rpc._rpc_force_exit(str(payload.tradeid), ordertype, amount=payload.amount)
+    return rpc._rpc_force_exit(
+        str(payload.tradeid), ordertype, amount=payload.amount, price=payload.price
+    )
 
 
 @router.get("/blacklist", response_model=BlacklistResponse, tags=["info", "pairlist"])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -992,7 +992,12 @@ class RPC:
                 sub_amount = amount
 
             self._freqtrade.execute_trade_exit(
-                trade, current_rate, exit_check, ordertype=order_type, sub_trade_amt=sub_amount
+                trade,
+                current_rate,
+                exit_check,
+                ordertype=order_type,
+                sub_trade_amt=sub_amount,
+                skip_custom_exit_price=price is not None and ordertype == "limit",
             )
 
             return True

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1013,7 +1013,7 @@ class RPC:
     ) -> dict[str, str]:
         """
         Handler for forceexit <id>.
-        exts the given trade. Uses current price if price is None.
+        exits the given trade. Uses current price if price is None.
         """
 
         if self._freqtrade.state == State.STOPPED:

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -940,7 +940,11 @@ class RPC:
         return {"status": "Reloaded from orders from exchange"}
 
     def __exec_force_exit(
-        self, trade: Trade, ordertype: str | None, amount: float | None = None
+        self,
+        trade: Trade,
+        ordertype: str | None,
+        amount: float | None = None,
+        price: float | None = None,
     ) -> bool:
         # Check if there is there are open orders
         trade_entry_cancelation_registry = []
@@ -964,8 +968,13 @@ class RPC:
                 # Order cancellation failed, so we can't exit.
                 return False
             # Get current rate and execute sell
-            current_rate = self._freqtrade.exchange.get_rate(
-                trade.pair, side="exit", is_short=trade.is_short, refresh=True
+
+            current_rate = (
+                self._freqtrade.exchange.get_rate(
+                    trade.pair, side="exit", is_short=trade.is_short, refresh=True
+                )
+                if ordertype == "market" or price is None
+                else price
             )
             exit_check = ExitCheckTuple(exit_type=ExitType.FORCE_EXIT)
             order_type = ordertype or self._freqtrade.strategy.order_types.get(
@@ -990,11 +999,16 @@ class RPC:
         return False
 
     def _rpc_force_exit(
-        self, trade_id: str, ordertype: str | None = None, *, amount: float | None = None
+        self,
+        trade_id: str,
+        ordertype: str | None = None,
+        *,
+        amount: float | None = None,
+        price: float | None = None,
     ) -> dict[str, str]:
         """
         Handler for forceexit <id>.
-        Sells the given trade at current price
+        exts the given trade. Uses current price if price is None.
         """
 
         if self._freqtrade.state == State.STOPPED:
@@ -1024,7 +1038,7 @@ class RPC:
                 logger.warning("force_exit: Invalid argument received")
                 raise RPCException("invalid argument")
 
-            result = self.__exec_force_exit(trade, ordertype, amount)
+            result = self.__exec_force_exit(trade, ordertype, amount, price)
             Trade.commit()
             self._freqtrade.wallets.update()
             if not result:

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -3092,7 +3092,7 @@ def test_execute_trade_exit_custom_exit_price(
         "exit_reason": "foo",
         "open_date": ANY,
         "close_date": ANY,
-        "close_rate": ANY,
+        "close_rate": 2.25,  # the custom exit price
         "sub_trade": False,
         "cumulative_profit": 0.0,
         "stake_amount": pytest.approx(60),


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Enhance the force-exit API to accept an explicit price parameter.

closes #12606

## Quick changelog

- Added price parameter to the force-exit endpoint.
- Updated logic to handle custom exit price conditions.
- Improved unit tests for force-exit functionality.
