### PR TITLE
feat: local signal file consumer for producer messages

### DIFF
--- a/docs/producer-consumer.md
+++ b/docs/producer-consumer.md
@@ -52,8 +52,29 @@ Enable subscribing to an instance by adding the `external_message_consumer` sect
 | `remove_entry_exit_signals` | Remove signal columns from the dataframe (set them to 0) on dataframe receipt.<br>*Defaults to `false`.*<br> **Datatype:** Boolean.
 | `initial_candle_limit` | Initial candles to expect from the Producer.<br>*Defaults to `1500`.*<br> **Datatype:** Integer - Number of candles.
 | `message_size_limit` | Size limit per message<br>*Defaults to `8`.*<br> **Datatype:** Integer - Megabytes.
+| `signal_file_poll_interval` | Default polling interval for `signal_file` producers.<br>*Defaults to `1`.*<br> **Datatype:** Number - in seconds.
 
 Instead of (or as well as) calculating indicators in `populate_indicators()` the follower instance listens on the connection to a producer instance's messages (or multiple producer instances in advanced configurations) and requests the producer's most recently analyzed dataframes for each pair in the active whitelist.
+
+### Local (file-based) producer
+
+In addition to websocket producers, the consumer can read ws-style messages from a local newline-delimited JSON file.
+This can be useful when running a producer that writes messages to disk (e.g. a SignalFileStrategy).
+
+```json
+{
+    "external_message_consumer": {
+        "enabled": true,
+        "producers": [
+            {
+                "name": "default",
+                "signal_file": "./user_data/signals/producer.ndjson",
+                "signal_file_poll_interval": 1
+            }
+        ]
+    }
+}
+```
 
 A consumer instance will then have a full copy of the analyzed dataframes without the need to calculate them itself.
 

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -1058,6 +1058,18 @@ CONF_SCHEMA = {
                                 "description": "Name of the producer.",
                                 "type": "string",
                             },
+                            "signal_file": {
+                                "description": (
+                                    "Local signal file to consume. If set, this producer will be read "
+                                    "as newline-delimited JSON messages instead of via websocket."
+                                ),
+                                "type": "string",
+                            },
+                            "signal_file_poll_interval": {
+                                "description": "Polling interval for signal_file producers (seconds).",
+                                "type": "number",
+                                "minimum": 0.1,
+                            },
                             "host": {
                                 "description": "Host of the producer.",
                                 "type": "string",
@@ -1079,7 +1091,10 @@ CONF_SCHEMA = {
                                 "type": "string",
                             },
                         },
-                        "required": ["name", "host", "ws_token"],
+                        "oneOf": [
+                            {"required": ["name", "host", "ws_token"]},
+                            {"required": ["name", "signal_file"]},
+                        ],
                     },
                 },
                 "wait_timeout": {
@@ -1115,6 +1130,12 @@ CONF_SCHEMA = {
                     "minimum": 1,
                     "maximum": 20,
                     "default": 8,
+                },
+                "signal_file_poll_interval": {
+                    "description": "Default polling interval for signal_file producers (seconds).",
+                    "type": "number",
+                    "minimum": 0.1,
+                    "default": 1,
                 },
             },
             "required": ["producers"],

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -391,7 +391,18 @@ def _validate_consumers(conf: dict[str, Any]) -> None:
         if len(emc_conf.get("producers", [])) < 1:
             raise ConfigurationError("You must specify at least 1 Producer to connect to.")
 
-        producer_names = [p["name"] for p in emc_conf.get("producers", [])]
+        # Validate producer config (either websocket or signal_file)
+        for p in emc_conf.get("producers", []):
+            if not p.get("name"):
+                raise ConfigurationError("Producer name is required.")
+            if p.get("signal_file"):
+                continue
+            if not (p.get("host") and p.get("ws_token")):
+                raise ConfigurationError(
+                    "Producer must specify either `signal_file` or both `host` and `ws_token`."
+                )
+
+        producer_names = [p["name"] for p in emc_conf.get("producers", []) if p.get("name")]
         duplicates = [item for item, count in Counter(producer_names).items() if count > 1]
         if duplicates:
             raise ConfigurationError(

--- a/freqtrade/rpc/external_message_consumer.py
+++ b/freqtrade/rpc/external_message_consumer.py
@@ -9,16 +9,18 @@ import asyncio
 import logging
 import socket
 from collections.abc import Callable
+from pathlib import Path
 from threading import Thread
 from typing import Any, TypedDict
 
+import rapidjson
 import websockets
 from pydantic import ValidationError
 
 from freqtrade.constants import FULL_DATAFRAME_THRESHOLD
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RPCMessageType
-from freqtrade.misc import remove_entry_exit_signals
+from freqtrade.misc import json_to_dataframe, remove_entry_exit_signals
 from freqtrade.rpc.api_server.ws.channel import WebSocketChannel, create_channel
 from freqtrade.rpc.api_server.ws.message_stream import MessageStream
 from freqtrade.rpc.api_server.ws_schemas import (
@@ -32,12 +34,21 @@ from freqtrade.rpc.api_server.ws_schemas import (
 )
 
 
-class Producer(TypedDict):
+class Producer(TypedDict, total=False):
+    """Producer configuration.
+
+    Supports websocket producers (host/ws_token/...) and local signal file producers (signal_file).
+    """
+
     name: str
     host: str
     port: int
     secure: bool
     ws_token: str
+
+    # Local signal file transport.
+    signal_file: str
+    signal_file_poll_interval: float
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +56,13 @@ logger = logging.getLogger(__name__)
 
 def schema_to_dict(schema: WSMessageSchema | WSRequestSchema):
     return schema.model_dump(exclude_none=True)
+
+
+def _signal_file_object_hook(obj: dict[str, Any]):
+    """RapidJSON object hook to decode DataFrame markers."""
+    if obj.get("__type__") == "dataframe":
+        return json_to_dataframe(obj.get("__value__"))
+    return obj
 
 
 class ExternalMessageConsumer:
@@ -98,6 +116,7 @@ class ExternalMessageConsumer:
         }
 
         self._channel_streams: dict[str, MessageStream] = {}
+        self._signal_file_offsets: dict[str, int] = {}
 
         self.start()
 
@@ -126,6 +145,7 @@ class ExternalMessageConsumer:
             self._running = False
 
             self._channel_streams = {}
+            self._signal_file_offsets = {}
 
             asyncio.run_coroutine_threadsafe(self._shutdown_async(), loop=self._loop)
 
@@ -154,10 +174,16 @@ class ExternalMessageConsumer:
 
         try:
             # Create a connection to each producer
-            self._sub_tasks = [
-                self._loop.create_task(self._handle_producer_connection(producer, lock))
-                for producer in self.producers
-            ]
+            self._sub_tasks = []
+            for producer in self.producers:
+                if producer.get("signal_file"):
+                    self._sub_tasks.append(
+                        self._loop.create_task(self._handle_signal_file_producer(producer, lock))
+                    )
+                else:
+                    self._sub_tasks.append(
+                        self._loop.create_task(self._handle_producer_connection(producer, lock))
+                    )
 
             await asyncio.gather(*self._sub_tasks)
         except asyncio.CancelledError:
@@ -176,6 +202,14 @@ class ExternalMessageConsumer:
         """
         try:
             await self._create_connection(producer, lock)
+        except asyncio.CancelledError:
+            # Exit silently
+            pass
+
+    async def _handle_signal_file_producer(self, producer: Producer, lock: asyncio.Lock):
+        """Main loop for consuming messages from a local signal file."""
+        try:
+            await self._consume_signal_file(producer, lock)
         except asyncio.CancelledError:
             # Exit silently
             pass
@@ -237,6 +271,93 @@ class ExternalMessageConsumer:
                 logger.exception(e)
                 await asyncio.sleep(self.sleep_time)
                 continue
+
+    def _read_signal_file_messages(
+        self, signal_file: Path, *, offset: int, producer_name: str
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """Read newline-delimited JSON messages from a local signal file.
+
+        The file format is expected to be one JSON object per line.
+        Dataframes must be encoded using the same marker as websocket messages:
+        {"__type__": "dataframe", "__value__": "<json>"}.
+        """
+
+        if not signal_file.exists():
+            return offset, []
+
+        try:
+            file_size = signal_file.stat().st_size
+        except OSError:
+            return offset, []
+
+        if offset > file_size:
+            # File rotated/truncated.
+            offset = 0
+
+        messages: list[dict[str, Any]] = []
+
+        try:
+            with signal_file.open("rb") as fp:
+                fp.seek(offset)
+                while True:
+                    pos = fp.tell()
+                    raw = fp.readline()
+                    if not raw:
+                        break
+                    if not raw.endswith(b"\n"):
+                        # Incomplete line - retry later.
+                        fp.seek(pos)
+                        break
+
+                    line = raw.decode("utf-8", errors="replace").strip()
+                    if not line:
+                        continue
+
+                    try:
+                        msg = rapidjson.loads(line, object_hook=_signal_file_object_hook)
+                    except Exception as e:
+                        logger.warning(
+                            f"Invalid signal_file message from `{producer_name}`: {e}"
+                        )
+                        continue
+
+                    if isinstance(msg, dict):
+                        messages.append(msg)
+
+                new_offset = fp.tell()
+        except OSError as e:
+            logger.debug(f"Could not read signal_file {signal_file}: {e}")
+            return offset, []
+
+        return new_offset, messages
+
+    async def _consume_signal_file(self, producer: Producer, lock: asyncio.Lock):
+        """Consume ws-style messages from a local signal file."""
+
+        producer_name = producer.get("name", "default")
+        signal_file = Path(str(producer.get("signal_file"))).expanduser()
+        poll_interval = float(
+            producer.get(
+                "signal_file_poll_interval",
+                self._emc_config.get("signal_file_poll_interval", 1.0),
+            )
+        )
+
+        while self._running:
+            offset = self._signal_file_offsets.get(producer_name, 0)
+            new_offset, messages = self._read_signal_file_messages(
+                signal_file, offset=offset, producer_name=producer_name
+            )
+            self._signal_file_offsets[producer_name] = new_offset
+
+            for msg in messages:
+                try:
+                    async with lock:
+                        self.handle_producer_message(producer, msg)
+                except Exception as e:
+                    logger.exception(f"Error handling producer message: {e}")
+
+            await asyncio.sleep(poll_interval)
 
     async def _send_requests(self, channel: WebSocketChannel, channel_stream: MessageStream):
         # Send the initial requests

--- a/tests/rpc/test_rpc_emc.py
+++ b/tests/rpc/test_rpc_emc.py
@@ -8,9 +8,12 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
+import rapidjson
 import websockets
 
+from freqtrade.constants import FULL_DATAFRAME_THRESHOLD
 from freqtrade.data.dataprovider import DataProvider
+from freqtrade.misc import dataframe_to_json
 from freqtrade.rpc.external_message_consumer import ExternalMessageConsumer
 from tests.conftest import log_has, log_has_re, log_has_when
 
@@ -466,3 +469,74 @@ async def test_emc_receive_messages_handle_error(default_conf, caplog, mocker):
         assert log_has_re(r"Error handling producer message.+", caplog)
     finally:
         emc.shutdown()
+
+
+async def test_emc_consume_signal_file(default_conf, tmp_path, caplog, mocker, ohlcv_history):
+    caplog.set_level(logging.DEBUG)
+
+    signal_file = tmp_path / "producer.ndjson"
+
+    default_conf.update(
+        {
+            "external_message_consumer": {
+                "enabled": True,
+                "producers": [
+                    {
+                        "name": "default",
+                        "signal_file": str(signal_file),
+                        "signal_file_poll_interval": 0.01,
+                    }
+                ],
+            }
+        }
+    )
+
+    # Avoid starting the threaded loop in unit test.
+    mocker.patch("freqtrade.rpc.external_message_consumer.ExternalMessageConsumer.start")
+
+    dp = DataProvider(default_conf, None, None, None)
+    emc = ExternalMessageConsumer(default_conf, dp)
+
+    # Ensure we store a full dataframe (bypass append / backfill logic)
+    import pandas as pd
+
+    mul = int(FULL_DATAFRAME_THRESHOLD / max(len(ohlcv_history), 1)) + 1
+    df_big = pd.concat([ohlcv_history] * mul, ignore_index=True)
+
+    whitelist_message = {"type": "whitelist", "data": ["BTC/USDT"]}
+    df_message = {
+        "type": "analyzed_df",
+        "data": {
+            "key": ["BTC/USDT", "5m", "spot"],
+            "df": {"__type__": "dataframe", "__value__": dataframe_to_json(df_big)},
+            "la": datetime.now(UTC).isoformat(),
+        },
+    }
+
+    signal_file.write_text(
+        rapidjson.dumps(whitelist_message) + "\n" + rapidjson.dumps(df_message) + "\n",
+        encoding="utf-8",
+    )
+
+    # Stop the loop after receiving 2 messages.
+    count = {"n": 0}
+    original = emc.handle_producer_message
+
+    def _wrapped(self, producer, message):
+        count["n"] += 1
+        original(producer, message)
+        if count["n"] >= 2:
+            self._running = False
+
+    emc.handle_producer_message = _wrapped.__get__(emc, ExternalMessageConsumer)
+
+    try:
+        emc._running = True
+        producer = default_conf["external_message_consumer"]["producers"][0]
+        await asyncio.wait_for(emc._consume_signal_file(producer, asyncio.Lock()), timeout=2)
+    finally:
+        emc.shutdown()
+
+    assert "BTC/USDT" in dp.get_producer_pairs("default")
+    df, _ = dp.get_producer_df("BTC/USDT", timeframe="5m")
+    assert not df.empty


### PR DESCRIPTION
## Summary
- Extend ExternalMessageConsumer to also consume ws-style messages from a local newline-delimited JSON file (signal_file producers).
- Add config schema + validation and documentation.
- Add unit test coverage for file consumption.

## Motivation
Enable a local (disk-based) consumer workflow for SignalFileStrategy-style producers when websocket transport is not desired.
