### PR TITLE
binance: reduce futures OHLCV default limit to 499

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -48,6 +48,8 @@ class Binance(Exchange):
         "has_delisting": True,
     }
     _ft_has_futures: FtHas = {
+        # Keep Binance futures OHLCV requests below the expensive weight tiers by default.
+        "ohlcv_candle_limit": 499,
         "funding_fee_candle_limit": 1000,
         "stoploss_order_types": {"limit": "stop", "market": "stop_market"},
         "stoploss_blocks_assets": False,  # Stoploss orders do not block assets

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -177,6 +177,15 @@ def test_stoploss_adjust_binance(mocker, default_conf, sl1, sl2, sl3, side):
     assert not exchange.stoploss_adjust(sl2, order, side=side)
 
 
+def test_binance_futures_ohlcv_candle_limit(default_conf_usdt, mocker):
+    default_conf_usdt["trading_mode"] = "futures"
+    default_conf_usdt["margin_mode"] = "isolated"
+    exchange = get_patched_exchange(mocker, default_conf_usdt, exchange="binance")
+
+    for timeframe in ("1m", "5m", "1h"):
+        assert exchange.ohlcv_candle_limit(timeframe, CandleType.FUTURES) == 499
+
+
 @pytest.mark.parametrize(
     "pair, is_short, trading_mode, margin_mode, wallet_balance, "
     "maintenance_amt, amount, open_rate, open_trades,"


### PR DESCRIPTION
## Summary
- set Binance futures default `ohlcv_candle_limit` to `499`
- keep funding-rate candle limit unchanged (`1000`)
- add regression test covering Binance futures candle-limit behavior

## Why
Binance futures `fetchOHLCV` has weight tiers where high limits become expensive and slow bulk data downloads. Using a lower default reduces API weight usage and improves refresh speed out-of-the-box while still allowing users to override via config.

Closes #12751

## Testing
- `python -m pytest tests/exchange/test_binance.py -k "futures_ohlcv_candle_limit" -q`
