### PR TITLE
dynamically load data from exchange when timeframe not cache

### DIFF
--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -416,6 +416,25 @@ class DataProvider:
                     return (DataFrame(), datetime.fromtimestamp(0, tz=UTC))
             return df, date
         else:
+            # Dynamic timeframe support: try to load data from exchange if not cached
+            if self.runmode in (RunMode.DRY_RUN, RunMode.LIVE) and self._exchange is not None:
+                try:
+                    candle_type = self._config.get("candle_type_def", CandleType.SPOT)
+                    logger.info(f"Loading data for {pair} {timeframe} dynamically")
+
+                    # Try to refresh data from exchange
+                    pair_with_timeframe = (pair, timeframe, candle_type)
+                    results = self._exchange.refresh_latest_ohlcv([pair_with_timeframe])
+
+                    if pair_with_timeframe in results and not results[pair_with_timeframe].empty:
+                        df = results[pair_with_timeframe]
+                        now = datetime.now(UTC)
+                        self.__cached_pairs[pair_key] = (df, now)
+                        return df, now
+                    else:
+                        logger.warning(f"No data available for {pair} {timeframe}")
+                except Exception as e:
+                    logger.warning(f"Failed to load data for {pair} {timeframe}: {e}")
             return (DataFrame(), datetime.fromtimestamp(0, tz=UTC))
 
     @property


### PR DESCRIPTION
## Summary

Add dynamic data loading from exchange when timeframe is not cached in `get_analyzed_dataframe()`.

With this PR: https://github.com/freqtrade/frequi/pull/2741


## Quick changelog

- Added dynamic data loading in `get_analyzed_dataframe()` when pair/timeframe combination is not found in cache
- Uses `refresh_latest_ohlcv()` to fetch data from exchange in live/dry-run modes
- Added proper error handling and logging for data loading failures

## What's new

This PR improves the `DataProvider.get_analyzed_dataframe()` method by adding fallback logic to dynamically load OHLCV data from the exchange when the requested pair/timeframe combination is not found in the internal cache.

**Key changes:**

- When running in `DRY_RUN` or `LIVE` mode, if the requested pair/timeframe is not cached, the method now attempts to fetch fresh data from the exchange using `refresh_latest_ohlcv()`
- Successfully loaded data is cached and returned immediately
- Added appropriate warning logs when data loading fails or no data is available
- This enhancement allows strategies to request informative pairs with different timeframes without requiring them to be pre-configured in the pairlis