### PR TITLE
Fix FreqAI return value index alignment

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -405,8 +405,9 @@ class FreqaiDataDrawer:
         :param dataframe: DataFrame = strategy dataframe
         :return: DataFrame = strat dataframe with return values attached
         """
-        df = self.model_return_values[pair]
+        df = self.model_return_values[pair].copy()
         to_keep = [col for col in dataframe.columns if not col.startswith("&")]
+        df.index = dataframe.index
         dataframe = pd.concat([dataframe[to_keep], df], axis=1)
         return dataframe
 

--- a/tests/freqai/test_freqai_datadrawer.py
+++ b/tests/freqai/test_freqai_datadrawer.py
@@ -8,6 +8,7 @@ import pytest
 from freqtrade.configuration import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.exceptions import OperationalException
+from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from tests.conftest import get_patched_exchange
 from tests.freqai.conftest import get_patched_freqai_strategy
@@ -237,3 +238,31 @@ def test_set_initial_return_values_warning(mocker, freqai_conf):
 
     # Ensure logger error is not called
     mock_logger_warning.assert_called()
+
+
+def test_attach_return_values_uses_strategy_dataframe_index(tmp_path, freqai_conf):
+    data_drawer = FreqaiDataDrawer(tmp_path, freqai_conf)
+    pair = "BTC/USD"
+
+    dataframe = pd.DataFrame(
+        {
+            "date": pd.date_range("2023-09-01", periods=3),
+            "close": [100, 101, 102],
+            "&old-label": [0, 0, 0],
+        },
+        index=[10, 11, 12],
+    )
+    data_drawer.model_return_values[pair] = pd.DataFrame(
+        {
+            "&target": [1, 2, 3],
+            "do_predict": [1, 1, 0],
+        }
+    )
+
+    result = data_drawer.attach_return_values_to_return_dataframe(pair, dataframe)
+
+    assert result.index.tolist() == [10, 11, 12]
+    assert result["&target"].tolist() == [1, 2, 3]
+    assert result["do_predict"].tolist() == [1, 1, 0]
+    assert "&old-label" not in result.columns
+    assert not result[["&target", "do_predict"]].isna().any().any()


### PR DESCRIPTION
Supersedes #13220 after renaming the contribution branch.

## Summary
- align FreqAI model return values to the strategy dataframe index before concatenating
- keep existing non-label columns and replace stale label columns with model output values
- add a regression test covering a non-default dataframe index

## Test
- .\\.venv\\Scripts\\python.exe -m pytest tests/freqai/test_freqai_datadrawer.py::test_attach_return_values_uses_strategy_dataframe_index -q