### PR TITLE
Freqtrade Downloader - don't drop latest candle for Funding Rates

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2563,7 +2563,9 @@ class Exchange:
                 )
             )
         logger.debug(f"Downloaded data for {pair} from ccxt with length {len(data)}.")
-        return ohlcv_to_dataframe(data, timeframe, pair, fill_missing=False, drop_incomplete=True)
+        return ohlcv_to_dataframe(data, timeframe, pair, fill_missing=False,
+            # funding_rates are always complete, so never need to be dropped.
+            drop_incomplete=self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE else False)
 
     async def _async_get_historic_ohlcv(
         self,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2563,10 +2563,15 @@ class Exchange:
                 )
             )
         logger.debug(f"Downloaded data for {pair} from ccxt with length {len(data)}.")
-        return ohlcv_to_dataframe(data, timeframe, pair, fill_missing=False,
-            # funding_rates are always complete, so never need to be dropped.
-            drop_incomplete=self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE
-            else False)
+        # funding_rates are always complete, so never need to be dropped.
+        drop = self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE else False
+        return ohlcv_to_dataframe(
+            data,
+            timeframe,
+            pair,
+            fill_missing=False,
+            drop_incomplete=drop
+        )
 
     async def _async_get_historic_ohlcv(
         self,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2565,7 +2565,8 @@ class Exchange:
         logger.debug(f"Downloaded data for {pair} from ccxt with length {len(data)}.")
         return ohlcv_to_dataframe(data, timeframe, pair, fill_missing=False,
             # funding_rates are always complete, so never need to be dropped.
-            drop_incomplete=self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE else False)
+            drop_incomplete=self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE
+            else False)
 
     async def _async_get_historic_ohlcv(
         self,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2564,13 +2564,11 @@ class Exchange:
             )
         logger.debug(f"Downloaded data for {pair} from ccxt with length {len(data)}.")
         # funding_rates are always complete, so never need to be dropped.
-        drop = self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE else False
+        drop_incomplete = (
+            self._ohlcv_partial_candle if candle_type != CandleType.FUNDING_RATE else False
+        )
         return ohlcv_to_dataframe(
-            data,
-            timeframe,
-            pair,
-            fill_missing=False,
-            drop_incomplete=drop
+            data, timeframe, pair, fill_missing=False, drop_incomplete=drop_incomplete
         )
 
     async def _async_get_historic_ohlcv(


### PR DESCRIPTION
## Summary

Downloading of Funding Rates using the Data Downloader is unnecessarily dropping the most recent candle.

## Quick changelog

- Added condition to not drop the last candle for Funding Rates as they are always live. Copied code for condition from elsewhere in exchange.py.

## What's new?

On Binance BTC Funding Rate candles are typically every 8 hours, so running at 1pm UTC Time, there should be two funding rates available for the day - midnight & 8am UTC. Currently Freqtrade Downoader gets both, but drops the 2nd one, so we are left with only midnight.

Using the folllowing :
`freqtrade download-data --pairs "BTC/USDT:USDT" -t 1h --timerange 20200101- --trading-mode futures --candle-type funding_rate -v`

Before:
Can see it drops the candle and End time is 00:00.
<img width="851" height="194" alt="image" src="https://github.com/user-attachments/assets/d5808629-7461-4ce6-9d65-a1c5757c189e" />

After:
No longer drops the candle, and End time is 08:00.
<img width="844" height="203" alt="image" src="https://github.com/user-attachments/assets/e9052f2e-22f6-4986-9359-01d0fd459f95" />

_Log timestamps in screengrabs are UTC+1._


