### PR TITLE
use FtTTLCache for background jobs to prevent memory leaks

### DIFF
--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -13,6 +13,7 @@ from freqtrade.constants import Config
 from freqtrade.exceptions import OperationalException
 from freqtrade.rpc.api_server.uvicorn_threaded import UvicornServer
 from freqtrade.rpc.api_server.webserver_bgwork import ApiBG
+from freqtrade.util import FtTTLCache
 from freqtrade.rpc.api_server.ws.message_stream import MessageStream
 from freqtrade.rpc.rpc import RPC, RPCException, RPCHandler
 from freqtrade.rpc.rpc_types import RPCSendMsg
@@ -157,7 +158,7 @@ class ApiServer(RPCHandler):
         ApiServer._has_rpc = False
         del ApiServer._rpc
         ApiBG.exchanges = {}
-        ApiBG.jobs = {}
+        ApiBG.jobs = FtTTLCache(maxsize=500, ttl=3600)
         if self._server and not self._standalone:
             logger.info("Stopping API Server")
             # self._server.force_exit, self._server.should_exit = True, True

--- a/freqtrade/rpc/api_server/webserver_bgwork.py
+++ b/freqtrade/rpc/api_server/webserver_bgwork.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from typing_extensions import TypedDict
 
 from freqtrade.exchange.exchange import Exchange
+from freqtrade.util import FtTTLCache
 
 
 class ProgressTask(TypedDict):
@@ -36,9 +37,8 @@ class ApiBG:
     exchanges: dict[str, Exchange] = {}
 
     # Generic background jobs
-
-    # TODO: Change this to FtTTLCache
-    jobs: dict[str, JobsContainer] = {}
+    # Using FtTTLCache to automatically expire old job results and prevent memory leaks
+    jobs: FtTTLCache = FtTTLCache(maxsize=500, ttl=3600)
     # Pairlist evaluate things
     pairlist_running: bool = False
     download_data_running: bool = False


### PR DESCRIPTION
## Summary
- Replace plain `dict` with `FtTTLCache` for storing background job results
- Implement the existing TODO comment in `webserver_bgwork.py`
- Add automatic expiration of old job results (1 hour TTL)
- Limit maximum entries to 500 to bound memory usage

## Rationale
The `ApiBG.jobs` dictionary can grow indefinitely as users trigger background jobs (pairlist evaluation, data download, etc.). Using `FtTTLCache` ensures that old job results are automatically expired and removed, preventing potential memory leaks in long-running instances.

## Changes
- `freqtrade/rpc/api_server/webserver_bgwork.py`: Changed `jobs` from `dict` to `FtTTLCache(maxsize=500, ttl=3600)`
- `freqtrade/rpc/api_server/webserver.py`: Updated `cleanup()` to reset with a new `FtTTLCache` instance

## Test plan
- [ ] Background jobs (pairlist, download_data) should work as before
- [ ] Job results should be accessible within the TTL window
- [ ] Old job entries should be automatically cleaned up