### PR TITLE
loop orders only once on to_json

### DIFF
--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -687,8 +687,7 @@ class LocalTrade:
             else:
                 if order.ft_order_side == entry_side:
                     filled_entry_orders.append(order)
-                    order_filled_utc = order.order_filled_utc
-                    if order_filled_utc:
+                    if order_filled_utc := order.order_filled_utc:
                         filled_entry_datetime_utc.append(order_filled_utc)
                 elif order.ft_order_side == exit_side:
                     filled_exit_orders.append(order)

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -666,8 +666,41 @@ class LocalTrade:
                          Only used for backtesting.
         :return: Dictionary with trade data
         """
+        entry_side = self.entry_side
+        exit_side = self.exit_side
         filled_or_open_orders = self.select_filled_or_open_orders()
-        orders_json = [order.to_json(self.entry_side, minified) for order in filled_or_open_orders]
+        orders_json = [order.to_json(entry_side, minified) for order in filled_or_open_orders]
+
+        filled_entry_orders = []
+        filled_entry_datetime_utc = []
+        filled_exit_orders = []
+        open_orders_wo_sl = []
+        open_sl_orders = []
+        open_sl_orders_ts = []
+        for order in filled_or_open_orders:
+            if order.ft_is_open:
+                if order.ft_order_side not in ["stoploss"]:
+                    open_orders_wo_sl.append(order)
+                else:
+                    open_sl_orders.append(order)
+                    open_sl_orders_ts.append(order.order_date_utc)
+            else:
+                if order.filled and order.status in NON_OPEN_EXCHANGE_STATES:
+                    if order.ft_order_side == entry_side:
+                        filled_entry_orders.append(order)
+                        order_filled_utc = order.order_filled_utc
+                        if order_filled_utc:
+                            filled_entry_datetime_utc.append(order_filled_utc)
+                    elif order.ft_order_side == exit_side:
+                        filled_exit_orders.append(order)
+
+        open_date_utc = self.open_date_utc
+        close_date_utc = self.close_date_utc
+        date_entry_fill_utc = min(filled_entry_datetime_utc) if filled_entry_datetime_utc else None
+        stoploss_last_update_utc = max(open_sl_orders_ts) if open_sl_orders_ts else None
+        trade_duration_s = (
+            int((close_date_utc - open_date_utc).total_seconds()) if self.close_date else None
+        )
 
         return {
             "trade_id": self.id,
@@ -690,20 +723,18 @@ class LocalTrade:
             "fee_close_cost": self.fee_close_cost,
             "fee_close_currency": self.fee_close_currency,
             "open_date": self.open_date.strftime(DATETIME_PRINT_FORMAT),
-            "open_timestamp": dt_ts_none(self.open_date_utc),
+            "open_timestamp": dt_ts_none(open_date_utc),
             "open_fill_date": (
-                self.date_entry_fill_utc.strftime(DATETIME_PRINT_FORMAT)
-                if self.date_entry_fill_utc
-                else None
+                date_entry_fill_utc.strftime(DATETIME_PRINT_FORMAT) if date_entry_fill_utc else None
             ),
-            "open_fill_timestamp": dt_ts_none(self.date_entry_fill_utc),
+            "open_fill_timestamp": dt_ts_none(date_entry_fill_utc),
             "open_rate": self.open_rate,
             "open_rate_requested": self.open_rate_requested,
             "open_trade_value": round(self.open_trade_value, 8),
             "close_date": (
                 self.close_date.strftime(DATETIME_PRINT_FORMAT) if self.close_date else None
             ),
-            "close_timestamp": dt_ts_none(self.close_date_utc),
+            "close_timestamp": dt_ts_none(close_date_utc),
             "realized_profit": self.realized_profit or 0.0,
             # Close-profit corresponds to relative realized_profit ratio
             "realized_profit_ratio": self.close_profit or None,
@@ -712,16 +743,8 @@ class LocalTrade:
             "close_profit": self.close_profit,  # Deprecated
             "close_profit_pct": round(self.close_profit * 100, 2) if self.close_profit else None,
             "close_profit_abs": self.close_profit_abs,  # Deprecated
-            "trade_duration_s": (
-                int((self.close_date_utc - self.open_date_utc).total_seconds())
-                if self.close_date
-                else None
-            ),
-            "trade_duration": (
-                int((self.close_date_utc - self.open_date_utc).total_seconds() // 60)
-                if self.close_date
-                else None
-            ),
+            "trade_duration_s": trade_duration_s,
+            "trade_duration": int(trade_duration_s // 60) if trade_duration_s else None,
             "profit_ratio": self.close_profit,
             "profit_pct": round(self.close_profit * 100, 2) if self.close_profit else None,
             "profit_abs": self.close_profit_abs,
@@ -731,11 +754,11 @@ class LocalTrade:
             "stop_loss_ratio": self.stop_loss_pct if self.stop_loss_pct else None,
             "stop_loss_pct": (self.stop_loss_pct * 100) if self.stop_loss_pct else None,
             "stoploss_last_update": (
-                self.stoploss_last_update_utc.strftime(DATETIME_PRINT_FORMAT)
-                if self.stoploss_last_update_utc
+                stoploss_last_update_utc.strftime(DATETIME_PRINT_FORMAT)
+                if stoploss_last_update_utc
                 else None
             ),
-            "stoploss_last_update_timestamp": dt_ts_none(self.stoploss_last_update_utc),
+            "stoploss_last_update_timestamp": dt_ts_none(stoploss_last_update_utc),
             "initial_stop_loss_abs": self.initial_stop_loss,
             "initial_stop_loss_ratio": (
                 self.initial_stop_loss_pct if self.initial_stop_loss_pct else None
@@ -756,9 +779,9 @@ class LocalTrade:
             "precision_mode": self.precision_mode,
             "precision_mode_price": self.precision_mode_price,
             "contract_size": self.contract_size,
-            "nr_of_successful_entries": self.nr_of_successful_entries,
-            "nr_of_successful_exits": self.nr_of_successful_exits,
-            "has_open_orders": self.has_open_orders,
+            "nr_of_successful_entries": len(filled_entry_orders),
+            "nr_of_successful_exits": len(filled_exit_orders),
+            "has_open_orders": len(open_orders_wo_sl) > 0,
             "orders": orders_json,
         }
 

--- a/freqtrade/persistence/trade_model.py
+++ b/freqtrade/persistence/trade_model.py
@@ -685,14 +685,13 @@ class LocalTrade:
                     open_sl_orders.append(order)
                     open_sl_orders_ts.append(order.order_date_utc)
             else:
-                if order.filled and order.status in NON_OPEN_EXCHANGE_STATES:
-                    if order.ft_order_side == entry_side:
-                        filled_entry_orders.append(order)
-                        order_filled_utc = order.order_filled_utc
-                        if order_filled_utc:
-                            filled_entry_datetime_utc.append(order_filled_utc)
-                    elif order.ft_order_side == exit_side:
-                        filled_exit_orders.append(order)
+                if order.ft_order_side == entry_side:
+                    filled_entry_orders.append(order)
+                    order_filled_utc = order.order_filled_utc
+                    if order_filled_utc:
+                        filled_entry_datetime_utc.append(order_filled_utc)
+                elif order.ft_order_side == exit_side:
+                    filled_exit_orders.append(order)
 
         open_date_utc = self.open_date_utc
         close_date_utc = self.close_date_utc
@@ -744,7 +743,7 @@ class LocalTrade:
             "close_profit_pct": round(self.close_profit * 100, 2) if self.close_profit else None,
             "close_profit_abs": self.close_profit_abs,  # Deprecated
             "trade_duration_s": trade_duration_s,
-            "trade_duration": int(trade_duration_s // 60) if trade_duration_s else None,
+            "trade_duration": int(trade_duration_s // 60) if trade_duration_s is not None else None,
             "profit_ratio": self.close_profit,
             "profit_pct": round(self.close_profit * 100, 2) if self.close_profit else None,
             "profit_abs": self.close_profit_abs,


### PR DESCRIPTION
this might not matter to all users, but as someone who fetches trades' data regularly over API for my own dashboard, having each trades looping over orders up to 9 times isn't ideal.

AI was used to found the issue, edits were done manually

This is a summary from AI
```
Current passes:
- select_filled_or_open_orders() — 1 pass
- date_entry_fill_utc property → select_filled_orders(entry_side) — 1 pass
- stoploss_last_update_utc property → has_open_sl_orders check — 1 pass
- stoploss_last_update_utc property → open_sl_orders property — 1 pass
- stoploss_last_update_utc accessed again for _timestamp key — 1 pass
- nr_of_successful_entries property → _count_filled_orders(entry_side) — 1 pass
- nr_of_successful_exits property → _count_filled_orders(exit_side) — 1 pass
- has_open_orders property — 1 short-circuit pass

Total: 7-9 passes per to_json() call
```