### PR TITLE
feat: add RedditSentimentPairList for remote crypto sentiment filtering

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -2,11 +2,11 @@
 
 Pairlist Handlers define the list of pairs (pairlist) that the bot should trade. They are configured in the `pairlists` section of the configuration settings.
 
-In your configuration, you can use Static Pairlist (defined by the [`StaticPairList`](#static-pair-list) Pairlist Handler) and Dynamic Pairlist (defined by the [`VolumePairList`](#volume-pair-list), [`CrossMarketPairList`](#crossmarketpairlist), [`MarketCapPairlist`](#marketcappairlist) and [`PercentChangePairList`](#percent-change-pair-list) Pairlist Handlers).
+In your configuration, you can use Static Pairlist (defined by the [`StaticPairList`](#static-pair-list) Pairlist Handler) and Dynamic Pairlist (defined by the [`VolumePairList`](#volume-pair-list), [`CrossMarketPairList`](#crossmarketpairlist), [`MarketCapPairlist`](#marketcappairlist), [`RedditSentimentPairList`](#redditsentimentpairlist) and [`PercentChangePairList`](#percent-change-pair-list) Pairlist Handlers).
 
 Additionally, [`AgeFilter`](#agefilter), [`DelistFilter`](#delistfilter), [`PrecisionFilter`](#precisionfilter), [`PriceFilter`](#pricefilter), [`ShuffleFilter`](#shufflefilter), [`SpreadFilter`](#spreadfilter) and [`VolatilityFilter`](#volatilityfilter) act as Pairlist Filters, removing certain pairs and/or moving their positions in the pairlist.
 
-If multiple Pairlist Handlers are used, they are chained and a combination of all Pairlist Handlers forms the resulting pairlist the bot uses for trading and backtesting. Pairlist Handlers are executed in the sequence they are configured. You can define either `StaticPairList`, `VolumePairList`, `ProducerPairList`, `RemotePairList`, `MarketCapPairList`, `PercentChangePairList` or `CrossMarketPairList` as the starting Pairlist Handler.
+If multiple Pairlist Handlers are used, they are chained and a combination of all Pairlist Handlers forms the resulting pairlist the bot uses for trading and backtesting. Pairlist Handlers are executed in the sequence they are configured. You can define either `StaticPairList`, `VolumePairList`, `ProducerPairList`, `RemotePairList`, `MarketCapPairList`, `RedditSentimentPairList`, `PercentChangePairList` or `CrossMarketPairList` as the starting Pairlist Handler.
 
 Inactive markets are always removed from the resulting pairlist. Explicitly blacklisted pairs (those in the `pair_blacklist` configuration setting) are also always removed from the resulting pairlist.
 
@@ -26,6 +26,7 @@ You may also use something like `.*DOWN/BTC` or `.*UP/BTC` to exclude leveraged 
 * [`ProducerPairList`](#producerpairlist)
 * [`RemotePairList`](#remotepairlist)
 * [`MarketCapPairList`](#marketcappairlist)
+* [`RedditSentimentPairList`](#redditsentimentpairlist)
 * [`CrossMarketPairList`](#crossmarketpairlist)
 * [`AgeFilter`](#agefilter)
 * [`DelistFilter`](#delistfilter)
@@ -404,6 +405,49 @@ Coins like 1000PEPE/USDT or KPEPE/USDT:USDT are detected on a best effort basis,
 
 !!! Danger "Duplicate symbols in coingecko"
     Coingecko often has duplicate symbols, where the same symbol is used for different coins. Freqtrade will use the symbol as is and try to search for it on the exchange. If the symbol exists - it will be used. Freqtrade will however not check if the _intended_ symbol is the one coingecko meant. This can sometimes lead to unexpected results, especially on low volume coins or with meme coin categories.
+
+#### RedditSentimentPairList
+
+`RedditSentimentPairList` generates or filters a crypto pairlist from a remote Reddit sentiment API. It is useful when you want to focus on pairs that are currently getting meaningful discussion volume on Reddit, or when you want to exclude those pairs from an otherwise static universe.
+
+The returned pairlist is sorted by remote `buzz_score`, then by `mentions`, when used in whitelist `mode`.
+
+```json
+"pairlists": [
+    {
+        "method": "RedditSentimentPairList",
+        "api_url": "https://api.example.com/reddit/crypto/v1/trending",
+        "api_key": "your-api-key",
+        "number_assets": 20,
+        "max_tokens": 50,
+        "days": 1,
+        "refresh_period": 21600,
+        "mode": "whitelist",
+        "min_buzz_score": 60,
+        "min_mentions": 25,
+        "allowed_trends": ["rising", "stable"]
+    }
+]
+```
+
+`number_assets` defines the maximum number of pairs returned by the pairlist in whitelist `mode`. In blacklist `mode`, this setting is ignored.
+
+`api_url` must point to a remote endpoint that returns a JSON list of sentiment rows with at least a `symbol` field. `api_key` is passed to that endpoint via the `X-API-Key` header.
+
+`max_tokens` controls how many remote sentiment rows are evaluated before matching them to exchange pairs. If your remote sentiment API returns more than `100` rows, values above `100` are capped.
+
+`days` defines the sentiment lookback window passed to the remote API. `refresh_period` defines how often the remote result is refreshed and cached locally.
+
+`min_buzz_score`, `min_mentions`, `min_bullish_pct`, and `allowed_trends` can be used to enforce minimum quality thresholds before a token becomes eligible for pair resolution.
+
+The `mode` setting defines whether the plugin filters in (whitelist `mode`) or filters out (blacklist `mode`) Reddit-driven tokens. By default, the plugin runs in whitelist mode.
+
+Coins like `1000PEPE/USDT` or `KBONK/USDT:USDT` are detected on a best-effort basis, using common prefixed-market conventions such as `1000` and `K`.
+
+If the remote request fails after the initial fetch, `keep_pairlist_on_failure` can preserve the last successfully fetched sentiment universe instead of aborting pairlist generation.
+
+!!! Warning "Backtesting"
+    `RedditSentimentPairList` depends on an external remote API and therefore introduces lookahead bias. It is available in backtesting mode for parity with live configuration testing, but results should not be interpreted as historically reproducible unless your remote service provides time-consistent historical snapshots.
 
 #### CrossMarketPairList
 

--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -432,7 +432,49 @@ The returned pairlist is sorted by remote `buzz_score`, then by `mentions`, when
 
 `number_assets` defines the maximum number of pairs returned by the pairlist in whitelist `mode`. In blacklist `mode`, this setting is ignored.
 
-`api_url` must point to a remote endpoint that returns a JSON list of sentiment rows with at least a `symbol` field. `api_key` is passed to that endpoint via the `X-API-Key` header.
+`api_url` must point to a remote endpoint implementing the following contract:
+
+- Method: `GET`
+- Query parameters sent by Freqtrade:
+  - `days`: sentiment lookback window
+  - `limit`: maximum number of remote tokens to evaluate
+- Header sent when `api_key` is configured:
+  - `X-API-Key`
+- Response:
+  - `200 OK`
+  - `Content-Type: application/json`
+  - top-level JSON array
+
+Each row in the response array must contain:
+
+- `symbol` (required): token symbol, used to resolve the exchange pair
+- `buzz_score` (optional): numeric ranking score, defaults to `0`
+- `mentions` (optional): numeric mention count, defaults to `0`
+- `bullish_pct` (optional): numeric bullish percentage, used when `min_bullish_pct` is set
+- `trend` (optional): one of `rising`, `stable`, or `falling`
+
+Unknown fields are ignored.
+
+Example response:
+
+```json
+[
+    {
+        "symbol": "BTC",
+        "buzz_score": 91.4,
+        "mentions": 1240,
+        "bullish_pct": 67,
+        "trend": "rising"
+    },
+    {
+        "symbol": "ETH",
+        "buzz_score": 84.2,
+        "mentions": 932,
+        "bullish_pct": 61,
+        "trend": "stable"
+    }
+]
+```
 
 `max_tokens` controls how many remote sentiment rows are evaluated before matching them to exchange pairs. If your remote sentiment API returns more than `100` rows, values above `100` are capped.
 

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -60,6 +60,7 @@ AVAILABLE_PAIRLISTS = [
     "PercentChangePairList",
     "ProducerPairList",
     "RemotePairList",
+    "RedditSentimentPairList",
     "MarketCapPairList",
     "CrossMarketPairList",
     "AgeFilter",

--- a/freqtrade/plugins/pairlist/RedditSentimentPairList.py
+++ b/freqtrade/plugins/pairlist/RedditSentimentPairList.py
@@ -1,0 +1,351 @@
+"""
+Reddit sentiment PairList provider
+
+Provides a dynamic crypto pairlist based on remote Reddit sentiment data.
+"""
+
+import logging
+from typing import Any
+
+import requests
+
+from freqtrade import __version__
+from freqtrade.constants import PairPrefixes
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange.exchange_types import Tickers
+from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
+from freqtrade.util import FtTTLCache
+
+
+logger = logging.getLogger(__name__)
+
+VALID_TRENDS = {"rising", "stable", "falling"}
+
+
+class RedditSentimentPairList(IPairList):
+    is_pairlist_generator = True
+    supports_backtesting = SupportsBacktesting.BIASED
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._mode = self._pairlistconfig.get("mode", "whitelist")
+        if (self._mode == "whitelist") and ("number_assets" not in self._pairlistconfig):
+            raise OperationalException(
+                "`number_assets` not specified. Please check your configuration "
+                'for "pairlist.config.number_assets"'
+            )
+
+        self._api_url = self._pairlistconfig.get("api_url", "")
+        if not self._api_url:
+            raise OperationalException(
+                "`api_url` not specified. Please check your configuration "
+                'for "pairlist.config.api_url"'
+            )
+
+        self._api_key = self._pairlistconfig.get("api_key", "")
+        if not self._api_key:
+            raise OperationalException(
+                "`api_key` not specified. Please check your configuration "
+                'for "pairlist.config.api_key"'
+            )
+
+        self._stake_currency = self._config["stake_currency"]
+        self._number_assets = self._pairlistconfig.get("number_assets", 30)
+        self._max_tokens = self._pairlistconfig.get("max_tokens", 50)
+        self._days = self._pairlistconfig.get("days", 1)
+        self._refresh_period = self._pairlistconfig.get("refresh_period", 21600)
+        self._read_timeout = self._pairlistconfig.get("read_timeout", 30)
+        self._keep_pairlist_on_failure = self._pairlistconfig.get("keep_pairlist_on_failure", True)
+        self._min_buzz_score = self._pairlistconfig.get("min_buzz_score", 0.0)
+        self._min_mentions = self._pairlistconfig.get("min_mentions", 0)
+        self._min_bullish_pct = self._pairlistconfig.get("min_bullish_pct", None)
+        self._allowed_trends = self._pairlistconfig.get("allowed_trends", [])
+        self._sentiment_cache: FtTTLCache = FtTTLCache(maxsize=1, ttl=self._refresh_period)
+        self._last_sentiment_rows: list[dict[str, Any]] = []
+        self._init_done = False
+
+        if self._mode not in ["whitelist", "blacklist"]:
+            raise OperationalException(
+                '`mode` not configured correctly. Supported Modes are "whitelist","blacklist"'
+            )
+
+        if self._max_tokens > 100:
+            self.logger.warning(
+                f"The max_tokens you have set ({self._max_tokens}) exceeds the API limit of 100. "
+                "It will be capped to 100."
+            )
+            self._max_tokens = 100
+
+        if self._allowed_trends and not set(self._allowed_trends).issubset(VALID_TRENDS):
+            raise OperationalException(
+                "`allowed_trends` not configured correctly. "
+                'Supported values are "rising", "stable", "falling".'
+            )
+
+    def short_desc(self) -> str:
+        num = self._number_assets if self._mode == "whitelist" else "blacklisting"
+        return f"{self.name} - {num} pairs filtered by Reddit sentiment."
+
+    @staticmethod
+    def description() -> str:
+        return "Provides pair list based on a remote Reddit crypto sentiment API."
+
+    @staticmethod
+    def available_parameters() -> dict[str, PairlistParameter]:
+        return {
+            "api_url": {
+                "type": "string",
+                "default": "",
+                "description": "Remote API URL",
+                "help": "API endpoint returning Reddit crypto sentiment rows.",
+            },
+            "api_key": {
+                "type": "string",
+                "default": "",
+                "description": "API key",
+                "help": "API key for the remote sentiment service.",
+            },
+            "number_assets": {
+                "type": "number",
+                "default": 30,
+                "description": "Number of assets",
+                "help": "Number of assets to use from the sentiment-ranked pairlist.",
+            },
+            "max_tokens": {
+                "type": "number",
+                "default": 50,
+                "description": "Maximum remote tokens to evaluate",
+                "help": "Maximum number of remote tokens fetched from the sentiment endpoint.",
+            },
+            "days": {
+                "type": "number",
+                "default": 1,
+                "description": "Lookback window in days",
+                "help": "Lookback window in days for the remote sentiment request.",
+            },
+            "min_buzz_score": {
+                "type": "number",
+                "default": 0,
+                "description": "Minimum buzz score",
+                "help": "Minimum buzz score required for a token to pass the filter.",
+            },
+            "min_mentions": {
+                "type": "number",
+                "default": 0,
+                "description": "Minimum mentions",
+                "help": "Minimum Reddit mentions required for a token to pass the filter.",
+            },
+            "min_bullish_pct": {
+                "type": "number",
+                "default": None,
+                "description": "Minimum bullish percentage",
+                "help": "Optional minimum bullish percentage required for a token to pass.",
+            },
+            "allowed_trends": {
+                "type": "list",
+                "default": [],
+                "description": "Allowed trends",
+                "help": 'Optional list of allowed trends. Supported values: ["rising", "stable", "falling"].',
+            },
+            "mode": {
+                "type": "option",
+                "default": "whitelist",
+                "options": ["whitelist", "blacklist"],
+                "description": "Mode of operation",
+                "help": "Mode of operation (whitelist/blacklist)",
+            },
+            "keep_pairlist_on_failure": {
+                "type": "boolean",
+                "default": True,
+                "description": "Keep last sentiment set on failure",
+                "help": "Keep the previous sentiment data if the remote API request fails.",
+            },
+            "read_timeout": {
+                "type": "number",
+                "default": 30,
+                "description": "Read timeout",
+                "help": "Request timeout in seconds for the remote sentiment service.",
+            },
+            **IPairList.refresh_period_parameter(),
+        }
+
+    @staticmethod
+    def _as_float(value: Any, default: float = 0.0) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _as_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+    def _process_rows(self, jsonparse: Any) -> list[dict[str, Any]]:
+        if not isinstance(jsonparse, list):
+            raise OperationalException("Remote sentiment API response is not a JSON list.")
+
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        for row in jsonparse:
+            if not isinstance(row, dict):
+                continue
+
+            symbol = str(row.get("symbol") or "").upper().strip()
+            if not symbol or symbol in seen:
+                continue
+
+            buzz_score = self._as_float(row.get("buzz_score"))
+            mentions = self._as_int(row.get("mentions"))
+            bullish_pct_raw = row.get("bullish_pct")
+            bullish_pct = None if bullish_pct_raw is None else self._as_int(bullish_pct_raw)
+            trend = str(row.get("trend") or "").lower().strip() or None
+
+            if buzz_score < self._min_buzz_score:
+                continue
+            if mentions < self._min_mentions:
+                continue
+            if self._min_bullish_pct is not None and (
+                bullish_pct is None or bullish_pct < self._min_bullish_pct
+            ):
+                continue
+            if self._allowed_trends and trend not in self._allowed_trends:
+                continue
+
+            seen.add(symbol)
+            results.append(
+                {
+                    "symbol": symbol,
+                    "buzz_score": buzz_score,
+                    "mentions": mentions,
+                    "bullish_pct": bullish_pct,
+                    "trend": trend,
+                }
+            )
+
+        results.sort(key=lambda row: (row["buzz_score"], row["mentions"]), reverse=True)
+        self._init_done = True
+        return results
+
+    def _handle_error(self, error: str) -> list[dict[str, Any]]:
+        if self._init_done and self._keep_pairlist_on_failure:
+            self.log_once("Error: " + error, logger.info)
+            self.log_once("Keeping last fetched sentiment universe", logger.info)
+            return self._last_sentiment_rows.copy()
+        raise OperationalException(error)
+
+    def fetch_sentiment_rows(self) -> list[dict[str, Any]]:
+        cached_rows = self._sentiment_cache.get("rows")
+        if cached_rows is not None:
+            return cached_rows.copy()
+
+        headers = {
+            "User-Agent": "Freqtrade/" + __version__ + " RedditSentimentPairList",
+            "X-API-Key": self._api_key,
+        }
+        params = {"days": self._days, "limit": self._max_tokens}
+
+        try:
+            response = requests.get(
+                self._api_url,
+                headers=headers,
+                params=params,
+                timeout=self._read_timeout,
+            )
+        except requests.exceptions.RequestException:
+            rows = self._handle_error(
+                f"Was not able to fetch sentiment data from: {self._api_url}"
+            )
+            self._sentiment_cache["rows"] = rows.copy()
+            return rows
+
+        content_type = response.headers.get("content-type", "")
+        if response.status_code != 200:
+            rows = self._handle_error(
+                f"Sentiment API returned status {response.status_code}: {self._api_url}"
+            )
+            self._sentiment_cache["rows"] = rows.copy()
+            return rows
+
+        if "application/json" not in str(content_type):
+            rows = self._handle_error(f"Sentiment API is not of type JSON. {self._api_url}")
+            self._sentiment_cache["rows"] = rows.copy()
+            return rows
+
+        try:
+            rows = self._process_rows(response.json())
+        except Exception as exc:
+            rows = self._handle_error(f"Failed processing sentiment JSON data: {type(exc)}")
+
+        self._last_sentiment_rows = rows.copy()
+        self._sentiment_cache["rows"] = rows.copy()
+        return rows
+
+    def get_markets_exchange(self) -> list[str]:
+        return [
+            market
+            for market in self._exchange.get_markets(
+                quote_currencies=[self._stake_currency], tradable_only=True, active_only=True
+            ).keys()
+        ]
+
+    def resolve_sentiment_pair(
+        self,
+        pair: str,
+        pairlist: list[str],
+        markets: list[str],
+        filtered_pairlist: list[str],
+    ) -> str | None:
+        if pair in filtered_pairlist:
+            return None
+
+        if pair in pairlist:
+            return pair
+
+        if pair not in markets:
+            for prefix in PairPrefixes:
+                test_prefix = f"{prefix}{pair}"
+                if test_prefix in pairlist:
+                    return test_prefix
+
+        return None
+
+    def gen_pairlist(self, tickers: Tickers) -> list[str]:
+        pairlist = self.get_markets_exchange()
+        pairlist = self.verify_blacklist(pairlist, logger.info)
+        return self.filter_pairlist(pairlist, tickers)
+
+    def filter_pairlist(self, pairlist: list[str], tickers: dict) -> list[str]:
+        is_whitelist_mode = self._mode == "whitelist"
+        filtered_pairlist: list[str] = []
+        sentiment_rows = self.fetch_sentiment_rows()
+
+        if not sentiment_rows:
+            return [] if is_whitelist_mode else pairlist
+
+        market = self._exchange._config["trading_mode"]
+        pair_format = f"{self._stake_currency.upper()}" + (
+            f":{self._stake_currency.upper()}" if market == "futures" else ""
+        )
+        markets = self.get_markets_exchange()
+
+        for row in sentiment_rows[: self._max_tokens]:
+            pair = f"{row['symbol'].upper()}/{pair_format}"
+            resolved = self.resolve_sentiment_pair(pair, pairlist, markets, filtered_pairlist)
+
+            if not resolved:
+                continue
+
+            if not is_whitelist_mode:
+                pairlist.remove(resolved)
+                continue
+
+            filtered_pairlist.append(resolved)
+            if len(filtered_pairlist) == self._number_assets:
+                break
+
+        return filtered_pairlist if is_whitelist_mode else pairlist

--- a/tests/plugins/test_redditsentimentpairlist.py
+++ b/tests/plugins/test_redditsentimentpairlist.py
@@ -1,0 +1,289 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+import requests
+
+from freqtrade.exceptions import OperationalException
+from freqtrade.plugins.pairlist.RedditSentimentPairList import RedditSentimentPairList
+from freqtrade.plugins.pairlistmanager import PairListManager
+from tests.conftest import EXMS, get_patched_exchange, log_has
+
+
+@pytest.fixture(scope="function")
+def rsp_config(default_conf):
+    default_conf["stake_currency"] = "USDT"
+    default_conf["exchange"]["pair_whitelist"] = [
+        "BTC/USDT",
+        "ETH/USDT",
+        "XRP/USDT",
+        "ADA/USDT",
+    ]
+    default_conf["exchange"]["pair_blacklist"] = ["BLK/USDT"]
+    return default_conf
+
+
+def _mock_response(rows):
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"content-type": "application/json"}
+    response.json.return_value = rows
+    return response
+
+
+def test_reddit_sentiment_pairlist_generator(mocker, rsp_config, markets):
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 2,
+        }
+    ]
+    mocker.patch.multiple(
+        EXMS,
+        markets=PropertyMock(return_value=markets),
+        exchange_has=MagicMock(return_value=True),
+    )
+    mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        return_value=_mock_response(
+            [
+                {"symbol": "ETH", "buzz_score": 82.4, "mentions": 215, "bullish_pct": 63},
+                {"symbol": "XRP", "buzz_score": 76.2, "mentions": 144, "bullish_pct": 58},
+                {"symbol": "ADA", "buzz_score": 61.8, "mentions": 91, "bullish_pct": 54},
+            ]
+        ),
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pm = PairListManager(exchange, rsp_config)
+    pm.refresh_pairlist()
+
+    assert pm.whitelist == ["ETH/USDT", "XRP/USDT"]
+
+
+def test_reddit_sentiment_pairlist_filters_thresholds(mocker, rsp_config, markets):
+    rsp_config["pairlists"] = [
+        {"method": "StaticPairList"},
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 3,
+            "min_buzz_score": 70,
+            "min_mentions": 100,
+            "min_bullish_pct": 55,
+            "allowed_trends": ["rising", "stable"],
+        },
+    ]
+    mocker.patch.multiple(
+        EXMS,
+        markets=PropertyMock(return_value=markets),
+        exchange_has=MagicMock(return_value=True),
+    )
+    mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        return_value=_mock_response(
+            [
+                {
+                    "symbol": "ETH",
+                    "buzz_score": 82.4,
+                    "mentions": 215,
+                    "bullish_pct": 63,
+                    "trend": "rising",
+                },
+                {
+                    "symbol": "XRP",
+                    "buzz_score": 74.1,
+                    "mentions": 80,
+                    "bullish_pct": 61,
+                    "trend": "rising",
+                },
+                {
+                    "symbol": "ADA",
+                    "buzz_score": 71.0,
+                    "mentions": 132,
+                    "bullish_pct": 49,
+                    "trend": "stable",
+                },
+            ]
+        ),
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pm = PairListManager(exchange, rsp_config)
+    pm.refresh_pairlist()
+
+    assert pm.whitelist == ["ETH/USDT"]
+
+
+def test_reddit_sentiment_pairlist_blacklist_mode(mocker, rsp_config, markets):
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "mode": "blacklist",
+            "max_tokens": 2,
+        }
+    ]
+    mocker.patch.multiple(
+        EXMS,
+        markets=PropertyMock(return_value=markets),
+        exchange_has=MagicMock(return_value=True),
+    )
+    mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        return_value=_mock_response(
+            [
+                {"symbol": "ETH", "buzz_score": 82.4, "mentions": 215},
+                {"symbol": "XRP", "buzz_score": 76.2, "mentions": 144},
+            ]
+        ),
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pm = PairListManager(exchange, rsp_config)
+    pm.refresh_pairlist()
+
+    assert "ETH/USDT" not in pm.whitelist
+    assert "XRP/USDT" not in pm.whitelist
+    assert "BTC/USDT" in pm.whitelist
+
+
+def test_reddit_sentiment_pairlist_prefix_resolution(mocker, rsp_config, markets):
+    rsp_config["exchange"]["pair_whitelist"] = []
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 2,
+        }
+    ]
+    markets["1000PEPE/USDT"] = markets["ETH/USDT"]
+    markets["KBONK/USDT"] = markets["XRP/USDT"]
+    del markets["ETH/USDT"]
+    del markets["XRP/USDT"]
+
+    markets_mock = MagicMock(return_value=markets)
+    mocker.patch.multiple(
+        EXMS,
+        get_markets=markets_mock,
+        exchange_has=MagicMock(return_value=True),
+    )
+    mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        return_value=_mock_response(
+            [
+                {"symbol": "PEPE", "buzz_score": 81.2, "mentions": 451},
+                {"symbol": "BONK", "buzz_score": 77.7, "mentions": 302},
+            ]
+        ),
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pm = PairListManager(exchange, rsp_config)
+    pm.refresh_pairlist()
+
+    assert pm.whitelist == ["1000PEPE/USDT", "KBONK/USDT"]
+
+
+def test_reddit_sentiment_pairlist_uses_cache(mocker, rsp_config, markets):
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 2,
+            "refresh_period": 21600,
+        }
+    ]
+    mocker.patch.multiple(
+        EXMS,
+        markets=PropertyMock(return_value=markets),
+        exchange_has=MagicMock(return_value=True),
+    )
+    get_mock = mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        return_value=_mock_response(
+            [
+                {"symbol": "ETH", "buzz_score": 82.4, "mentions": 215},
+                {"symbol": "XRP", "buzz_score": 76.2, "mentions": 144},
+            ]
+        ),
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pm = PairListManager(exchange, rsp_config)
+    pm.refresh_pairlist()
+    pm.refresh_pairlist()
+
+    assert get_mock.call_count == 1
+
+
+def test_reddit_sentiment_pairlist_keep_last_on_failure(mocker, rsp_config, markets, caplog):
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 2,
+            "refresh_period": 0,
+            "keep_pairlist_on_failure": True,
+        }
+    ]
+    mocker.patch.multiple(
+        EXMS,
+        markets=PropertyMock(return_value=markets),
+        exchange_has=MagicMock(return_value=True),
+    )
+    get_mock = mocker.patch(
+        "freqtrade.plugins.pairlist.RedditSentimentPairList.requests.get",
+        side_effect=[
+            _mock_response(
+                [
+                    {"symbol": "ETH", "buzz_score": 82.4, "mentions": 215},
+                    {"symbol": "XRP", "buzz_score": 76.2, "mentions": 144},
+                ]
+            ),
+            requests.exceptions.RequestException,
+        ],
+    )
+
+    exchange = get_patched_exchange(mocker, rsp_config)
+    pairlistmanager = PairListManager(exchange, rsp_config)
+    pairlist = RedditSentimentPairList(
+        exchange,
+        pairlistmanager,
+        rsp_config,
+        rsp_config["pairlists"][0],
+        0,
+    )
+
+    first_rows = pairlist.fetch_sentiment_rows()
+    pairlist._sentiment_cache.clear()
+    second_rows = pairlist.fetch_sentiment_rows()
+
+    assert get_mock.call_count == 2
+    assert first_rows == second_rows
+    assert log_has("Keeping last fetched sentiment universe", caplog)
+
+
+def test_reddit_sentiment_pairlist_exceptions(mocker, rsp_config):
+    exchange = get_patched_exchange(mocker, rsp_config)
+    rsp_config["pairlists"] = [{"method": "RedditSentimentPairList"}]
+    with pytest.raises(OperationalException, match=r"`number_assets` not specified.*"):
+        PairListManager(exchange, rsp_config)
+
+    rsp_config["pairlists"] = [
+        {
+            "method": "RedditSentimentPairList",
+            "api_url": "https://example.com/trending",
+            "api_key": "test-key",
+            "number_assets": 10,
+            "allowed_trends": ["up-only"],
+        }
+    ]
+    with pytest.raises(OperationalException, match=r"`allowed_trends` not configured correctly.*"):
+        PairListManager(exchange, rsp_config)

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -2809,6 +2809,7 @@ def test_api_pairlists_available(botclient, tmp_path):
     assert len(response["pairlists"]) > 0
 
     assert len([r for r in response["pairlists"] if r["name"] == "AgeFilter"]) == 1
+    assert len([r for r in response["pairlists"] if r["name"] == "RedditSentimentPairList"]) == 1
     assert len([r for r in response["pairlists"] if r["name"] == "VolumePairList"]) == 1
     assert len([r for r in response["pairlists"] if r["name"] == "StaticPairList"]) == 1
 


### PR DESCRIPTION
## Summary

- add `RedditSentimentPairList` as an optional PairList handler for remote crypto Reddit sentiment data
- support both `whitelist` and `blacklist` modes
- allow filtering by `buzz_score`, `mentions`, `bullish_pct`, and `trend`
- cache remote results and optionally keep the last successful universe on request failures
- document the new PairList, including the expected remote endpoint contract, and expose it through `/pairlists/available`

## Why this is useful

Freqtrade already has strong pair selection tools based on market structure, volume, price movement, and market cap.
This PairList adds a different signal class: **current social attention**.

That can be useful for traders who want to:

- focus on coins that are actively being discussed on Reddit right now
- reduce a large altcoin universe to pairs with real crowd attention
- exclude highly social-driven coins from otherwise systematic strategies
- combine sentiment-driven discovery with existing filters such as `VolumePairList`, `PriceFilter`, or `AgeFilter`

In practice, this is most relevant for fast-moving crypto markets where discussion intensity often changes much faster than slower structural metrics.

## Scope

This PR intentionally keeps the integration narrow:

- no changes to existing PairList behavior
- no changes to strategy APIs
- no exchange-specific logic beyond normal pair resolution
- remote API is fully optional and configured per PairList instance

The implementation follows the same native PairList pattern already used by built-in generators such as `MarketCapPairList`.

## Notes

- The PairList expects a remote JSON endpoint returning Reddit crypto sentiment rows with a `symbol` field and ranking metrics.
- The exact request/response contract is now documented in `docs/includes/pairlists.md`.
- It supports prefixed markets such as `1000PEPE/USDT` and `KBONK/USDT` on a best-effort basis, similar to other symbol-resolution logic already present in the codebase.
- Because it depends on a remote service, it is marked as `SupportsBacktesting.BIASED`.

## Tests

- `pytest tests/plugins/test_redditsentimentpairlist.py -q`
- `pytest tests/rpc/test_rpc_apiserver.py -q -k pairlists_available`
