### PR TITLE
chore: move `scipy` from `optional-dependencies.hyperopt` to `dependencies`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "httpx>=0.24.1",
   "urllib3",
   "jsonschema",
+  "scipy",
   "numpy>2.0,<3.0",
   "pandas>=2.2.0,<4.0",
   "TA-Lib<0.7",
@@ -81,7 +82,6 @@ hyperopt = [
   "filelock",
   "optuna > 4.0.0",
   "scikit-learn",
-  "scipy",
 ]
 freqai = [
   "datasieve>=0.1.5",


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->
`scipy` was added in `requirements.txt` since 07b9491eae12c95a65a80a2b70b375329c646b59 of #13227 to use it in `freqtrade/data/metrics.py`.
There are other deps that only listed in `requirements.txt` but not in `pyproject.toml` like `numexpr` `bottleneck` `certifi`, I'm not sure did they get used in runtime as literal grep gives no result.

## Quick changelog

- `scipy` is now required as dependency instead of optional dependency of `hyperopt` in `pyproject.toml`

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
Nothing.