### PR TITLE
feat: add check for portfolio margin in Binance exchange

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -119,10 +119,17 @@ class Binance(Exchange):
         """
         try:
             if self.trading_mode == TradingMode.FUTURES and not self._config["dry_run"]:
-                if self._config.get("exchange", {}).get("ccxt_config", {}).get("options", {}).get("portfolioMargin"):
-                    logger.info("Portfolio Margin enabled. Skipping fapiPrivateGetPositionSideDual checks.")
+                if (
+                    self._config.get("exchange", {})
+                    .get("ccxt_config", {})
+                    .get("options", {})
+                    .get("portfolioMargin")
+                ):
+                    logger.info(
+                        "Portfolio Margin enabled. Skipping fapiPrivateGetPositionSideDual checks."
+                    )
                     return
-                
+
                 position_side = self._api.fapiPrivateGetPositionSideDual()
                 self._log_exchange_response("position_side_setting", position_side)
                 assets_margin = self._api.fapiPrivateGetMultiAssetsMargin()

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -119,6 +119,10 @@ class Binance(Exchange):
         """
         try:
             if self.trading_mode == TradingMode.FUTURES and not self._config["dry_run"]:
+                if self._config.get("exchange", {}).get("ccxt_config", {}).get("options", {}).get("portfolioMargin"):
+                    logger.info("Portfolio Margin enabled. Skipping fapiPrivateGetPositionSideDual checks.")
+                    return
+                
                 position_side = self._api.fapiPrivateGetPositionSideDual()
                 self._log_exchange_response("position_side_setting", position_side)
                 assets_margin = self._api.fapiPrivateGetMultiAssetsMargin()


### PR DESCRIPTION
## Summary

This PR enables Freqtrade initialization for Binance **Portfolio Margin (Unified)** accounts by bypassing incompatible API-level configuration checks.

Solve the issue: # (None, found during live trading setup)

## AI usage declaration

Yes, this PR was developed with the assistance of an AI assistant (GitHub Copilot), which helped in diagnosing the Binance API Error `-2015` and implementing the bypass logic in binance.py.

## Quick changelog

- Detect `portfolioMargin: true` flag from `ccxt_config` in binance.py.
- Skip `fapiPrivateGetPositionSideDual` and `fapiPrivateGetMultiAssetsMargin` calls when Portfolio Margin mode is detected.
- Improve logging to inform users that these checks are being bypassed for Unified accounts.

## What's new?

Currently, when a user has a Binance account with **Portfolio Margin (Unified Account)** mode enabled, Freqtrade fails to start. This is because Binance disables standard `fapi` private endpoints (like `/fapi/v1/positionSide/dual`) for these accounts, returning `AuthenticationError: -2015` (Invalid permissions).

These accounts manage their settings via the `papi` (Portfolio API) endpoints instead, which are not currently integrated into Freqtrade.

This PR introduces a safe bypass:
1. Users can add `"portfolioMargin": true` to their `ccxt_config` -> `options`.
2. Fypassing these specific initialization checks allows the bot to enter the trading loop.
3. Once initialized, standard trading operations (fetch balance, create/cancel orders, etc.) still work correctly via standard CCXT methods as they are handled by CCXT's internal routing.

**Example Configuration:**
```json
"exchange": {
    "name": "binance",
    "ccxt_config": {
        "options": {
            "defaultType": "future",
            "portfolioMargin": true
        }
    }
}
```