### PR TITLE
perf(backtest): reuse current_profit_best in stoploss check, drop a redundant calc

### DIFF
--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -1448,6 +1448,7 @@ class IStrategy(ABC, HyperStrategyMixin):
             force_stoploss=force_stoploss,
             low=low,
             high=high,
+            bound_profit=current_profit_best,
         )
 
         # if enter signal and ignore_roi is set, we don't need to evaluate min_roi.
@@ -1522,6 +1523,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         force_stoploss: float,
         low: float | None = None,
         high: float | None = None,
+        bound_profit: float | None = None,
         after_fill: bool = False,
     ) -> None:
         """
@@ -1529,6 +1531,8 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_profit: current profit as ratio
         :param low: Low value of this candle, only set in backtesting
         :param high: High value of this candle, only set in backtesting
+        :param bound_profit: profit at the candle bound (high for long, low for short);
+            computed on demand when None.
         """
         if after_fill and not self._ft_stop_uses_after_fill:
             # Skip if the strategy doesn't support after fill.
@@ -1547,7 +1551,8 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         # Make sure current_profit is calculated using high for backtesting.
         bound = low if trade.is_short else high
-        bound_profit = current_profit if not bound else trade.calc_profit_ratio(bound)
+        if bound_profit is None:
+            bound_profit = current_profit if not bound else trade.calc_profit_ratio(bound)
         if self.use_custom_stoploss and dir_correct:
             stop_loss_value_custom = strategy_safe_wrapper(
                 self.custom_stoploss, default_retval=None, supress_error=True
@@ -1596,6 +1601,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         force_stoploss: float,
         low: float | None = None,
         high: float | None = None,
+        bound_profit: float | None = None,
     ) -> ExitCheckTuple:
         """
         Based on current profit of the trade and configured (trailing) stoploss,
@@ -1603,9 +1609,18 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_profit: current profit as ratio
         :param low: Low value of this candle, only set in backtesting
         :param high: High value of this candle, only set in backtesting
+        :param bound_profit: profit at the candle bound, forwarded to ft_stoploss_adjust;
+            computed on demand when None.
         """
         self.ft_stoploss_adjust(
-            current_rate, trade, current_time, current_profit, force_stoploss, low, high
+            current_rate,
+            trade,
+            current_time,
+            current_profit,
+            force_stoploss,
+            low,
+            high,
+            bound_profit=bound_profit,
         )
 
         sl_higher_long = trade.stop_loss >= (low or current_rate) and not trade.is_short

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -1531,8 +1531,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_profit: current profit as ratio
         :param low: Low value of this candle, only set in backtesting
         :param high: High value of this candle, only set in backtesting
-        :param bound_profit: profit at the candle bound (high for long, low for short);
-            computed on demand when None.
+        :param bound_profit: profit at the candle bound (high for long, low for short)
         """
         if after_fill and not self._ft_stop_uses_after_fill:
             # Skip if the strategy doesn't support after fill.
@@ -1551,6 +1550,10 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         # Make sure current_profit is calculated using high for backtesting.
         bound = low if trade.is_short else high
+        # should_exit forwards bound_profit (its current_profit_best); in dry/live, where
+        # low/high are None, that already equals current_profit. It's only None when called
+        # from the after-fill paths that don't forward it -- and those pass no candle bound,
+        # so this recompute likewise yields current_profit there.
         if bound_profit is None:
             bound_profit = current_profit if not bound else trade.calc_profit_ratio(bound)
         if self.use_custom_stoploss and dir_correct:
@@ -1609,8 +1612,7 @@ class IStrategy(ABC, HyperStrategyMixin):
         :param current_profit: current profit as ratio
         :param low: Low value of this candle, only set in backtesting
         :param high: High value of this candle, only set in backtesting
-        :param bound_profit: profit at the candle bound, forwarded to ft_stoploss_adjust;
-            computed on demand when None.
+        :param bound_profit: profit at the candle bound, forwarded to ft_stoploss_adjust
         """
         self.ft_stoploss_adjust(
             current_rate,

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -647,32 +647,29 @@ def test_ft_stoploss_reached(
 @pytest.mark.parametrize(
     "trailing,custom_stop",
     [
-        pytest.param(True, None, id="trailing"),
-        pytest.param(
-            False,
-            lambda current_profit, **kwargs: -0.02 if current_profit > 0.05 else -0.04,
-            id="custom",
-        ),
-        pytest.param(
-            True,
-            lambda current_profit, **kwargs: -0.02 if current_profit > 0.05 else -0.04,
-            id="trailing+custom",
-        ),
+        pytest.param(True, False, id="trailing"),
+        pytest.param(False, True, id="custom"),
+        pytest.param(True, True, id="trailing+custom"),
     ],
 )
 def test_should_exit_bound_profit_reuse(default_conf, fee, is_short, trailing, custom_stop) -> None:
-    """should_exit's forwarded bound_profit must adjust the stop identically to the
-    on-demand fallback (bound_profit=None). Only stoploss test with a truthy candle bound."""
+    """should_exit forwards the candle-bound profit it already computed into the stoploss
+    check; that must adjust the stop identically to ft_stoploss_adjust recomputing it
+    (bound_profit=None). This is the only stoploss test that sets a candle bound (low/high)."""
     strategy = StrategyResolver.load_strategy(default_conf)
     strategy.trailing_stop = trailing
     strategy.trailing_stop_positive = 0.01
-    strategy.use_custom_stoploss = custom_stop is not None
-    if custom_stop is not None:
-        strategy.custom_stoploss = custom_stop
+    strategy.use_custom_stoploss = custom_stop
+    if custom_stop:
+        # Profit-sensitive stop: a wrong forwarded profit lands on the wrong branch.
+        strategy.custom_stoploss = lambda current_profit, **kwargs: (
+            -0.02 if current_profit > 0.05 else -0.04
+        )
 
     now = dt_now()
     current_rate = 1.0
-    # Favorable, truthy bound -> caller derives current_profit_best from it, not current_rate.
+    # Favorable candle bound (above open for a long, below for a short), so the bound profit
+    # differs from the profit at current_rate and the reuse path is actually exercised.
     bound_rate = 0.90 if is_short else 1.10
     low = bound_rate if is_short else None
     high = None if is_short else bound_rate
@@ -696,11 +693,11 @@ def test_should_exit_bound_profit_reuse(default_conf, fee, is_short, trailing, c
         trade.adjust_min_max_rates(trade.open_rate, trade.open_rate)
         return trade
 
-    # Optimized: real caller forwards current_profit_best as bound_profit.
+    # should_exit forwards its precomputed bound profit into the stoploss check.
     trade_opt = make_trade()
     strategy.should_exit(trade_opt, current_rate, now, enter=False, exit_=False, low=low, high=high)
 
-    # Fallback: bound_profit=None -> ft_stoploss_adjust recomputes it (develop behaviour).
+    # With bound_profit=None, ft_stoploss_adjust recomputes the bound profit from low/high itself.
     trade_ref = make_trade()
     trade_ref.adjust_min_max_rates(high or current_rate, low or current_rate)
     strategy.ft_stoploss_reached(
@@ -713,10 +710,10 @@ def test_should_exit_bound_profit_reuse(default_conf, fee, is_short, trailing, c
         high=high,
     )
 
-    # (1) should_exit's current_profit_best matches the recompute.
+    # (1) Forwarding the bound profit lands on the same stop as recomputing it.
     assert trade_opt.stop_loss == trade_ref.stop_loss
 
-    # (2) Explicit bound_profit must equal recomputing it.
+    # (2) Passing bound_profit explicitly matches the recompute too.
     trade_explicit = make_trade()
     trade_explicit.adjust_min_max_rates(high or current_rate, low or current_rate)
     bound_best = trade_explicit.calc_profit_ratio((low if is_short else high) or current_rate)
@@ -732,7 +729,8 @@ def test_should_exit_bound_profit_reuse(default_conf, fee, is_short, trailing, c
     )
     assert trade_explicit.stop_loss == trade_ref.stop_loss
 
-    # (3) Non-vacuous: the truthy bound must move the stop vs the no-bound case.
+    # (3) Guard against a vacuous test: with no candle bound (low/high None) the stop must
+    # land somewhere different, otherwise (1) and (2) would hold even if the bound were ignored.
     trade_nobound = make_trade()
     strategy.ft_stoploss_reached(
         current_rate=current_rate,

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -643,6 +643,109 @@ def test_ft_stoploss_reached(
     strategy.custom_stoploss = original_stopvalue
 
 
+@pytest.mark.parametrize("is_short", [False, True])
+@pytest.mark.parametrize(
+    "trailing,custom_stop",
+    [
+        pytest.param(True, None, id="trailing"),
+        pytest.param(
+            False,
+            lambda current_profit, **kwargs: -0.02 if current_profit > 0.05 else -0.04,
+            id="custom",
+        ),
+        pytest.param(
+            True,
+            lambda current_profit, **kwargs: -0.02 if current_profit > 0.05 else -0.04,
+            id="trailing+custom",
+        ),
+    ],
+)
+def test_should_exit_bound_profit_reuse(default_conf, fee, is_short, trailing, custom_stop) -> None:
+    """should_exit's forwarded bound_profit must adjust the stop identically to the
+    on-demand fallback (bound_profit=None). Only stoploss test with a truthy candle bound."""
+    strategy = StrategyResolver.load_strategy(default_conf)
+    strategy.trailing_stop = trailing
+    strategy.trailing_stop_positive = 0.01
+    strategy.use_custom_stoploss = custom_stop is not None
+    if custom_stop is not None:
+        strategy.custom_stoploss = custom_stop
+
+    now = dt_now()
+    current_rate = 1.0
+    # Favorable, truthy bound -> caller derives current_profit_best from it, not current_rate.
+    bound_rate = 0.90 if is_short else 1.10
+    low = bound_rate if is_short else None
+    high = None if is_short else bound_rate
+
+    def make_trade() -> Trade:
+        trade = Trade(
+            pair="ETH/BTC",
+            stake_amount=0.01,
+            amount=1,
+            open_date=now - timedelta(hours=1),
+            fee_open=fee.return_value,
+            fee_close=fee.return_value,
+            exchange="binance",
+            open_rate=1,
+            is_short=is_short,
+            leverage=1.0,
+            price_precision=4,
+            precision_mode=2,
+            precision_mode_price=2,
+        )
+        trade.adjust_min_max_rates(trade.open_rate, trade.open_rate)
+        return trade
+
+    # Optimized: real caller forwards current_profit_best as bound_profit.
+    trade_opt = make_trade()
+    strategy.should_exit(trade_opt, current_rate, now, enter=False, exit_=False, low=low, high=high)
+
+    # Fallback: bound_profit=None -> ft_stoploss_adjust recomputes it (develop behaviour).
+    trade_ref = make_trade()
+    trade_ref.adjust_min_max_rates(high or current_rate, low or current_rate)
+    strategy.ft_stoploss_reached(
+        current_rate=current_rate,
+        trade=trade_ref,
+        current_time=now,
+        current_profit=trade_ref.calc_profit_ratio(current_rate),
+        force_stoploss=0,
+        low=low,
+        high=high,
+    )
+
+    # (1) should_exit's current_profit_best matches the recompute.
+    assert trade_opt.stop_loss == trade_ref.stop_loss
+
+    # (2) Explicit bound_profit must equal recomputing it.
+    trade_explicit = make_trade()
+    trade_explicit.adjust_min_max_rates(high or current_rate, low or current_rate)
+    bound_best = trade_explicit.calc_profit_ratio((low if is_short else high) or current_rate)
+    strategy.ft_stoploss_reached(
+        current_rate=current_rate,
+        trade=trade_explicit,
+        current_time=now,
+        current_profit=trade_explicit.calc_profit_ratio(current_rate),
+        force_stoploss=0,
+        low=low,
+        high=high,
+        bound_profit=bound_best,
+    )
+    assert trade_explicit.stop_loss == trade_ref.stop_loss
+
+    # (3) Non-vacuous: the truthy bound must move the stop vs the no-bound case.
+    trade_nobound = make_trade()
+    strategy.ft_stoploss_reached(
+        current_rate=current_rate,
+        trade=trade_nobound,
+        current_time=now,
+        current_profit=trade_nobound.calc_profit_ratio(current_rate),
+        force_stoploss=0,
+        low=None,
+        high=None,
+    )
+    assert trade_opt.stop_loss != trade_nobound.stop_loss
+
+
 def test_custom_exit(default_conf, fee, caplog) -> None:
     strategy = StrategyResolver.load_strategy(default_conf)
     trade = Trade(


### PR DESCRIPTION
I used AI assistance to write and verify this change, and I've reviewed it myself and reproduced the numbers below.

## Summary

In backtesting, `should_exit` already computes the candle-bound profit; reuse it in the stoploss check instead of computing `calc_profit_ratio` on the same bound a second time.

Issue: N/A (standalone backtest perf improvement).

## Quick changelog

- `should_exit` forwards its already-computed `current_profit_best` to `ft_stoploss_adjust` as a new optional `bound_profit` argument.
- `bound_profit` defaults to `None`; when `None`, `ft_stoploss_adjust` recomputes it exactly as before, so every other caller is unchanged.
- Adds a unit test covering the truthy-candle-bound path.

## What's new?

`should_exit` computes `current_profit_best = calc_profit_ratio((low if short else high) or rate)` and uses it for the ROI check. `ft_stoploss_adjust` then independently recomputed the same `calc_profit_ratio(bound)` for the trailing / custom-stoploss check. This passes the value down so it's only computed once.

Dry/live is unchanged. `should_exit` runs in dry/live as well, but there `low` and `high` are always `None` (only the backtest loop sets them), so `current_profit_best == current_profit`, the bound is `None`, and the new code yields exactly `current_profit` — same as before. The two direct callers of `ft_stoploss_adjust` (the live after-fill path and the backtest after-fill path) don't pass `bound_profit`, so they take the `None` default and run the unchanged recompute. The dedup only fires in backtesting, where the candle bound is set.

Output is identical. Backtesting StrategyTestV3 on the repo's own test data (BTC/USDT + XRP/USDT, 5m, 2025-11-24 to 2025-12-04) gives the same 34 trades on develop and this branch, with a byte-identical SHA-256 over the trade records.

On that run, `calc_profit_ratio` calls drop from 1436 to 980 (about 32% fewer), measured with cProfile. The exact saving is strategy- and range-dependent — it scales with the number of exit checks that see a truthy bound — so 32% is specific to this benchmark, not a universal figure.

Repro (USDT-stake spot config with a StaticPairList over BTC/USDT and XRP/USDT, data from `tests/testdata`):

```
python -m cProfile -o prof.out -m freqtrade backtesting \
  --strategy StrategyTestV3 --strategy-path tests/strategy/strats \
  --datadir tests/testdata --timeframe 5m --timerange 20251124-20251204
python -c "import pstats; s=pstats.Stats('prof.out'); \
  print(sum(v[0] for k,v in s.stats.items() if k[2]=='calc_profit_ratio'))"
```

## Tests

`test_should_exit_bound_profit_reuse` drives a truthy candle bound (high for a long, low for a short) across trailing and custom-stoploss strategies. The existing stoploss tests all use `low=None`/`high=None`, so this reuse branch was previously only hit by end-to-end backtest tests. The test asserts the optimized path adjusts the stop identically to the on-demand fallback (`bound_profit=None`), and a profit-sensitive `custom_stoploss` makes that assertion sensitive to a wrong forwarded value.
