### PR TITLE
fix: prevent OverflowError in CAGR calculation

### DIFF
--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -297,10 +297,13 @@ def calculate_cagr(days_passed: int, starting_balance: float, final_balance: flo
     :return: CAGR
     """
     if final_balance < 0:
-        # With leveraged trades, final_balance can become negative.
         return 0
-    return (final_balance / starting_balance) ** (1 / (days_passed / 365)) - 1
-
+    if days_passed == 0 or starting_balance <= 0:
+        return 0
+    try:
+        return (final_balance / starting_balance) ** (1 / (days_passed / 365)) - 1
+    except (OverflowError, ValueError):
+        return 0
 
 def calculate_expectancy(trades: pd.DataFrame) -> tuple[float, float]:
     """


### PR DESCRIPTION
## Summary

Fix an `OverflowError` crash in the CAGR calculation that causes the `/api/v1/profit_all` endpoint to fail, making FreqUI display the bot as OFFLINE.

## Quick changelog

- Add overflow protection to `calculate_cagr()` in `freqtrade/data/metrics.py`
- Return 0 instead of crashing when calculation overflows

## What's new?

### Problem

When `days_passed` is very small (e.g., 1 day), the CAGR exponent becomes very large (365). If the balance ratio is not very close to 1.0, the calculation overflows Python's float capacity:
```python
return (final_balance / starting_balance) ** (1 / (days_passed / 365)) - 1
# When days_passed=1, exponent = 365
# Example: 2 ** 365 = OverflowError
```

This causes:
- **API crash**: The `/api/v1/profit_all` endpoint returns HTTP 500
- **FreqUI shows OFFLINE**: Even though the bot is still running normally
- **Poor UX**: Users think their bot has crashed when it hasn't

### Solution

Wrap the calculation in a try/except block to catch `OverflowError` and `ValueError`, returning 0 instead of crashing:
```python
if days_passed == 0 or starting_balance <= 0:
    return 0
try:
    return (final_balance / starting_balance) ** (1 / (days_passed / 365)) - 1
except (OverflowError, ValueError):
    return 0
```

The CAGR will display 0% for extreme values instead of crashing, and will show accurate values once `days_passed` is large enough for a meaningful calculation.