### PR TITLE
fix: extract exit code from SystemExit instead of passing instance

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -63,7 +63,7 @@ def main(sysargv: list[str] | None = None) -> None:
             )
 
     except SystemExit as e:  # pragma: no cover
-        return_code = e
+        return_code = e.code
     except KeyboardInterrupt:
         logger.info("SIGINT received, aborting ...")
         return_code = 0


### PR DESCRIPTION
## Summary
- Fixes #12988 — `SystemExit` instance was being passed to `sys.exit()` instead of the exit code
- Root cause: `return_code = e` assigns the exception object; `sys.exit(return_code)` wraps it in another `SystemExit(SystemExit(...))`, causing Python to print the exception and exit with status 1 even for `sys.exit(0)`
- Fix: `return_code = e.code` extracts the actual exit code

## Changes
- `freqtrade/main.py` — 1 line changed

## Test plan
- [x] `sys.exit(0)` no longer prints to stderr
- [x] Non-zero exit codes propagate correctly