### PR TITLE
Skip loop iteration if train_queue is empty

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -227,6 +227,10 @@ class IFreqaiModel(ABC):
         """
         while not self._stop_event.is_set():
             time.sleep(1)
+
+            if not self.train_queue:
+                continue
+                
             pair = self.train_queue[0]
 
             # ensure pair is available in dp

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -230,7 +230,7 @@ class IFreqaiModel(ABC):
 
             if not self.train_queue:
                 continue
-                
+
             pair = self.train_queue[0]
 
             # ensure pair is available in dp


### PR DESCRIPTION
## Summary

Prevent a `deque index out of range` exception by safely handling an empty training queue in the FreqAI scanning thread.

## Solve the issue

<img width="1843" height="432" alt="image" src="https://github.com/user-attachments/assets/f09dd7c4-eb4d-4524-8273-33ceff72de61" />

## Quick changelog

* Add a guard to skip processing when `train_queue` is empty
* Prevent background training thread from crashing due to empty deque access

## What's new?

This PR fixes a race condition in the FreqAI training scan loop where `train_queue[0]` could be accessed while the deque was empty, resulting in a `deque index out of range` exception.

The scanning loop now checks whether the training queue is empty and continues gracefully until new items are available. This makes the training thread more robust during:

* startup
* dynamic whitelist changes
* queue depletion scenarios

The change is minimal, does not alter existing training logic, and avoids unnecessary thread crashes in live and dry-run environments.

## Additional notes

* No functional behavior changes aside from improved safety
* No performance impact
* Code is PEP8 conformant
* No unit tests were added as this change affects a threaded runtime path that is difficult to unit-test reliably

## AI usage disclosure

AI assistance was used to help analyze the root cause and suggest a safe fix for the deque access issue.