### PR TITLE
feat(freqtrade): add trailing stop order type enum

### DIFF
--- a/freqtrade/enums/ordertypevalue.py
+++ b/freqtrade/enums/ordertypevalue.py
@@ -4,3 +4,5 @@ from enum import StrEnum
 class OrderTypeValues(StrEnum):
     limit = "limit"
     market = "market"
+    trailing_stop_market = "trailing_stop_market"
+    trailing_stop = "trailing_stop"

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -50,7 +50,7 @@ class Binance(Exchange):
     _ft_has_futures: FtHas = {
         "ohlcv_candle_limit": 499,
         "funding_fee_candle_limit": 1000,
-        "stoploss_order_types": {"limit": "stop", "market": "stop_market"},
+        "stoploss_order_types": {"limit": "stop", "market": "stop_market", "trailing_stop_market": "trailing_stop_market"},
         "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
         "stoploss_query_requires_stop_flag": True,
         "stoploss_algo_order_info_id": "actualOrderId",


### PR DESCRIPTION
## New Feature

### Problem
Add a new order type value for exchange-native trailing stops to distinguish them from regular stop-loss orders. This will allow the system to differentiate between Freqtrade-managed trailing stops and exchange-native trailing stops.

**Severity**: `medium`
**File**: `freqtrade/enums/ordertypevalue.py`

### Solution
Add a new enum value like `TRAILING_STOP_MARKET` or `TRAILING_STOP` to the OrderTypeValues enum. This should be added alongside existing values like `STOP_LOSS`, `STOP_LOSS_LIMIT`, etc. The enum should support both market and limit variants if exchanges support them.

### Changes
- `freqtrade/enums/ordertypevalue.py` (modified)
- `freqtrade/exchange/binance.py` (modified)


## Summary



Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?


Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.
