### PR TITLE
Add pandas-market-calendars as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "TA-Lib<0.7",
   "ft-pandas-ta",
   "technical",
+  "pandas_market_calendars",
   "tabulate",
   "pycoingecko>=3.2.0",
   "python-rapidjson",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numexpr==2.14.1
 ft-pandas-ta==0.3.16
 ta-lib==0.6.8
 technical==1.5.3
+pandas_market_calendars==5.2.3
 
 ccxt==4.5.29
 cryptography==46.0.3


### PR DESCRIPTION
Depending on the type of strategy, it may be useful to avoid trading your strategy when the US stock market is closed, as this often indirectly affects cryptocurrency markets by eliminating a large part of the trading volume, potentially causing unusual price movements (such as pump and dumps) that are not predictable by our strategies.

This is an example of use::

```python
import pandas_market_calendars as mcal
from pandas import to_datetime

def is_market_holiday(df):
    """
    Returns a boolean Series indicating whether each date in the DataFrame
    is a NYSE holiday or non-trading day.
    """
    nyse = mcal.get_calendar("NYSE")
    start_date = df["date"].min()
    end_date = df["date"].max()
    schedule = nyse.schedule(start_date=start_date, end_date=end_date)
    open_days = set(schedule.index.date)
    dates = to_datetime(df["date"]).dt.date

    return ~dates.isin(open_days)