### PR TITLE
block base64 encoded strategies in /pair_history endpoints

### DIFF
--- a/freqtrade/rpc/api_server/api_pair_history.py
+++ b/freqtrade/rpc/api_server/api_pair_history.py
@@ -25,6 +25,8 @@ def pair_history(
     config=Depends(get_config),
     exchange=Depends(get_exchange),
 ):
+    if ":" in strategy:
+        raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")
     # The initial call to this endpoint can be slow, as it may need to initialize
     # the exchange class.
     config_loc = deepcopy(config)
@@ -45,6 +47,8 @@ def pair_history(
 
 @router.post("/pair_history", response_model=PairHistory, tags=["Candle data"])
 def pair_history_filtered(payload: PairHistoryRequest, config=Depends(get_config)):
+    if ":" in payload.strategy:
+        raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")
     # The initial call to this endpoint can be slow, as it may need to initialize
     # the exchange class.
     config_loc = deepcopy(config)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -2327,6 +2327,32 @@ def test_api_pair_history(botclient, tmp_path, mocker):
     )
     assert_response(rc, 502)
 
+    # base64 encoded strategy is rejected (GET) - prevents RCE via strategy parameter
+    import base64
+
+    b64_payload = base64.urlsafe_b64encode(b"import os\nos.system('id')\n").decode()
+    rc = client_get(
+        client,
+        f"{BASE_URI}/pair_history?pair=UNITTEST%2FBTC&timeframe={timeframe}"
+        f"&timerange=20180111-20180112&strategy=EvilStrategy:{b64_payload}",
+    )
+    assert_response(rc, 500)
+    assert rc.json()["detail"] == "base64 encoded strategies are not allowed."
+
+    # base64 encoded strategy is rejected (POST)
+    rc = client_post(
+        client,
+        f"{BASE_URI}/pair_history",
+        data={
+            "pair": "UNITTEST/BTC",
+            "timeframe": timeframe,
+            "timerange": "20180111-20180112",
+            "strategy": f"EvilStrategy:{b64_payload}",
+        },
+    )
+    assert_response(rc, 500)
+    assert rc.json()["detail"] == "base64 encoded strategies are not allowed."
+
     # Working
     for call in ("get", "post"):
         if call == "get":


### PR DESCRIPTION
> **Note:** This fix was identified and written with AI assistance. I've reviewed the generated code carefully before submitting.

## Summary

Solve the issue: (no prior issue — this is the initial report)

The `/pair_history` GET and POST endpoints accept a `strategy` query parameter that is passed directly to `StrategyResolver.load_strategy()`. When the strategy name contains a colon (`:`), the resolver treats it as base64-encoded Python source **removed**

The `/backtest` endpoint already blocks this with an explicit check:

```python
if ":" in bt_settings.strategy:
    raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")
```

`/pair_history` (both GET and POST) had no equivalent check.

## Quick changelog

- Added colon check to `pair_history` GET handler in `api_pair_history.py`
- Added colon check to `pair_history_filtered` POST handler in `api_pair_history.py`
- Added two test cases to `test_api_pair_history` covering both blocked variants

## What's new?

**The fix is two lines**, one per handler, identical to the existing backtest guard:

```python
# GET handler (line 28)
if ":" in strategy:
    raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")

# POST handler (line 50)
if ":" in payload.strategy:
    raise HTTPException(status_code=500, detail="base64 encoded strategies are not allowed.")
```

**To verify the vulnerability exists today**, send a request with a base64-encoded strategy name (Python code that writes to `/tmp`) to `GET /api/v1/pair_history?strategy=Name:<b64>` while running in webserver mode. The response returns a `502` (no historical data), but the code executes before that. The server reflects credentials and filesystem contents.

*REMOVED*

**Tests added** (`tests/rpc/test_rpc_apiserver.py`):

*REMOVED* 
Both tests were modelled on the existing validation tests immediately above them in `test_api_pair_history`.