### PR TITLE
Fix path traversal in web UI static file serving

### DIFF
--- a/freqtrade/rpc/api_server/web_ui.py
+++ b/freqtrade/rpc/api_server/web_ui.py
@@ -38,14 +38,14 @@ async def index_html(rest_of_path: str):
     if rest_of_path.startswith("api") or rest_of_path.startswith("."):
         raise HTTPException(status_code=404, detail="Not Found")
     uibase = Path(__file__).parent / "ui/installed/"
-    filename = uibase / rest_of_path
+    filename = (uibase / rest_of_path).resolve()
     # It's security relevant to check "relative_to".
     # Without this, Directory-traversal is possible.
     media_type: str | None = None
     if filename.suffix == ".js":
         # Force text/javascript for .js files - Circumvent faulty system configuration
         media_type = "application/javascript"
-    if filename.is_file() and filename.is_relative_to(uibase):
+    if filename.is_file() and filename.is_relative_to(uibase.resolve()):
         return FileResponse(str(filename), media_type=media_type)
 
     index_file = uibase / "index.html"

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -186,6 +186,11 @@ def test_api_ui_fallback(botclient, mocker):
 
     assert "`freqtrade install-ui`" in rc.text
 
+    # Test that ../ path traversal is blocked after resolve()
+    rc = client_get(client, "/assets/../../web_ui.py")
+    assert rc.status_code == 200
+    assert "rest_of_path" not in rc.text
+
 
 def test_api_ui_version(botclient, mocker):
     _ftbot, client = botclient


### PR DESCRIPTION
### Summary

`Path.is_relative_to()` in `web_ui.py:48` performs a purely lexical comparison *removed* bypassing the containment check added in commit 6b2ef36 for #5427.

This PR adds `.resolve()` before the `is_relative_to()` check so that `..` components are collapsed before the path is compared against the UI base directory.

**Proof:**

*removed*

### Changes

- `web_ui.py`: resolve the constructed path before checking `is_relative_to()`
- `test_rpc_apiserver.py`: add a `../` traversal test case to `test_api_ui_fallback`