### PR TITLE
perf(backtest): cache runmode gate for per-candle wallet capture

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -148,6 +148,8 @@ class Backtesting:
 
         self.dataprovider = DataProvider(self.config, self.exchange)
 
+        self._capture_wallet_enabled = self.dataprovider.runmode == RunMode.BACKTEST
+
         if self.config.get("strategy_list"):
             if self.config.get("freqai", {}).get("enabled", False):
                 logger.warning(
@@ -1695,7 +1697,7 @@ class Backtesting:
         """
         Capture the current wallet state.
         """
-        if self.dataprovider.runmode != RunMode.BACKTEST:
+        if not self._capture_wallet_enabled:
             return
         if total := self.wallets.get_total(currency):
             self.wallet_captures.append((current_time, currency, price, total))


### PR DESCRIPTION
## Summary

Cache the invariant runmode gate in `Backtesting` instead of rebuilding the `RunMode` enum on every per-candle wallet-capture call.

## Quick changelog

- Resolve `self._capture_wallet_enabled` once in `Backtesting.__init__` and check it in `_capture_wallet`, dropping the per-call `RunMode(...)` construction.

## What's new?

`_capture_wallet` snapshots wallet balances for the `wallet_summary` report, called roughly once per pair per candle. Each call evaluated `self.dataprovider.runmode != RunMode.BACKTEST`, and that property builds `RunMode(self._config.get("runmode", ...))` on every access. runmode does not change during a run, so this rebuilt the enum ~40k times per backtest for no reason.

`_capture_wallet` is called only from the backtest loop (`time_pair_generator`), not from dry/live, and the cached value equals `runmode == RunMode.BACKTEST` — so snapshots are taken in exactly the same modes as before.

Measurement (StrategyTestV3, 9 `*/BTC` pairs, 2018-01-10..30, 5m): ~159k fewer calls per run (cProfile counts). An interleaved single-process A/B of the old check vs the new one inside `backtest()` (40 reps each) shows ~5-6% on the inner loop. This is strategy/range-dependent — the saving scales with candles × pairs and is a smaller end-to-end share when indicator computation dominates. Trades and `wallet_summary` are byte-identical (SHA-256) vs develop on that run.
