### PR TITLE
migrate fastapi add event handler

### DIFF
--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 import logging
 from ipaddress import ip_address
 from typing import Any
@@ -100,6 +101,19 @@ class FTJSONResponse(JSONResponse):
         return orjson.dumps(content, option=orjson.OPT_SERIALIZE_NUMPY)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup logic
+    if not ApiServer._message_stream:
+        # Creates the MessageStream class on startup so it has access to the same event loop
+        # as uvicorn
+        ApiServer._message_stream = MessageStream()
+    yield
+    # Shutdown logic
+    if ApiServer._message_stream:
+        ApiServer._message_stream = None
+
+
 class ApiServer(RPCHandler):
     __instance = None
     __initialized = False
@@ -137,6 +151,7 @@ class ApiServer(RPCHandler):
             redoc_url=None,
             default_response_class=FTJSONResponse,
             openapi_tags=_OPENAPI_TAGS,
+            lifespan=lifespan,
         )
         self.configure_app(self.app, self._config)
         self.start_api()
@@ -261,24 +276,6 @@ class ApiServer(RPCHandler):
         )
 
         app.add_exception_handler(RPCException, self.handle_rpc_exception)
-        app.add_event_handler(event_type="startup", func=self._api_startup_event)
-        app.add_event_handler(event_type="shutdown", func=self._api_shutdown_event)
-
-    async def _api_startup_event(self):
-        """
-        Creates the MessageStream class on startup
-        so it has access to the same event loop
-        as uvicorn
-        """
-        if not ApiServer._message_stream:
-            ApiServer._message_stream = MessageStream()
-
-    async def _api_shutdown_event(self):
-        """
-        Removes the MessageStream class on shutdown
-        """
-        if ApiServer._message_stream:
-            ApiServer._message_stream = None
 
     def start_api(self):
         """

--- a/freqtrade/rpc/api_server/webserver.py
+++ b/freqtrade/rpc/api_server/webserver.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 import logging
+from contextlib import asynccontextmanager
 from ipaddress import ip_address
 from typing import Any
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,6 @@ sdnotify==0.3.2
 
 # API Server
 fastapi==0.135.1
-# TODO: starlette should not be pinned, but had breaking changes in 1.0.0.
-starlette<1.0.0
 pydantic==2.12.5
 uvicorn==0.41.0
 pyjwt==2.12.0


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

migrate from add_event_handler to lifespan.
Startup / shutdown events in fastapi are deprecated, with [lifespan](https://fastapi.tiangolo.com/advanced/events/?h=lifespan#lifespan) providing a equivalent alternative.

