### PR TITLE
test: cover key-value entries in convert-db command

### DIFF
--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -44,9 +44,9 @@ from freqtrade.commands.deploy_ui import (
 from freqtrade.configuration import setup_utils_configuration
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
+from freqtrade.persistence.key_value_store import KeyValueStore
 from freqtrade.persistence.models import init_db
 from freqtrade.persistence.pairlock_middleware import PairLocks
-from freqtrade.persistence.wallet_history import WalletHistory
 from freqtrade.util import dt_utc
 from tests.conftest import (
     CURRENT_TEST_STRATEGY,
@@ -2026,20 +2026,7 @@ def test_start_convert_db(fee, tmp_path):
 
     PairLocks.timeframe = "5m"
     PairLocks.lock_pair("XRP/USDT", datetime.now(), "Random reason 125", side="long")
-    wallet_history = WalletHistory(
-        timestamp=datetime(2024, 1, 1),
-        currency="USDT",
-        quote_currency="USDT",
-        balance=100.0,
-        rate=1.0,
-        total_quote=100.0,
-        total_position_value=0.0,
-        collateral=100.0,
-        leverage=1.0,
-        bot_managed=True,
-    )
-    WalletHistory.session.add(wallet_history)
-    WalletHistory.session.commit()
+    KeyValueStore.store_value("bot_start_time", dt_utc(2024, 1, 1))
     assert db_src_file.is_file()
     assert not db_target_file.is_file()
 
@@ -2050,12 +2037,7 @@ def test_start_convert_db(fee, tmp_path):
     assert db_target_file.is_file()
 
     init_db(db_to)
-    migrated_wallet_history = WalletHistory.session.query(WalletHistory).one()
-    assert migrated_wallet_history.currency == "USDT"
-    assert migrated_wallet_history.quote_currency == "USDT"
-    assert migrated_wallet_history.balance == 100.0
-    assert migrated_wallet_history.total_quote == 100.0
-    assert migrated_wallet_history.bot_managed is True
+    assert KeyValueStore.get_datetime_value("bot_start_time") == dt_utc(2024, 1, 1)
 
 
 def test_start_strategy_updater(mocker, tmp_path):

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -46,6 +46,7 @@ from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.persistence.models import init_db
 from freqtrade.persistence.pairlock_middleware import PairLocks
+from freqtrade.persistence.wallet_history import WalletHistory
 from freqtrade.util import dt_utc
 from tests.conftest import (
     CURRENT_TEST_STRATEGY,
@@ -2025,6 +2026,20 @@ def test_start_convert_db(fee, tmp_path):
 
     PairLocks.timeframe = "5m"
     PairLocks.lock_pair("XRP/USDT", datetime.now(), "Random reason 125", side="long")
+    wallet_history = WalletHistory(
+        timestamp=datetime(2024, 1, 1),
+        currency="USDT",
+        quote_currency="USDT",
+        balance=100.0,
+        rate=1.0,
+        total_quote=100.0,
+        total_position_value=0.0,
+        collateral=100.0,
+        leverage=1.0,
+        bot_managed=True,
+    )
+    WalletHistory.session.add(wallet_history)
+    WalletHistory.session.commit()
     assert db_src_file.is_file()
     assert not db_target_file.is_file()
 
@@ -2033,6 +2048,14 @@ def test_start_convert_db(fee, tmp_path):
     start_convert_db(pargs)
 
     assert db_target_file.is_file()
+
+    init_db(db_to)
+    migrated_wallet_history = WalletHistory.session.query(WalletHistory).one()
+    assert migrated_wallet_history.currency == "USDT"
+    assert migrated_wallet_history.quote_currency == "USDT"
+    assert migrated_wallet_history.balance == 100.0
+    assert migrated_wallet_history.total_quote == 100.0
+    assert migrated_wallet_history.bot_managed is True
 
 
 def test_start_strategy_updater(mocker, tmp_path):


### PR DESCRIPTION
## Summary
- extend the `convert-db` command regression test with a real `WalletHistory` row in the source sqlite database
- run `start_convert_db()` and reopen the target sqlite database
- assert the migrated wallet history row keeps its key fields in the target database

## Tests
- `.venv/bin/python -m pytest tests/commands/test_commands.py::test_start_convert_db -q`
- `python -m py_compile tests/commands/test_commands.py`
- `git diff --check`
