### PR TITLE
Enhance futures wallet calculations

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -879,7 +879,13 @@ class RPC:
                 try:
                     rate = self._freqtrade.exchange.get_conversion_rate(pos_base, stake_currency)
                     if rate:
-                        # est_stake = collateral + PnL
+                        # For a leveraged position, equity (what we want as est_stake) is:
+                        #   equity = collateral + PnL
+                        #   notional = rate * pos.position
+                        #   borrowed = pos.collateral * (pos.leverage - 1)
+                        # Equity is notional minus borrowed:
+                        #   equity = notional - borrowed
+                        #          = rate * pos.position - pos.collateral * (pos.leverage - 1)
                         est_stake = rate * pos.position - pos.collateral * (pos.leverage - 1)
                 except (ExchangeError, PricingError) as e:
                     logger.warning(f"Error {e} getting rate for futures {symbol} / {pos_base}")

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -873,8 +873,21 @@ class RPC:
         symbol: str
         pos: PositionWallet
         for symbol, pos in self._freqtrade.wallets.get_all_positions().items():
-            total += pos.collateral
-            total_bot += pos.collateral
+            est_stake = pos.collateral
+            pos_base = self._freqtrade.exchange.get_pair_base_currency(symbol)
+            if pos.leverage:
+                try:
+                    rate = self._freqtrade.exchange.get_conversion_rate(pos_base, stake_currency)
+                    if rate:
+                        # est_stake = collateral + PnL
+                        est_stake = rate * pos.position - pos.collateral * (pos.leverage - 1)
+                except (ExchangeError, PricingError) as e:
+                    logger.warning(f"Error {e} getting rate for futures {symbol} / {pos_base}")
+                    pass
+
+            # Add the estimated stake (collateral + unlevered PnL) to totals
+            total += est_stake
+            total_bot += est_stake
 
             currencies.append(
                 {
@@ -883,11 +896,11 @@ class RPC:
                     "balance": 0,
                     "used": 0,
                     "position": pos.position,
-                    "est_stake": pos.collateral,
-                    "est_stake_bot": pos.collateral,
+                    "est_stake": est_stake,
+                    "est_stake_bot": est_stake,
                     "stake": stake_currency,
                     "side": pos.side,
-                    "is_bot_managed": True,
+                    "is_bot_managed": pos_base in open_assets,
                     "is_position": True,
                 }
             )

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -624,10 +624,10 @@ def test_rpc_balance_handle(default_conf_usdt, mocker, tickers, proxy_coin, marg
         default_conf_usdt["stake_currency"], default_conf_usdt["fiat_display_currency"]
     )
 
-    assert tickers.call_count == 4 if not proxy_coin else 6
+    assert tickers.call_count == (7 if proxy_coin and margin_mode != "cross" else 5)
     assert tickers.call_args_list[0][1]["cached"] is True
     # Testing futures - so we should get spot tickers
-    assert tickers.call_args_list[-1][1]["market_type"] == "spot"
+    tickers.assert_any_call(symbols=None, cached=True, market_type=TradingMode.SPOT)
     assert "USD" == result["symbol"]
     expected_curr = [
         {
@@ -692,11 +692,11 @@ def test_rpc_balance_handle(default_conf_usdt, mocker, tickers, proxy_coin, marg
             "balance": 0,
             "used": 0,
             "position": 10.0,
-            "est_stake": 20,
-            "est_stake_bot": 20,
+            "est_stake": 5222.1,
+            "est_stake_bot": 5222.1,
             "stake": "USDT",
             "side": "short",
-            "is_bot_managed": True,
+            "is_bot_managed": False,
             "is_position": True,
         },
     ]
@@ -755,15 +755,15 @@ def test_rpc_balance_handle(default_conf_usdt, mocker, tickers, proxy_coin, marg
 
     assert result["currencies"] == expected_curr
     if proxy_coin and margin_mode == "cross":
-        assert pytest.approx(result["total_bot"]) == 1505.0
-        assert pytest.approx(result["total"]) == 2186.6972  # ETH stake is missing.
+        assert pytest.approx(result["total_bot"]) == 6707.1
+        assert pytest.approx(result["total"]) == 7388.7972  # ETH stake is missing.
         assert result["starting_capital"] == 1500 * default_conf_usdt["tradable_balance_ratio"]
-        assert result["starting_capital_ratio"] == pytest.approx(0.013468013468013407)
+        assert result["starting_capital_ratio"] == pytest.approx(3.5165656)
     else:
-        assert pytest.approx(result["total_bot"]) == 69.5
-        assert pytest.approx(result["total"]) == 686.6972  # ETH stake is missing.
+        assert pytest.approx(result["total_bot"]) == 5271.6
+        assert pytest.approx(result["total"]) == 5888.7972  # ETH stake is missing.
         assert result["starting_capital"] == 50 * default_conf_usdt["tradable_balance_ratio"]
-        assert result["starting_capital_ratio"] == pytest.approx(0.4040404)
+        assert result["starting_capital_ratio"] == pytest.approx(105.496969)
     assert pytest.approx(result["value"]) == result["total"] * 1.2
 
 

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -619,7 +619,12 @@ def test_rpc_balance_handle(default_conf_usdt, mocker, tickers, proxy_coin, marg
     rpc = RPC(freqtradebot)
     rpc._fiat_converter = CryptoToFiatConverter({})
     mocker.patch.object(rpc._fiat_converter, "get_price", return_value=1.2)
-
+    mocker.patch(
+        "freqtrade.persistence.trade_model.Trade.get_open_trades",
+        return_value=[
+            MagicMock(pair="ETH/USDT:USDT", safe_base_currency="ETH"),
+        ],
+    )
     result = rpc._rpc_balance(
         default_conf_usdt["stake_currency"], default_conf_usdt["fiat_display_currency"]
     )
@@ -696,7 +701,7 @@ def test_rpc_balance_handle(default_conf_usdt, mocker, tickers, proxy_coin, marg
             "est_stake_bot": 5222.1,
             "stake": "USDT",
             "side": "short",
-            "is_bot_managed": False,
+            "is_bot_managed": True,
             "is_position": True,
         },
     ]

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -1155,7 +1155,7 @@ async def test_telegram_balance_handle_futures(
             "percentage": None,
         },
         {
-            "symbol": "XRP/USDT:USDT",
+            "symbol": "ADA/USDT:USDT",
             "timestamp": None,
             "datetime": None,
             "initialMargin": 0.0,
@@ -1181,9 +1181,17 @@ async def test_telegram_balance_handle_futures(
     mocker.patch(f"{EXMS}.fetch_positions", return_value=mock_pos)
     mocker.patch(f"{EXMS}.get_tickers", tickers)
     mocker.patch(f"{EXMS}.get_valid_pair_combination", side_effect=lambda a, b: [f"{a}/{b}"])
+    mocker.patch(f"{EXMS}.get_conversion_rate", return_value=3200)
 
     telegram, freqtradebot, msg_mock = get_telegram_testobject(mocker, default_conf)
     patch_get_signal(freqtradebot)
+    mocker.patch(
+        "freqtrade.persistence.trade_model.Trade.get_open_trades",
+        return_value=[
+            MagicMock(pair="ETH/USDT:USDT", safe_base_currency="ETH"),
+            MagicMock(pair="ADA/USDT:USDT", safe_base_currency="ADA"),
+        ],
+    )
 
     await telegram._balance(update=update, context=MagicMock())
     result = msg_mock.call_args_list[0][0][0]
@@ -1191,7 +1199,7 @@ async def test_telegram_balance_handle_futures(
 
     assert "ETH/USDT:USDT" in result
     assert "`short: 10" in result
-    assert "XRP/USDT:USDT" in result
+    assert "ADA/USDT:USDT" in result
 
 
 async def test_balance_handle_empty_response(default_conf, update, mocker) -> None:


### PR DESCRIPTION

## Summary

Improve balance visualization for futures positions to show the current balance position.

This is calculated as collateral + profit/loss in collateral.

Conversion rates are cached for 10 minutes, so don't expect up to the minute precision. 
The calculation for the wallets feature also doesn't consider fees - as they're an estimate at best at that point.

## Quick changelog

- Update rpc_balance est_stake calculation for futures positions