### PR TITLE
refactor: replace get_mock_coro with AsyncMock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import re
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock
 
 import numpy as np
 import pandas as pd
@@ -209,24 +209,9 @@ def generate_test_data_raw(timeframe: str, size: int, start: str = "2020-07-05",
     return list(list(x) for x in zip(*(df[x].values.tolist() for x in df.columns), strict=False))
 
 
-# Source: https://stackoverflow.com/questions/29881236/how-to-mock-asyncio-coroutines
-# TODO: This should be replaced with AsyncMock once support for python 3.7 is dropped.
 def get_mock_coro(return_value=None, side_effect=None):
-    async def mock_coro(*args, **kwargs):
-        if side_effect:
-            if isinstance(side_effect, list):
-                effect = side_effect.pop(0)
-            else:
-                effect = side_effect
-            if isinstance(effect, Exception):
-                raise effect
-            if callable(effect):
-                return effect(*args, **kwargs)
-            return effect
-        else:
-            return return_value
-
-    return Mock(wraps=mock_coro)
+    """Create an AsyncMock with the given return value or side effect."""
+    return AsyncMock(return_value=return_value, side_effect=side_effect)
 
 
 def patched_configuration_load_config_file(mocker, config) -> None:


### PR DESCRIPTION
## Summary
- Replace the custom `get_mock_coro` helper function with Python's standard library `AsyncMock`
- Remove outdated TODO comment referencing Python 3.7 support
- Simplify test code by using built-in async mocking capabilities

## Rationale
Since freqtrade now requires Python >= 3.11, the custom implementation is no longer needed. `AsyncMock` has been available since Python 3.8 and provides the same functionality.

## Test plan
- [ ] Existing tests using `get_mock_coro` should continue to pass
- [ ] No behavioral changes expected - `AsyncMock` provides equivalent functionality