### PR TITLE
perf(backtest): slice funding-fee window with searchsorted instead of a full-frame mask

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -19,7 +19,7 @@ import ccxt
 import ccxt.pro as ccxt_pro
 from ccxt import TICK_SIZE
 from dateutil import parser
-from pandas import DataFrame, concat
+from pandas import DataFrame, Timestamp, concat
 
 from freqtrade.configuration import remove_exchange_credentials
 from freqtrade.constants import (
@@ -3963,7 +3963,11 @@ class Exchange:
         fees: float = 0
 
         if not df.empty:
-            df1 = df[(df["date"] >= open_date) & (df["date"] <= close_date)]
+            dates = df["date"]
+            unit = dates.dtype.unit
+            lo = Timestamp(open_date).ceil(unit).as_unit(unit)
+            hi = Timestamp(close_date).floor(unit).as_unit(unit)
+            df1 = df.iloc[dates.searchsorted(lo, "left") : dates.searchsorted(hi, "right")]
             fees = sum(df1["open_fund"] * df1["open_mark"] * amount)
         if isnan(fees):
             fees = 0.0

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -3965,6 +3965,9 @@ class Exchange:
         if not df.empty:
             dates = df["date"]
             unit = dates.dtype.unit
+            # Timestamps must be converted to column unit for dry/live mode
+            # where open/close dates can have microsecond precision - but the column may not have
+            # that precision.
             lo = Timestamp(open_date).ceil(unit).as_unit(unit)
             hi = Timestamp(close_date).floor(unit).as_unit(unit)
             df1 = df.iloc[dates.searchsorted(lo, "left") : dates.searchsorted(hi, "right")]


### PR DESCRIPTION
## Summary

Replace the full-frame boolean mask in `calculate_funding_fees` with a `searchsorted` range slice on the sorted `date` column.

This change was developed with AI assistance (Claude Code). I reviewed the final diff and ran the verification described below myself before opening the PR.

Follow-up to #13219 (same searchsorted-on-a-sorted-date-column idea, applied here to the funding-fee window instead of the detail-candle window).

## Quick changelog

- `calculate_funding_fees` now locates the `[open_date, close_date]` window via `searchsorted` and slices with `iloc`, instead of building two full-length boolean Series and a fancy-index.
- Inclusive bounds are aligned to the `date` column resolution (ceil the lower bound, floor the upper bound) so the slice reproduces the original mask exactly.
- Fee summation is unchanged (still `sum()` over the same rows in the same order).
- Imports `Timestamp` from pandas.

## What's new?

`calculate_funding_fees` is called on the funding path during futures backtesting. The previous implementation built two full-length boolean Series and a boolean fancy-index on every call:

```python
df1 = df[(df["date"] >= open_date) & (df["date"] <= close_date)]
```

The combined funding/mark frame is date-sorted, so the closed `[open_date, close_date]` window is a contiguous slice that `searchsorted` locates in O(log n):

```python
dates = df["date"]
unit = dates.dtype.unit
lo = Timestamp(open_date).ceil(unit).as_unit(unit)
hi = Timestamp(close_date).floor(unit).as_unit(unit)
df1 = df.iloc[dates.searchsorted(lo, "left") : dates.searchsorted(hi, "right")]
```

The bounds are aligned to the column's resolution before searching: ceil the inclusive lower bound, floor the inclusive upper bound. This reproduces `(date >= open_date) & (date <= close_date)` exactly even when a trade date carries finer resolution than the funding frame — for example a `close_date` with sub-frame resolution, where flooring keeps the boundary candle that a raw `searchsorted` against a finer timestamp would otherwise handle incorrectly.

**Correctness.** Output is identical to the old code. The existing parametrized tests `tests/exchange/test_exchange.py::test_calculate_funding_fees` and `test_combine_funding_and_mark` pass (25 tests). I separately cross-checked old vs new over 10k+ real trade windows — including off-grid dates, duplicate timestamps, zero-width and reversed windows, and a finer-than-frame `close_date` — and got bit-identical fees in every case, and verified the ceil/floor boundary alignment reproduces the inclusive mask across 3600 boundary cases.

**Performance.** Roughly 1.5x faster per call in a microbenchmark of the funding path. This is a per-call win only; funding-fee calculation is a small fraction of total backtest runtime, so the end-to-end effect is modest and shows up only on futures backtests that produce many open-trade funding fires. The speedup is strategy-dependent — it scales with how many funding fires a strategy generates — and should not be read as a general backtest speedup.

**Assumption introduced.** The new code assumes `df["date"]` is a sorted `datetime64` (or tz-aware `datetime64`) column. The old boolean mask was order- and dtype-agnostic; the slice is not. Both hold at the call sites: `combine_funding_and_mark` merges with the already-sorted `mark_rates` frame as the left operand (pandas `merge` preserves left-key order), and loaded OHLCV dates are `datetime64[ms, UTC]`. This is the same sorted-date invariant the detail-window selection in `get_detail_data` already relies on via `searchsorted`.