### PR TITLE
fix: keep FreqAI backtests running after training failure

### DIFF
--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -382,6 +382,10 @@ class IFreqaiModel(ABC):
                         self.model = None
 
                     self.dd.pair_dict[pair]["trained_timestamp"] = int(tr_train.stopts)
+                    if self.model is None:
+                        self._append_null_backtesting_predictions(dk, dataframe_backtest)
+                        continue
+
                     if self.plot_features and self.model is not None:
                         plot_feature_importance(self.model, pair, dk, self.plot_features)
                     if self.save_backtest_models and self.model is not None:
@@ -402,6 +406,27 @@ class IFreqaiModel(ABC):
         dk.fill_predictions(dataframe)
 
         return dk
+
+    def _append_null_backtesting_predictions(
+        self, dk: FreqaiDataKitchen, dataframe_backtest: DataFrame
+    ) -> None:
+        """
+        Append neutral predictions for a backtest window whose model training failed.
+        """
+        labels = dk.label_list + dk.unique_class_list
+        predictions = DataFrame(0, index=range(len(dataframe_backtest)), columns=labels)
+        do_preds = np.zeros(len(dataframe_backtest), dtype=np.int_)
+        dk.DI_values = np.zeros(len(dataframe_backtest))
+
+        labels_mean = dk.data.setdefault("labels_mean", {})
+        labels_std = dk.data.setdefault("labels_std", {})
+        for label in labels:
+            labels_mean[label] = 0
+            labels_std[label] = 0
+
+        append_df = dk.get_predictions_to_append(predictions, do_preds, dataframe_backtest)
+        dk.append_predictions(append_df)
+        dk.save_backtesting_prediction(append_df)
 
     def start_live(
         self, dataframe: DataFrame, metadata: dict, strategy: IStrategy, dk: FreqaiDataKitchen

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -381,11 +381,13 @@ class IFreqaiModel(ABC):
                         )
                         self.model = None
 
-                    self.dd.pair_dict[pair]["trained_timestamp"] = int(tr_train.stopts)
                     if self.model is None:
+                        # Persist metadata (feature list) to enable freqUI after backtest
+                        self.dd.save_metadata(dk)
                         self._append_null_backtesting_predictions(dk, dataframe_backtest)
                         continue
 
+                    self.dd.pair_dict[pair]["trained_timestamp"] = int(tr_train.stopts)
                     if self.plot_features and self.model is not None:
                         plot_feature_importance(self.model, pair, dk, self.plot_features)
                     if self.save_backtest_models and self.model is not None:

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -341,6 +341,24 @@ def test_start_backtesting_appends_null_predictions_when_training_fails(mocker, 
     assert "do_predict" in dk.return_dataframe
     assert dk.return_dataframe["do_predict"].eq(0).all()
 
+    # Second run reuses the cached predictions - ensure 2nd backtest run or
+    # API rendering does not trigger training or prediction
+    strategy2 = get_patched_freqai_strategy(mocker, freqai_conf)
+    strategy2.dp = DataProvider(freqai_conf, exchange)
+    strategy2.freqai_info = freqai_conf.get("freqai", {})
+    freqai2 = strategy2.freqai
+    freqai2.live = False
+    freqai2.dk = FreqaiDataKitchen(freqai_conf)
+    freqai2.dd.load_all_pair_histories(timerange, freqai2.dk)
+    train_mock = mocker.patch.object(freqai2, "train")
+    predict_mock2 = mocker.patch.object(freqai2, "predict")
+    freqai2.dk.set_paths("LTC/BTC", None)
+    dk2 = freqai2.start_backtesting(df, metadata, freqai2.dk, strategy2)
+
+    train_mock.assert_not_called()
+    predict_mock2.assert_not_called()
+    assert len(dk2.return_dataframe) == len(df)
+
     shutil.rmtree(Path(freqai.dk.full_path))
 
 

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -8,6 +8,7 @@ import pytest
 from freqtrade.configuration import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RunMode
+from freqtrade.exceptions import OperationalException
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.utils import download_all_data_for_training, get_required_data_timerange
 from freqtrade.optimize.backtesting import Backtesting
@@ -301,6 +302,45 @@ def test_start_backtesting(mocker, freqai_conf, model, num_files, strat, caplog)
     assert len(model_folders) == num_files
     Trade.use_db = True
     Backtesting.cleanup()
+    shutil.rmtree(Path(freqai.dk.full_path))
+
+
+def test_start_backtesting_appends_null_predictions_when_training_fails(mocker, freqai_conf):
+    freqai_conf.update({"freqaimodel": "LightGBMRegressor"})
+    freqai_conf.update({"timerange": "20180120-20180130"})
+    freqai_conf.update({"strategy": "freqai_test_strat"})
+    freqai_conf.get("freqai", {}).get("feature_parameters", {}).update(
+        {"indicator_periods_candles": [2]}
+    )
+
+    strategy = get_patched_freqai_strategy(mocker, freqai_conf)
+    exchange = get_patched_exchange(mocker, freqai_conf)
+    strategy.dp = DataProvider(freqai_conf, exchange)
+    strategy.freqai_info = freqai_conf.get("freqai", {})
+    freqai = strategy.freqai
+    freqai.live = False
+    freqai.dk = FreqaiDataKitchen(freqai_conf)
+    timerange = TimeRange.parse_timerange("20180110-20180130")
+    freqai.dd.load_all_pair_histories(timerange, freqai.dk)
+    sub_timerange = TimeRange.parse_timerange("20180110-20180130")
+    _, base_df = freqai.dd.get_base_and_corr_dataframes(sub_timerange, "LTC/BTC", freqai.dk)
+    df = base_df[freqai_conf["timeframe"]]
+
+    mocker.patch.object(
+        freqai,
+        "train",
+        side_effect=OperationalException("all training data dropped due to NaNs"),
+    )
+    predict_mock = mocker.patch.object(freqai, "predict")
+
+    metadata = {"pair": "LTC/BTC"}
+    freqai.dk.set_paths("LTC/BTC", None)
+    dk = freqai.start_backtesting(df, metadata, freqai.dk, strategy)
+
+    predict_mock.assert_not_called()
+    assert "do_predict" in dk.return_dataframe
+    assert dk.return_dataframe["do_predict"].eq(0).all()
+
     shutil.rmtree(Path(freqai.dk.full_path))
 
 


### PR DESCRIPTION
## Summary
- When FreqAI backtesting training fails for a pair, append neutral zero predictions for that window and continue instead of crashing the whole run
- Preserve the existing log warning while preventing `predict()` from being called with a missing model
- Add a regression test for the missing-data / training-failure path

Resolves #9671

## Testing
- `uv run --extra freqai --extra freqai_rl --extra plot --extra develop python -m pytest tests/freqai -q`
- `uv run --extra develop ruff check freqtrade/freqai/freqai_interface.py tests/freqai/test_freqai_interface.py`

AI-assisted change; manually reviewed before opening.