### PR TITLE
docs: add VARRD to community showcase

### DIFF
--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -9,3 +9,4 @@ This section will highlight a few projects from members of the community.
 - [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
 - [FTUI - Terminal UI for freqtrade](https://github.com/freqtrade/ftui) (by Froggleston).
 - [Bot Academy](https://botacademy.ddns.net/) (by stash86) - Blog about crypto bot projects.
+- [VARRD - Statistical edge validation for strategies](https://github.com/augiemazza/varrd) (by augiemazza) - Validates whether a strategy has a real statistical edge before deployment. Generates ready-to-run Freqtrade strategy files from validated edges.


### PR DESCRIPTION
## What is VARRD?

[VARRD](https://github.com/augiemazza/varrd) (`pip install varrd`) validates whether a trading strategy has a real statistical edge before deployment. It runs event studies with forward-return analysis, applies Bonferroni correction for multiple testing, and tracks test count (K) to prevent p-hacking.

## Freqtrade Integration

We built a native Freqtrade integration that generates ready-to-run IStrategy v3 files from validated edges:

```python
from varrd import VARRD
from varrd.freqtrade import generate_strategy

v = VARRD()
result = v.discover("RSI oversold reversal on BTC")

if result.has_edge:
    hyp = v.get_hypothesis(result.hypothesis_id)
    strategy_code, config = generate_strategy(hyp)
    # Produces a complete strategy file with:
    # - populate_indicators() from validated setup code
    # - populate_entry_trend() from validated formula
    # - custom_stoploss() with ATR-based stops
    # - custom_exit() with ATR take-profit + time limit
```

The generated strategy includes full validation stats in the header (win rate, EV/trade, total trades, horizon).

## Why this complements Freqtrade

Freqtrade handles execution. VARRD adds a pre-validation layer — checking if the edge is statistically significant before you spend time on hyperopt and backtesting. We tested 10 ideas during development; only 1 survived statistical testing (BTC RSI oversold, 58.3% win rate, 26 trades). That filtering is the value.

Related to discussions in #7190 (forward validation) and #2472 (overfitting detection).