### PR TITLE
Enforce SKDecimal 'name' parameter as string

### DIFF
--- a/freqtrade/optimize/space/decimalspace.py
+++ b/freqtrade/optimize/space/decimalspace.py
@@ -9,7 +9,7 @@ class SKDecimal(FloatDistribution):
         *,
         step: float | None = None,
         decimals: int | None = None,
-        name=None,
+        name: str | None = None,
     ):
         """
         FloatDistribution with a fixed step size.
@@ -26,7 +26,7 @@ class SKDecimal(FloatDistribution):
             raise ValueError("You must set one of decimals or step")
         # Convert decimals to step
         self.step = step or (1 / 10**decimals if decimals else 1)
-        self.name = name
+        self.name = name or ""
 
         super().__init__(
             low=round(low, decimals) if decimals else low,


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Make SKDecimal 'name' type consistent with other space paramater.

Just to improve typing correctness.

## Quick changelog
Enfoce `name` parameter of SKDecimal as str 

## What's new?
It start with pyright complain:
```
        def roi_space() -> List[Dimension]:
            return [
                Integer(10, 120, name='roi_t1'),
                SKDecimal(0.01, 0.04, decimals=3, name='roi_p1'),
            ]
```
```
Diagnostics:
1. Pyright: Type "list[Integer | SKDecimal]" is not assignable to return type "List[Dimension]"
     "SKDecimal" is incompatible with protocol "DimensionProtocol"
       "name" is invariant because it is mutable
       "name" is an incompatible type
         Type "Unknown | None" is not assignable to type "str"
           "None" is not assignable to "str" [reportReturnType]
```
SKDecimal `name` need to be str just like other space parameter. This PR maintain backward compatibility since there is a test that call SKDecimal without `name` https://github.com/freqtrade/freqtrade/blob/3a76235c489a26b08fff6ba1d727492d31841bb2/tests/optimize/test_hyperopt.py#L1238-L1260
