### PR TITLE
`/ping` endpoint support HEAD request method

### DIFF
--- a/freqtrade/rpc/api_server/api_v1.py
+++ b/freqtrade/rpc/api_server/api_v1.py
@@ -71,7 +71,7 @@ router_public = APIRouter()
 router = APIRouter()
 
 
-@router_public.get("/ping", response_model=Ping, tags=["Info"])
+@router_public.api_route("/ping", methods=["GET", "HEAD"], response_model=Ping, tags=["Info"])
 def ping():
     """simple ping"""
     return {"status": "pong"}


### PR DESCRIPTION
Allow services like Uptimerobot to monitor the WebUI which uses `HEAD` request method because it is lighter whereas in order to use `GET` method, payment is required.

There's no significant impact for this changes.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Enable HEAD request support for the public /ping endpoint to facilitate uptime monitoring by third-party services.

## Quick changelog

- Modified the `/api/v1/ping` route to use `@router_public.api_route` instead of `@router_public.get`
- Added explicit support for HEAD and GET methods to the `/ping` endpoint

## What's new?

Currently, the `/ping` endpoint only accepts GET requests. Many uptime monitoring services (such as the free tier of UptimeRobot) utilize HEAD requests to verify service availability with minimal bandwidth overhead.

By allowing HEAD requests, users can monitor their bot's WebUI availability more easily without requiring paid tiers of monitoring services or triggering unnecessary data processing on the API side.

This change has no impact on existing GET functionality or bot security, as the `/ping` endpoint is already part of the public router and returns a static string.