### PR TITLE
Change max drawdown protection calculation

### DIFF
--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -69,10 +69,16 @@ def protections(self):
 
 #### MaxDrawdown
 
-`MaxDrawdown` calculates the maximum relative drawdown using the account's equity curve within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`).
-It evaluates the portfolio's peak-to-trough declines by considering the starting balance and the cumulative profit of all trades within the window. If the observed drawdown exceeds `max_allowed_drawdown`, trading will stop for `stop_duration` after the last trade - assuming that the bot needs some time to let markets recover.
+`MaxDrawdown` supports 2 calculation modes within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`):
 
-The default calculation method is the sum-of-profit-ratios method (`calculation_mode: "ratios"`) for backward compatibility. To use the standard peak-to-trough equity drawdown (recommended), set `calculation_mode: "equity"`.
+- `calculation_mode: "ratios"` (default): Legacy approximation based on cumulative profit ratios.
+- `calculation_mode: "equity"`: Standard peak-to-trough drawdown on the account equity curve, using starting balance and cumulative absolute profit.
+
+With `calculation_mode: "ratios"`, drawdown is derived from cumulative trade profit ratios, not from the account equity curve. This is kept for backward compatibility and can differ from account-level drawdown when position sizing changes over time.
+
+For new setups, `calculation_mode: "equity"` is recommended. Prefer `calculation_mode: "ratios"` only when you intentionally rely on legacy behavior, especially with fixed stake amount configurations where ratio-based behavior is easier to reason about.
+
+If the observed drawdown exceeds `max_allowed_drawdown`, trading will stop for `stop_duration` after the last trade - assuming that the bot needs some time to let markets recover.
 
 The below sample stops trading for 12 candles if max-drawdown is > 20% considering all pairs - with a minimum of `trade_limit` trades - within the last 48 candles. If desired, `lookback_period` and/or `stop_duration` can be used.
 
@@ -82,6 +88,7 @@ def protections(self):
     return  [
         {
             "method": "MaxDrawdown",
+            "calculation_mode": "equity",
             "lookback_period_candles": 48,
             "trade_limit": 20,
             "stop_duration_candles": 12,

--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -72,7 +72,7 @@ def protections(self):
 `MaxDrawdown` calculates the maximum relative drawdown using the account's equity curve within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`).
 It evaluates the portfolio's peak-to-trough declines by considering the starting balance and the cumulative profit of all trades within the window. If the observed drawdown exceeds `max_allowed_drawdown`, trading will stop for `stop_duration` after the last trade - assuming that the bot needs some time to let markets recover.
 
-The default calculation method is the sum-of-profit-ratios method (`method: "ratios"`) for backward compatibility. To use the standard peak-to-trough equity drawdown (recommended), set `method: "equity"`.
+The default calculation method is the sum-of-profit-ratios method (`calculation_mode: "ratios"`) for backward compatibility. To use the standard peak-to-trough equity drawdown (recommended), set `calculation_mode: "equity"`.
 
 The below sample stops trading for 12 candles if max-drawdown is > 20% considering all pairs - with a minimum of `trade_limit` trades - within the last 48 candles. If desired, `lookback_period` and/or `stop_duration` can be used.
 

--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -72,6 +72,8 @@ def protections(self):
 `MaxDrawdown` calculates the maximum relative drawdown using the account's equity curve within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`).
 It evaluates the portfolio's peak-to-trough declines by considering the starting balance and the cumulative profit of all trades within the window. If the observed drawdown exceeds `max_allowed_drawdown`, trading will stop for `stop_duration` after the last trade - assuming that the bot needs some time to let markets recover.
 
+The default calculation method is the sum-of-profit-ratios method (`method: "ratios"`) for backward compatibility. To use the standard peak-to-trough equity drawdown (recommended), set `method: "equity"`.
+
 The below sample stops trading for 12 candles if max-drawdown is > 20% considering all pairs - with a minimum of `trade_limit` trades - within the last 48 candles. If desired, `lookback_period` and/or `stop_duration` can be used.
 
 ``` python

--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -69,7 +69,8 @@ def protections(self):
 
 #### MaxDrawdown
 
-`MaxDrawdown` uses all trades within `lookback_period` in minutes (or in candles when using `lookback_period_candles`) to determine the maximum drawdown. If the drawdown is below `max_allowed_drawdown`, trading will stop for `stop_duration` in minutes (or in candles when using `stop_duration_candles`) after the last trade - assuming that the bot needs some time to let markets recover.
+`MaxDrawdown` calculates the maximum relative drawdown using the account's equity curve within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`).
+It evaluates the portfolio's peak-to-trough declines by considering the starting balance and the cumulative profit of all trades within the window. If the observed drawdown exceeds `max_allowed_drawdown`, trading will stop for `stop_duration` after the last trade - assuming that the bot needs some time to let markets recover.
 
 The below sample stops trading for 12 candles if max-drawdown is > 20% considering all pairs - with a minimum of `trade_limit` trades - within the last 48 candles. If desired, `lookback_period` and/or `stop_duration` can be used.
 

--- a/docs/includes/protections.md
+++ b/docs/includes/protections.md
@@ -69,7 +69,7 @@ def protections(self):
 
 #### MaxDrawdown
 
-`MaxDrawdown` supports 2 calculation modes within the `lookback_period` in minutes (or in candles when using `lookback_period_candles`):
+The `MaxDrawdown` protection evaluates trades that closed within the current `lookback_period` (or `lookback_period_candles`). It supports 2 calculation modes:
 
 - `calculation_mode: "ratios"` (default): Legacy approximation based on cumulative profit ratios.
 - `calculation_mode: "equity"`: Standard peak-to-trough drawdown on the account equity curve, using starting balance and cumulative absolute profit.
@@ -173,7 +173,8 @@ class AwesomeStrategy(IStrategy)
                 "lookback_period_candles": 48,
                 "trade_limit": 20,
                 "stop_duration_candles": 4,
-                "max_allowed_drawdown": 0.2
+                "max_allowed_drawdown": 0.2,
+                "calculation_mode": "equity"
             },
             {
                 "method": "StoplossGuard",

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2421,7 +2421,9 @@ class FreqtradeBot(LoggingMixin):
     def handle_protections(self, pair: str, side: LongShort) -> None:
         # Lock pair for one candle to prevent immediate re-entries
         self.strategy.lock_pair(pair, datetime.now(UTC), reason="Auto lock", side=side)
-        prot_trig = self.protections.stop_per_pair(pair, side=side)
+        starting_balance = self.wallets.get_starting_balance()
+        prot_trig = self.protections.stop_per_pair(
+            pair, side=side, starting_balance=starting_balance)
         if prot_trig:
             msg: RPCProtectionMsg = {
                 "type": RPCMessageType.PROTECTION_TRIGGER,
@@ -2430,7 +2432,7 @@ class FreqtradeBot(LoggingMixin):
             }
             self.rpc.send_msg(msg)
 
-        prot_trig_glb = self.protections.global_stop(side=side)
+        prot_trig_glb = self.protections.global_stop(side=side, starting_balance=starting_balance)
         if prot_trig_glb:
             msg = {
                 "type": RPCMessageType.PROTECTION_TRIGGER_GLOBAL,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2423,7 +2423,8 @@ class FreqtradeBot(LoggingMixin):
         self.strategy.lock_pair(pair, datetime.now(UTC), reason="Auto lock", side=side)
         starting_balance = self.wallets.get_starting_balance()
         prot_trig = self.protections.stop_per_pair(
-            pair, side=side, starting_balance=starting_balance)
+            pair, side=side, starting_balance=starting_balance
+        )
         if prot_trig:
             msg: RPCProtectionMsg = {
                 "type": RPCMessageType.PROTECTION_TRIGGER,

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -136,6 +136,7 @@ class Backtesting:
             "exited": {},
         }
         self.rejected_dict: dict[str, list] = {}
+        self.starting_balance: float = 0.0
 
         self._exchange_name = self.config["exchange"]["name"]
         self.__initial_backtest = exchange is None
@@ -277,6 +278,7 @@ class Backtesting:
         self.reset_backtest(False)
 
         self.wallets = Wallets(self.config, self.exchange, is_backtest=True)
+        self.starting_balance = self.wallets.get_starting_balance()
 
         self.progress = BTProgress()
         self.abort = False
@@ -1271,9 +1273,8 @@ class Backtesting:
 
     def run_protections(self, pair: str, current_time: datetime, side: LongShort):
         if self.enable_protections:
-            starting_balance = self.wallets.get_starting_balance()
-            self.protections.stop_per_pair(pair, current_time, side, starting_balance)
-            self.protections.global_stop(current_time, side, starting_balance)
+            self.protections.stop_per_pair(pair, current_time, side, self.starting_balance)
+            self.protections.global_stop(current_time, side, self.starting_balance)
 
     def manage_open_orders(self, trade: LocalTrade, current_time: datetime, row: tuple) -> bool:
         """

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1271,8 +1271,9 @@ class Backtesting:
 
     def run_protections(self, pair: str, current_time: datetime, side: LongShort):
         if self.enable_protections:
-            self.protections.stop_per_pair(pair, current_time, side)
-            self.protections.global_stop(current_time, side)
+            starting_balance = self.wallets.get_starting_balance()
+            self.protections.stop_per_pair(pair, current_time, side, starting_balance)
+            self.protections.global_stop(current_time, side, starting_balance)
 
     def manage_open_orders(self, trade: LocalTrade, current_time: datetime, row: tuple) -> bool:
         """

--- a/freqtrade/plugins/protectionmanager.py
+++ b/freqtrade/plugins/protectionmanager.py
@@ -66,8 +66,11 @@ class ProtectionManager:
         return result
 
     def stop_per_pair(
-        self, pair, now: datetime | None = None, side: LongShort = "long",
-        starting_balance: float = 0.0
+        self,
+        pair,
+        now: datetime | None = None,
+        side: LongShort = "long",
+        starting_balance: float = 0.0,
     ) -> PairLock | None:
         if not now:
             now = datetime.now(UTC)

--- a/freqtrade/plugins/protectionmanager.py
+++ b/freqtrade/plugins/protectionmanager.py
@@ -47,13 +47,17 @@ class ProtectionManager:
         """
         return [{p.name: p.short_desc()} for p in self._protection_handlers]
 
-    def global_stop(self, now: datetime | None = None, side: LongShort = "long") -> PairLock | None:
+    def global_stop(
+        self, now: datetime | None = None, side: LongShort = "long", starting_balance: float = 0.0
+    ) -> PairLock | None:
         if not now:
             now = datetime.now(UTC)
         result = None
         for protection_handler in self._protection_handlers:
             if protection_handler.has_global_stop:
-                lock = protection_handler.global_stop(date_now=now, side=side)
+                lock = protection_handler.global_stop(
+                    date_now=now, side=side, starting_balance=starting_balance
+                )
                 if lock and lock.until:
                     if not PairLocks.is_global_lock(lock.until, side=lock.lock_side):
                         result = PairLocks.lock_pair(
@@ -62,14 +66,17 @@ class ProtectionManager:
         return result
 
     def stop_per_pair(
-        self, pair, now: datetime | None = None, side: LongShort = "long"
+        self, pair, now: datetime | None = None, side: LongShort = "long",
+        starting_balance: float = 0.0
     ) -> PairLock | None:
         if not now:
             now = datetime.now(UTC)
         result = None
         for protection_handler in self._protection_handlers:
             if protection_handler.has_local_stop:
-                lock = protection_handler.stop_per_pair(pair=pair, date_now=now, side=side)
+                lock = protection_handler.stop_per_pair(
+                    pair=pair, date_now=now, side=side, starting_balance=starting_balance
+                )
                 if lock and lock.until:
                     if not PairLocks.is_pair_locked(pair, lock.until, lock.lock_side):
                         result = PairLocks.lock_pair(

--- a/freqtrade/plugins/protections/cooldown_period.py
+++ b/freqtrade/plugins/protections/cooldown_period.py
@@ -53,7 +53,7 @@ class CooldownPeriod(IProtection):
         return None
 
     def global_stop(
-        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
@@ -65,7 +65,7 @@ class CooldownPeriod(IProtection):
         return None
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/cooldown_period.py
+++ b/freqtrade/plugins/protections/cooldown_period.py
@@ -52,7 +52,9 @@ class CooldownPeriod(IProtection):
 
         return None
 
-    def global_stop(self, date_now: datetime, side: LongShort) -> ProtectionReturn | None:
+    def global_stop(
+        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+    ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
         This must evaluate to true for the whole period of the "cooldown period".
@@ -63,7 +65,7 @@ class CooldownPeriod(IProtection):
         return None
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/iprotection.py
+++ b/freqtrade/plugins/protections/iprotection.py
@@ -102,7 +102,9 @@ class IProtection(LoggingMixin, ABC):
         """
 
     @abstractmethod
-    def global_stop(self, date_now: datetime, side: LongShort) -> ProtectionReturn | None:
+    def global_stop(
+        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+    ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
         This must evaluate to true for the whole period of the "cooldown period".
@@ -110,7 +112,7 @@ class IProtection(LoggingMixin, ABC):
 
     @abstractmethod
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/iprotection.py
+++ b/freqtrade/plugins/protections/iprotection.py
@@ -103,7 +103,7 @@ class IProtection(LoggingMixin, ABC):
 
     @abstractmethod
     def global_stop(
-        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
@@ -112,7 +112,7 @@ class IProtection(LoggingMixin, ABC):
 
     @abstractmethod
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/low_profit_pairs.py
+++ b/freqtrade/plugins/protections/low_profit_pairs.py
@@ -82,7 +82,7 @@ class LowProfitPairs(IProtection):
         return None
 
     def global_stop(
-        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
@@ -93,7 +93,7 @@ class LowProfitPairs(IProtection):
         return None
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/low_profit_pairs.py
+++ b/freqtrade/plugins/protections/low_profit_pairs.py
@@ -81,7 +81,9 @@ class LowProfitPairs(IProtection):
 
         return None
 
-    def global_stop(self, date_now: datetime, side: LongShort) -> ProtectionReturn | None:
+    def global_stop(
+        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+    ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
         This must evaluate to true for the whole period of the "cooldown period".
@@ -91,7 +93,7 @@ class LowProfitPairs(IProtection):
         return None
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/max_drawdown_protection.py
+++ b/freqtrade/plugins/protections/max_drawdown_protection.py
@@ -54,17 +54,17 @@ class MaxDrawdown(IProtection):
         if len(trades_in_window) < self._trade_limit:
             return None
 
-        # Get all trades to calculate cumulative profit before the window
-        all_closed_trades = Trade.get_trades_proxy(is_open=False)
-        profit_before_window = sum(
-            trade.close_profit_abs or 0.0
-            for trade in all_closed_trades
-            if trade.close_date_utc <= look_back_until
-        )
-
         try:
             if self._calculation_mode == "equity":
                 # Standard equity-based drawdown
+                # Get all trades to calculate cumulative profit before the window
+                all_closed_trades = Trade.get_trades_proxy(is_open=False)
+                profit_before_window = sum(
+                    trade.close_profit_abs or 0.0
+                    for trade in all_closed_trades
+                    if trade.close_date_utc <= look_back_until
+                )
+
                 trades_df = pd.DataFrame(
                     [
                         {"close_date": t.close_date_utc, "profit_abs": t.close_profit_abs}

--- a/freqtrade/plugins/protections/max_drawdown_protection.py
+++ b/freqtrade/plugins/protections/max_drawdown_protection.py
@@ -22,6 +22,7 @@ class MaxDrawdown(IProtection):
 
         self._trade_limit = protection_config.get("trade_limit", 1)
         self._max_allowed_drawdown = protection_config.get("max_allowed_drawdown", 0.0)
+        self._calculation_mode = protection_config.get("calculation_mode", "ratios")
         # TODO: Implement checks to limit max_drawdown to sensible values
 
     def short_desc(self) -> str:
@@ -61,11 +62,8 @@ class MaxDrawdown(IProtection):
             if trade.close_date_utc <= look_back_until
         )
 
-        # Get calculation mode
-        method = self._protection_config.get("method", "ratios")
-
         try:
-            if method == "equity":
+            if self._calculation_mode == "equity":
                 # Standard equity-based drawdown
                 trades_df = pd.DataFrame(
                     [

--- a/freqtrade/plugins/protections/stoploss_guard.py
+++ b/freqtrade/plugins/protections/stoploss_guard.py
@@ -87,7 +87,7 @@ class StoplossGuard(IProtection):
         )
 
     def global_stop(
-        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
@@ -100,7 +100,7 @@ class StoplossGuard(IProtection):
         return self._stoploss_guard(date_now, None, side)
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/freqtrade/plugins/protections/stoploss_guard.py
+++ b/freqtrade/plugins/protections/stoploss_guard.py
@@ -86,7 +86,9 @@ class StoplossGuard(IProtection):
             lock_side=(side if self._only_per_side else "*"),
         )
 
-    def global_stop(self, date_now: datetime, side: LongShort) -> ProtectionReturn | None:
+    def global_stop(
+        self, date_now: datetime, side: LongShort, starting_balance: float = 0.0
+    ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for all pairs
         This must evaluate to true for the whole period of the "cooldown period".
@@ -98,7 +100,7 @@ class StoplossGuard(IProtection):
         return self._stoploss_guard(date_now, None, side)
 
     def stop_per_pair(
-        self, pair: str, date_now: datetime, side: LongShort
+        self, pair: str, date_now: datetime, side: LongShort, starting_balance: float = 0.0
     ) -> ProtectionReturn | None:
         """
         Stops trading (position entering) for this pair

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -604,6 +604,7 @@ def get_default_conf(testdatadir):
         "cancel_open_orders_on_exit": False,
         "minimal_roi": {"40": 0.0, "30": 0.01, "20": 0.02, "0": 0.04},
         "dry_run_wallet": 1000,
+        "tradable_balance_ratio": 0.99,
         "stoploss": -0.10,
         "unfilledtimeout": {"entry": 10, "exit": 30},
         "entry_pricing": {

--- a/tests/plugins/test_protections.py
+++ b/tests/plugins/test_protections.py
@@ -99,9 +99,9 @@ def test_protectionmanager(mocker, default_conf):
     for handler in freqtrade.protections._protection_handlers:
         assert handler.name in AVAILABLE_PROTECTIONS
         if not handler.has_global_stop:
-            assert handler.global_stop(datetime.now(UTC), "*") is None
+            assert handler.global_stop(datetime.now(UTC), "*", 1000.0) is None
         if not handler.has_local_stop:
-            assert handler.stop_per_pair("XRP/BTC", datetime.now(UTC), "*") is None
+            assert handler.stop_per_pair("XRP/BTC", datetime.now(UTC), "*", 1000.0) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_protections.py
+++ b/tests/plugins/test_protections.py
@@ -1,5 +1,6 @@
 import random
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
@@ -658,7 +659,7 @@ def test_LowProfitPairs(mocker, default_conf, fee, caplog, only_per_side):
 
 
 @pytest.mark.usefixtures("init_persistence")
-def test_MaxDrawdown(mocker, default_conf, fee, caplog):
+def test_MaxDrawdown_ratio_mode(mocker, default_conf, fee, caplog):
     default_conf["_strategy_protections"] = [
         {
             "method": "MaxDrawdown",
@@ -774,6 +775,204 @@ def test_MaxDrawdown(mocker, default_conf, fee, caplog):
     assert freqtrade.protections.global_stop(starting_balance=starting_balance)
     assert PairLocks.is_global_lock()
     assert log_has_re(message, caplog)
+
+
+@pytest.mark.usefixtures("init_persistence")
+def test_MaxDrawdown_equity_mode(mocker, default_conf, fee):
+    default_conf["_strategy_protections"] = [
+        {
+            "method": "MaxDrawdown",
+            "lookback_period": 1000,
+            "stop_duration": 60,
+            "trade_limit": 1,
+            "max_allowed_drawdown": 0.01,
+            "calculation_mode": "equity",
+        }
+    ]
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    starting_balance = 0.01
+
+    assert not freqtrade.protections.global_stop(starting_balance=starting_balance)
+
+    generate_mock_trade(
+        "XRP/BTC",
+        fee.return_value,
+        False,
+        exit_reason=ExitType.STOP_LOSS.value,
+        min_ago_open=30,
+        min_ago_close=10,
+        profit_rate=0.5,
+    )
+    Trade.commit()
+
+    assert freqtrade.protections.global_stop(starting_balance=starting_balance)
+    assert PairLocks.is_global_lock()
+
+
+@pytest.mark.parametrize(
+    "calculation_mode,expected_locked",
+    [("ratios", True), ("equity", False)],
+)
+@pytest.mark.usefixtures("init_persistence")
+def test_MaxDrawdown_mode_comparison(mocker, default_conf, fee, calculation_mode, expected_locked):
+    default_conf["_strategy_protections"] = [
+        {
+            "method": "MaxDrawdown",
+            "lookback_period": 1000,
+            "stop_duration": 60,
+            "trade_limit": 3,
+            "max_allowed_drawdown": 0.15,
+            "calculation_mode": calculation_mode,
+        }
+    ]
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    starting_balance = 1000.0
+
+    # Same trade sequence for both modes: ratios mode lock expected,equity mode no lock expected.
+    generate_mock_trade(
+        "XRP/BTC",
+        fee.return_value,
+        False,
+        exit_reason=ExitType.ROI.value,
+        min_ago_open=120,
+        min_ago_close=50,
+        profit_rate=1.2,
+    )
+    generate_mock_trade(
+        "ETH/BTC",
+        fee.return_value,
+        False,
+        exit_reason=ExitType.STOP_LOSS.value,
+        min_ago_open=80,
+        min_ago_close=20,
+        profit_rate=0.9,
+    )
+    generate_mock_trade(
+        "NEO/BTC",
+        fee.return_value,
+        False,
+        exit_reason=ExitType.STOP_LOSS.value,
+        min_ago_open=40,
+        min_ago_close=10,
+        profit_rate=0.9,
+    )
+    Trade.commit()
+
+    lock = freqtrade.protections.global_stop(starting_balance=starting_balance)
+    assert bool(lock) is expected_locked
+    assert PairLocks.is_global_lock(side="long") is expected_locked
+
+
+@pytest.mark.parametrize("calculation_mode", ["ratios", "equity"])
+@pytest.mark.usefixtures("init_persistence")
+def test_MaxDrawdown_threshold_boundary(mocker, default_conf, calculation_mode):
+    threshold = 0.15
+    default_conf["_strategy_protections"] = [
+        {
+            "method": "MaxDrawdown",
+            "lookback_period": 1000,
+            "stop_duration": 60,
+            "trade_limit": 1,
+            "max_allowed_drawdown": threshold,
+            "calculation_mode": calculation_mode,
+        }
+    ]
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    handler = next(p for p in freqtrade.protections._protection_handlers if p.name == "MaxDrawdown")
+    md_globals = handler._max_drawdown.__globals__
+
+    now = datetime.now(UTC)
+    trades_in_window = [
+        SimpleNamespace(
+            close_date_utc=now - timedelta(minutes=10), close_profit_abs=-1.0, close_profit=-0.1
+        )
+    ]
+    all_closed_trades = [
+        SimpleNamespace(
+            close_date_utc=now - timedelta(minutes=1500), close_profit_abs=5.0, close_profit=0.2
+        ),
+        trades_in_window[0],
+    ]
+
+    proxy_side_effect = [trades_in_window]
+    if calculation_mode == "equity":
+        proxy_side_effect.append(all_closed_trades)
+
+    mocker.patch.object(
+        md_globals["Trade"],
+        "get_trades_proxy",
+        side_effect=proxy_side_effect,
+    )
+    calc_mock = mocker.Mock(
+        return_value=SimpleNamespace(relative_account_drawdown=threshold, drawdown_abs=threshold)
+    )
+    mocker.patch.dict(md_globals, {"calculate_max_drawdown": calc_mock})
+
+    assert not handler.global_stop(datetime.now(UTC), "long", starting_balance=1000.0)
+    assert not PairLocks.is_global_lock()
+
+
+@pytest.mark.parametrize(
+    "calculation_mode,expected_value_col,expected_proxy_calls",
+    [("ratios", "close_profit", 1), ("equity", "profit_abs", 2)],
+)
+@pytest.mark.usefixtures("init_persistence")
+def test_MaxDrawdown_calculation_mode_dispatch(
+    mocker, default_conf, calculation_mode, expected_value_col, expected_proxy_calls
+):
+    default_conf["_strategy_protections"] = [
+        {
+            "method": "MaxDrawdown",
+            "lookback_period": 1000,
+            "stop_duration": 60,
+            "trade_limit": 1,
+            "max_allowed_drawdown": 0.15,
+            "calculation_mode": calculation_mode,
+        }
+    ]
+    freqtrade = get_patched_freqtradebot(mocker, default_conf)
+    handler = next(p for p in freqtrade.protections._protection_handlers if p.name == "MaxDrawdown")
+    md_globals = handler._max_drawdown.__globals__
+
+    now = datetime.now(UTC)
+    trades_in_window = [
+        SimpleNamespace(
+            close_date_utc=now - timedelta(minutes=10), close_profit_abs=-1.0, close_profit=-0.1
+        )
+    ]
+    all_closed_trades = [
+        SimpleNamespace(
+            close_date_utc=now - timedelta(minutes=1500), close_profit_abs=5.0, close_profit=0.2
+        ),
+        trades_in_window[0],
+    ]
+
+    proxy_side_effect = [trades_in_window]
+    if calculation_mode == "equity":
+        proxy_side_effect.append(all_closed_trades)
+
+    proxy_mock = mocker.patch.object(
+        md_globals["Trade"],
+        "get_trades_proxy",
+        side_effect=proxy_side_effect,
+    )
+    calc_mock = mocker.Mock(
+        return_value=SimpleNamespace(relative_account_drawdown=0.0, drawdown_abs=0.0)
+    )
+    mocker.patch.dict(md_globals, {"calculate_max_drawdown": calc_mock})
+
+    assert not handler.global_stop(datetime.now(UTC), "long", starting_balance=1000.0)
+
+    assert proxy_mock.call_count == expected_proxy_calls
+    kwargs = calc_mock.call_args.kwargs
+    assert kwargs["value_col"] == expected_value_col
+
+    if calculation_mode == "equity":
+        assert kwargs["starting_balance"] == 1005.0
+        assert kwargs["relative"] is True
+    else:
+        assert "starting_balance" not in kwargs
+        assert "relative" not in kwargs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Refactor the `MaxDrawdown` protection to use a mathematically accurate equity-curve-based drawdown calculation instead of a simple profit ratio sum.

Solve the issue: #8373

## Quick changelog

- Updated `IProtection` interface and `ProtectionManager` to support `starting_balance` context.
- Implemented "Balance at Window Start" logic (Starting Balance + Prior Profits) to provide a correct baseline for drawdown.
- Switched to `calculate_max_drawdown(relative=True)` from the metrics module for standard financial drawdown calculation.
- Fixed `TypeError` caused by comparing timezone-naive database timestamps with timezone-aware system timestamps.
- Updated `docs/includes/protections.md` to reflect the new accurate behavior.
- Adjusted `test_MaxDrawdown` unit tests to use non-zero balance mocks for percentage validation.

## What's new?

This PR addresses a long-standing issue (#8373) where the `MaxDrawdown` protection relied on a mathematically unsound approach. The previous method merely summed up profit ratios (`sum(profit_ratios)`), which is not a rigorous method and deviates significantly from the formal definition of Maximum Drawdown.

Drawdown is formally defined as the **maximum peak-to-trough decline of an equity curve**. Treating percentages as additive units is mathematically incorrect for assessing portfolio risk and can lead to misleading protection triggers (or lack thereof).

By refactoring the protection to reconstruct a proper equity curve—using the `starting_balance` and accounting for historical profits/losses—this PR makes the `MaxDrawdown` protection both mathematically rigorous and compliant with industry-standard financial risk metrics.


**AI Usage Disclosure:**
This PR was prepared with the assistance of Gemini 3. I have thoroughly reviewed the generated logic, performed a self-review of all changes, and verified the fix through local unit tests (`pytest tests/plugins/test_protections.py`) and linting (`ruff`, `mypy`).