### PR TITLE
[codex] Add native XCoin exchange adapter

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -50,3 +50,4 @@ from freqtrade.exchange.lbank import Lbank
 from freqtrade.exchange.luno import Luno
 from freqtrade.exchange.modetrade import Modetrade
 from freqtrade.exchange.okx import Myokx, Okx, Okxus
+from freqtrade.exchange.xcoin import Xcoin

--- a/freqtrade/exchange/check_exchange.py
+++ b/freqtrade/exchange/check_exchange.py
@@ -4,7 +4,7 @@ from freqtrade.constants import Config
 from freqtrade.enums import RunMode
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import available_exchanges, is_exchange_known_ccxt, validate_exchange
-from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS, SUPPORTED_EXCHANGES
+from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS, NATIVE_EXCHANGES, SUPPORTED_EXCHANGES
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,13 @@ def check_exchange(config: Config, check_for_bad: bool = True) -> bool:
             f"The following exchanges are available for Freqtrade: "
             f"{', '.join(available_exchanges())}"
         )
+
+    if exchange in NATIVE_EXCHANGES:
+        logger.info(
+            f'Exchange "{exchange}" uses a native Freqtrade adapter instead of ccxt. '
+            "Use it at your own discretion."
+        )
+        return True
 
     if not is_exchange_known_ccxt(exchange):
         raise OperationalException(

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -66,6 +66,10 @@ SUPPORTED_EXCHANGES = [
     "myokx",
 ]
 
+NATIVE_EXCHANGES = [
+    "xcoin",
+]
+
 # either the main, or replacement methods (array) is required
 EXCHANGE_HAS_REQUIRED: dict[str, list[str]] = {
     # Required / private

--- a/freqtrade/exchange/xcoin.py
+++ b/freqtrade/exchange/xcoin.py
@@ -1,0 +1,100 @@
+"""XCoin exchange subclass using the native XCoin REST API."""
+
+import logging
+import os
+from typing import Any
+
+from freqtrade.constants import ExchangeConfig
+from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exceptions import OperationalException
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+from freqtrade.exchange.xcoin_api import XCoinAsync, XCoinSync
+from freqtrade.exchange.xcoin_connector import XCOIN_DEFAULT_BASE_URL
+
+
+logger = logging.getLogger(__name__)
+
+
+class Xcoin(Exchange):
+    """XCoin exchange class.
+
+    XCoin is not provided by ccxt, so this subclass injects a small ccxt-like
+    REST wrapper while keeping Freqtrade's regular Exchange call path intact.
+    """
+
+    _ft_has: FtHas = {
+        "ohlcv_candle_limit": 1000,
+        "l2_limit_range_required": False,
+        "l2_limit_upper": 5000,
+        "order_time_in_force": ["GTC", "IOC", "FOK"],
+        "stoploss_on_exchange": False,
+        "tickers_have_bid_ask": True,
+        "tickers_have_price": True,
+        "exchange_has_overrides": {
+            "createMarketOrder": True,
+            "fetchMyTrades": False,
+            "fetchTrades": False,
+        },
+    }
+
+    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
+        (TradingMode.SPOT, MarginMode.NONE),
+    ]
+
+    def _init_ccxt(
+        self, exchange_config: ExchangeConfig, sync: bool, ccxt_kwargs: dict[str, Any]
+    ) -> XCoinSync:
+        if self.trading_mode != TradingMode.SPOT:
+            raise OperationalException("XCoin adapter currently supports spot trading only.")
+
+        live_enabled = exchange_config.get("xcoin_live_trading_enabled", False)
+        if not self._config.get("dry_run", True) and not live_enabled:
+            raise OperationalException(
+                "XCoin live trading is disabled. Set "
+                "`exchange.xcoin_live_trading_enabled=true` explicitly after dry-run testing."
+            )
+
+        api_key = os.environ.get("FREQTRADE__EXCHANGE__KEY") or os.environ.get("XCOIN_API_KEY")
+        api_secret = os.environ.get("FREQTRADE__EXCHANGE__SECRET") or os.environ.get(
+            "XCOIN_API_SECRET"
+        )
+        if not self._config.get("dry_run", True) and (not api_key or not api_secret):
+            raise OperationalException(
+                "XCoin live trading requires API credentials from environment variables "
+                "`FREQTRADE__EXCHANGE__KEY` and `FREQTRADE__EXCHANGE__SECRET`."
+            )
+
+        sanitized_ccxt_kwargs = {
+            key: value
+            for key, value in ccxt_kwargs.items()
+            if key
+            not in {
+                "apiKey",
+                "api_key",
+                "key",
+                "secret",
+                "password",
+                "privateKey",
+                "private_key",
+            }
+        }
+        wrapper_config = {
+            "apiKey": api_key or "",
+            "secret": api_secret or "",
+            "accountName": exchange_config.get("account_name")
+            or exchange_config.get("accountName")
+            or os.environ.get("XCOIN_ACCOUNT_NAME", ""),
+            "base_url": exchange_config.get("xcoin_base_url")
+            or exchange_config.get("base_url")
+            or XCOIN_DEFAULT_BASE_URL,
+            "timeout": exchange_config.get("xcoin_timeout", 10),
+        }
+        wrapper_config.update(sanitized_ccxt_kwargs)
+
+        return XCoinSync(wrapper_config) if sync else XCoinAsync(wrapper_config)
+
+    def close(self) -> None:
+        if api := getattr(self, "_api", None):
+            api.close()
+        super().close()

--- a/freqtrade/exchange/xcoin_api.py
+++ b/freqtrade/exchange/xcoin_api.py
@@ -1,0 +1,523 @@
+"""ccxt-like XCoin facade backed by the internal REST connector."""
+
+import asyncio
+from copy import deepcopy
+from typing import Any
+
+import ccxt
+from ccxt import DECIMAL_PLACES
+
+from freqtrade.exchange.xcoin_connector import (
+    XCOIN_DEFAULT_BASE_URL,
+    XCOIN_TIMEFRAMES,
+    XCoinClient,
+    ccxt_symbol_to_xcoin,
+    xcoin_symbol_to_ccxt,
+)
+
+
+__all__ = [
+    "XCOIN_DEFAULT_BASE_URL",
+    "XCOIN_HAS",
+    "XCOIN_TIMEFRAMES",
+    "XCoinAsync",
+    "XCoinSync",
+    "ccxt_symbol_to_xcoin",
+    "xcoin_symbol_to_ccxt",
+]
+
+
+XCOIN_HAS = {
+    "fetchOrder": True,
+    "fetchOpenOrder": False,
+    "fetchClosedOrder": False,
+    "fetchOpenOrders": True,
+    "fetchOrders": False,
+    "fetchBalance": True,
+    "fetchOHLCV": True,
+    "fetchTicker": True,
+    "fetchTickers": True,
+    "fetchL2OrderBook": True,
+    "fetchOrderBook": True,
+    "fetchMyTrades": False,
+    "fetchTrades": False,
+    "cancelOrder": True,
+    "createOrder": True,
+    "createLimitOrder": True,
+    "createMarketOrder": True,
+    "watchOHLCV": False,
+}
+
+XCOIN_STATUS_MAP = {
+    "new": "open",
+    "partially_filled": "open",
+    "filled": "closed",
+    "canceled": "canceled",
+    "partially_canceled": "canceled",
+}
+
+
+def _clean_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def _num(value: Any, fallback: float = 0.0) -> float:
+    result = _clean_float(value)
+    return fallback if result is None else result
+
+
+def _str_num(value: float | int | str | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+class XCoinSync:
+    """Small ccxt-compatible subset used by Freqtrade's Exchange base class."""
+
+    id = "xcoin"
+    name = "XCoin"
+    precisionMode = DECIMAL_PLACES
+    timeframes = XCOIN_TIMEFRAMES
+    features = {"spot": {"fetchOHLCV": {"limit": 1000}}}
+    has = XCOIN_HAS
+    session = None
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        self.client = XCoinClient(config)
+        self.apiKey = self.client.api_key
+        self.secret = self.client.api_secret
+        self.password = self.client.password
+        self.uid = self.client.uid
+        self.account_name = self.client.account_name
+        self.base_url = self.client.base_url
+        self.timeout = self.client.timeout
+        self.markets: dict[str, dict[str, Any]] = {}
+        self.markets_by_id: dict[str, dict[str, Any]] = {}
+        self.options = {
+            "createMarketBuyOrderRequiresPrice": False,
+            "timeframes": {"spot": XCOIN_TIMEFRAMES},
+        }
+
+    def milliseconds(self) -> int:
+        return self.client.milliseconds()
+
+    def iso8601(self, timestamp: int | None) -> str | None:
+        return ccxt.Exchange.iso8601(timestamp) if timestamp is not None else None
+
+    def set_markets_from_exchange(self, exchange: Any) -> None:
+        self.markets = deepcopy(exchange.markets)
+        self.markets_by_id = {
+            market["id"]: market for market in self.markets.values() if market.get("id")
+        }
+
+    def market_id(self, symbol: str) -> str:
+        if symbol in self.markets:
+            return self.markets[symbol]["id"]
+        return ccxt_symbol_to_xcoin(symbol)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        private: bool = False,
+    ) -> dict[str, Any]:
+        return self.client.request(method, path, params=params, data=data, private=private)
+
+    def _private_params(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.client.private_params(params)
+
+    def _parse_market(self, raw: dict[str, Any]) -> dict[str, Any]:
+        symbol = xcoin_symbol_to_ccxt(raw["symbol"])
+        order_params = raw.get("orderParameters") or {}
+        return {
+            "id": raw["symbol"],
+            "symbol": symbol,
+            "base": raw.get("baseCurrency"),
+            "quote": raw.get("quoteCurrency"),
+            "settle": raw.get("settleCurrency"),
+            "type": "spot",
+            "spot": raw.get("businessType") == "spot",
+            "margin": False,
+            "swap": False,
+            "future": False,
+            "active": raw.get("status") == "trading",
+            "precision": {
+                "amount": int(raw.get("quantityPrecision") or 8),
+                "price": int(raw.get("pricePrecision") or 8),
+            },
+            "limits": {
+                "amount": {
+                    "min": _clean_float(order_params.get("minOrderQty")),
+                    "max": _clean_float(order_params.get("maxLmtOrderQty")),
+                },
+                "price": {"min": _clean_float(raw.get("tickSize")), "max": None},
+                "cost": {
+                    "min": _clean_float(order_params.get("minOrderAmt")),
+                    "max": _clean_float(order_params.get("maxLmtOrderAmt")),
+                },
+            },
+            "maker": 0.001,
+            "taker": 0.001,
+            "info": raw,
+        }
+
+    def load_markets(
+        self, reload: bool = False, params: dict[str, Any] | None = None
+    ) -> dict[str, dict[str, Any]]:
+        if self.markets and not reload:
+            return self.markets
+        payload = self.client.public_symbols(params)
+        markets = {
+            market["symbol"]: market
+            for market in (self._parse_market(item) for item in payload.get("data", []))
+        }
+        self.markets = markets
+        self.markets_by_id = {market["id"]: market for market in markets.values()}
+        return markets
+
+    def _parse_ticker(
+        self,
+        raw: dict[str, Any],
+        *,
+        bid: float | None = None,
+        ask: float | None = None,
+        timestamp: int | None = None,
+    ) -> dict[str, Any]:
+        last = _clean_float(raw.get("lastPrice"))
+        symbol = xcoin_symbol_to_ccxt(raw["symbol"])
+        return {
+            "symbol": symbol,
+            "timestamp": timestamp,
+            "datetime": self.iso8601(timestamp),
+            "high": None,
+            "low": None,
+            "bid": bid if bid is not None else last,
+            "bidVolume": None,
+            "ask": ask if ask is not None else last,
+            "askVolume": None,
+            "vwap": None,
+            "open": None,
+            "close": last,
+            "last": last,
+            "previousClose": None,
+            "change": _clean_float(raw.get("priceChange")),
+            "percentage": _clean_float(raw.get("priceChangePercent")),
+            "average": None,
+            "baseVolume": _clean_float(raw.get("fillQty")),
+            "quoteVolume": _clean_float(raw.get("fillAmount")),
+            "info": raw,
+        }
+
+    def fetch_ticker(self, symbol: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        market_id = self.market_id(symbol)
+        payload = self.client.ticker_mini(market_id, params)
+        data = payload.get("data") or []
+        if not data:
+            raise ccxt.BadSymbol(f"XCoin ticker not found for {symbol}")
+        orderbook = self.fetch_l2_order_book(symbol, 1)
+        bid = orderbook["bids"][0][0] if orderbook["bids"] else None
+        ask = orderbook["asks"][0][0] if orderbook["asks"] else None
+        return self._parse_ticker(data[0], bid=bid, ask=ask, timestamp=_num(payload.get("ts"), 0))
+
+    def fetch_tickers(
+        self, symbols: list[str] | None = None, params: dict[str, Any] | None = None
+    ) -> dict[str, dict[str, Any]]:
+        market_id = self.market_id(symbols[0]) if symbols and len(symbols) == 1 else None
+        payload = self.client.ticker_mini(market_id, params)
+        tickers = {
+            ticker["symbol"]: ticker
+            for ticker in (
+                self._parse_ticker(item, timestamp=_num(payload.get("ts"), 0))
+                for item in payload.get("data", [])
+            )
+        }
+        if symbols:
+            symbols = [xcoin_symbol_to_ccxt(s) for s in symbols]
+            tickers = {symbol: ticker for symbol, ticker in tickers.items() if symbol in symbols}
+        return tickers
+
+    def _parse_depth_side(self, values: list[Any]) -> list[list[float]]:
+        if (
+            values
+            and isinstance(values[0], list)
+            and len(values) == 1
+            and isinstance(values[0][0], list)
+        ):
+            values = values[0]
+        return [[float(price), float(amount)] for price, amount in values]
+
+    def fetch_l2_order_book(
+        self, symbol: str, limit: int | None = 100, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        payload = self.client.depth(self.market_id(symbol), limit, params)
+        data = payload.get("data") or {}
+        timestamp = _num(payload.get("ts"), 0)
+        return {
+            "symbol": xcoin_symbol_to_ccxt(symbol),
+            "bids": self._parse_depth_side(data.get("bids") or []),
+            "asks": self._parse_depth_side(data.get("asks") or []),
+            "timestamp": timestamp,
+            "datetime": self.iso8601(timestamp),
+            "nonce": _clean_float(data.get("lastUpdateId")),
+        }
+
+    def fetch_order_book(
+        self, symbol: str, limit: int | None = 100, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return self.fetch_l2_order_book(symbol, limit, params)
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1m",
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[list[float]]:
+        if timeframe not in self.timeframes:
+            raise ccxt.BadRequest(f"Unsupported XCoin timeframe: {timeframe}")
+        payload = self.client.klines(
+            self.market_id(symbol),
+            self.timeframes[timeframe],
+            since=since,
+            limit=limit,
+            params=params,
+        )
+        candles = [
+            [
+                int(row[1]),
+                float(row[3]),
+                float(row[5]),
+                float(row[6]),
+                float(row[4]),
+                float(row[7]),
+            ]
+            for row in payload.get("data", [])
+        ]
+        return sorted(candles, key=lambda candle: candle[0])
+
+    def fetch_balance(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = self.client.balance(params)
+        balances: dict[str, Any] = {"info": payload, "free": {}, "used": {}, "total": {}}
+        for item in (payload.get("data") or {}).get("details", []):
+            currency = item["currency"]
+            free = _num(item.get("cashBalance"), 0.0)
+            used = _num(item.get("frozen"), 0.0)
+            total = _num(item.get("totalBalance"), free + used)
+            balances[currency] = {"free": free, "used": used, "total": total}
+            balances["free"][currency] = free
+            balances["used"][currency] = used
+            balances["total"][currency] = total
+        return balances
+
+    def _parse_order(
+        self,
+        raw: dict[str, Any],
+        *,
+        symbol: str | None = None,
+        amount: float | None = None,
+        price: float | None = None,
+        order_type: str | None = None,
+        side: str | None = None,
+        status: str | None = None,
+        timestamp: int | None = None,
+    ) -> dict[str, Any]:
+        symbol = xcoin_symbol_to_ccxt(raw.get("symbol") or symbol or "")
+        timestamp = int(raw.get("createTime") or timestamp or raw.get("ts") or self.milliseconds())
+        amount = _clean_float(raw.get("qty")) if raw.get("qty") is not None else amount
+        price = _clean_float(raw.get("price")) if raw.get("price") is not None else price
+        filled = _num(raw.get("totalFillQty"), 0.0)
+        average = _clean_float(raw.get("avgPrice"))
+        cost = _clean_float(raw.get("quoteQty"))
+        if cost is None and filled and average:
+            cost = filled * average
+        fee = self._parse_order_fee(raw, symbol)
+        return {
+            "id": raw.get("orderId"),
+            "clientOrderId": raw.get("clientOrderId") or None,
+            "timestamp": timestamp,
+            "datetime": self.iso8601(timestamp),
+            "lastTradeTimestamp": int(raw["updateTime"]) if raw.get("updateTime") else None,
+            "symbol": symbol,
+            "type": (raw.get("orderType") or order_type or "limit").lower(),
+            "timeInForce": (raw.get("timeInForce") or "").upper() or None,
+            "side": raw.get("side") or side,
+            "price": price,
+            "average": average,
+            "amount": amount,
+            "filled": filled,
+            "remaining": max((amount or 0.0) - filled, 0.0) if amount is not None else None,
+            "cost": cost,
+            "status": status or XCOIN_STATUS_MAP.get(raw.get("status"), raw.get("status", "open")),
+            "fee": fee,
+            "trades": [],
+            "info": raw,
+        }
+
+    def _parse_order_fee(self, raw: dict[str, Any], symbol: str) -> dict[str, Any] | None:
+        market = self.markets.get(symbol, {})
+        base = market.get("base")
+        quote = market.get("quote")
+        quote_fee = _clean_float(raw.get("quoteFee"))
+        if quote_fee:
+            return {"currency": quote, "cost": abs(quote_fee), "rate": None}
+        base_fee = _clean_float(raw.get("baseFee"))
+        if base_fee:
+            return {"currency": base, "cost": abs(base_fee), "rate": None}
+        return None
+
+    def create_order(
+        self,
+        symbol: str,
+        order_type: str,
+        side: str,
+        amount: float,
+        price: float | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        order_type = order_type.lower()
+        if order_type not in {"limit", "market", "post_only"}:
+            raise ccxt.InvalidOrder(
+                "XCoin adapter only supports limit/market/post_only spot orders"
+            )
+        if order_type in {"limit", "post_only"} and price is None:
+            raise ccxt.InvalidOrder("XCoin limit orders require a price")
+        params = params or {}
+        if order_type == "market":
+            time_in_force = "ioc"
+        else:
+            time_in_force = (
+                params.get("timeInForce") or params.get("time_in_force") or "gtc"
+            ).lower()
+        body = {
+            "symbol": self.market_id(symbol),
+            "side": side.lower(),
+            "orderType": order_type,
+            "qty": _str_num(amount),
+            "marketUnit": params.get("marketUnit") or params.get("market_unit") or "baseCoin",
+            "timeInForce": time_in_force,
+            "clientOrderId": params.get("clientOrderId"),
+        }
+        if order_type in {"limit", "post_only"}:
+            body["price"] = _str_num(price)
+        payload = self.client.place_order(body)
+        raw = {
+            **(payload.get("data") or {}),
+            "symbol": self.market_id(symbol),
+            "side": side.lower(),
+            "orderType": order_type,
+            "qty": _str_num(amount),
+            "price": _str_num(price),
+            "status": "new",
+            "ts": payload.get("ts"),
+        }
+        return self._parse_order(
+            raw,
+            symbol=symbol,
+            amount=amount,
+            price=price,
+            order_type=order_type,
+            side=side.lower(),
+            status="open",
+            timestamp=int(payload.get("ts") or self.milliseconds()),
+        )
+
+    def cancel_order(
+        self, order_id: str, symbol: str | None = None, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        payload = self.client.cancel_order(
+            {
+                "symbol": self.market_id(symbol or ""),
+                "orderFilter": "order",
+                "orderId": order_id,
+                **(params or {}),
+            }
+        )
+        raw = {
+            **(payload.get("data") or {}),
+            "symbol": self.market_id(symbol or ""),
+            "status": "canceled",
+            "ts": payload.get("ts"),
+        }
+        return self._parse_order(
+            raw,
+            symbol=symbol,
+            status="canceled",
+            timestamp=int(payload["ts"]),
+        )
+
+    def fetch_order(
+        self, order_id: str, symbol: str | None = None, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        payload = self.client.order_info(
+            {"orderId": order_id, "orderFilter": "order", **(params or {})}
+        )
+        return self._parse_order(payload.get("data") or {}, symbol=symbol)
+
+    def fetch_open_orders(
+        self,
+        symbol: str | None = None,
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        payload = self.client.open_orders(
+            {
+                "businessType": "spot",
+                "symbol": self.market_id(symbol) if symbol else None,
+                "orderFilter": "order",
+                **(params or {}),
+            }
+        )
+        orders = [self._parse_order(item) for item in payload.get("data", [])]
+        return orders[:limit] if limit else orders
+
+    def calculate_fee(
+        self,
+        symbol: str,
+        side: str,
+        amount: float,
+        price: float,
+        takerOrMaker: str = "maker",
+        params: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        market = self.markets.get(symbol, {})
+        rate = _num(market.get(takerOrMaker), 0.001)
+        return {
+            "type": takerOrMaker,
+            "currency": market.get("quote"),
+            "rate": rate,
+            "cost": amount * price * rate,
+        }
+
+    def close(self) -> None:
+        self.client.close()
+
+
+class XCoinAsync(XCoinSync):
+    """Async facade used by Freqtrade candle and market refresh paths."""
+
+    async def load_markets(
+        self, reload: bool = False, params: dict[str, Any] | None = None
+    ) -> dict[str, dict[str, Any]]:
+        return await asyncio.to_thread(super().load_markets, reload, params)
+
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1m",
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[list[float]]:
+        return await asyncio.to_thread(super().fetch_ohlcv, symbol, timeframe, since, limit, params)
+
+    async def close(self) -> None:
+        super().close()

--- a/freqtrade/exchange/xcoin_connector/__init__.py
+++ b/freqtrade/exchange/xcoin_connector/__init__.py
@@ -1,0 +1,17 @@
+"""Internal XCoin connector primitives used by the Freqtrade adapter."""
+
+from freqtrade.exchange.xcoin_connector.client import XCoinClient
+from freqtrade.exchange.xcoin_connector.constants import (
+    XCOIN_DEFAULT_BASE_URL,
+    XCOIN_TIMEFRAMES,
+)
+from freqtrade.exchange.xcoin_connector.symbols import ccxt_symbol_to_xcoin, xcoin_symbol_to_ccxt
+
+
+__all__ = [
+    "XCOIN_DEFAULT_BASE_URL",
+    "XCOIN_TIMEFRAMES",
+    "XCoinClient",
+    "ccxt_symbol_to_xcoin",
+    "xcoin_symbol_to_ccxt",
+]

--- a/freqtrade/exchange/xcoin_connector/client.py
+++ b/freqtrade/exchange/xcoin_connector/client.py
@@ -1,0 +1,209 @@
+"""Low-level XCoin REST connector.
+
+This module intentionally stays free of Freqtrade exchange semantics. It owns
+HTTP transport, authentication, response validation, endpoint paths, and small
+request-shaping helpers. The ccxt-like response parsing lives in xcoin_api.py.
+"""
+
+import hmac
+import json
+import time
+from hashlib import sha256
+from typing import Any
+from urllib.parse import urlencode
+
+import ccxt
+import requests
+
+from freqtrade.exchange.xcoin_connector.constants import XCOIN_DEFAULT_BASE_URL
+
+
+class XCoinClient:
+    """Thin XCoin REST client used by the Freqtrade exchange facade."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        config = config or {}
+        self.api_key = config.get("apiKey") or ""
+        self.api_secret = config.get("secret") or ""
+        self.password = config.get("password") or ""
+        self.uid = config.get("uid") or ""
+        self.account_name = config.get("accountName") or config.get("account_name") or ""
+        self.base_url = (config.get("base_url") or XCOIN_DEFAULT_BASE_URL).rstrip("/")
+        self.timeout = config.get("timeout", 10)
+        self._http = requests.Session()
+
+    def milliseconds(self) -> int:
+        return int(time.time() * 1000)
+
+    def close(self) -> None:
+        self._http.close()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        private: bool = False,
+    ) -> dict[str, Any]:
+        query = self._query(params)
+        body = self._body(data)
+        headers = {"Content-Type": "application/json"}
+        if private:
+            if not self.api_key or not self.api_secret:
+                raise ccxt.AuthenticationError("XCoin API credentials are required")
+            timestamp = str(self.milliseconds())
+            headers.update(
+                {
+                    "X-ACCESS-APIKEY": self.api_key,
+                    "X-ACCESS-TIMESTAMP": timestamp,
+                    "X-ACCESS-SIGN": self._sign(timestamp, method, path, query, body),
+                }
+            )
+
+        url = f"{self.base_url}{path}{query}"
+        try:
+            response = self._http.request(
+                method.upper(),
+                url,
+                data=body or None,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as e:
+            raise ccxt.NetworkError(str(e)) from e
+
+        if response.status_code >= 500:
+            raise ccxt.ExchangeNotAvailable(f"XCoin HTTP {response.status_code}")
+        if response.status_code != 200:
+            raise ccxt.ExchangeError(f"XCoin HTTP {response.status_code}: {response.text}")
+        try:
+            payload = response.json()
+        except ValueError as e:
+            raise ccxt.ExchangeError("XCoin returned invalid JSON") from e
+        return self._handle_response(payload)
+
+    def public_symbols(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.request(
+            "GET",
+            "/v2/public/symbols",
+            params={"businessType": "spot", **(params or {})},
+        )
+
+    def ticker_mini(
+        self, symbol: str | None = None, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        request_params = {"businessType": "spot", **(params or {})}
+        if symbol:
+            request_params["symbol"] = symbol
+        return self.request("GET", "/v1/market/ticker/mini", params=request_params)
+
+    def depth(
+        self, symbol: str, limit: int | None = 100, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return self.request(
+            "GET",
+            "/v1/market/depth",
+            params={
+                "businessType": "spot",
+                "symbol": symbol,
+                "limit": limit or 100,
+                **(params or {}),
+            },
+        )
+
+    def klines(
+        self,
+        symbol: str,
+        period: str,
+        *,
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        request_params = {
+            "businessType": "spot",
+            "symbol": symbol,
+            "period": period,
+            "limit": min(limit or 1000, 1000),
+            **(params or {}),
+        }
+        if since:
+            request_params["startTime"] = since
+        return self.request("GET", "/v1/market/kline", params=request_params)
+
+    def balance(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.request(
+            "GET",
+            "/v1/account/balance",
+            params=self.private_params(params),
+            private=True,
+        )
+
+    def place_order(self, data: dict[str, Any]) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            "/v2/trade/order",
+            data=self.private_params(data),
+            private=True,
+        )
+
+    def cancel_order(self, data: dict[str, Any]) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            "/v1/trade/cancelOrder",
+            data=self.private_params(data),
+            private=True,
+        )
+
+    def order_info(self, params: dict[str, Any]) -> dict[str, Any]:
+        return self.request(
+            "GET",
+            "/v2/trade/order/info",
+            params=self.private_params(params),
+            private=True,
+        )
+
+    def open_orders(self, params: dict[str, Any]) -> dict[str, Any]:
+        return self.request(
+            "GET",
+            "/v2/trade/openOrders",
+            params=self.private_params(params),
+            private=True,
+        )
+
+    def private_params(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        result = dict(params or {})
+        if self.account_name and "accountName" not in result:
+            result["accountName"] = self.account_name
+        return result
+
+    def _sign(self, timestamp: str, method: str, path: str, query: str, body: str) -> str:
+        message = f"{timestamp}{method.upper()}{path}{query}{body}"
+        return hmac.new(self.api_secret.encode(), message.encode(), sha256).hexdigest()
+
+    def _query(self, params: dict[str, Any] | None) -> str:
+        clean = {k: v for k, v in (params or {}).items() if v is not None}
+        return f"?{urlencode(sorted(clean.items()))}" if clean else ""
+
+    def _body(self, data: dict[str, Any] | None) -> str:
+        if not data:
+            return ""
+        clean = {k: v for k, v in data.items() if v is not None}
+        return json.dumps(clean, separators=(",", ":"), ensure_ascii=False)
+
+    def _handle_response(self, payload: dict[str, Any]) -> dict[str, Any]:
+        code = str(payload.get("code", "0"))
+        if code == "0":
+            return payload
+        msg = payload.get("msg") or payload.get("message") or "XCoin API error"
+        if code in {"11004", "14001"}:
+            raise ccxt.DDoSProtection(msg)
+        if code in {"40013", "20010"}:
+            raise ccxt.OrderNotFound(msg)
+        if code in {"60103", "60104", "60106"}:
+            raise ccxt.InsufficientFunds(msg)
+        if code.startswith("5") or code.startswith("4"):
+            raise ccxt.InvalidOrder(msg)
+        raise ccxt.ExchangeError(f"{code}: {msg}")

--- a/freqtrade/exchange/xcoin_connector/constants.py
+++ b/freqtrade/exchange/xcoin_connector/constants.py
@@ -1,0 +1,21 @@
+"""Constants for the internal XCoin REST connector."""
+
+XCOIN_DEFAULT_BASE_URL = "https://api.xcoin.com/api"
+
+XCOIN_TIMEFRAMES = {
+    "1m": "1m",
+    "3m": "3m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1h",
+    "2h": "2h",
+    "4h": "4h",
+    "6h": "6h",
+    "8h": "8h",
+    "12h": "12h",
+    "1d": "1d",
+    "3d": "3d",
+    "1w": "1w",
+    "1M": "1M",
+}

--- a/freqtrade/exchange/xcoin_connector/symbols.py
+++ b/freqtrade/exchange/xcoin_connector/symbols.py
@@ -1,0 +1,18 @@
+"""Symbol conversion helpers for XCoin spot markets."""
+
+
+def xcoin_symbol_to_ccxt(symbol: str) -> str:
+    """Convert XCoin symbol format to Freqtrade/ccxt spot symbol format."""
+    if not symbol:
+        return symbol
+    if "/" in symbol:
+        return symbol
+    base, quote, *_ = symbol.split("-")
+    return f"{base}/{quote}"
+
+
+def ccxt_symbol_to_xcoin(symbol: str) -> str:
+    """Convert Freqtrade/ccxt spot symbol format to XCoin symbol format."""
+    if "-" in symbol and "/" not in symbol:
+        return symbol
+    return symbol.replace("/", "-")

--- a/tests/exchange/test_xcoin.py
+++ b/tests/exchange/test_xcoin.py
@@ -1,0 +1,379 @@
+from copy import deepcopy
+
+import pytest
+
+from freqtrade.enums import CandleType, RunMode
+from freqtrade.exchange import Xcoin
+from freqtrade.exchange.check_exchange import check_exchange
+from freqtrade.exchange.xcoin_connector import XCoinClient
+from freqtrade.resolvers.exchange_resolver import ExchangeResolver
+
+
+def _xcoin_config(default_conf: dict, *, dry_run: bool = True) -> dict:
+    conf = deepcopy(default_conf)
+    conf.update(
+        {
+            "dry_run": dry_run,
+            "stake_currency": "USDT",
+            "stake_amount": 25,
+            "timeframe": "5m",
+            "trading_mode": "spot",
+            "margin_mode": "",
+        }
+    )
+    conf["exchange"].update(
+        {
+            "name": "xcoin",
+            "pair_whitelist": ["BTC/USDT"],
+            "pair_blacklist": [],
+            "xcoin_live_trading_enabled": not dry_run,
+        }
+    )
+    return conf
+
+
+def _xcoin_response(method, path, params=None, data=None, private=False):
+    if path == "/v2/public/symbols":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": [
+                {
+                    "businessType": "spot",
+                    "symbol": "BTC-USDT",
+                    "quoteCurrency": "USDT",
+                    "baseCurrency": "BTC",
+                    "settleCurrency": "USDT",
+                    "tickSize": "0.01",
+                    "status": "trading",
+                    "pricePrecision": "2",
+                    "quantityPrecision": "6",
+                    "orderParameters": {
+                        "minOrderQty": "0.00001",
+                        "minOrderAmt": "5",
+                        "maxLmtOrderQty": "100",
+                        "maxLmtOrderAmt": "1000000",
+                    },
+                }
+            ],
+            "ts": "1732193257273",
+        }
+    if path == "/v1/market/ticker/mini":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": [
+                {
+                    "symbol": "BTC-USDT",
+                    "priceChange": "10",
+                    "priceChangePercent": "0.01",
+                    "lastPrice": "80000",
+                    "fillQty": "1.2",
+                    "fillAmount": "96000",
+                    "baseCurrency": "BTC",
+                }
+            ],
+            "ts": "1732193257273",
+        }
+    if path == "/v1/market/depth":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": {
+                "bids": [["79999.99", "0.5"]],
+                "asks": [["80000.01", "0.4"]],
+                "lastUpdateId": "5001",
+            },
+            "ts": "1732193257273",
+        }
+    if path == "/v1/market/kline":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": [
+                [
+                    "5m",
+                    "1732193400000",
+                    "1732193699999",
+                    "80100",
+                    "80200",
+                    "80300",
+                    "80000",
+                    "2.0",
+                    "160400",
+                    "10",
+                    "100",
+                    "0.001",
+                ],
+                [
+                    "5m",
+                    "1732193100000",
+                    "1732193399999",
+                    "80000",
+                    "80100",
+                    "80200",
+                    "79900",
+                    "1.5",
+                    "120150",
+                    "8",
+                    "100",
+                    "0.001",
+                ],
+            ],
+            "ts": "1732193700000",
+        }
+
+    assert private
+    if path == "/v1/account/balance":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": {
+                "details": [
+                    {
+                        "currency": "USDT",
+                        "totalBalance": "100",
+                        "cashBalance": "80",
+                        "frozen": "20",
+                    },
+                    {
+                        "currency": "BTC",
+                        "totalBalance": "0.5",
+                        "cashBalance": "0.4",
+                        "frozen": "0.1",
+                    },
+                ]
+            },
+            "ts": "1732193257273",
+        }
+    if path == "/v2/trade/order":
+        assert method == "POST"
+        assert data["symbol"] == "BTC-USDT"
+        assert data["side"] == "buy"
+        assert data["marketUnit"] == "baseCoin"
+        if data["orderType"] == "limit":
+            assert float(data["price"]) == 80000
+            assert data["timeInForce"] == "gtc"
+        elif data["orderType"] == "market":
+            assert "price" not in data
+            assert data["timeInForce"] == "ioc"
+        else:
+            raise AssertionError(f"Unexpected XCoin order type: {data['orderType']}")
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": {"orderId": "1322590062927904769", "clientOrderId": "Client1001"},
+            "ts": "1732193257273",
+        }
+    if path == "/v1/trade/cancelOrder":
+        assert method == "POST"
+        assert data["orderId"] == "1322590062927904769"
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": {"orderId": "1322590062927904769"},
+            "ts": "1732193257273",
+        }
+    if path == "/v2/trade/order/info":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": {
+                "businessType": "spot",
+                "symbol": "BTC-USDT",
+                "orderId": "1322590062927904769",
+                "clientOrderId": "Client1001",
+                "price": "80000",
+                "qty": "0.01",
+                "quoteQty": "400",
+                "orderType": "limit",
+                "side": "buy",
+                "totalFillQty": "0.005",
+                "avgPrice": "80000",
+                "status": "partially_filled",
+                "baseFee": "0",
+                "quoteFee": "-0.4",
+                "timeInForce": "gtc",
+                "createTime": "1732193257000",
+                "updateTime": "1732193257273",
+            },
+            "ts": "1732193257273",
+        }
+    if path == "/v2/trade/openOrders":
+        return {
+            "code": "0",
+            "msg": "success",
+            "data": [
+                {
+                    "businessType": "spot",
+                    "symbol": "BTC-USDT",
+                    "orderId": "1322590062927904769",
+                    "clientOrderId": "Client1001",
+                    "price": "80000",
+                    "qty": "0.01",
+                    "quoteQty": "400",
+                    "orderType": "limit",
+                    "side": "buy",
+                    "totalFillQty": "0.005",
+                    "avgPrice": "80000",
+                    "status": "partially_filled",
+                    "timeInForce": "gtc",
+                    "createTime": "1732193257000",
+                    "updateTime": "1732193257273",
+                }
+            ],
+            "ts": "1732193257273",
+        }
+    raise AssertionError(f"Unhandled XCoin mock path: {method} {path}")
+
+
+def _patch_xcoin_request(mocker):
+    calls = []
+
+    def fake_request(self, method, path, *, params=None, data=None, private=False):
+        calls.append((method, path, params, data, private))
+        return _xcoin_response(method, path, params=params, data=data, private=private)
+
+    mocker.patch.object(XCoinClient, "request", fake_request)
+    return calls
+
+
+def test_check_exchange_accepts_native_xcoin(default_conf):
+    conf = _xcoin_config(default_conf)
+    conf["runmode"] = RunMode.DRY_RUN
+    assert check_exchange(conf)
+
+
+def test_xcoin_resolver_loads_native_exchange(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    _patch_xcoin_request(mocker)
+
+    exchange = ExchangeResolver.load_exchange(_xcoin_config(default_conf))
+
+    assert isinstance(exchange, Xcoin)
+    assert exchange.name == "XCoin"
+    assert exchange.markets["BTC/USDT"]["id"] == "BTC-USDT"
+    assert exchange.markets["BTC/USDT"]["limits"]["amount"]["min"] == 0.00001
+
+
+def test_xcoin_credentials_are_read_from_environment(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    _patch_xcoin_request(mocker)
+    conf = _xcoin_config(default_conf)
+    conf["exchange"]["key"] = "config-key"
+    conf["exchange"]["secret"] = "config-secret"
+    conf["exchange"]["ccxt_config"] = {"apiKey": "ccxt-key", "secret": "ccxt-secret"}
+
+    exchange = ExchangeResolver.load_exchange(conf)
+
+    assert exchange._api.apiKey == "env-key"
+    assert exchange._api.secret == "env-secret"
+
+
+def test_xcoin_public_market_data(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    _patch_xcoin_request(mocker)
+    exchange = ExchangeResolver.load_exchange(_xcoin_config(default_conf))
+
+    ticker = exchange.fetch_ticker("BTC/USDT")
+    assert ticker["last"] == 80000
+    assert ticker["bid"] == 79999.99
+    assert ticker["ask"] == 80000.01
+
+    candles = exchange.refresh_latest_ohlcv(
+        [("BTC/USDT", "5m", CandleType.SPOT)], cache=False, drop_incomplete=False
+    )
+    candle_df = candles[("BTC/USDT", "5m", CandleType.SPOT)]
+    assert len(candle_df) == 2
+    assert candle_df.iloc[0]["open"] == 80000
+    assert candle_df.iloc[1]["close"] == 80200
+
+
+def test_xcoin_private_account_and_order_methods(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    _patch_xcoin_request(mocker)
+    exchange = ExchangeResolver.load_exchange(_xcoin_config(default_conf, dry_run=False))
+
+    balances = exchange.get_balances()
+    assert balances["USDT"] == {"free": 80.0, "used": 20.0, "total": 100.0}
+
+    order = exchange.create_order(
+        pair="BTC/USDT",
+        ordertype="limit",
+        side="buy",
+        amount=0.01,
+        rate=80000,
+        leverage=1,
+    )
+    assert order["id"] == "1322590062927904769"
+    assert order["status"] == "open"
+    assert order["type"] == "limit"
+
+    fetched = exchange.fetch_order("1322590062927904769", "BTC/USDT")
+    assert fetched["status"] == "open"
+    assert fetched["filled"] == 0.005
+    assert fetched["remaining"] == 0.005
+
+    canceled = exchange.cancel_order("1322590062927904769", "BTC/USDT")
+    assert canceled["status"] == "canceled"
+
+    open_orders = exchange._api.fetch_open_orders("BTC/USDT")
+    assert len(open_orders) == 1
+    assert open_orders[0]["status"] == "open"
+
+
+def test_xcoin_private_market_order(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    calls = _patch_xcoin_request(mocker)
+    exchange = ExchangeResolver.load_exchange(_xcoin_config(default_conf, dry_run=False))
+
+    order = exchange.create_order(
+        pair="BTC/USDT",
+        ordertype="market",
+        side="buy",
+        amount=0.01,
+        rate=80000,
+        leverage=1,
+    )
+
+    assert order["id"] == "1322590062927904769"
+    assert order["status"] == "open"
+    assert order["type"] == "market"
+    live_order_calls = [call for call in calls if call[1] == "/v2/trade/order"]
+    assert live_order_calls[-1][3]["orderType"] == "market"
+    assert live_order_calls[-1][3]["timeInForce"] == "ioc"
+
+
+def test_xcoin_dry_run_order_does_not_call_live_order(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    calls = _patch_xcoin_request(mocker)
+    exchange = ExchangeResolver.load_exchange(_xcoin_config(default_conf))
+
+    order = exchange.create_order(
+        pair="BTC/USDT",
+        ordertype="limit",
+        side="buy",
+        amount=0.01,
+        rate=70000,
+        leverage=1,
+    )
+
+    assert order["id"].startswith("dry_run_buy_BTC/USDT")
+    assert all(call[1] != "/v2/trade/order" for call in calls)
+
+
+def test_xcoin_live_requires_explicit_enable(default_conf, mocker, monkeypatch):
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__KEY", "env-key")
+    monkeypatch.setenv("FREQTRADE__EXCHANGE__SECRET", "env-secret")
+    _patch_xcoin_request(mocker)
+    conf = _xcoin_config(default_conf, dry_run=False)
+    conf["exchange"]["xcoin_live_trading_enabled"] = False
+
+    with pytest.raises(Exception, match="XCoin live trading is disabled"):
+        ExchangeResolver.load_exchange(conf)


### PR DESCRIPTION
## Summary

- add a native XCoin spot exchange adapter for Freqtrade without relying on ccxt support
- add a small ccxt-like facade and REST connector for public market data, balances, and basic order lifecycle methods
- allow native exchanges through exchange validation and cover the XCoin behavior with focused exchange tests

## Notes

- API credentials are read from environment variables instead of persisted config values
- live trading requires an explicit `exchange.xcoin_live_trading_enabled=true` safeguard after dry-run testing
- this PR excludes the local `uv.lock` file and unrelated FreqUI docker-compose change

## Validation

- `uv run --extra develop --with scipy pytest tests/exchange/test_xcoin.py`
- `uv run --extra develop ruff check freqtrade/exchange/__init__.py freqtrade/exchange/check_exchange.py freqtrade/exchange/common.py freqtrade/exchange/xcoin.py freqtrade/exchange/xcoin_api.py freqtrade/exchange/xcoin_connector tests/exchange/test_xcoin.py`
- `uv run --extra develop ruff format --check freqtrade/exchange/__init__.py freqtrade/exchange/check_exchange.py freqtrade/exchange/common.py freqtrade/exchange/xcoin.py freqtrade/exchange/xcoin_api.py freqtrade/exchange/xcoin_connector tests/exchange/test_xcoin.py`