### PR TITLE
docs: use repo-relative contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ in the bug reports.
 Feel like the bot is missing a feature? We welcome your pull requests!
 
 Please read the
-[Contributing document](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
+[Contributing document](CONTRIBUTING.md)
 to understand the requirements before sending your pull-requests.
 
 Coding is not a necessity to contribute - maybe start with improving the documentation?


### PR DESCRIPTION
## Summary
- replace the hard-coded GitHub `blob/develop` link to `CONTRIBUTING.md` in the root README with a repo-relative link
- keep the contributing entrypoint branch-agnostic and consistent with the rest of the README internal docs links

## Testing
- not run (README-only change)