### PR TITLE
ci: sync mypy pre-commit dependencies

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -35,7 +35,10 @@ jobs:
       run: uv pip install $(grep -E "^pre-commit==" requirements-dev.txt)
 
     - name: Run auto-update
-      run: pre-commit autoupdate
+      run: |
+        pre-commit autoupdate
+        uv pip install $(grep -E "^pyyaml==" requirements-dev.txt)
+        python build_helpers/pre_commit_update.py --fix
 
     - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:

--- a/build_helpers/pre_commit_update.py
+++ b/build_helpers/pre_commit_update.py
@@ -1,51 +1,100 @@
-# File used in CI to ensure pre-commit dependencies are kept up-to-date.
-
+import argparse
 import sys
 from pathlib import Path
 
 import yaml
 
 
-pre_commit_file = Path(".pre-commit-config.yaml")
-require_dev = Path("requirements-dev.txt")
-require = Path("requirements.txt")
-
-with require_dev.open("r") as rfile:
-    requirements = rfile.readlines()
-
-with require.open("r") as rfile:
-    requirements.extend(rfile.readlines())
-
-# Extract relevant types only
-supported = ("types-", "SQLAlchemy", "scipy-stubs")
-
-# Find relevant dependencies
-# Only keep the first part of the line up to the first space
-type_reqs = [r.strip("\n").split()[0] for r in requirements if r.startswith(supported)]
-
-with pre_commit_file.open("r") as file:
-    f = yaml.load(file, Loader=yaml.SafeLoader)
+PRE_COMMIT_FILE = Path(".pre-commit-config.yaml")
+REQUIRE_DEV = Path("requirements-dev.txt")
+REQUIRE = Path("requirements.txt")
+SUPPORTED = ("types-", "SQLAlchemy", "scipy-stubs")
+MYPY_REPO = "https://github.com/pre-commit/mirrors-mypy"
 
 
-mypy_repo = [
-    repo for repo in f["repos"] if repo["repo"] == "https://github.com/pre-commit/mirrors-mypy"
-]
+def get_type_requirements(requirement_paths: list[Path]) -> list[str]:
+    requirements: list[str] = []
+    for path in requirement_paths:
+        with path.open("r") as rfile:
+            requirements.extend(rfile.readlines())
 
-hooks = mypy_repo[0]["hooks"][0]["additional_dependencies"]
-
-errors = []
-for hook in hooks:
-    if hook not in type_reqs:
-        errors.append(f"{hook} is missing in requirements-dev.txt.")
-
-for req in type_reqs:
-    if req not in hooks:
-        errors.append(f"{req} is missing in pre-config file.")
+    return [line.strip("\n").split()[0] for line in requirements if line.startswith(SUPPORTED)]
 
 
-if errors:
-    for e in errors:
-        print(e)
-    sys.exit(1)
+def get_mypy_dependencies(pre_commit_file: Path) -> list[str]:
+    with pre_commit_file.open("r") as file:
+        config = yaml.load(file, Loader=yaml.SafeLoader)
 
-sys.exit(0)
+    mypy_repo = [repo for repo in config["repos"] if repo["repo"] == MYPY_REPO]
+    return mypy_repo[0]["hooks"][0]["additional_dependencies"]
+
+
+def get_dependency_errors(type_reqs: list[str], hook_deps: list[str]) -> list[str]:
+    errors = []
+    for hook in hook_deps:
+        if hook not in type_reqs:
+            errors.append(f"{hook} is missing in requirements-dev.txt.")
+
+    for req in type_reqs:
+        if req not in hook_deps:
+            errors.append(f"{req} is missing in pre-config file.")
+
+    return errors
+
+
+def replace_mypy_additional_dependencies(pre_commit_file: Path, dependencies: list[str]) -> None:
+    lines = pre_commit_file.read_text().splitlines(keepends=True)
+
+    repo_index = next(i for i, line in enumerate(lines) if MYPY_REPO in line)
+    additional_index = next(
+        i
+        for i in range(repo_index, len(lines))
+        if lines[i].lstrip().startswith("additional_dependencies:")
+    )
+
+    additional_indent = len(lines[additional_index]) - len(lines[additional_index].lstrip())
+    item_indent = " " * (additional_indent + 2)
+
+    end_index = additional_index + 1
+    while end_index < len(lines):
+        line = lines[end_index]
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if stripped and indent <= additional_indent:
+            break
+        end_index += 1
+
+    replacement = [lines[additional_index]] + [
+        f"{item_indent}- {dependency}\n" for dependency in dependencies
+    ]
+    pre_commit_file.write_text("".join(lines[:additional_index] + replacement + lines[end_index:]))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate or sync mypy pre-commit dependencies.")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Update mypy additional_dependencies in .pre-commit-config.yaml",
+    )
+    args = parser.parse_args()
+
+    type_reqs = get_type_requirements([REQUIRE_DEV, REQUIRE])
+    hook_deps = get_mypy_dependencies(PRE_COMMIT_FILE)
+    errors = get_dependency_errors(type_reqs, hook_deps)
+
+    if errors and args.fix:
+        replace_mypy_additional_dependencies(PRE_COMMIT_FILE, type_reqs)
+        hook_deps = get_mypy_dependencies(PRE_COMMIT_FILE)
+        errors = get_dependency_errors(type_reqs, hook_deps)
+
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/build_helpers/test_pre_commit_update.py
+++ b/tests/build_helpers/test_pre_commit_update.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from build_helpers.pre_commit_update import (
+    get_dependency_errors,
+    get_mypy_dependencies,
+    get_type_requirements,
+    replace_mypy_additional_dependencies,
+)
+
+
+def write_pre_commit(path: Path, dependencies: list[str]) -> None:
+    dependency_lines = "\n".join(f"          - {dependency}" for dependency in dependencies)
+    path.write_text(
+        f"""
+repos:
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.0
+    hooks:
+      - id: mypy
+        exclude: build_helpers
+        additional_dependencies:
+{dependency_lines}
+        # stages: [push]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+""".lstrip()
+    )
+
+
+def test_get_dependency_errors_reports_both_directions() -> None:
+    type_reqs = ["types-requests==1", "SQLAlchemy==2"]
+    hook_deps = ["types-requests==0", "scipy-stubs==1"]
+
+    assert get_dependency_errors(type_reqs, hook_deps) == [
+        "types-requests==0 is missing in requirements-dev.txt.",
+        "scipy-stubs==1 is missing in requirements-dev.txt.",
+        "types-requests==1 is missing in pre-config file.",
+        "SQLAlchemy==2 is missing in pre-config file.",
+    ]
+
+
+def test_replace_mypy_additional_dependencies_syncs_only_mypy_block(tmp_path: Path) -> None:
+    pre_commit_file = tmp_path / ".pre-commit-config.yaml"
+    write_pre_commit(pre_commit_file, ["types-requests==0", "scipy-stubs==1"])
+
+    replace_mypy_additional_dependencies(
+        pre_commit_file,
+        ["types-requests==1", "SQLAlchemy==2"],
+    )
+
+    assert get_mypy_dependencies(pre_commit_file) == ["types-requests==1", "SQLAlchemy==2"]
+    assert "repo: https://github.com/pre-commit/pre-commit-hooks" in pre_commit_file.read_text()
+
+
+def test_get_type_requirements_reads_supported_lines_in_order(tmp_path: Path) -> None:
+    requirements_dev = tmp_path / "requirements-dev.txt"
+    requirements = tmp_path / "requirements.txt"
+    requirements_dev.write_text(
+        "\n".join(
+            [
+                "ruff==1",
+                "types-cachetools==1  # comment",
+                "scipy-stubs==2",
+            ]
+        )
+    )
+    requirements.write_text("SQLAlchemy==2\nrequests==1\n")
+
+    assert get_type_requirements([requirements_dev, requirements]) == [
+        "types-cachetools==1",
+        "scipy-stubs==2",
+        "SQLAlchemy==2",
+    ]


### PR DESCRIPTION
## Summary
- add a `--fix` mode to `build_helpers/pre_commit_update.py` so it can rewrite mypy `additional_dependencies` from the requirements files
- run that sync after `pre-commit autoupdate` in the scheduled pre-commit update workflow
- add focused coverage for mismatch reporting, dependency extraction, and block replacement

## Tests
- `python3 build_helpers/pre_commit_update.py`
- `python3 build_helpers/pre_commit_update.py --fix`
- `python3 -m compileall -q build_helpers/pre_commit_update.py tests/build_helpers/test_pre_commit_update.py`
- manual helper smoke covering the new sync helpers
- `git diff --check`

I did not run the repository pytest target locally because this checkout is missing runtime test dependencies such as `rapidjson`.
