### PR TITLE
fix: return error message if type is invalid

### DIFF
--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -77,7 +77,6 @@ async def _process_consumer_request(request: dict[str, Any], channel: WebSocketC
         return
 
     type_, data = websocket_request.type, websocket_request.data
-    response: WSMessageSchema
 
     logger.debug(f"Request of type {type_} from {channel}")
 

--- a/freqtrade/rpc/api_server/api_ws.py
+++ b/freqtrade/rpc/api_server/api_ws.py
@@ -66,10 +66,14 @@ async def _process_consumer_request(request: dict[str, Any], channel: WebSocketC
     Validate and handle a request from a websocket consumer
     """
     # Validate the request, makes sure it matches the schema
+    response: WSMessageSchema
     try:
         websocket_request = WSRequestSchema.model_validate(request)
     except ValidationError as e:
         logger.error(f"Invalid request from {channel}: {e}")
+        response = WSErrorMessage(data=f"Invalid request type: {request.get('type')}")
+
+        await channel.send(response.dict(exclude_none=True))
         return
 
     type_, data = websocket_request.type, websocket_request.data

--- a/tests/rpc/test_rpc_apiserver.py
+++ b/tests/rpc/test_rpc_apiserver.py
@@ -3501,6 +3501,18 @@ def test_api_ws_requests(botclient, caplog):
     assert response["type"] == "analyzed_df"
 
 
+def test_channel_reader_handles_freqtrade_exception(botclient):
+    _ftbot, client = botclient
+    ws_url = f"/api/v1/message/ws?token={_TEST_WS_TOKEN}"
+
+    # Test with wrong request -> wrong_type is not a valid type
+    with client.websocket_connect(ws_url) as ws:
+        ws.send_json({"type": "wrong_type", "data": ["test"]})
+        response = ws.receive_json()
+
+        assert response["data"] == "Invalid request type: wrong_type"
+
+
 def test_api_ws_send_msg(default_conf, mocker, caplog):
     try:
         caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
## Summary

RPC '/message/ws' should return an error, if the type is invalid