### PR TITLE
fix: align pairlock backtesting expiration condition with live/dry run

### DIFF
--- a/freqtrade/persistence/pairlock_middleware.py
+++ b/freqtrade/persistence/pairlock_middleware.py
@@ -86,7 +86,7 @@ class PairLocks:
                 lock
                 for lock in PairLocks.locks
                 if (
-                    lock.lock_end_time >= now
+                    lock.lock_end_time > now
                     and lock.active is True
                     and (pair is None or lock.pair == pair)
                     and (side is None or lock.side == "*" or lock.side == side)

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1346,11 +1346,11 @@ def test_backtest_pricecontours_protections(default_conf, fee, mocker, testdatad
     mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
     mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
     tests = [
-        ["sine", 9],
-        ["raise", 10],
+        ["sine", 10],
+        ["raise", 11],
         ["lower", 0],
-        ["sine", 9],
-        ["raise", 10],
+        ["sine", 10],
+        ["raise", 11],
     ]
     backtesting = Backtesting(default_conf)
     backtesting._set_strategy(backtesting.strategylist[0])
@@ -1380,11 +1380,11 @@ def test_backtest_pricecontours_protections(default_conf, fee, mocker, testdatad
         (None, "lower", 0),
         (None, "sine", 35),
         (None, "raise", 19),
-        ([{"method": "CooldownPeriod", "stop_duration": 3}], "sine", 9),
-        ([{"method": "CooldownPeriod", "stop_duration": 3}], "raise", 10),
+        ([{"method": "CooldownPeriod", "stop_duration": 3}], "sine", 10),
+        ([{"method": "CooldownPeriod", "stop_duration": 3}], "raise", 11),
         ([{"method": "CooldownPeriod", "stop_duration": 3}], "lower", 0),
-        ([{"method": "CooldownPeriod", "stop_duration": 3}], "sine", 9),
-        ([{"method": "CooldownPeriod", "stop_duration": 3}], "raise", 10),
+        ([{"method": "CooldownPeriod", "stop_duration": 3}], "sine", 10),
+        ([{"method": "CooldownPeriod", "stop_duration": 3}], "raise", 11),
     ],
 )
 def test_backtest_pricecontours(


### PR DESCRIPTION
## Summary
Align `PairLocks` expiration threshold in backtesting with the live/dry-run behavior to ensure consistency.

## Quick changelog
- Changed `>= now` to `> now` in `PairLocks.get_pair_locks` (when `use_db=False`) to match the strict greater than filtering behavior used in database queries (`PairLock.query_pair_locks`) for live/dry-run trading.

## What's new?
Previously, `PairLocks.get_pair_locks` natively used by backtesting implementations checked if a pair lock was active by verifying `lock.lock_end_time >= now`. 
https://github.com/freqtrade/freqtrade/blob/246a9049e619a2390824ae221a6b71d6052c56cd/freqtrade/persistence/pairlock_middleware.py#L85-L94

However, the live and dry-run modes use the database model `PairLock.query_pair_locks` which strictly checks `PairLock.lock_end_time > now`. 
https://github.com/freqtrade/freqtrade/blob/246a9049e619a2390824ae221a6b71d6052c56cd/freqtrade/persistence/pairlock.py#L49-L53

This tiny inconsistency meant that exactly at the candle boundary (when `lock_end_time == now`), a pair might still be considered locked during backtests while it would already be unlocked in a live environment, leading to divergent trading results in edge cases.

This PR aligns the memory list filtering (`use_db=False`) with the DB query to strictly use `>`.