### PR TITLE
fix: avoid DataFrame fragmentation in get_predictions_to_append

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -445,11 +445,11 @@ class FreqaiDataKitchen:
         for extra_col in self.data["extra_returns_per_train"]:
             append_dict[f"{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
 
-        append_df = DataFrame(append_dict)
-
-        append_df["do_predict"] = do_predict
+        append_dict["do_predict"] = do_predict
         if self.freqai_config["feature_parameters"].get("DI_threshold", 0) > 0:
-            append_df["DI_values"] = self.DI_values
+            append_dict["DI_values"] = self.DI_values
+
+        append_df = DataFrame(append_dict)
 
         user_cols = [col for col in dataframe_backtest.columns if col.startswith("%%")]
         cols = ["date"]

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -428,18 +428,24 @@ class FreqaiDataKitchen:
         Get backtest prediction from current backtest period
         """
 
-        append_df = DataFrame()
+        # Build dict first and construct DataFrame once to avoid
+        # column-by-column assignment which causes DataFrame fragmentation
+        # and PerformanceWarning on large prediction sets.
+        append_dict: dict[str, Any] = {}
+
         for label in predictions.columns:
-            append_df[label] = predictions[label]
-            if append_df[label].dtype == object:
+            append_dict[label] = predictions[label]
+            if predictions[label].dtype == object:
                 continue
-            if "labels_mean" in self.data:
-                append_df[f"{label}_mean"] = self.data["labels_mean"][label]
-            if "labels_std" in self.data:
-                append_df[f"{label}_std"] = self.data["labels_std"][label]
+            if "labels_mean" in self.data and label in self.data["labels_mean"]:
+                append_dict[f"{label}_mean"] = self.data["labels_mean"][label]
+            if "labels_std" in self.data and label in self.data["labels_std"]:
+                append_dict[f"{label}_std"] = self.data["labels_std"][label]
 
         for extra_col in self.data["extra_returns_per_train"]:
-            append_df[f"{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
+            append_dict[f"{extra_col}"] = self.data["extra_returns_per_train"][extra_col]
+
+        append_df = DataFrame(append_dict)
 
         append_df["do_predict"] = do_predict
         if self.freqai_config["feature_parameters"].get("DI_threshold", 0) > 0:


### PR DESCRIPTION
## Summary
- Replace column-by-column DataFrame assignment with dict-based construction in `FreqaiDataKitchen.get_predictions_to_append()`
- The previous approach triggered pandas `PerformanceWarning` about DataFrame fragmentation when many prediction columns (and their corresponding `_mean`/`_std` columns) were added one at a time
- Add defensive key checks (`label in self.data["labels_mean"]`) to prevent `KeyError` when custom models produce prediction columns that don't have corresponding entries in `labels_mean`/`labels_std`

## Problem
```python
# Before: column-by-column assignment causes fragmentation
append_df = DataFrame()
for label in predictions.columns:
    append_df[label] = predictions[label]          # fragment 1
    append_df[f"{label}_mean"] = ...               # fragment 2
    append_df[f"{label}_std"] = ...                # fragment 3
```

With 4+ prediction targets, this creates 12+ fragments, triggering:
```
PerformanceWarning: DataFrame is highly fragmented.
This is usually the result of calling `frame.insert` many times,
which has poor performance. Consider joining all columns at once
using pd.concat(axis=1) instead.
```

## Solution
```python
# After: build dict first, construct DataFrame once
append_dict = {}
for label in predictions.columns:
    append_dict[label] = predictions[label]
    if label in self.data["labels_mean"]:           # defensive check
        append_dict[f"{label}_mean"] = ...
append_df = DataFrame(append_dict)                  # single allocation
```

## Test plan
- [x] Pre-commit hooks pass (flake8, mypy, ruff, isort)
- [ ] Existing FreqAI backtesting tests pass
- [ ] Manual test: backtesting with multi-target FreqAI model produces no PerformanceWarning

🤖 Generated with [Claude Code](https://claude.com/claude-code)