### PR TITLE
Support per-event webhook URL overrides

### DIFF
--- a/freqtrade/rpc/webhook.py
+++ b/freqtrade/rpc/webhook.py
@@ -104,16 +104,20 @@ class Webhook(RPCHandler):
                 logger.debug("Message type '%s' not configured for webhooks", msg["type"])
                 return
 
-            payload = self.recursive_format(valuedict, msg)
-            self._send_msg(payload)
+            # Allow per-event URL override — strip "url" before formatting
+            # so it doesn't end up in the POST body.
+            url = valuedict.get("url", self._url)
+            payload = self.recursive_format({k: v for k, v in valuedict.items() if k != "url"}, msg)
+            self._send_msg(payload, url)
         except KeyError as exc:
             logger.exception(
                 "Problem calling Webhook. Please check your webhook configuration. Exception: %s",
                 exc,
             )
 
-    def _send_msg(self, payload: dict) -> None:
+    def _send_msg(self, payload: dict, url: str | None = None) -> None:
         """do the actual call to the webhook"""
+        target_url = url if url is not None else self._url
 
         success = False
         attempts = 0
@@ -127,12 +131,12 @@ class Webhook(RPCHandler):
 
             try:
                 if self._format == "form":
-                    response = post(self._url, data=payload, timeout=self._timeout)
+                    response = post(target_url, data=payload, timeout=self._timeout)
                 elif self._format == "json":
-                    response = post(self._url, json=payload, timeout=self._timeout)
+                    response = post(target_url, json=payload, timeout=self._timeout)
                 elif self._format == "raw":
                     response = post(
-                        self._url,
+                        target_url,
                         data=payload["data"],
                         headers={"Content-Type": "text/plain"},
                         timeout=self._timeout,

--- a/tests/rpc/test_rpc_webhook.py
+++ b/tests/rpc/test_rpc_webhook.py
@@ -416,6 +416,55 @@ def test__send_msg(default_conf, mocker, caplog):
     assert log_has("Could not call webhook url. Exception: ", caplog)
 
 
+def test_send_msg_webhook_per_event_url(default_conf, mocker):
+    default_conf["webhook"] = get_webhook_dict()
+    default_conf["webhook"]["webhookstatus"]["url"] = "https://example.com/status-only"
+    msg_mock = MagicMock()
+    mocker.patch("freqtrade.rpc.webhook.Webhook._send_msg", msg_mock)
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
+
+    # Per-event "url" is used, and stripped out of the outgoing payload.
+    msg = {"type": RPCMessageType.STATUS, "status": "running"}
+    webhook.send_msg(msg)
+    assert msg_mock.call_count == 1
+    payload, url = msg_mock.call_args[0]
+    assert url == "https://example.com/status-only"
+    assert "url" not in payload
+
+    # Event types without a per-event "url" fall back to the top-level webhook url.
+    msg_mock.reset_mock()
+    msg2 = {
+        "type": RPCMessageType.ENTRY_CANCEL,
+        "exchange": "Binance",
+        "pair": "ETH/BTC",
+        "leverage": 1.0,
+        "direction": "Long",
+        "limit": 0.005,
+        "stake_amount": 0.8,
+        "stake_amount_fiat": 500,
+        "stake_currency": "BTC",
+        "fiat_currency": "EUR",
+    }
+    webhook.send_msg(msg2)
+    _payload2, url2 = msg_mock.call_args[0]
+    assert url2 == default_conf["webhook"]["url"]
+
+
+def test__send_msg_per_event_url(default_conf, mocker):
+    default_conf["webhook"] = get_webhook_dict()
+    webhook = Webhook(RPC(get_patched_freqtradebot(mocker, default_conf)), default_conf)
+    msg = {"value1": "DEADBEEF"}
+    post = MagicMock()
+    mocker.patch("freqtrade.rpc.webhook.post", post)
+
+    webhook._send_msg(msg, "https://example.com/override")
+    assert post.call_args[0] == ("https://example.com/override",)
+
+    post.reset_mock()
+    webhook._send_msg(msg)
+    assert post.call_args[0] == (default_conf["webhook"]["url"],)
+
+
 def test__send_msg_with_json_format(default_conf, mocker, caplog):
     default_conf["webhook"] = get_webhook_dict()
     default_conf["webhook"]["format"] = "json"


### PR DESCRIPTION
## Summary

`Webhook.send_msg()` only ever posts to the single top-level `config.webhook.url`, silently ignoring any `url` key set on an individual event's value dict (e.g. `webhookstatus`, `webhookentry`). This makes it impossible to route different event types to different endpoints — e.g. `status`/`startup` notifications to one Discord channel and `entry`/`exit` trade messages to another — without running multiple bot instances or an external relay.

This PR adds an optional per-event `url` override, falling back to the existing top-level `url` when not set, so existing configs are unaffected.

## Changes

- `send_msg()` reads an optional `url` key from the event's value dict, falling back to the configured top-level `url`. The key is stripped before payload formatting so it never leaks into the outgoing POST body.
- `_send_msg()` now takes an optional `url` param (defaults to `self._url`), used for all three payload formats (`form`/`json`/`raw`).
- Added `test_send_msg_webhook_per_event_url` and `test__send_msg_per_event_url` covering both the override and fallback paths.

## Example config

```json
"webhook": {
  "url": "https://example.com/default",
  "webhookstatus": {
    "url": "https://example.com/status-channel",
    "value1": "Status: {status}"
  }
}
```

## Test plan

- [x] `pytest tests/rpc/test_rpc_webhook.py` — 10/10 passed (8 existing + 2 new)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy freqtrade/rpc/webhook.py` — no issues
- [x] Verified in production: I've been running this exact patch against a live Freqtrade instance since 2026-06-30 (webhook.py patched in-container), routing status/running messages to one Discord channel and trade messages to another — confirmed working as intended.

## Disclosure

This PR was drafted with AI assistance (Claude Code) under my direction — I reviewed the diff and test coverage myself before opening it, per the contributing guidelines.