### PR TITLE
fix: /api/v1/historic_balance returns 500 on MySQL/MariaDB backends

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -795,8 +795,10 @@ class RPC:
 
         results = results.rename({"timestamp": "date"}, axis=1)
         results.loc[:, "__date_ts"] = results.loc[:, "date"].dt.as_unit("ms").astype("int64")
-        # Exclude non-bot managed for now
-        results_filtered = results.loc[results["bot_managed"]]
+        # Exclude non-bot managed rows. Coerce to bool: read_sql may return the
+        # Boolean column as an integer dtype (e.g. MySQL/MariaDB), which would
+        # make .loc do label-based indexing instead of boolean masking.
+        results_filtered = results.loc[results["bot_managed"].astype(bool)]
 
         results_final = (
             results_filtered.groupby(["date", "__date_ts"])

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -795,9 +795,7 @@ class RPC:
 
         results = results.rename({"timestamp": "date"}, axis=1)
         results.loc[:, "__date_ts"] = results.loc[:, "date"].dt.as_unit("ms").astype("int64")
-        # Exclude non-bot managed rows. Coerce to bool: read_sql may return the
-        # Boolean column as an integer dtype (e.g. MySQL/MariaDB), which would
-        # make .loc do label-based indexing instead of boolean masking.
+        # Exclude non-bot managed for now
         results_filtered = results.loc[results["bot_managed"].astype(bool)]
 
         results_final = (

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1472,13 +1472,13 @@ def test_api_historic_balance(botclient, mocker, ticker, fee, markets, is_short)
 
 
 def test_api_historic_balance_int_bot_managed(botclient, mocker):
-    """Regression: read_sql may return the wallet_history `bot_managed` Boolean
-    column as an integer dtype (e.g. MySQL/MariaDB TINYINT); the `.loc[...]`
-    filter must boolean-mask, not label-index."""
+    """
+    read_sql may return the wallet_history `bot_managed` column as an
+    integer (e.g. MySQL/MariaDB TINYINT)
+    """
     _, client = botclient
 
-    # Single bot-managed row: with an int64 `bot_managed`, label-based `.loc`
-    # indexing looks up label 1, which the RangeIndex lacks -> KeyError -> 500.
+    # Single row: with an int64 `bot_managed`
     one_row = pd.DataFrame(
         {
             "timestamp": pd.to_datetime(["2024-01-01"]),
@@ -1490,6 +1490,8 @@ def test_api_historic_balance_int_bot_managed(botclient, mocker):
     rc = client_get(client, f"{BASE_URI}/historic_balance")
     assert_response(rc, 200)
     assert rc.json()["length"] == 1
+    assert rc.json()["data"][0][0] == "2024-01-01T00:00:00"
+    assert rc.json()["data"][0][2] == 100.0
 
     # Mixed rows: the non-bot-managed row (bot_managed=0) must be excluded.
     two_rows = pd.DataFrame(
@@ -1503,6 +1505,8 @@ def test_api_historic_balance_int_bot_managed(botclient, mocker):
     rc = client_get(client, f"{BASE_URI}/historic_balance")
     assert_response(rc, 200)
     assert rc.json()["length"] == 1
+    assert rc.json()["data"][0][0] == "2024-01-02T00:00:00"
+    assert rc.json()["data"][0][2] == 200.0
 
 
 def test_api_performance(botclient, fee):

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -1471,6 +1471,40 @@ def test_api_historic_balance(botclient, mocker, ticker, fee, markets, is_short)
     assert "total_quote" in resp1["columns"]
 
 
+def test_api_historic_balance_int_bot_managed(botclient, mocker):
+    """Regression: read_sql may return the wallet_history `bot_managed` Boolean
+    column as an integer dtype (e.g. MySQL/MariaDB TINYINT); the `.loc[...]`
+    filter must boolean-mask, not label-index."""
+    _, client = botclient
+
+    # Single bot-managed row: with an int64 `bot_managed`, label-based `.loc`
+    # indexing looks up label 1, which the RangeIndex lacks -> KeyError -> 500.
+    one_row = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-01"]),
+            "total_quote": [100.0],
+            "bot_managed": [1],
+        }
+    ).astype({"bot_managed": "int64"})
+    mocker.patch("freqtrade.rpc.rpc.read_sql", return_value=one_row)
+    rc = client_get(client, f"{BASE_URI}/historic_balance")
+    assert_response(rc, 200)
+    assert rc.json()["length"] == 1
+
+    # Mixed rows: the non-bot-managed row (bot_managed=0) must be excluded.
+    two_rows = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "total_quote": [100.0, 200.0],
+            "bot_managed": [0, 1],
+        }
+    ).astype({"bot_managed": "int64"})
+    mocker.patch("freqtrade.rpc.rpc.read_sql", return_value=two_rows)
+    rc = client_get(client, f"{BASE_URI}/historic_balance")
+    assert_response(rc, 200)
+    assert rc.json()["length"] == 1
+
+
 def test_api_performance(botclient, fee):
     ftbot, client = botclient
     patch_get_signal(ftbot)


### PR DESCRIPTION
## Summary

`GET /api/v1/historic_balance` (added in 2026.4) returns **HTTP 500** on bots backed by **MySQL/MariaDB**.

`RPC._rpc_get_historic_balance` filters wallet-history rows with:

```python
results_filtered = results.loc[results["bot_managed"]]
```

This treats `results["bot_managed"]` as a boolean mask, but `pandas.read_sql` does not guarantee a `bool` dtype for that column — it depends on the DB backend:

| Backend | `bot_managed` dtype from `read_sql` | Result |
| --- | --- | --- |
| SQLite (default) | `bool` | works |
| MySQL / MariaDB | `int64` (`Boolean` → `TINYINT(1)`) | **broken** |

With an `int64` Series, `DataFrame.loc[...]` does **label-based indexing**, not boolean masking. When `wallet_history` has a row whose `bot_managed` value (`1`) is not a valid index label, it raises:

```
KeyError: 'None of [RangeIndex(start=1, stop=2, step=1)] are in the [index]'
```

(With ≥2 rows it does not raise, but silently selects the wrong rows.)

## Impact

On a MySQL/MariaDB-backed bot every `/api/v1/historic_balance` request 500s, so the FreqUI dashboard's balance view breaks. SQLite (the default) is unaffected — which is also why the existing `test_api_historic_balance` stays green, as the test suite runs on SQLite.

## Reproduction

pandas 3.0.3, MariaDB backend, `wallet_history` with a single row:

```python
>>> df = pd.read_sql_table("wallet_history", engine)
>>> df["bot_managed"].dtype
dtype('int64')
>>> df.loc[df["bot_managed"]]
KeyError: 'None of [RangeIndex(start=1, stop=2, step=1)] are in the [index]'
```

## Fix

Coerce to a real boolean mask:

```python
results_filtered = results.loc[results["bot_managed"].astype(bool)]
```

`.astype(bool)` is a no-op when the column is already `bool` (SQLite) and corrects the `int64` case (MySQL/MariaDB) — backend-agnostic.

## Test

Adds `test_api_historic_balance_int_bot_managed`: it patches `read_sql` to return an `int64` `bot_managed` column (the MySQL/MariaDB shape) and asserts `/historic_balance` returns 200 with correct filtering. Fails on `develop` (HTTP 500), passes with this fix.
