### PR TITLE
Fix regex pattern for model folder matching

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -446,7 +446,7 @@ class FreqaiDataDrawer:
 
         model_folders = [x for x in self.full_path.iterdir() if x.is_dir()]
 
-        pattern = re.compile(r"sub-train-(\w+)_(\d{10})")
+        pattern = re.compile(r"sub-train-([^_]+)_(\d{10})")
 
         delete_dict: dict[str, Any] = {}
 

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -446,7 +446,7 @@ class FreqaiDataDrawer:
 
         model_folders = [x for x in self.full_path.iterdir() if x.is_dir()]
 
-        pattern = re.compile(r"sub-train-([^_]+)_(\d{10})")
+        pattern = re.compile(r"^sub-train-(.+)_(\d{10})$")
 
         delete_dict: dict[str, Any] = {}
 


### PR DESCRIPTION
Allows freqai to purge model train folders with non-alphanumeric characters in them (eg. hip3 pairs with hyphen)
This was a combination of figuring out the root of the problem and using Claude AI to identify the code change required in data_drawer.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).


Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
