### PR TITLE
adjusted the error message of "more than 5 queries needed for exchange"

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -879,13 +879,13 @@ class Exchange:
                 # Only allow 5 calls per pair to somewhat limit the impact
                 raise ConfigurationError(
                     f"This strategy requires {startup_candles} candles to start, "
-                    "which is more than 5x "
-                    f"the amount of candles {self.name} provides for {timeframe} "
-                    f"at a startup_candle_count limit of {candle_limit * 5 - 1}."
+                    f"which is more than 5x ({candle_limit * 5 - 1} candles) "
+                    f"the amount of candles {self.name} provides for {timeframe}."
                 )
         elif required_candle_call_count > 1:
             raise ConfigurationError(
-                f"This strategy requires {startup_candles} candles to start, which is more than "
+                f"This strategy requires {startup_candles} candles to start, "
+                f"which is more than ({candle_limit - 1} candles) "
                 f"the amount of candles {self.name} provides for {timeframe}."
             )
         if required_candle_call_count > 1:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -880,7 +880,7 @@ class Exchange:
                 raise ConfigurationError(
                     f"This strategy requires {startup_candles} candles to start, "
                     "which is more than 5x "
-                    f"the amount of candles {self.name} provides for {timeframe}"
+                    f"the amount of candles {self.name} provides for {timeframe} "
                     f"at a startup_candle_count limit of {candle_limit * 5 - 1}."
                 )
         elif required_candle_call_count > 1:
@@ -892,7 +892,7 @@ class Exchange:
             logger.warning(
                 f"Using {required_candle_call_count} calls to get OHLCV. "
                 f"This can result in slower operations for the bot. Please check "
-                f"if you really need {startup_candles} candles for your strategy"
+                f"if you really need {startup_candles} candles for your strategy."
             )
         return required_candle_call_count
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -880,7 +880,8 @@ class Exchange:
                 raise ConfigurationError(
                     f"This strategy requires {startup_candles} candles to start, "
                     "which is more than 5x "
-                    f"the amount of candles {self.name} provides for {timeframe}."
+                    f"the amount of candles {self.name} provides for {timeframe}"
+                    f"at a startup_candle_count limit of {candle_limit * 5 - 1}."
                 )
         elif required_candle_call_count > 1:
             raise ConfigurationError(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1012,7 +1012,7 @@ def test_validate_required_startup_candles(default_conf, mocker, caplog):
     ex._ft_has["ohlcv_has_history"] = False
     with pytest.raises(
         OperationalException,
-        match=r"This strategy requires 2500.*, " r"which is more than the amount.*",
+        match=r"This strategy requires 2500.*, " r"which is more than .* the amount",
     ):
         ex.validate_required_startup_candles(2500, "5m")
 


### PR DESCRIPTION
## Summary
I found myself second guessing what the exchanges candle amount per query actually is and seeing those error messages.
Without debugging there is no way for the user to actually know what it is.
Now users don't have to guess what the limit actually is to then work towards, helping to better understand the error message.