### PR TITLE
Add support for 3.14 in setup-scripts

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -9,8 +9,8 @@ $VenvName = ".venv"
 $VenvDir = Join-Path $PSScriptRoot $VenvName
 
 # Supported Python minor versions (detection order: prefer newest first)
-$SupportedMinorVersions = @(13,12,11)
-# Build a human-readable supported versions string like "3.11, 3.12 and 3.13"
+$SupportedMinorVersions = @(14,13,12,11)
+# Build a human-readable supported versions string like "3.11, 3.12 3.13 and 3.14"
 $asc = $SupportedMinorVersions | Sort-Object
 if ($asc.Count -eq 1) {
   $SupportedPythonVersions = "3.$($asc[0])"

--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,8 @@ function echo_block() {
 }
 UV=false
 # Supported Python minor versions (order matters for detection)
-SUPPORTED_MINOR_VERS=(13 12 11)
-SUPPORTED_PY_VERSIONS="3.11, 3.12 and 3.13"
+SUPPORTED_MINOR_VERS=(14 13 12 11)
+SUPPORTED_PY_VERSIONS="3.11, 3.12, 3.13 and 3.14"
 
 function check_installed_pip() {
    ${PYTHON} -m pip > /dev/null
@@ -254,7 +254,7 @@ function install() {
         install_redhat
     else
         echo "This script does not support your OS."
-        echo "If you have Python version 3.11 - 3.13, pip, virtualenv installed you can continue."
+        echo "If you have Python version 3.11 - 3.14, pip, virtualenv installed you can continue."
         echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
         sleep 10
     fi


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary
Setup-scripts can use python 3.14 now.
