### PR TITLE
Hyperopt params-as-seed

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -748,6 +748,19 @@ If you have not set this value explicitly in the command line options, Hyperopt 
 
 If you have not changed anything in the command line options, configuration, timerange, Strategy and Hyperopt classes, historical data and the Loss Function -- you should obtain same hyper-optimization results with same random state value used.
 
+### Start from current parameters
+
+You can use the `--params-as-seed` command line option to tell Hyperopt to use the current strategy parameters (as defined in your strategy file or loaded from a parameters file) as the initial trial.
+
+```bash
+freqtrade hyperopt --params-as-seed --spaces buy sell stoploss --config config.json
+```
+
+This is useful if you have a good working strategy and want to see if Hyperopt can find slight improvements, rather than starting from completely random points.
+
+*   **Fully Seeded:** If all optimized spaces (e.g., `buy`, `sell`) are covered by your current parameters, Hyperopt will run exactly one initial trial with these values.
+*   **Partially Seeded:** If you include spaces that cannot be fully defined by existing parameters (such as `roi`, which uses a generated table rather than raw parameters), Hyperopt will run **5 initial trials**. Each trial will use your fixed known parameters (like `buy`/`sell`) combined with different random values for the missing spaces (like `roi`).
+
 ## Output formatting
 
 By default, hyperopt prints colorized results -- epochs with positive profit are printed in the green color. This highlighting helps you find epochs that can be interesting for later analysis. Epochs with zero total profit or with negative profits (losses) are printed in the normal color. If you do not need colorization of results (for instance, when you are redirecting hyperopt output to a file) you can switch colorization off by specifying the `--no-color` option in the command line.

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -82,6 +82,7 @@ ARGS_HYPEROPT = [
     "hyperopt_ignore_missing_space",
     "analyze_per_epoch",
     "early_stop",
+    "hyperopt_params_as_seed",
 ]
 
 ARGS_EDGE = [*ARGS_COMMON_OPTIMIZE]

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -364,6 +364,11 @@ AVAILABLE_CLI_OPTIONS = {
         f"{', '.join(HYPEROPT_LOSS_BUILTIN)}",
         metavar="NAME",
     ),
+    "hyperopt_params_as_seed": Arg(
+        "--params-as-seed",
+        help="Use the current strategy parameters as the first trial in hyperopt.",
+        action="store_true",
+    ),
     "hyperoptexportfilename": Arg(
         "--hyperopt-filename",
         help="Hyperopt result filename."

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -343,6 +343,11 @@ class Configuration:
             ("spaces", "Parameter -s/--spaces detected: {}"),
             ("analyze_per_epoch", "Parameter --analyze-per-epoch detected."),
             ("print_all", "Parameter --print-all detected ..."),
+            (
+                "hyperopt_params_as_seed",
+                "Parameter --params-as-seed detected. "
+                "Using current strategy parameters as first hyperopt trial.",
+            ),
         ]
         self._args_to_config_loop(config, configurations)
         es_epochs = self.args.get("early_stop", 0)

--- a/freqtrade/optimize/hyperopt/hyperopt.py
+++ b/freqtrade/optimize/hyperopt/hyperopt.py
@@ -8,7 +8,7 @@ import gc
 import logging
 import random
 from datetime import datetime
-from math import ceil
+from math import ceil, isinf
 from pathlib import Path
 from typing import Any
 
@@ -228,6 +228,77 @@ class Hyperopt:
         logger.info(f"Number of parallel jobs set as: {config_jobs}")
 
         self.opt = self.hyperopter.get_optimizer(self.random_state)
+
+        if self.config.get("hyperopt_params_as_seed", False):
+            try:
+                current_params = {}
+                strat = self.hyperopter.backtesting.strategy
+
+                # 1. Strategy Parameters (buy/sell/protection/etc)
+                for attr_name, attr in strat.enumerate_parameters():
+                    if attr.optimize and attr.in_space:
+                        current_params[attr_name] = attr.value
+
+                # 2. Stoploss
+                if "stoploss" in self.hyperopter.o_dimensions:
+                    current_params["stoploss"] = strat.stoploss
+
+                # 3. Max Open Trades
+                if "max_open_trades" in self.hyperopter.o_dimensions:
+                    if isinf(strat.max_open_trades):
+                        current_params["max_open_trades"] = -1
+                    else:
+                        current_params["max_open_trades"] = strat.max_open_trades
+
+                # 4. Trailing
+                if "trailing_stop_positive" in self.hyperopter.o_dimensions:
+                    if strat.trailing_stop_positive is not None:
+                        current_params["trailing_stop_positive"] = strat.trailing_stop_positive
+
+                    if (
+                        strat.trailing_stop_positive is not None
+                        and strat.trailing_stop_positive_offset is not None
+                    ):
+                        # trailing_stop_positive_offset = trailing_stop_positive + trailing_stop_positive_offset_p1
+                        # So p1 = offset - positive
+                        current_params["trailing_stop_positive_offset_p1"] = (
+                            strat.trailing_stop_positive_offset - strat.trailing_stop_positive
+                        )
+
+                    if hasattr(strat, "trailing_only_offset_is_reached"):
+                        current_params["trailing_only_offset_is_reached"] = (
+                            strat.trailing_only_offset_is_reached
+                        )
+
+                    current_params["trailing_stop"] = (
+                        True  # If space is active, it's forced True in space definition usually
+                    )
+
+                # Filter params that are actually in the search space to avoid errors
+                params_to_enqueue = {
+                    k: v for k, v in current_params.items() if k in self.hyperopter.o_dimensions
+                }
+
+                if params_to_enqueue:
+                    # If we have missing dimensions (e.g. ROI which cannot be seeded),
+                    # we repeat the trial multiple times to allow the optimizer to sample
+                    # different random values for the missing dimensions against our fixed known params.
+                    is_partial_seed = len(params_to_enqueue) < len(self.hyperopter.o_dimensions)
+                    count = 5 if is_partial_seed else 1
+
+                    logger.info(
+                        f"Enqueuing current strategy parameters as initial trial ({count} times): {params_to_enqueue}"
+                    )
+                    for _ in range(count):
+                        self.opt.enqueue_trial(params_to_enqueue)
+                else:
+                    logger.info(
+                        "No current strategy parameters found matching the search space to enqueue."
+                    )
+
+            except Exception as e:
+                logger.warning(f"Failed to enqueue current parameters: {e}")
+
         try:
             with Parallel(n_jobs=config_jobs) as parallel:
                 jobs = parallel._effective_n_jobs()


### PR DESCRIPTION
### Description

This PR adds a new feature to Hyperopt that allows users to "seed" the optimization process with their strategy's current parameters.

Currently, Hyperopt starts with completely random points. This feature allows users who have a working strategy to start the search from their known "good" configuration, potentially speeding up the discovery of improvements or fine-tuning existing parameters.

### Usage

```bash
freqtrade hyperopt --params-as-seed --spaces buy sell ...
```

### Implementation Details

*   **Flag:** Added `--params-as-seed` boolean flag.
*   **Fully Seeded:** If only standard parameter spaces (buy, sell, stoploss, trailing, max_open_trades) are optimized, a single trial is enqueued with the current values.
*   **Partially Seeded (ROI handling):** If the optimization includes spaces that cannot be reconstructed from the strategy file (specifically `roi`), the system automatically enqueues **5 trials**. These trials keep the known parameters (e.g., `buy`/`sell`) fixed while testing 5 different random ROI tables. This helps establish a strong baseline even when the ROI table is being re-optimized.

### Disclaimer

This code is partially AI-generated.