### PR TITLE
fix: dynamic-pairlist backtesting replays stale candles on re-entry

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1494,23 +1494,16 @@ class Backtesting:
         self, data: dict, pair: str, row_index: int, current_time: datetime
     ) -> int:
         """
-        Skip rows older than the last closed candle and return the resulting index.
+        Fast-forward a stale row index to the row dated current_time.
 
-        A dynamic pairlist can drop a pair and re-add it later, and indexes[pair]
-        only advances while the pair is processed, so on re-entry it is stale and the
-        pair would replay the candles it missed.
-
-        :param data: dict of lists with per-pair rows
-        :param pair: pair to look up
-        :param row_index: the pair's current (possibly stale) row index
-        :param current_time: the candle currently being processed
-        :return: the row index of the last closed candle for `current_time`
+        A dynamic pairlist can drop a pair and re-add it later. indexes[pair] only
+        advances while the pair is processed, so on re-entry it points at old rows
+        the pair would otherwise replay. Each main row must be dated at current_time.
         """
         if not self.dynamic_pairlist:
             return row_index
         pair_rows = data[pair]
-        prev_time = current_time - self.timeframe_td
-        while row_index < len(pair_rows) and pair_rows[row_index][DATE_IDX] < prev_time:
+        while row_index < len(pair_rows) and pair_rows[row_index][DATE_IDX] < current_time:
             row_index += 1
         return row_index
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1498,7 +1498,7 @@ class Backtesting:
 
         A dynamic pairlist can drop a pair and re-add it later. indexes[pair] only
         advances while the pair is processed, so on re-entry it points at old rows
-        the pair would otherwise replay. Each main row must be dated at current_time.
+        the pair would otherwise replay.
         """
         if not self.dynamic_pairlist:
             return row_index
@@ -1687,7 +1687,6 @@ class Backtesting:
                 if is_first:
                     # Main candle
                     row_index = self._sync_pair_index(data, pair, indexes[pair], current_time)
-                    indexes[pair] = row_index
                     row = self.validate_row(data, pair, row_index, current_time)
                     if not row:
                         continue

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1490,6 +1490,30 @@ class Backtesting:
             return None
         return row
 
+    def _sync_pair_index(
+        self, data: dict, pair: str, row_index: int, current_time: datetime
+    ) -> int:
+        """
+        Skip rows older than the last closed candle and return the resulting index.
+
+        A dynamic pairlist can drop a pair and re-add it later, and indexes[pair]
+        only advances while the pair is processed, so on re-entry it is stale and the
+        pair would replay the candles it missed.
+
+        :param data: dict of lists with per-pair rows
+        :param pair: pair to look up
+        :param row_index: the pair's current (possibly stale) row index
+        :param current_time: the candle currently being processed
+        :return: the row index of the last closed candle for `current_time`
+        """
+        if not self.dynamic_pairlist:
+            return row_index
+        pair_rows = data[pair]
+        prev_time = current_time - self.timeframe_td
+        while row_index < len(pair_rows) and pair_rows[row_index][DATE_IDX] < prev_time:
+            row_index += 1
+        return row_index
+
     def _collate_rejected(self, pair, row):
         """
         Temporarily store rejected signal information for downstream use in backtesting_analysis
@@ -1669,7 +1693,8 @@ class Backtesting:
                 trade_dir: LongShort | None = None
                 if is_first:
                     # Main candle
-                    row_index = indexes[pair]
+                    row_index = self._sync_pair_index(data, pair, indexes[pair], current_time)
+                    indexes[pair] = row_index
                     row = self.validate_row(data, pair, row_index, current_time)
                     if not row:
                         continue

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -32,6 +32,7 @@ from tests.conftest import (
     CURRENT_TEST_STRATEGY,
     EXMS,
     generate_test_data,
+    generate_test_data_raw,
     get_args,
     log_has,
     log_has_re,
@@ -2879,36 +2880,81 @@ def test_time_pair_generator_open_trades_first(mocker, default_conf, dynamic_pai
 
 
 def test_time_pair_generator_dynamic_pairlist_no_stale_replay(mocker, default_conf):
-    # A pair that leaves the whitelist and re-enters must resume at the current
-    # candle, not replay the candles it missed while absent (lookahead).
     patch_exchange(mocker)
     default_conf["enable_dynamic_pairlist"] = True
     backtesting = Backtesting(default_conf)
     backtesting._set_strategy(backtesting.strategylist[0])
 
+    n = 10
+    tf = backtesting.timeframe_td
     start = datetime(2025, 1, 1, tzinfo=UTC)
-    times = [start + timedelta(minutes=5 * i) for i in range(4)]
-
-    def row(t):
-        return (t, 1.0, 1.1, 0.9, 1.0, 0, 0, 0, 0, None, None)
-
+    # data[pair][0] is dated start + tf - backtest() drops the first candle
+    candles = generate_test_data_raw(backtesting.timeframe, n)
+    rows = [
+        [start + tf * (i + 1), c[1], c[2], c[3], c[4], 0, 0, 0, 0, None, None]
+        for i, c in enumerate(candles)
+    ]
     pairs = ["A/BTC", "B/BTC"]
-    data = {p: [row(t) for t in times] for p in pairs}
+    data = {p: list(rows) for p in pairs}
 
-    # B/BTC is absent from the whitelist on the first candle, then re-enters.
-    calls = {"n": 0}
+    # B/BTC absent for candles 3-5, then re-enters
+    absent = {3, 4, 5}
+    calls = {"n": -1}
 
     def mock_refresh(self, **kwargs):
         calls["n"] += 1
-        self._whitelist = ["A/BTC"] if calls["n"] == 1 else ["A/BTC", "B/BTC"]
+        self._whitelist = ["A/BTC"] if calls["n"] in absent else ["A/BTC", "B/BTC"]
 
     mocker.patch("freqtrade.plugins.pairlistmanager.PairListManager.refresh_pairlist", mock_refresh)
 
-    end = times[-1]
-    b_rows = [
-        (current_time, r[DATE_IDX])
-        for current_time, pair, r, _, _ in backtesting.time_pair_generator(start, end, pairs, data)
-        if pair == "B/BTC"
+    end = start + tf * n
+    a_rows, b_rows = [], []
+    for current_time, pair, r, _, _ in backtesting.time_pair_generator(start, end, pairs, data):
+        (a_rows if pair == "A/BTC" else b_rows).append((current_time, r[DATE_IDX]))
+
+    # Every row is dated at its candle, and B resumes with no replay on re-entry
+    assert a_rows == [(ct, ct) for ct, _ in a_rows]
+    assert len(a_rows) == n
+    b_present = [a for a in a_rows if a[0] not in {start + tf * (i + 1) for i in absent}]
+    assert b_rows == b_present
+
+
+def test_time_pair_generator_dynamic_pairlist_real_filters(mocker, default_conf):
+    patch_exchange(mocker)
+    pairs = ["ETH/BTC", "LTC/BTC", "XRP/BTC", "NEO/BTC", "ADA/BTC", "DASH/BTC"]
+    default_conf["exchange"]["pair_whitelist"] = pairs
+    default_conf["enable_dynamic_pairlist"] = True
+    # Rotates the active 2 pairs each candle, so pairs leave and re-enter (seeded)
+    default_conf["pairlists"] = [
+        {"method": "StaticPairList"},
+        {"method": "ShuffleFilter", "seed": 42, "shuffle_frequency": "iteration"},
+        {"method": "OffsetFilter", "number_assets": 2},
     ]
-    # On re-entry at 00:10, B resumes at the last closed candle (00:05), not 00:00.
-    assert b_rows == [(times[2], times[1]), (times[3], times[2])]
+    backtesting = Backtesting(default_conf)
+    backtesting._set_strategy(backtesting.strategylist[0])
+    backtesting.available_pairs = list(pairs)
+
+    n = 20
+    tf = backtesting.timeframe_td
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    grid = [start + tf * (i + 1) for i in range(n)]
+
+    def row(t):
+        return [t, 1.0, 1.1, 0.9, 1.0, 0, 0, 0, 0, None, None]
+
+    data = {p: [row(t) for t in grid] for p in pairs}
+    end = start + tf * n
+
+    present_at: dict = {}
+    for current_time, pair, r, _, _ in backtesting.time_pair_generator(start, end, pairs, data):
+        assert r[DATE_IDX] == current_time
+        present_at.setdefault(pair, []).append(current_time)
+
+    # Confirm the rotation drops and re-adds a pair, so re-entry was exercised
+    candles = sorted({c for cs in present_at.values() for c in cs})
+    reentered = [
+        p
+        for p, cs in present_at.items()
+        if any(c not in cs for c in candles[candles.index(cs[0]) : candles.index(cs[-1])])
+    ]
+    assert reentered

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -24,7 +24,7 @@ from freqtrade.exceptions import DependencyException, OperationalException
 from freqtrade.exchange import timeframe_to_next_date, timeframe_to_prev_date
 from freqtrade.exchange.exchange_utils import DECIMAL_PLACES, TICK_SIZE
 from freqtrade.optimize.backtest_caching import get_backtest_metadata_filename, get_strategy_run_id
-from freqtrade.optimize.backtesting import HEADERS, Backtesting
+from freqtrade.optimize.backtesting import DATE_IDX, HEADERS, Backtesting
 from freqtrade.persistence import LocalTrade, Trade
 from freqtrade.resolvers import StrategyResolver
 from freqtrade.util import dt_now, dt_utc
@@ -2876,3 +2876,39 @@ def test_time_pair_generator_open_trades_first(mocker, default_conf, dynamic_pai
         assert processed_pairs == ["XRP/BTC", "NEO/BTC", "ETH/BTC", "LTC/BTC"]
     else:
         assert processed_pairs == ["XRP/BTC", "NEO/BTC", "LTC/BTC", "ETH/BTC"]
+
+
+def test_time_pair_generator_dynamic_pairlist_no_stale_replay(mocker, default_conf):
+    # A pair that leaves the whitelist and re-enters must resume at the current
+    # candle, not replay the candles it missed while absent (lookahead).
+    patch_exchange(mocker)
+    default_conf["enable_dynamic_pairlist"] = True
+    backtesting = Backtesting(default_conf)
+    backtesting._set_strategy(backtesting.strategylist[0])
+
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    times = [start + timedelta(minutes=5 * i) for i in range(4)]
+
+    def row(t):
+        return (t, 1.0, 1.1, 0.9, 1.0, 0, 0, 0, 0, None, None)
+
+    pairs = ["A/BTC", "B/BTC"]
+    data = {p: [row(t) for t in times] for p in pairs}
+
+    # B/BTC is absent from the whitelist on the first candle, then re-enters.
+    calls = {"n": 0}
+
+    def mock_refresh(self, **kwargs):
+        calls["n"] += 1
+        self._whitelist = ["A/BTC"] if calls["n"] == 1 else ["A/BTC", "B/BTC"]
+
+    mocker.patch("freqtrade.plugins.pairlistmanager.PairListManager.refresh_pairlist", mock_refresh)
+
+    end = times[-1]
+    b_rows = [
+        (current_time, r[DATE_IDX])
+        for current_time, pair, r, _, _ in backtesting.time_pair_generator(start, end, pairs, data)
+        if pair == "B/BTC"
+    ]
+    # On re-entry at 00:10, B resumes at the last closed candle (00:05), not 00:00.
+    assert b_rows == [(times[2], times[1]), (times[3], times[2])]

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -2888,8 +2888,8 @@ def test_time_pair_generator_dynamic_pairlist_no_stale_replay(mocker, default_co
     n = 10
     tf = backtesting.timeframe_td
     start = datetime(2025, 1, 1, tzinfo=UTC)
-    # data[pair][0] is dated start + tf - backtest() drops the first candle
-    candles = generate_test_data_raw(backtesting.timeframe, n)
+    # data[pair][0] is dated start + tf
+    candles = generate_test_data_raw(backtesting.timeframe, n, start=start)
     rows = [
         [start + tf * (i + 1), c[1], c[2], c[3], c[4], 0, 0, 0, 0, None, None]
         for i, c in enumerate(candles)
@@ -2913,7 +2913,7 @@ def test_time_pair_generator_dynamic_pairlist_no_stale_replay(mocker, default_co
         (a_rows if pair == "A/BTC" else b_rows).append((current_time, r[DATE_IDX]))
 
     # Every row is dated at its candle, and B resumes with no replay on re-entry
-    assert a_rows == [(ct, ct) for ct, _ in a_rows]
+    assert all(ct == d for ct, d in a_rows)
     assert len(a_rows) == n
     b_present = [a for a in a_rows if a[0] not in {start + tf * (i + 1) for i in absent}]
     assert b_rows == b_present


### PR DESCRIPTION
## Summary

Fix lookahead bias in `--enable-dynamic-pairlist` backtesting, where a pair that leaves the whitelist and re-enters later replays the candles it missed.

Solve the issue: #13303

## Quick changelog

- Fast-forward a pair's row index to the current candle on re-entry, so it resumes instead of replaying skipped candles.
- Add a regression test that fails before this change and passes after.

## What's new?

`Backtesting.time_pair_generator` advances each pair's row position with `indexes[pair]`, incremented only when the pair is processed. With a static pairlist every pair is processed every candle, so the index stays in lockstep with time. With a dynamic pairlist a pair can be absent for some candles, so on re-entry its index is stale and the pair replays its earlier rows. Any coin that joins the universe partway through a backtest then trades its pre-membership history.

Example: with a market-cap pairlist, a coin that rises into the top-N in July re-enters the whitelist and replays its January data, opening January-dated trades it could never have taken. In one backtest this contaminated 19% of trades.

The fix fast-forwards a re-entered pair's row index to the candle being processed, so every processed row is dated at `current_time`, the same invariant a static pairlist holds. Static backtests call the same helper, which returns immediately, so they run unchanged. Two regression tests cover it: one aligns the data the way `backtest()` does and checks a re-entering pair against an always-present one, the other runs a real `StaticPairList -> ShuffleFilter -> OffsetFilter` stack and asserts every row lands on its own candle. Both fail before the fix and pass after.

## AI disclosure

This change was developed with AI assistance (Claude). I reviewed the code and the test, confirmed the reproducer fails without the fix and passes with it, and ran the full backtesting test suite locally.
