### PR TITLE
Add WhiteBit exchange support

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -48,3 +48,4 @@ from freqtrade.exchange.lbank import Lbank
 from freqtrade.exchange.luno import Luno
 from freqtrade.exchange.modetrade import Modetrade
 from freqtrade.exchange.okx import Myokx, Okx, Okxus
+from freqtrade.exchange.whitebit import Whitebit

--- a/freqtrade/exchange/whitebit.py
+++ b/freqtrade/exchange/whitebit.py
@@ -1,0 +1,34 @@
+"""WhiteBit exchange subclass"""
+
+import logging
+
+from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+
+logger = logging.getLogger(__name__)
+
+
+class Whitebit(Exchange):
+    """WhiteBit exchange class.
+    Contains adjustments needed for Freqtrade to work with this exchange.
+    """
+
+    _ft_has: FtHas = {
+        "trades_has_history": False,
+    }
+    _ft_has_futures: FtHas = {
+        "uses_leverage_tiers": False,
+    }
+
+    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
+        (TradingMode.SPOT, MarginMode.NONE),
+        (TradingMode.FUTURES, MarginMode.ISOLATED),
+    ]
+
+    def get_max_leverage(self, pair: str, stake_amount: float | None) -> float:
+        if self.trading_mode == TradingMode.FUTURES:
+            return self.markets[pair]["limits"]["leverage"]["max"]
+        else:
+            return 1.0


### PR DESCRIPTION
## Summary

Add WhiteBit exchange integration to Freqtrade with support for spot and futures trading modes.

## Quick changelog

- Add new `Whitebit` exchange subclass with spot and futures trading support
- Implement `get_max_leverage()` method for futures leverage retrieval
- Register WhiteBit in exchange module exports

## What's new?

This PR adds support for the WhiteBit cryptocurrency exchange to Freqtrade. The implementation includes:

- **New exchange class**: `Whitebit` extending the base `Exchange` class
- **Trading mode support**: 
  - Spot trading (no margin)
  - Futures trading with isolated margin
- **Leverage handling**: Dynamic max leverage retrieval for futures pairs from market data
- **Exchange capabilities**: Configured with WhiteBit-specific limitations (e.g., `trades_has_history: False`)

The exchange is now available for use in Freqtrade bot configurations.
