### PR TITLE
fix: nullify FreqAI object before pickling hyperopt workers

### DIFF
--- a/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
+++ b/freqtrade/optimize/hyperopt/hyperopt_optimizer.py
@@ -141,6 +141,19 @@ class HyperOptimizer:
         # self.backtesting.exchange = None  # type: ignore
         self.backtesting.pairlists = None  # type: ignore
 
+        # FreqAI: predictions are already cached in pickle file,
+        # nullify the entire freqai object to allow parallel hyperopt (-j > 1).
+        # FreqAI models may contain unpicklable objects (e.g. CUDA tensors,
+        # CatBoost internals) that cause cloudpickle to fail when sending
+        # the strategy to worker processes.
+        strategy = self.backtesting.strategy
+        if hasattr(strategy, "freqai") and strategy.freqai is not None:
+            try:
+                strategy.freqai.shutdown()
+            except Exception:
+                logger.debug("FreqAI shutdown failed during hyperopt cleanup, ignoring.")
+            strategy.freqai = None  # type: ignore
+
     def get_strategy_name(self) -> str:
         return self.backtesting.strategy.get_strategy_name()
 


### PR DESCRIPTION
## Summary
- When running hyperopt with parallel workers (`-j > 1`) on a FreqAI strategy, cloudpickle fails to serialize the strategy because the `freqai` attribute may contain unpicklable objects (CUDA tensors, CatBoost Pool internals, threading locks, etc.)
- Since FreqAI predictions are already cached in the backtesting predictions pickle at this point, the `freqai` object is no longer needed
- This adds `shutdown()` + nullification of `strategy.freqai`, following the same cleanup pattern already used for `exchange` and `pairlists` in `prepare_hyperopt()`

## Reproduction
1. Create a FreqAI strategy with any PyTorch or CatBoost model
2. Run `freqtrade hyperopt --strategy MyFreqAIStrategy --freqaimodel MyModel -j 4`
3. Observe pickling errors when workers try to serialize the strategy

## Test plan
- [x] Pre-commit hooks pass (flake8, mypy, ruff, isort)
- [ ] Existing hyperopt tests pass
- [ ] Manual test: `freqtrade hyperopt -j 4` with FreqAI strategy completes without pickling errors
- [ ] Manual test: `freqtrade hyperopt -j 1` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)