### PR TITLE
feat(myokx): add X-Perps futures support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Please read the [exchange-specific notes](https://www.freqtrade.io/en/stable/exc
 - [X] [Gate](https://www.gate.com/ref/6266643)
 - [X] [Hyperliquid](https://hyperliquid.xyz/) (A decentralized exchange, or DEX)
 - [X] [Kraken](https://www.kraken.com/features/futures)
+- [X] [MyOKX](https://my.okx.com/) (OKX EEA)
 - [X] [OKX](https://okx.com/)
 
 Please make sure to read the [exchange specific notes](https://www.freqtrade.io/en/stable/exchanges/), as well as the [trading with leverage](https://www.freqtrade.io/en/stable/leverage/) documentation before diving in.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -298,6 +298,48 @@ Using the wrong exchange will result in the error "OKX Error 50119: API key does
     Freqtrade supports both modes (we recommend to use Buy/Sell mode) - but changing the mode mid-trading is not supported and will lead to exceptions and failures to place trades.
     OKX also only provides MARK candles for the past ~3 months. Backtesting futures prior to that date will therefore lead to slight deviations, as funding-fees cannot be calculated correctly without this data.
 
+### MyOKX (OKX EEA / Europe)
+
+MyOKX is the European Economic Area (EEA) subsidiary of OKX (my.okx.com / eea.okx.com).
+It operates under MiCA regulations and offers a different set of products compared to the global OKX platform.
+
+The main difference for futures traders is that MyOKX offers **X-Perps**, dated futures contracts settled in **USD**, instead of the USDT perpetual swaps available on the main OKX platform.
+
+!!! Note "X-Perps vs Perpetual Swaps"
+    X-Perps are futures contracts with a far expiry date (typically in 2031). They function like perpetual swaps
+    for all practical trading purposes, but they are technically `type=future` rather than `type=swap`.
+    MyOKX does **not** support USDT. Only USD-settled X-Perps are available.
+
+**Configuration for MyOKX futures:**
+
+```json
+"exchange": {
+    "name": "myokx",
+    "key": "your_api_key",
+    "secret": "your_api_secret",
+    "password": "your_api_passphrase",
+    "pair_whitelist": [
+        "BTC/USD:USD-310404",
+        "ETH/USD:USD-310404",
+        "SOL/USD:USD-310404"
+    ]
+},
+"trading_mode": "futures",
+"margin_mode": "isolated",
+"stake_currency": "USD"
+```
+
+Key points for MyOKX futures:
+
+* **Stake currency must be `USD`**: all X-Perps are USD-settled.
+* **Use the XPERP contract variant**: each symbol has multiple expiry dates (e.g. `SOL/USD:USD-260925`, `SOL/USD:USD-261225`, `SOL/USD:USD-310404`). Always pick the XPERP one (furthest expiry, ~2031) for continuous trading without rollover.
+* **List available pairs** with `freqtrade list-pairs --config config.json --quote USD` to see all USD-settled futures.
+* **Spot trading** with USDC is also available: set `"trading_mode": "spot"` and `"stake_currency": "USDC"`.
+
+!!! Warning "Wrong exchange name"
+    Using `"okx"` instead of `"myokx"` for an EEA account will result in the error
+    `"OKX Error 50119: API key doesn't exist"`. The two entities are separate and use different API endpoints.
+
 ## Gate.io
 
 !!! Tip "Stoploss on Exchange"

--- a/docs/includes/exchange-features.md
+++ b/docs/includes/exchange-features.md
@@ -20,5 +20,7 @@
 | [Kraken](exchanges.md#kraken-futures) | futures | isolated | market, limit |
 | [OKX](exchanges.md#okx) | spot | | limit |
 | [OKX](exchanges.md#okx) | futures | isolated | limit |
+| [MyOKX](exchanges.md#myokx-okx-eea-europe) | spot | | limit |
+| [MyOKX](exchanges.md#myokx-okx-eea-europe) | futures | isolated | limit |
 | [Bitvavo](exchanges.md#bitvavo) | spot | | ❌ (not available) |
 | [Kucoin](exchanges.md#kucoin) | spot | | market, limit |

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from typing import Any
 
 import ccxt
 
@@ -279,12 +280,18 @@ class Okx(Exchange):
 
 class Myokx(Okx):
     """MyOkx exchange class.
-    Minimal adjustment to disable futures trading for the EU subsidiary of Okx
+    OKX EEA/EU subsidiary. Supports futures trading via X-Perps (USD-settled dated futures).
+
+    MyOKX does not offer USDT perpetual swaps. It only offers X-Perps,
+    which have type='future' rather than type='swap'.
     """
 
-    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
-        (TradingMode.SPOT, MarginMode.NONE),
-    ]
+    def market_is_future(self, market: dict[str, Any]) -> bool:
+        return (
+            market.get("future", False) is True
+            and market.get("type", False) == "future"
+            and market.get("linear", False) is True
+        )
 
 
 class Okxus(Okx):

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import ccxt
@@ -8,6 +9,7 @@ from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import RetryableOrderError, TemporaryError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import timeframe_to_minutes
+from freqtrade.exchange.okx import Myokx
 from tests.conftest import EXMS, get_patched_exchange, log_has
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
 
@@ -747,3 +749,76 @@ def test_fetch_orders_okx(default_conf, mocker, limit_order):
     assert api_mock.fetch_closed_orders.call_count == 2
     assert "params" not in api_mock.fetch_closed_orders.call_args_list[0][1]
     assert api_mock.fetch_closed_orders.call_args_list[1][1]["params"] == history_params
+
+
+@pytest.mark.parametrize(
+    "market,expected",
+    [
+        # USDT perpetual swap - not available on MyOKX
+        (
+            {
+                "swap": True,
+                "future": False,
+                "type": "swap",
+                "linear": True,
+            },
+            False,
+        ),
+        # X-Perp (USD-margined dated future) - tradable on MyOKX
+        (
+            {
+                "swap": False,
+                "future": True,
+                "type": "future",
+                "linear": True,
+            },
+            True,
+        ),
+        # Spot market
+        (
+            {
+                "swap": False,
+                "future": False,
+                "type": "spot",
+                "linear": None,
+            },
+            False,
+        ),
+        # Inverse coin-margined swap (e.g. ADA/USD:ADA)
+        (
+            {
+                "swap": True,
+                "future": False,
+                "type": "swap",
+                "linear": False,
+            },
+            False,
+        ),
+        # Future type but not linear
+        (
+            {
+                "swap": False,
+                "future": True,
+                "type": "future",
+                "linear": False,
+            },
+            False,
+        ),
+        # Future type but future flag not set
+        (
+            {
+                "swap": False,
+                "future": False,
+                "type": "future",
+                "linear": True,
+            },
+            False,
+        ),
+    ],
+)
+def test_myokx_market_is_future(mocker, market: dict[str, Any], expected: bool):
+    mocker.patch.object(Myokx, "__init__", lambda self, *args, **kwargs: None)
+    myokx = Myokx.__new__(Myokx)
+    myokx.trading_mode = TradingMode.FUTURES
+    myokx._ft_has = {"ccxt_futures_name": "swap"}
+    assert myokx.market_is_future(market) == expected


### PR DESCRIPTION
   ## Summary

   Add MyOKX (OKX EEA) futures support: recognize X-Perps (USD-settled dated futures)
   as valid futures markets via `market_is_future()`.

   Solve the issue: N/A

   AI usage: yes, used to explore the codebase, identify the root cause, and draft
   the implementation. All changes reviewed and tested manually.

   ## Quick changelog

   - Override `market_is_future()` in `Myokx` to accept `type=future` X-Perps
   - Add paramatrized unit tests for `Myokx.market_is_future` (6 cases)
   - Add MyOKX documentation: `docs/exchanges.md`, `docs/includes/exchange-features.md`, `README.md`

   ## What's new?

   MyOKX (OKX EEA, my.okx.com / eea.okx.com) does not offer USDT perpetual swaps
   to European users. Instead it offers X-Perps: USD-settled dated futures with far
   expiry dates (~2031). These have `type=future` in ccxt markets, not `type=swap`.

   Before this fix, `market_is_future()` in the base `Exchange` class required
   `market["type"] == "swap"`, so X-Perps were invisible to `list-pairs`,
   `test-pairlist`, and the trading engine. Users with MyOKX accounts only saw
   USDT pairs they cannot trade.

   **Root cause:** `market_is_future()` checks for `type=swap`. X-Perps have
   `type=future`.

   **Fix:** `Myokx.market_is_future()` recognizes markets with `type=future`,
   `future=True`, `linear=True`. USDT perpetual swaps are NOT recognized since
   they are not available on the EEA platform anyway. Inverse coin-margined swaps
   (`linear=False`) remain excluded, which is the correct behavior.

   **Config for MyOKX futures:**
   ```json
   {
       "trading_mode": "futures",
       "margin_mode": "isolated",
       "stake_currency": "USD",
       "exchange": {
           "name": "myokx",
           "pair_whitelist": [
               "BTC/USD:USD-310404",
               "ETH/USD:USD-310404",
               "SOL/USD:USD-310404"
           ]
       }
   }