### PR TITLE
refactor(freqtrade): systemexit instance improperly passed to sys.exit()

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -63,7 +63,7 @@ def main(sysargv: list[str] | None = None) -> None:
             )
 
     except SystemExit as e:  # pragma: no cover
-        return_code = e
+        return_code = e.code
     except KeyboardInterrupt:
         logger.info("SIGINT received, aborting ...")
         return_code = 0


### PR DESCRIPTION
## Code Quality

### Problem
Catching `SystemExit as e` and assigning `return_code = e` results in the exception instance itself being passed to `sys.exit(return_code)` in the `finally` block. 
Python's `sys.exit()` wraps arguments in a `SystemExit` exception. Passing a `SystemExit` instance creates a nested `SystemExit(SystemExit(...))`. During interpreter shutdown, Python's default exception handler sees that the `.code` attribute is an object (not an integer or None), which causes it to print the object to stderr and forcefully exit with status code `1`.
This converts successful intended exits (e.g., `sys.exit(0)`) into failed exits (status code 1) while printing "0" to stderr, breaking CI/CD pipelines and Docker container status checks.


**Severity**: `medium`
**File**: `freqtrade/main.py`

### Solution
Assign `e.code` to `return_code` so the correct integer status or string message is preserved.

### Changes
- `freqtrade/main.py` (modified)


## Summary



Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?


Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #12988