### PR TITLE
fix: detect and handle Hyperliquid liquidation events

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -4028,6 +4028,18 @@ class Exchange:
         else:
             return None
 
+    def fetch_liquidation_fills(
+        self, pair: str, since: datetime
+    ) -> list[dict]:
+        """
+        Fetch user fills for a pair and return only liquidation fills.
+        Override in exchange-specific subclasses that support liquidation detection.
+        :param pair: Trading pair
+        :param since: Datetime to fetch fills from
+        :return: List of liquidation fill dicts
+        """
+        return []
+
     def dry_run_liquidation_price(
         self,
         pair: str,

--- a/freqtrade/exchange/hyperliquid.py
+++ b/freqtrade/exchange/hyperliquid.py
@@ -1,6 +1,7 @@
 """Hyperliquid exchange subclass"""
 
 import logging
+import ccxt
 from copy import deepcopy
 from datetime import datetime
 from typing import Any
@@ -8,7 +9,13 @@ from typing import Any
 from freqtrade.constants import BuySell
 from freqtrade.enums import MarginMode, TradingMode
 from freqtrade.enums.runmode import NON_UTIL_MODES
-from freqtrade.exceptions import ConfigurationError, ExchangeError, OperationalException
+from freqtrade.exceptions import (
+    ConfigurationError,
+    DDosProtection,
+    ExchangeError,
+    OperationalException,
+    TemporaryError,
+)
 from freqtrade.exchange import Exchange
 from freqtrade.exchange.exchange_types import CcxtBalances, CcxtOrder, CcxtPosition, FtHas
 from freqtrade.util.datetime_helpers import dt_from_ts
@@ -272,6 +279,50 @@ class Hyperliquid(Exchange):
             except ExchangeError:
                 logger.warning(f"Could not update funding fees for {pair}.")
         return 0.0
+
+    def fetch_liquidation_fills(
+        self, pair: str, since: datetime
+    ) -> list[dict]:
+        """
+        Fetch user fills for a pair and return only liquidation fills.
+        On Hyperliquid, a liquidation fill has a non-null 'liquidationMarkPx' in the raw data.
+        """
+        if self._config["dry_run"]:
+            return []
+        try:
+            since_ms = int((since.timestamp() - 5) * 1000)
+            my_trades = self._api.fetch_my_trades(pair, since_ms)
+            self._log_exchange_response("fetch_liquidation_fills", my_trades)
+
+            liquidation_fills = []
+            for trade in my_trades:
+                info = trade.get("info", {})
+                liq_mark_px = info.get("liquidationMarkPx")
+                if liq_mark_px is not None:
+                    liquidation_fills.append({
+                        "price": float(trade.get("price", liq_mark_px)),
+                        "amount": float(trade.get("amount", 0)),
+                        "timestamp": trade.get("timestamp"),
+                        "side": trade.get("side"),
+                        "liq_mark_price": float(liq_mark_px),
+                        "info": info,
+                    })
+
+            if liquidation_fills:
+                logger.info(
+                    f"Found {len(liquidation_fills)} liquidation fill(s) for {pair}."
+                )
+            return liquidation_fills
+
+        except ccxt.DDoSProtection as e:
+            raise DDosProtection(e) from e
+        except (ccxt.OperationFailed, ccxt.ExchangeError) as e:
+            raise TemporaryError(
+                f"Could not fetch liquidation fills for {pair}: "
+                f"{e.__class__.__name__}. Message: {e}"
+            ) from e
+        except ccxt.BaseError as e:
+            raise OperationalException(e) from e
 
     def _adjust_hyperliquid_order(
         self,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -569,6 +569,14 @@ class FreqtradeBot(LoggingMixin):
                         )
                         trade.delete()
                         return True
+                    # In futures mode, when the position is completely gone,
+                    # check if it was liquidated on the exchange.
+                    if (
+                        self.trading_mode == TradingMode.FUTURES
+                        and total == 0
+                        and self._handle_liquidation(trade)
+                    ):
+                        return False
                     if total > trade.amount * 0.98:
                         logger.warning(
                             f"{trade} has a total of {trade.amount} {trade.base_currency}, "
@@ -595,6 +603,46 @@ class FreqtradeBot(LoggingMixin):
             # catching https://github.com/freqtrade/freqtrade/issues/9025
             logger.warning("Error finding onexchange order", exc_info=True)
         return False
+
+    def _handle_liquidation(self, trade: Trade) -> bool:
+        """
+        Check if a trade was liquidated on the exchange by fetching user fills
+        and looking for liquidation markers.
+        """
+        try:
+            liq_fills = self.exchange.fetch_liquidation_fills(
+                trade.pair, trade.open_date_utc
+            )
+            if not liq_fills:
+                return False
+
+            liq_fill = liq_fills[-1]
+            liq_price = liq_fill["liq_mark_price"]
+            liq_timestamp = liq_fill.get("timestamp")
+
+            logger.warning(
+                f"Position for {trade.pair} was LIQUIDATED on exchange "
+                f"at mark price {liq_price}. Trade: {trade}"
+            )
+
+            trade = self.cancel_stoploss_on_exchange(trade)
+            trade.exit_reason = ExitType.LIQUIDATION.value
+            trade.close(liq_price, show_msg=False)
+            if liq_timestamp:
+                trade.close_date = dt_from_ts(liq_timestamp)
+            Trade.commit()
+
+            self._notify_exit(trade, "liquidation", fill=True)
+            self.handle_protections(trade.pair, trade.trade_direction)
+
+            logger.info(f"Trade {trade} closed due to liquidation at price {liq_price}.")
+            return True
+
+        except Exception:
+            logger.warning(
+                f"Error checking for liquidation of {trade.pair}.", exc_info=True
+            )
+            return False
 
     #
     # enter positions / open trades logic and methods


### PR DESCRIPTION
## Summary

Detect and properly handle positions liquidated on Hyperliquid, which currently leave trades stuck in an inconsistent open state.

## Quick changelog

- Add `fetch_liquidation_fills()` base method to `Exchange` class
- Implement Hyperliquid-specific liquidation fill detection via `liquidationMarkPx` field
- Integrate liquidation check into `handle_onexchange_order()` when a futures position disappears
- Properly close liquidated trades with `LIQUIDATION` exit reason, cancel orphaned stoploss orders, and send user notifications

## What's new?

### Problem

When a position is liquidated on Hyperliquid, the exchange closes the position but Freqtrade has no mechanism to detect this. The trade remains open in Freqtrade's database with a stale state, causing:

- **Ghost trades**: The UI shows an open trade that no longer exists on the exchange
- **Incorrect P&L**: The actual liquidation loss is never recorded
- **Blocked capital**: Freqtrade may avoid opening new trades on the same pair
- **No notification**: The user is never alerted that a liquidation occurred

### Solution

This PR adds liquidation detection by leveraging Hyperliquid's user fill data. When `handle_onexchange_order()` detects that a futures position has completely disappeared (`total == 0`), it now calls `_handle_liquidation()` which:

1. Fetches the user's trade fills via `fetch_my_trades()`
2. Checks for the Hyperliquid-specific `liquidationMarkPx` field (non-null indicates a liquidation)
3. If a liquidation fill is found:
   - Cancels any remaining stoploss orders on the exchange
   - Closes the trade at the liquidation mark price
   - Sets the exit reason to `LIQUIDATION`
   - Sends a notification to the user
   - Triggers protection handlers

### Design

- The base `Exchange.fetch_liquidation_fills()` returns an empty list, making this a no-op for exchanges that don't support liquidation detection
- Exchange-specific subclasses (currently only `Hyperliquid`) override this method with their own detection logic
- This follows the existing pattern used for other exchange-specific features in Freqtrade
- Other exchanges can be added by simply overriding `fetch_liquidation_fills()` in their subclass