### PR TITLE
Consume signals.json replay and dry-run E2E

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1376,6 +1376,10 @@
                 "description": "Name of the producer.",
                 "type": "string"
               },
+              "signals_file": {
+                "description": "Optional JSON file containing captured websocket messages (replay). When set, no websocket connection is created.",
+                "type": "string"
+              },
               "host": {
                 "description": "Host of the producer.",
                 "type": "string"
@@ -1398,9 +1402,20 @@
               }
             },
             "required": [
-              "name",
-              "host",
-              "ws_token"
+              "name"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "signals_file"
+                ]
+              },
+              {
+                "required": [
+                  "host",
+                  "ws_token"
+                ]
+              }
             ]
           }
         },

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -1058,6 +1058,13 @@ CONF_SCHEMA = {
                                 "description": "Name of the producer.",
                                 "type": "string",
                             },
+                            "signals_file": {
+                                "description": (
+                                    "Optional JSON file containing captured websocket messages "
+                                    "(replay). When set, no websocket connection is created."
+                                ),
+                                "type": "string",
+                            },
                             "host": {
                                 "description": "Host of the producer.",
                                 "type": "string",
@@ -1079,7 +1086,11 @@ CONF_SCHEMA = {
                                 "type": "string",
                             },
                         },
-                        "required": ["name", "host", "ws_token"],
+                        "required": ["name"],
+                        "anyOf": [
+                            {"required": ["signals_file"]},
+                            {"required": ["host", "ws_token"]},
+                        ],
                     },
                 },
                 "wait_timeout": {

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -9,16 +9,18 @@ import asyncio
 import logging
 import socket
 from collections.abc import Callable
+from pathlib import Path
 from threading import Thread
-from typing import Any, TypedDict
+from typing import Any, NotRequired, Required, TypedDict
 
 import websockets
+import rapidjson
 from pydantic import ValidationError
 
 from freqtrade.constants import FULL_DATAFRAME_THRESHOLD
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RPCMessageType
-from freqtrade.misc import remove_entry_exit_signals
+from freqtrade.misc import json_to_dataframe, remove_entry_exit_signals
 from freqtrade.rpc.api_server.ws.channel import WebSocketChannel, create_channel
 from freqtrade.rpc.api_server.ws.message_stream import MessageStream
 from freqtrade.rpc.api_server.ws_schemas import (
@@ -33,11 +35,12 @@ from freqtrade.rpc.api_server.ws_schemas import (
 
 
 class Producer(TypedDict):
-    name: str
-    host: str
-    port: int
-    secure: bool
-    ws_token: str
+    name: Required[str]
+    host: NotRequired[str]
+    port: NotRequired[int]
+    secure: NotRequired[bool]
+    ws_token: NotRequired[str]
+    signals_file: NotRequired[str]
 
 
 logger = logging.getLogger(__name__)
@@ -190,6 +193,11 @@ class ExternalMessageConsumer:
         """
         while self._running:
             try:
+                signals_file = producer.get("signals_file")
+                if signals_file:
+                    await self._consume_signals_file(producer, lock, signals_file)
+                    break
+
                 host, port = producer["host"], producer["port"]
                 token = producer["ws_token"]
                 name = producer["name"]
@@ -237,6 +245,64 @@ class ExternalMessageConsumer:
                 logger.exception(e)
                 await asyncio.sleep(self.sleep_time)
                 continue
+
+    async def _consume_signals_file(
+        self, producer: Producer, lock: asyncio.Lock, filename: str
+    ) -> None:
+        """Load and consume messages from a JSON file.
+
+        This allows replaying captured websocket messages for debugging and tests.
+        The file must contain either a list of websocket messages or an object with
+        a `messages` list.
+        """
+
+        producer_name = producer.get("name", "default")
+        path = Path(filename)
+        if not path.is_file():
+            logger.error(f"signals_file for `{producer_name}` does not exist: {path}")
+            return
+
+        def _json_object_hook(z: dict[str, Any]):
+            if z.get("__type__") == "dataframe":
+                return json_to_dataframe(z.get("__value__"))
+            return z
+
+        try:
+            with path.open("r") as fp:
+                payload = rapidjson.load(fp, object_hook=_json_object_hook)
+        except Exception as e:
+            logger.error(
+                f"Unable to load signals_file for `{producer_name}`: {path} - {e}"
+            )
+            return
+
+        messages: list[dict[str, Any]]
+        if isinstance(payload, list):
+            messages = payload
+        elif isinstance(payload, dict) and isinstance(payload.get("messages"), list):
+            messages = payload["messages"]
+        elif isinstance(payload, dict):
+            messages = [payload]
+        else:
+            logger.error(
+                f"signals_file for `{producer_name}` must be a list of messages or an object "
+                "with a `messages` list."
+            )
+            return
+
+        for message in messages:
+            if not self._running:
+                break
+            if not isinstance(message, dict):
+                logger.error(f"Invalid message in signals_file for `{producer_name}`: {message}")
+                continue
+            try:
+                async with lock:
+                    self.handle_producer_message(producer, message)
+            except Exception as e:
+                logger.exception(
+                    f"Error handling signals_file message for `{producer_name}`: {e}"
+                )
 
     async def _send_requests(self, channel: WebSocketChannel, channel_stream: MessageStream):
         # Send the initial requests

--- a/tests/freqtradebot/test_dry_run_e2e_signals_file.py
+++ b/tests/freqtradebot/test_dry_run_e2e_signals_file.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import time
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import rapidjson
+
+from freqtrade.data.converter.converter import ohlcv_to_dataframe
+from freqtrade.enums import CandleType
+from freqtrade.freqtradebot import FreqtradeBot
+from freqtrade.misc import dataframe_to_json
+from freqtrade.persistence import Trade
+from tests.conftest import EXMS, patch_exchange
+
+
+def _write_signals_file(filename: Path, pair: str, timeframe: str, ohlcv_df) -> None:
+    signals_df = ohlcv_df[["date"]].copy()
+    signals_df["enter_long"] = 0
+    signals_df.loc[signals_df.index[-1], "enter_long"] = 1
+    signals_df["exit_long"] = 0
+    signals_df["enter_short"] = 0
+    signals_df["exit_short"] = 0
+    signals_df["enter_tag"] = None
+    signals_df["exit_tag"] = None
+
+    messages = [
+        {"type": "whitelist", "data": [pair]},
+        {
+            "type": "analyzed_df",
+            "data": {
+                "key": [pair, timeframe, CandleType.SPOT.value],
+                "la": datetime.now(UTC).isoformat(),
+                "df": {
+                    "__type__": "dataframe",
+                    "__value__": dataframe_to_json(signals_df),
+                },
+            },
+        },
+    ]
+
+    with filename.open("w") as fp:
+        rapidjson.dump(messages, fp)
+
+
+def test_dry_run_e2e_signals_file(default_conf, mocker, tmp_path) -> None:
+    pair = "ETH/BTC"
+    timeframe = "5m"
+
+    config = deepcopy(default_conf)
+    config["strategy"] = "StrategyTestProducerSignals"
+    config["exchange"]["pair_whitelist"] = [pair]
+
+    # Provide upstream signals via signals.json replay
+    signals_file = tmp_path / "signals.json"
+
+    now = datetime.now(UTC).replace(second=0, microsecond=0)
+    start = now - timedelta(minutes=10)
+    ohlcv = [
+        [int(start.timestamp() * 1000), 1.0, 1.0, 1.0, 1.0, 1.0],
+        [int((start + timedelta(minutes=5)).timestamp() * 1000), 1.0, 1.0, 1.0, 1.0, 1.0],
+        [int((start + timedelta(minutes=10)).timestamp() * 1000), 1.0, 1.0, 1.0, 1.0, 1.0],
+    ]
+    ohlcv_df = ohlcv_to_dataframe(
+        ohlcv, timeframe, pair=pair, fill_missing=True, drop_incomplete=False
+    )
+    _write_signals_file(signals_file, pair, timeframe, ohlcv_df)
+
+    config["external_message_consumer"] = {
+        "enabled": True,
+        "producers": [
+            {
+                "name": "default",
+                "signals_file": str(signals_file),
+            }
+        ],
+    }
+
+    # Patch exchange + RPC, but keep the real ExternalMessageConsumer.
+    mocker.patch("freqtrade.freqtradebot.RPCManager", MagicMock())
+    mocker.patch("freqtrade.freqtradebot.RPCManager._init", MagicMock())
+    mocker.patch("freqtrade.freqtradebot.RPCManager.send_msg", MagicMock())
+    patch_exchange(mocker)
+    mocker.patch(
+        "freqtrade.freqtradebot.FreqtradeBot._refresh_active_whitelist",
+        MagicMock(return_value=[pair]),
+    )
+
+    # Avoid waiting on exchange interaction.
+    mocker.patch(f"{EXMS}.create_order", side_effect=lambda **kwargs: {
+        "id": "dry-run-order",
+        "status": "closed",
+        "filled": kwargs["amount"],
+        "amount": kwargs["amount"],
+        "remaining": 0.0,
+        "average": kwargs["rate"],
+        "price": kwargs["rate"],
+    })
+    mocker.patch(f"{EXMS}.get_rate", return_value=1.0)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.0)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=1e9)
+    mocker.patch(f"{EXMS}.get_pair_base_currency", return_value="ETH")
+    mocker.patch(f"{EXMS}.get_pair_quote_currency", return_value="BTC")
+    mocker.patch(f"{EXMS}.get_funding_fees", return_value=0.0)
+    mocker.patch(f"{EXMS}.get_precision_amount", return_value=8)
+    mocker.patch(f"{EXMS}.get_precision_price", return_value=8)
+    mocker.patch(f"{EXMS}.get_contract_size", return_value=1)
+    mocker.patch(f"{EXMS}.amount_to_precision", side_effect=lambda *a, **k: a[-1])
+    mocker.patch(f"{EXMS}.price_to_precision", side_effect=lambda *a, **k: a[-1])
+
+    freqtrade = FreqtradeBot(config)
+    try:
+        # Make OHLCV available for analysis.
+        freqtrade.exchange._klines[(pair, timeframe, CandleType.SPOT)] = ohlcv_df
+
+        # Wait for the signals file to be consumed.
+        for _ in range(50):
+            pdf, _ = freqtrade.dataprovider.get_producer_df(
+                pair, timeframe=timeframe, candle_type=CandleType.SPOT, producer_name="default"
+            )
+            if not pdf.empty:
+                break
+            time.sleep(0.05)
+
+        # Analyze candles (strategy merges upstream signals) and enter based on last candle.
+        freqtrade.strategy.analyze_pair(pair)
+        n = freqtrade.enter_positions()
+        assert n == 1
+        assert len(Trade.get_open_trades()) == 1
+        assert Trade.get_open_trades()[0].pair == pair
+    finally:
+        if freqtrade.emc:
+            freqtrade.emc.shutdown()

--- a/tests/strategy/strats/strategy_test_producer_signals.py
+++ b/tests/strategy/strats/strategy_test_producer_signals.py
@@ -1,0 +1,76 @@
+# pragma pylint: disable=missing-docstring, invalid-name
+
+from pandas import DataFrame
+
+from freqtrade.enums import CandleType
+from freqtrade.strategy import IStrategy
+
+
+class StrategyTestProducerSignals(IStrategy):
+    """Strategy used by tests to validate upstream signal replay."""
+
+    INTERFACE_VERSION = 3
+
+    timeframe = "5m"
+    startup_candle_count: int = 1
+
+    minimal_roi = {"0": 0.0}
+    stoploss = -0.99
+
+    process_only_new_candles = False
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        pair = str(metadata["pair"])
+        candle_type = self.config.get("candle_type_def", CandleType.SPOT)
+
+        producer_df, _la = self.dp.get_producer_df(
+            pair,
+            timeframe=self.timeframe,
+            candle_type=candle_type,
+            producer_name="default",
+        )
+
+        if not producer_df.empty and "date" in producer_df.columns:
+            cols = [
+                "enter_long",
+                "exit_long",
+                "enter_short",
+                "exit_short",
+                "enter_tag",
+                "exit_tag",
+            ]
+            available = [c for c in cols if c in producer_df.columns]
+            if available:
+                p_df = producer_df[["date", *available]].copy()
+                p_df.rename(columns={c: f"{c}_default" for c in available}, inplace=True)
+                dataframe = dataframe.merge(p_df, on="date", how="left")
+
+        for col in [
+            "enter_long_default",
+            "exit_long_default",
+            "enter_short_default",
+            "exit_short_default",
+        ]:
+            if col not in dataframe.columns:
+                dataframe[col] = 0
+            dataframe[col] = dataframe[col].fillna(0).astype(int)
+
+        for col in ["enter_tag_default", "exit_tag_default"]:
+            if col not in dataframe.columns:
+                dataframe[col] = None
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[dataframe["enter_long_default"] == 1, "enter_long"] = 1
+        dataframe.loc[dataframe["enter_short_default"] == 1, "enter_short"] = 1
+        dataframe.loc[dataframe["enter_long_default"] == 1, "enter_tag"] = dataframe[
+            "enter_tag_default"
+        ]
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[dataframe["exit_long_default"] == 1, "exit_long"] = 1
+        dataframe.loc[dataframe["exit_short_default"] == 1, "exit_short"] = 1
+        dataframe.loc[dataframe["exit_long_default"] == 1, "exit_tag"] = dataframe["exit_tag_default"]
+        return dataframe


### PR DESCRIPTION
## What
- Add `signals_file` support to `external_message_consumer` producers to replay captured websocket messages from a JSON file.
- Extend config schema to allow `signals_file`-only producers.
- Add a dry-run integration test that replays `signals.json`, analyzes candles, and opens a trade based on upstream signals.

## Why
This enables deterministic/offline dry-run validation using pre-recorded producer messages.

## How to test
- `pytest tests/freqtradebot/test_dry_run_e2e_signals_file.py`

Ref: Consume signals.json and dry-run E2E