### PR TITLE
fix: Replace print() with logger in core modules

### DIFF
--- a/freqtrade/commands/build_config_commands.py
+++ b/freqtrade/commands/build_config_commands.py
@@ -43,7 +43,7 @@ def start_show_config(args: dict[str, Any]) -> None:
 
     config = setup_utils_configuration(args, RunMode.UTIL_EXCHANGE, set_dry=False)
 
-    print("Your combined configuration is:")
+    logger.info("Your combined configuration is:")
     config_sanitized = sanitize_config(
         config["original_config"], show_sensitive=args.get("show_sensitive", False)
     )

--- a/freqtrade/commands/strategy_utils_commands.py
+++ b/freqtrade/commands/strategy_utils_commands.py
@@ -46,9 +46,9 @@ def start_strategy_update(args: dict[str, Any]) -> None:
 def start_conversion(strategy_obj, config):
     from freqtrade.strategy.strategyupdater import StrategyUpdater
 
-    print(f"Conversion of {Path(strategy_obj['location']).name} started.")
+    logger.info(f"Conversion of {Path(strategy_obj['location']).name} started.")
     instance_strategy_updater = StrategyUpdater()
     start = time.perf_counter()
     instance_strategy_updater.start(config, strategy_obj)
     elapsed = time.perf_counter() - start
-    print(f"Conversion of {Path(strategy_obj['location']).name} took {elapsed:.1f} seconds.")
+    logger.info(f"Conversion of {Path(strategy_obj['location']).name} took {elapsed:.1f} seconds.")

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -32,7 +32,7 @@ def _process_candles_and_indicators(
                     pair, trades, signal_candles[strategy_name][pair], date_col
                 )
     except Exception as e:
-        print(f"Cannot process entry/exit reasons for {strategy_name}: ", e)
+        logger.error(f"Cannot process entry/exit reasons for {strategy_name}: {e}")
 
     return analysed_trades_dict
 
@@ -241,7 +241,7 @@ def print_results(
 
         if rejected_signals is not None:
             if rejected_signals.empty:
-                print("There were no rejected signals.")
+                logger.info("There were no rejected signals.")
             else:
                 _do_rejected_signals_output(rejected_signals, to_csv=to_csv, csv_path=csv_path)
 
@@ -267,7 +267,7 @@ def print_results(
                 csv_path=csv_path,
             )
     else:
-        print("\\No trades to show")
+        logger.info("\\No trades to show")
 
 
 def _merge_dfs(
@@ -311,10 +311,10 @@ def _print_table(
     if to_csv:
         safe_name = Path(csv_path, name.lower().replace(" ", "_").replace(":", "") + ".csv")
         data.to_csv(safe_name)
-        print(f"Saved {name} to {safe_name}")
+        logger.info(f"Saved {name} to {safe_name}")
     else:
         if name is not None:
-            print(name)
+            logger.debug(name)
 
         print_df_rich_table(data, data.keys(), show_index=show_index)
 

--- a/freqtrade/system/version_info.py
+++ b/freqtrade/system/version_info.py
@@ -1,4 +1,7 @@
+import logging
 from freqtrade import __version__
+
+logger = logging.getLogger(__name__)
 
 
 def print_version_info():
@@ -8,8 +11,8 @@ def print_version_info():
 
     import ccxt
 
-    print(f"Operating System:\t{platform.platform()}")
-    print(f"Python Version:\t\tPython {sys.version.split(' ')[0]}")
-    print(f"CCXT Version:\t\t{ccxt.__version__}")
-    print()
-    print(f"Freqtrade Version:\tfreqtrade {__version__}")
+    logger.info(f"Operating System:\t{platform.platform()}")
+    logger.info(f"Python Version:\t\tPython {sys.version.split(' ')[0]}")
+    logger.info(f"CCXT Version:\t\t{ccxt.__version__}")
+    logger.info("")
+    logger.info(f"Freqtrade Version:\tfreqtrade {__version__}")


### PR DESCRIPTION
## Summary
Replaces print() statements with proper logging (logger.debug/info/warning) in freqtrade core modules.

## Root Cause
print() statements bypass the logging system, making it impossible to filter/control output in production.

## Proposed Changes
- freqtrade/data/entryexitanalysis.py: 5 print() → logger
- freqtrade/system/version_info.py: 5 print() → logger  
- freqtrade/commands/build_config_commands.py: 1 print() → logger
- freqtrade/commands/strategy_utils_commands.py: 2 print() → logger

## Verification
- Code compiles without errors
- GPG signed commits (verified)
- Existing tests still pass