### PR TITLE
freqai/RL: clarify fit_labels() usage in BaseReinforcementLearningModel

### DIFF
--- a/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
+++ b/freqtrade/freqai/RL/BaseReinforcementLearningModel.py
@@ -117,7 +117,10 @@ class BaseReinforcementLearningModel(IFreqaiModel):
 
         dd: dict[str, Any] = dk.make_train_test_datasets(features_filtered, labels_filtered)
         self.df_raw = copy.deepcopy(dd["train_features"])
-        dk.fit_labels()  # FIXME useless for now, but just satiating append methods
+        # RL models do not use label pipelines for prediction (unlike Regression/Classifier
+        # models). fit_labels() is called here only to populate labels_mean/labels_std
+        # metadata so that downstream append methods do not encounter missing keys.
+        dk.fit_labels()
 
         # normalize all data based on train_dataset only
         prices_train, prices_test = self.build_ohlc_price_dataframes(dk.data_dictionary, pair, dk)


### PR DESCRIPTION
Replace misleading FIXME comment with a clear explanation of why fit_labels() is called in the RL training path.

Unlike Regression/Classifier models, RL models do not use label pipelines for prediction. fit_labels() is retained here solely to populate labels_mean/labels_std metadata so that downstream append methods do not encounter missing keys.

Note: This commit was authored with AI assistance (OpenClaw). The change has been reviewed and verified by the PR author.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
