### PR TITLE
Fix freqai torch model loading

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -260,6 +260,10 @@ freqtrade trade --config config_examples/config_freqai.example.json --strategy F
 
     PyTorch dropped support for macOS x64 (intel based Apple devices) in version 2.3. Subsequently, freqtrade also dropped support for PyTorch on this platform.
 
+!!! Danger "Security notice"
+    Loading saved models from disk can cause security issues if using remote model files (files you downloaded from the internet or received from an untrusted source) due to having the necessity to have `weights_only=False`, which can cause security problems.
+    As long as you only load models that you have trained yourself, there is no risk.
+
 ### Structure
 
 #### Model

--- a/docs/freqai-running.md
+++ b/docs/freqai-running.md
@@ -87,6 +87,10 @@ To save the models generated during a particular backtest so that you can start 
     To ensure that the model can be reused, freqAI will call your strategy with a dataframe of length 1. 
     If your strategy requires more data than this to generate the same features, you can't reuse backtest predictions for live deployment and need to update your `identifier` for each new backtest.
 
+!!! Danger "Security notice"
+    Loading saved models from disk can cause security issues if using remote model files (files you downloaded from the internet or received from an untrusted source) due to having the necessity to have `weights_only=False`, which can cause security problems.
+    As long as you only load models that you have trained yourself, there is no risk.
+
 ### Backtest live collected predictions
 
 FreqAI allow you to reuse live historic predictions through the backtest parameter `--freqai-backtest-live-models`. This can be useful when you want to reuse predictions generated in dry/run for comparison or other study.

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -614,9 +614,13 @@ class FreqaiDataDrawer:
         elif self.model_type == "pytorch":
             import torch
 
-            zipfile = torch.load(dk.data_path / f"{dk.model_filename}_model.zip")
-            model = zipfile["pytrainer"]
-            model = model.load_from_checkpoint(zipfile)
+            zipfile = torch.load(
+                dk.data_path / f"{dk.model_filename}_model.zip",
+                weights_only=False,
+            )
+            # weights_only is necessary due to pytrainer being a serialized python object.
+            _trainer = zipfile["pytrainer"]
+            model = _trainer.load_from_checkpoint(zipfile)
 
         if not model:
             raise OperationalException(


### PR DESCRIPTION
## Summary

pytorch switched weights_only default to True in 2.6 - causing load errors when using `save_backtest_models` - and making adjustments that cause `backtesting_predictions` to be ejected.

Under the hood, it's caused by serializing pytrainer - a loaded python object - which i currently don't see a way around to.

as such - i think the fix must be to set weights_only to False - and add warning messages about the risks it introduces to the documentation.

The reproduction is in the linked issue - which reproduces pretty much immediately (on the 2nd run of backtesting) when used with `save_backtest_models=true`.

closes #12964

## Quick changelog

- add documentation warning about pytorch model loading
- use `weights_only=False` to load models