### PR TITLE
Allow non-ascii characters in pair names

### DIFF
--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 class IDataHandler(ABC):
-    _OHLCV_REGEX = r"^([a-zA-Z_\d-]+)\-(\d+[a-zA-Z]{1,2})\-?([a-zA-Z_]*)?(?=\.)"
-    _TRADES_REGEX = r"^([a-zA-Z_\d-]+)\-(trades)?(?=\.)"
+    _OHLCV_REGEX = r"^([\w-]+)\-(\d+[a-zA-Z]{1,2})\-?([a-zA-Z_]*)?(?=\.)"
+    _TRADES_REGEX = r"^([\w-]+)\-(trades)?(?=\.)"
 
     def __init__(self, datadir: Path) -> None:
         self._datadir = datadir
@@ -336,11 +336,10 @@ class IDataHandler(ABC):
     def rebuild_pair_from_filename(pair: str) -> str:
         """
         Rebuild pair name from filename
-        Assumes a asset name of max. 7 length to also support BTC-PERP and BTC-PERP:USD names.
+        Replaces the first '_' with '/' and the second '_' (if present) with ':'.
+        e.g. BTC_USDT -> BTC/USDT, BTC_USDT_USDT -> BTC/USDT:USDT
         """
-        res = re.sub(r"^(([A-Za-z\d]{1,10})|^([A-Za-z\-]{1,6}))(_)", r"\g<1>/", pair, count=1)
-        res = re.sub("_", ":", res, count=1)
-        return res
+        return pair.replace("_", "/", 1).replace("_", ":", 1)
 
     def ohlcv_load(
         self,

--- a/freqtrade/plugins/pairlist/pairlist_helpers.py
+++ b/freqtrade/plugins/pairlist/pairlist_helpers.py
@@ -28,7 +28,11 @@ def expand_pairlist(
                 raise ValueError(f"Wildcard error in {pair_wc}, {err}")
 
         # Remove wildcard pairs that didn't have a match.
-        result = [element for element in result if re.fullmatch(r"^[\w:/-]+$", element)]
+        result = [
+            element
+            for element in result
+            if re.fullmatch(r"^[\w:/-]+$", element) and "_" not in element
+        ]
 
     else:
         for pair_wc in wildcardpl:

--- a/freqtrade/plugins/pairlist/pairlist_helpers.py
+++ b/freqtrade/plugins/pairlist/pairlist_helpers.py
@@ -28,7 +28,7 @@ def expand_pairlist(
                 raise ValueError(f"Wildcard error in {pair_wc}, {err}")
 
         # Remove wildcard pairs that didn't have a match.
-        result = [element for element in result if re.fullmatch(r"^[A-Za-z0-9:/-]+$", element)]
+        result = [element for element in result if re.fullmatch(r"^[\w:/-]+$", element)]
 
     else:
         for pair_wc in wildcardpl:

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -56,9 +56,9 @@ def test_datahandler_ohlcv_regex(filename, pair, timeframe, candletype):
         ("USDT_BUSD", "USDT/BUSD"),
         ("BTC_USDT_USDT", "BTC/USDT:USDT"),  # Futures
         ("XRP_USDT_USDT", "XRP/USDT:USDT"),  # futures
-        ("BTC-PERP", "BTC-PERP"),
-        ("BTC-PERP_USDT", "BTC-PERP:USDT"),
+        ("XYZ-XRP_USDT_USDT", "XYZ-XRP/USDT:USDT"),  # hip3 futures
         ("UNITTEST_USDT", "UNITTEST/USDT"),
+        ("币安人生_USDT_USDT", "币安人生/USDT:USDT"),  # futures
     ],
 )
 def test_rebuild_pair_from_filename(pair, expected):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Allow non-chinese characters in pair names
This is currently important for chinese pairnames on binance - but might become relevant for other pairs in the future, too.

closes #12868

## Quick changelog

- Update regex's to allow non-ascii characters in pair names
- Update data-reading to make sure these pairs are "found" with commands like "list-data".