### PR TITLE
Pin individual installs in CI

### DIFF
--- a/.github/workflows/binance-lev-tier-update.yml
+++ b/.github/workflows/binance-lev-tier-update.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: "3.14"
 
     - name: Install ccxt
-      run: uv pip install ccxt orjson
+      run: uv pip install $(grep -E "^ccxt==" requirements.txt) $(grep -E "^orjson==" requirements.txt)
 
     - name: Run leverage tier update
       env:
@@ -55,7 +55,7 @@ jobs:
           Dependencies
         branch: update/binance-leverage-tiers
         title: Update Binance Leverage Tiers
-        commit-message: "chore: update pre-commit hooks"
+        commit-message: "chore: update binance leverage tiers"
         committer: Freqtrade Bot <154552126+freqtrade-bot@users.noreply.github.com>
         author: Freqtrade Bot <154552126+freqtrade-bot@users.noreply.github.com>
         body: Update binance leverage tiers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
 
     - name: Build distribution
       run: |
-        uv pip install -U build
+        uv pip install $(grep -E "^build==" requirements-dev.txt)
         python -m build --sdist --wheel
 
     - name: Upload artifacts 📦

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
 
     - name: Installation (python)
       run: |
-        uv pip install --upgrade wheel
         uv pip install -r requirements-dev.txt
         uv pip install -e ft_client/
         uv pip install -e .
@@ -267,7 +266,6 @@ jobs:
 
     - name: Installation - *nix
       run: |
-        uv pip install --upgrade wheel
         uv pip install -r requirements-dev.txt
         uv pip install -e ft_client/
         uv pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,11 +180,17 @@ jobs:
     - name: Set up Python 🐍
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
-        python-version: "3.12"
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      with:
+        activate-environment: true
+        python-version: "3.13"
 
     - name: pre-commit dependencies
       run: |
-        pip install pyaml
+        uv pip install $(grep -E "^pyyaml==" requirements-dev.txt)
         python build_helpers/pre_commit_update.py
 
   pre-commit:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -27,11 +27,16 @@ jobs:
 
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      with:
+        activate-environment: true
+        python-version: "3.13"
 
     - name: Install pre-commit
-      run: pip install pre-commit
+      run: uv pip install $(grep -E "^pre-commit==" requirements-dev.txt)
 
     - name: Run auto-update
       run: pre-commit autoupdate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,3 +30,4 @@ types-requests==2.32.4.20260107
 types-tabulate==0.10.0.20260308
 types-python-dateutil==2.9.0.20260305
 pip-audit==2.10.0
+build==1.4.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,4 +30,7 @@ types-requests==2.32.4.20260107
 types-tabulate==0.10.0.20260308
 types-python-dateutil==2.9.0.20260305
 pip-audit==2.10.0
+# For build step in CI
 build==1.4.2
+# For pre-commit-update check
+pyyaml==6.0.3


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary
We have most dependencies pinned already - so we should also pin them when installing individual dependencies in CI.

## Short changelog

* Adds build and pyyaml builds to dev requirements
* use grep from requirements files to install individual dependencies where needed (this keeps dependency versions aligned)