### PR TITLE
Improve DB URI password masking

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator, Mapping
 from io import StringIO
 from pathlib import Path
 from typing import Any, TextIO
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import pandas as pd
 import rapidjson
@@ -202,10 +202,10 @@ def parse_db_uri_for_logging(uri: str):
     :param uri: DB URI to parse for logging
     """
     parsed_db_uri = urlparse(uri)
-    if not parsed_db_uri.netloc:  # No need for censoring as no password was provided
+    if parsed_db_uri.password is None:  # No need for censoring as no password was provided
         return uri
-    pwd = parsed_db_uri.netloc.split(":")[1].split("@")[0]
-    return parsed_db_uri.geturl().replace(f":{pwd}@", ":*****@")
+    netloc = parsed_db_uri.netloc.replace(f":{parsed_db_uri.password}@", ":*****@", 1)
+    return urlunparse(parsed_db_uri._replace(netloc=netloc))
 
 
 def dataframe_to_json(dataframe: pd.DataFrame) -> str:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -205,6 +205,26 @@ def test_plural() -> None:
             "mysql+pymysql://user:*****@some_mariadb/dbname?charset=utf8mb4",
         ),
         (
+            "postgresql+psycopg://scott:p%40ss@host/dbname",
+            "postgresql+psycopg://scott:*****@host/dbname",
+        ),
+        (
+            "postgresql+psycopg://scott:pa:ss@host/dbname",
+            "postgresql+psycopg://scott:*****@host/dbname",
+        ),
+        (
+            "postgresql+psycopg://scott:scott@[::1]:5432/dbname",
+            "postgresql+psycopg://scott:*****@[::1]:5432/dbname",
+        ),
+        (
+            "postgresql+psycopg://scott@host/dbname",
+            "postgresql+psycopg://scott@host/dbname",
+        ),
+        (
+            "postgresql+psycopg://host/dbname",
+            "postgresql+psycopg://host/dbname",
+        ),
+        (
             "sqlite:////freqtrade/user_data/tradesv3.sqlite",
             "sqlite:////freqtrade/user_data/tradesv3.sqlite",
         ),


### PR DESCRIPTION
## Summary

Improve DB URI logging redaction so password masking handles valid database URLs without relying on fragile netloc string splitting.

Solve the issue: n/a

## Quick changelog

- Use urllib parsing metadata to decide whether a DB URI contains a password before masking.
- Add coverage for URL-encoded passwords, passwords containing colons, IPv6 hosts, and DB URLs without passwords.

## What's new?

The previous implementation split the URI netloc on ':' and '@'. That could raise or mask incorrectly for valid URLs such as username-only URLs, IPv6 hosts, or passwords containing ':' characters.

This PR keeps URLs without passwords unchanged and masks only the password portion when present.

AI assistance: I used OpenAI Codex to help identify and prepare this change, then reviewed the diff and ran the focused checks below.

## Testing

- .\.venv\Scripts\python -m pytest tests/test_misc.py::test_parse_db_uri_for_logging -q
- .\.venv\Scripts\python -m ruff check freqtrade/misc.py tests/test_misc.py
- git diff --check
