### PR TITLE
perf(backtest): build detail rows without broadcasting signals into the frame

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1533,15 +1533,16 @@ class Backtesting:
         end_idx = dates.searchsorted(exit_candle_end, side="left")
         if end_idx <= start_idx:
             return None
-        detail_data = detail_data.iloc[start_idx:end_idx].copy()
-
-        detail_data.loc[:, "enter_long"] = row[LONG_IDX]
-        detail_data.loc[:, "exit_long"] = row[ELONG_IDX]
-        detail_data.loc[:, "enter_short"] = row[SHORT_IDX]
-        detail_data.loc[:, "exit_short"] = row[ESHORT_IDX]
-        detail_data.loc[:, "enter_tag"] = row[ENTER_TAG_IDX]
-        detail_data.loc[:, "exit_tag"] = row[EXIT_TAG_IDX]
-        return detail_data[HEADERS].values.tolist()
+        detail_rows = detail_data.iloc[start_idx:end_idx, : CLOSE_IDX + 1].values.tolist()
+        signals = [
+            row[LONG_IDX],
+            row[ELONG_IDX],
+            row[SHORT_IDX],
+            row[ESHORT_IDX],
+            row[ENTER_TAG_IDX],
+            row[EXIT_TAG_IDX],
+        ]
+        return [candle + signals for candle in detail_rows]
 
     def _time_generator(self, start_date: datetime, end_date: datetime):
         current_time = start_date + self.timeframe_td

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1542,6 +1542,7 @@ class Backtesting:
             row[ENTER_TAG_IDX],
             row[EXIT_TAG_IDX],
         ]
+        # Column sequence per row must correspond to HEADERS
         return [candle + signals for candle in detail_rows]
 
     def _time_generator(self, start_date: datetime, end_date: datetime):


### PR DESCRIPTION
This change was developed with AI assistance (Claude Code). I reviewed the final diff and ran the verification described below myself.

## Summary

`get_detail_data` (used only with `--timeframe-detail`) no longer broadcasts the six constant entry/exit signal and tag values into DataFrame columns before converting to a list; it slices the OHLCV columns and appends the constants to each row directly.

Follow-up to #13219.

## Quick changelog

- Replace the six per-column `.loc` set-item broadcasts in `get_detail_data` with a single OHLCV slice plus per-row append of the constant signal/tag values.
- No behaviour change: same rows, same values, same Python types out.
- Only affects detail backtests (`--timeframe-detail`); non-detail backtests never call this path.

## What's new?

**What and why.** `get_detail_data` copied the detail-candle slice, broadcast the six entry/exit signal and tag values into DataFrame columns via `.loc`, then converted the frame to a list. The six values are constant across every detail candle of a given main candle (they come from the single main row), so they do not need to be materialised as columns. The new code slices only the canonical OHLCV columns by position and appends the six constant values to each row list directly, avoiding the per-column DataFrame writes entirely.

**Correctness.** Output is verified identical:

- `tests/optimize/test_backtesting.py::test_get_detail_data` compares `get_detail_data` against an independent boolean-mask oracle over the half-open window and still passes; 32 detail-related backtesting tests pass in total.
- Separately cross-checked old vs new over ~223k real detail windows: every element identical in value and in Python type. The date comes back as a pandas `Timestamp` and OHLCV as Python `float` in both paths, because the slice still includes the float64 columns so `.values` stays an object array.
- A full 2-month 1m-detail BTC/USDT:USDT futures backtest produced identical trades (2547 trades, identical across every column).

**Performance.** On a deliberately high-trade-count benchmark — BTC/USDT:USDT futures, 2 months, `--timeframe-detail 1m` — end-to-end wall time went from 62.8s to 20.5s on one machine, roughly 3x. This is strategy-dependent: the win scales with how many detail candles are materialised, so a strategy with few or short trades sees little and one with many long-held trades sees more. It is not a universal figure. Non-detail backtests are unaffected since the function is not called without `--timeframe-detail`.

**Assumption introduced.** The new code selects the OHLCV columns by position (`iloc[:, :CLOSE_IDX + 1]`), whereas the original selected them by name (`detail_data[HEADERS]`). This assumes `detail_data` keeps the canonical column order `date, open, high, low, close`. That holds in freqtrade today because detail frames are raw OHLCV loaded by the data handler — strategies populate indicators on the main timeframe, not on the detail frame — but it is a positional assumption worth stating explicitly.