### PR TITLE
docs: add Kraken futures row to exchange features

### DIFF
--- a/docs/includes/exchange-features.md
+++ b/docs/includes/exchange-features.md
@@ -15,6 +15,7 @@
 | [Hyperliquid](exchanges.md#hyperliquid) | spot | | ❌ (not supported) |
 | [Hyperliquid](exchanges.md#hyperliquid) | futures | isolated, cross | limit |
 | [Kraken](exchanges.md#kraken) | spot | | market, limit |
+| [Kraken](exchanges.md#kraken-futures) | futures | isolated | market, limit |
 | [OKX](exchanges.md#okx) | spot | | limit |
 | [OKX](exchanges.md#okx) | futures | isolated | limit |
 | [Bitvavo](exchanges.md#bitvavo) | spot | | ❌ (not supported) |


### PR DESCRIPTION
## Summary

Add the missing Kraken futures entry to the exchange features table.

## What's new?

This is a small docs-only follow-up to #12706.

`exchange-features.md` already listed Kraken spot support, but it was missing the futures row even though Kraken Futures support and its documentation are already merged. This change adds the missing table entry.