### PR TITLE
Prevent UI zip path traversal

### DIFF
--- a/freqtrade/commands/deploy_ui.py
+++ b/freqtrade/commands/deploy_ui.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import requests
 
+from freqtrade.exceptions import OperationalException
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +41,15 @@ def download_and_install_ui(dest_folder: Path, dl_url: str, version: str):
     logger.info(f"Downloading {dl_url}")
     resp = requests.get(dl_url, timeout=req_timeout).content
     dest_folder.mkdir(parents=True, exist_ok=True)
+    dest_folder_resolved = dest_folder.resolve()
     with ZipFile(BytesIO(resp)) as zf:
         for fn in zf.filelist:
+            destfile = (dest_folder / fn.filename).resolve()
+            if not destfile.is_relative_to(dest_folder_resolved):
+                raise OperationalException(
+                    f"Refusing to extract UI file outside target directory: {fn.filename}"
+                )
             with zf.open(fn) as x:
-                destfile = dest_folder / fn.filename
                 if fn.is_dir():
                     destfile.mkdir(exist_ok=True)
                 else:

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -811,6 +811,27 @@ def test_download_and_install_ui(mocker, tmp_path):
     assert read_ui_version(folder) == "22"
 
 
+def test_download_and_install_ui_rejects_zip_traversal(mocker, tmp_path):
+    requests_mock = MagicMock()
+    file_like_object = BytesIO()
+    with ZipFile(file_like_object, mode="w") as zipfile:
+        zipfile.writestr("../outside.txt", "outside")
+    file_like_object.seek(0)
+    requests_mock.content = file_like_object.read()
+
+    mocker.patch("freqtrade.commands.deploy_ui.requests.get", return_value=requests_mock)
+
+    folder = tmp_path / "uitests_dl"
+
+    with pytest.raises(
+        OperationalException,
+        match=r"Refusing to extract UI file outside target directory: \.\./outside\.txt",
+    ):
+        download_and_install_ui(folder, "http://whatever.xxx/download/file.zip", "22")
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
 def test_get_ui_download_url(mocker):
     response = MagicMock()
     responses = [


### PR DESCRIPTION
## Summary

Prevent `freqtrade install-ui` from extracting UI zip entries outside the configured UI installation directory.

Solve the issue: N/A

## Quick changelog

- Resolve each zip entry target path before writing it during UI installation.
- Reject zip entries that would escape the UI installation directory.
- Add a regression test covering `../` traversal entries.

## What's new?

`download_and_install_ui()` previously joined `dest_folder` with the raw zip entry name and wrote the file directly. A zip entry such as `../outside.txt` could therefore be written outside `freqtrade/rpc/api_server/ui/installed/`.

This PR resolves both the target directory and each zip entry destination, then refuses entries whose resolved target is outside the install directory.

AI assistance was used to help identify and draft this change. I reviewed the resulting diff and kept the PR scoped to the UI zip extraction path and its regression test.

## Verification

- `python -m pytest tests/commands/test_commands.py::test_start_install_ui tests/commands/test_commands.py::test_download_and_install_ui tests/commands/test_commands.py::test_download_and_install_ui_rejects_zip_traversal -q`
- `python -m ruff check freqtrade/commands/deploy_ui.py tests/commands/test_commands.py`
- `python -m ruff format --check freqtrade/commands/deploy_ui.py tests/commands/test_commands.py`
- `git diff --check`

I also tried `python -m pytest tests/commands/test_commands.py -q`, but the local environment is missing optional test dependencies/fixtures (`time_machine`, `optuna`, `datasieve`), so unrelated tests in that file cannot complete locally.