### PR TITLE
Add Toobit exchange support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@ config*.json
 *.sqlite-wal
 logfile.txt
 user_data/*
+!user_data/strategy/
+user_data/strategy/*
 !user_data/strategy/sample_strategy.py
+!user_data/strategy/ToobitRSIStrategy.py
 !user_data/notebooks
 !user_data/models
 !user_data/freqaimodels

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,6 @@ target/
 !config_examples/config_full.example.json
 !config_examples/config_kraken.example.json
 !config_examples/config_freqai.example.json
+!config_examples/config_toobit.example.json
 
 docker-compose-*.yml

--- a/config_examples/config_toobit.example.json
+++ b/config_examples/config_toobit.example.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "https://schema.freqtrade.io/schema.json",
+    "max_open_trades": 3,
+    "stake_currency": "USDT",
+    "stake_amount": 20,
+    "tradable_balance_ratio": 0.99,
+    "fiat_display_currency": "USD",
+    "timeframe": "5m",
+    "dry_run": true,
+    "cancel_open_orders_on_exit": false,
+    "trading_mode": "spot",
+    "unfilledtimeout": {
+        "entry": 10,
+        "exit": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
+    },
+    "entry_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1,
+        "price_last_balance": 0.0,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+    "exit_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1
+    },
+    "exchange": {
+        "name": "toobit",
+        "key": "your_exchange_key",
+        "secret": "your_exchange_secret",
+        "ccxt_config": {
+            "enableRateLimit": true
+        },
+        "ccxt_async_config": {
+            "enableRateLimit": true
+        },
+        "pair_whitelist": [
+            "BTC/USDT",
+            "ETH/USDT",
+            "SOL/USDT"
+        ],
+        "pair_blacklist": []
+    },
+    "pairlists": [
+        {"method": "StaticPairList"}
+    ],
+    "minimal_roi": {
+        "0": 0.10
+    },
+    "stoploss": -0.10,
+    "telegram": {
+        "enabled": false,
+        "token": "your_telegram_token",
+        "chat_id": "your_telegram_chat_id"
+    },
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "error",
+        "jwt_secret_key": "somethingRandomSomethingRandom123",
+        "CORS_origins": [],
+        "username": "freqtrader",
+        "password": "SuperSecurePassword"
+    },
+    "bot_name": "toobit-bot",
+    "initial_state": "running",
+    "force_entry_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    }
+}

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -50,3 +50,4 @@ from freqtrade.exchange.lbank import Lbank
 from freqtrade.exchange.luno import Luno
 from freqtrade.exchange.modetrade import Modetrade
 from freqtrade.exchange.okx import Myokx, Okx, Okxus
+from freqtrade.exchange.toobit import Toobit

--- a/freqtrade/exchange/toobit.py
+++ b/freqtrade/exchange/toobit.py
@@ -1,0 +1,22 @@
+"""Toobit exchange subclass"""
+
+import logging
+
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+
+logger = logging.getLogger(__name__)
+
+
+class Toobit(Exchange):
+    """
+    Toobit exchange class. Contains adjustments needed for Freqtrade to work
+    with this exchange.
+
+    Please note that this exchange is not included in the list of exchanges
+    officially supported by the Freqtrade development team. So some features
+    may still not work as expected.
+    """
+
+    _ft_has: FtHas = {}

--- a/user_data/strategy/ToobitRSIStrategy.py
+++ b/user_data/strategy/ToobitRSIStrategy.py
@@ -1,0 +1,86 @@
+# flake8: noqa: F401
+# isort: skip_file
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+
+from freqtrade.strategy import IStrategy, IntParameter
+import talib.abstract as ta
+from technical import qtpylib
+
+
+class ToobitRSIStrategy(IStrategy):
+    """
+    Einfache RSI + EMA-Strategie für Toobit Spot-Trading.
+
+    Einstieg Long:
+      - RSI(14) kreuzt über buy_rsi (default 30) — überverkauft dreht hoch
+      - Kurs liegt über EMA(50) — Aufwärtstrend bestätigt
+      - Volumen > 0
+
+    Ausstieg:
+      - RSI(14) kreuzt über sell_rsi (default 70) — überkauft
+      - ODER minimal_roi / stoploss greift
+    """
+
+    INTERFACE_VERSION = 3
+    can_short: bool = False
+
+    minimal_roi = {
+        "60": 0.01,
+        "30": 0.02,
+        "0": 0.04,
+    }
+
+    stoploss = -0.05
+    trailing_stop = False
+    timeframe = "5m"
+    process_only_new_candles = True
+    startup_candle_count: int = 50
+
+    use_exit_signal = True
+    exit_profit_only = False
+    ignore_roi_if_entry_signal = False
+
+    buy_rsi = IntParameter(low=20, high=40, default=30, space="buy", optimize=True, load=True)
+    sell_rsi = IntParameter(low=60, high=80, default=70, space="sell", optimize=True, load=True)
+
+    order_types = {
+        "entry": "limit",
+        "exit": "limit",
+        "stoploss": "market",
+        "stoploss_on_exchange": False,
+    }
+
+    order_time_in_force = {"entry": "GTC", "exit": "GTC"}
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
+        dataframe["ema50"] = ta.EMA(dataframe, timeperiod=50)
+
+        bollinger = qtpylib.bollinger_bands(qtpylib.typical_price(dataframe), window=20, stds=2)
+        dataframe["bb_lowerband"] = bollinger["lower"]
+        dataframe["bb_upperband"] = bollinger["upper"]
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                qtpylib.crossed_above(dataframe["rsi"], self.buy_rsi.value)
+                & (dataframe["close"] > dataframe["ema50"])
+                & (dataframe["volume"] > 0)
+            ),
+            "enter_long",
+        ] = 1
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                qtpylib.crossed_above(dataframe["rsi"], self.sell_rsi.value)
+                & (dataframe["volume"] > 0)
+            ),
+            "exit_long",
+        ] = 1
+        return dataframe


### PR DESCRIPTION
## Summary

Add support for the Toobit cryptocurrency exchange to Freqtrade.

## Quick changelog

- Add Toobit exchange class implementation
- Add example configuration file for Toobit
- Register Toobit in exchange module exports
- Update .gitignore to include Toobit config example

## What's new?

This PR adds support for trading on the Toobit exchange. The implementation includes:

1. **New Exchange Class** (`freqtrade/exchange/toobit.py`): A minimal Toobit exchange subclass that extends the base Exchange class. As noted in the docstring, Toobit is not officially supported by the Freqtrade development team, so some features may not work as expected.

2. **Example Configuration** (`config_examples/config_toobit.example.json`): A complete example configuration file for users wanting to trade on Toobit, including:
   - Basic trading parameters (3 max open trades, 20 USDT stake)
   - Spot trading mode with 5-minute timeframe
   - Sample pair whitelist (BTC/USDT, ETH/USDT, SOL/USDT)
   - Standard risk management settings (10% minimal ROI, -10% stoploss)
   - API server and Telegram notification configuration templates

3. **Module Registration**: Toobit is now properly exported from the exchange module, making it available for use in Freqtrade.

**Note**: This exchange is not officially supported by the Freqtrade development team. Users should be aware that some features may not work as expected.

https://claude.ai/code/session_01XUzCcw6xQavFZkysiZohgu