### PR TITLE
round float directly

### DIFF
--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -1155,7 +1155,7 @@ class LocalTrade:
                 profit_ratio = (1 - (close_trade_value / open_trade_value)) * self.leverage
             else:
                 profit_ratio = ((close_trade_value / open_trade_value) - 1) * self.leverage
-            profit_ratio = float(f"{profit_ratio:.8f}")
+            profit_ratio = round(profit_ratio, 8)
         except ZeroDivisionError:
             profit_ratio = 0.0
 
@@ -1165,11 +1165,11 @@ class LocalTrade:
                 (1 - self.fee_open) if self.is_short else (1 + self.fee_open)
             )
             total_profit_ratio = total_profit_abs / max_stake
-            total_profit_ratio = float(f"{total_profit_ratio:.8f}")
+            total_profit_ratio = round(total_profit_ratio, 8)
         else:
             total_profit_ratio = 0.0
-        profit_abs = float(f"{profit_abs:.8f}")
-        total_profit_abs = float(f"{total_profit_abs:.8f}")
+        profit_abs = round(profit_abs, 8)
+        total_profit_abs = round(total_profit_abs, 8)
 
         return ProfitStruct(
             profit_abs=profit_abs,
@@ -1206,7 +1206,7 @@ class LocalTrade:
             else:
                 profit_ratio = ((close_trade_value / open_trade_value) - 1) * self.leverage
 
-        return float(f"{profit_ratio:.8f}")
+        return round(profit_ratio, 8)
 
     def calc_close_rate_for_roi(self, target_roi: float) -> float:
         """


### PR DESCRIPTION
all these variables are already on float, so no reason to change them to string, just to be changed into float again.

AI was used to find the locations, and to create a test script below. Changes were done manually.

```py
import timeit
import random

ITERATIONS = 5_000_000
SEED = 42

random.seed(SEED)
samples = [random.uniform(-100, 100) for _ in range(1000)]
setup = f"samples = {samples}; i = 0"

t_fstr = timeit.timeit(
    "x = samples[i % 1000]; i += 1; float(f'{x:.8f}')",
    setup=setup,
    number=ITERATIONS,
)
t_round = timeit.timeit(
    "x = samples[i % 1000]; i += 1; round(x, 8)",
    setup=setup,
    number=ITERATIONS,
)

print(f"{'Method':<30} {'Time':>8}  {'per call':>12}")
print("-" * 55)
print(f"{'float(f\"{x:.8f}\")':<30} {t_fstr:>7.3f}s  {t_fstr/ITERATIONS*1e9:>9.2f} ns")
print(f"{'round(x, 8)':<30} {t_round:>7.3f}s  {t_round/ITERATIONS*1e9:>9.2f} ns")
print(f"\nSpeedup: {t_fstr/t_round:.3f}x")

# Correctness check
mismatches = 0
for x in samples:
    if float(f"{x:.8f}") != round(x, 8):
        mismatches += 1
print(f"Equivalence check: {'PASS' if mismatches == 0 else f'FAIL ({mismatches} mismatches)'}")

```

After running the test 3 times, I got

```
Method                             Time      per call
-------------------------------------------------------
float(f"{x:.8f}")                0.930s     185.96 ns
round(x, 8)                      0.817s     163.42 ns

Speedup: 1.138x
Equivalence check: PASS

Method                             Time      per call
-------------------------------------------------------
float(f"{x:.8f}")                1.010s     201.91 ns
round(x, 8)                      0.932s     186.41 ns

Speedup: 1.083x
Equivalence check: PASS

Method                             Time      per call
-------------------------------------------------------
float(f"{x:.8f}")                0.902s     180.34 ns
round(x, 8)                      0.788s     157.63 ns

Speedup: 1.144x
Equivalence check: PASS
```