### PR TITLE
fix(binance): treat error -4067 as no-op when margin mode already correctly set

### DIFF
--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -557,6 +557,43 @@ class Binance(Exchange):
 
         return cache.get(pair, None)
 
+    def set_margin_mode(
+        self,
+        pair: str,
+        margin_mode: MarginMode,
+        accept_fail: bool = False,
+        params: dict | None = None,
+    ) -> None:
+        """
+        Override base implementation to gracefully handle Binance error -4067.
+
+        Binance returns ``-4067`` ("Position side cannot be changed if there exists
+        open orders.") from ``setMarginType`` for pairs with no open position even
+        when the requested margin mode is already in effect, despite the message
+        referencing open orders that do not exist. Functionally equivalent to
+        ``-4046`` ("No need to change margin type."), which ccxt already swallows
+        transparently. Without this override the resulting TemporaryError aborts
+        ``create_trade``, blocking entries on affected pairs.
+
+        :param pair: base/quote currency pair
+        :param margin_mode: requested margin mode
+        :param accept_fail: forwarded to base implementation
+        :param params: forwarded to base implementation
+        """
+        try:
+            super().set_margin_mode(pair, margin_mode, accept_fail, params)
+        except TemporaryError as e:
+            if "-4067" in str(e):
+                logger.debug(
+                    "Binance error -4067 on %s with margin_mode=%s "
+                    "treated as no-op (margin mode already correct). %s",
+                    pair,
+                    margin_mode.value,
+                    e,
+                )
+                return
+            raise
+
 
 class Binanceusdm(Binance):
     """Binance USDM Exchange

--- a/tests/exchange/test_binance.py
+++ b/tests/exchange/test_binance.py
@@ -9,7 +9,12 @@ import pytest
 
 from freqtrade.data.converter.trade_converter import trades_dict_to_list
 from freqtrade.enums import CandleType, MarginMode, RunMode, TradingMode
-from freqtrade.exceptions import DependencyException, InvalidOrderException, OperationalException
+from freqtrade.exceptions import (
+    DependencyException,
+    InvalidOrderException,
+    OperationalException,
+    TemporaryError,
+)
 from freqtrade.exchange.exchange_utils_timeframe import timeframe_to_seconds
 from freqtrade.persistence import Trade
 from freqtrade.util.datetime_helpers import dt_from_ts, dt_ts, dt_utc
@@ -1203,3 +1208,42 @@ def test__get_spot_delist_schedule_binance(default_conf_usdt, mocker):
         "sapi_get_spot_delist_schedule",
         retries=1,
     )
+
+
+@pytest.mark.parametrize("margin_mode", [MarginMode.CROSS, MarginMode.ISOLATED])
+def test_set_margin_mode_binance_handles_4067_no_op(mocker, default_conf, margin_mode):
+    """
+    Binance returns error -4067 from setMarginType for pairs with no open position
+    even when the margin mode is already correctly set. The override should
+    swallow it as a no-op (equivalent to ccxt's handling of -4046).
+    """
+    api_mock = MagicMock()
+    api_mock.set_margin_mode = MagicMock(
+        side_effect=ccxt.OperationRejected(
+            'binance {"code":-4067,'
+            '"msg":"Position side cannot be changed if there exists open orders."}'
+        )
+    )
+    type(api_mock).has = PropertyMock(return_value={"setMarginMode": True})
+    default_conf["dry_run"] = False
+
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, exchange="binance")
+    # Must not raise; the quirk is swallowed as a no-op.
+    exchange.set_margin_mode("ADA/USDT:USDT", margin_mode)
+
+
+def test_set_margin_mode_binance_propagates_other_operation_rejected(mocker, default_conf):
+    """
+    Non-4067 OperationRejected responses should still surface as TemporaryError;
+    the override must not mask other genuine setMarginType failures.
+    """
+    api_mock = MagicMock()
+    api_mock.set_margin_mode = MagicMock(
+        side_effect=ccxt.OperationRejected('binance {"code":-1234,"msg":"Some other error"}')
+    )
+    type(api_mock).has = PropertyMock(return_value={"setMarginMode": True})
+    default_conf["dry_run"] = False
+
+    exchange = get_patched_exchange(mocker, default_conf, api_mock=api_mock, exchange="binance")
+    with pytest.raises(TemporaryError, match="Could not set margin mode"):
+        exchange.set_margin_mode("ADA/USDT:USDT", MarginMode.CROSS)


### PR DESCRIPTION
## Problem

`freqtrade.exchange.exchange.set_margin_mode()` raises `TemporaryError` when Binance returns error code `-4067` ("Position side cannot be changed if there exists open orders.") from `setMarginType`, even when:

- 0 open orders exist on the account
- 0 positions exist on the pair (`positionAmt: 0`)
- Margin mode is already correctly set
- Position mode is One-Way (`dualSidePosition: False`)

This is a Binance API quirk: `-4067` *should* be `-4046` ("No need to change margin type.") for this scenario, and the message reference to "open orders" is misleading. ccxt swallows `-4046` transparently; `-4067` is treated as a hard error and propagates through `@retrier` to abort `create_trade`, silently blocking new entries.

Operating live freqtrade futures bots on Binance surfaced this: `freqtrade-trendrider-long-live` had 2,490 "Long signal found" log lines over 24h but 0 trades opened across 4 days (2026-05-21 → 2026-05-25). After applying this fix locally to the running containers, a new trade opened within 90 seconds.

## Repro

```python
import ccxt
ex = ccxt.binance({"apiKey": ..., "secret": ..., "options": {"defaultType": "future"}})

# Pair with no open position, no open orders, already in cross margin:
ex.set_margin_mode("cross", "ADA/USDT:USDT")
# Raises: binance {"code":-4067,"msg":"Position side cannot be changed
#                  if there exists open orders."}
# But: ex.fetch_open_orders("ADA/USDT:USDT") == []
# And: fapiPrivateV2GetPositionRisk shows marginType=cross already.

# Pair WITH a position, already in cross margin:
ex.set_margin_mode("cross", "XRP/USDT:USDT")
# Returns: {"code":-4046, "msg":"No need to change margin type."} (handled silently by ccxt)
```

The `-4067` response in this scenario is functionally identical to `-4046` but freqtrade treats it as a hard error.

## Fix

Override `set_margin_mode` in the `Binance` subclass. Call the base implementation, catch `TemporaryError`, and if the message contains the `-4067` fingerprint, log at debug and return. Any other `TemporaryError` (including unrelated `OperationRejected` like `-1234`) continues to propagate so genuine setMarginType failures still surface.

Scope kept deliberately narrow: only the `-4067` string match in the resolved error message. No general BadRequest squelch.

## Tests

Two new tests in `tests/exchange/test_binance.py`, exercising both axes:

- **Positive (`test_set_margin_mode_binance_handles_4067_no_op`, parametrized over CROSS/ISOLATED)** — mock raises `ccxt.OperationRejected` with `-4067` payload; the override must not propagate `TemporaryError`.
- **Negative (`test_set_margin_mode_binance_propagates_other_operation_rejected`)** — mock raises with `-1234` payload; the override must still raise `TemporaryError` so unrelated failures are not masked.

Verified locally:

- Without the fix, the positive tests fail on `develop` (TemporaryError propagates after 4 `@retrier` retries) — confirming the bug reproduces in test infrastructure.
- With the fix, all 55 tests in `tests/exchange/test_binance.py` pass.
- `ruff check` and `ruff format --check` clean on both modified files.

## Prior art

There was an earlier attempt in #6431 (closed 2022-02 without merge) which was scoped as a broad "BadRequest squelch" and pointed at ccxt#11936 to handle the underlying issue upstream. ccxt#11936 was also closed without merge in 2022. This PR keeps the scope narrow to the single `-4067` fingerprint, addressing the specific over-broad concern that led to #6431's closure while not waiting on a ccxt PR that did not land.

## Note on disclosure

Bug discovery, empirical reproduction, local-patch verification on live trading containers, and code review are mine; AI assistance was used for drafting parts of this PR body and test scaffolding. I reviewed and ran every test myself; the fix and tests reflect my own engineering decisions.