### PR TITLE
Enter position logic

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -638,8 +638,11 @@ class FreqtradeBot(LoggingMixin):
             )
             return trades_created
 
-        if free_trade_slots is None:
-            free_trade_slots = max(0, self.config["max_open_trades"] - len(open_trades))
+        free_trade_slots = (
+            free_trade_slots
+            if free_trade_slots is not None
+            else max(0, self.config["max_open_trades"] - len(open_trades))
+        )
         if free_trade_slots <= 0:
             return trades_created
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -697,47 +697,47 @@ class FreqtradeBot(LoggingMixin):
             pair, self.strategy.timeframe, analyzed_df
         )
 
-        if not signal:
-            return False
-
-        if self.strategy.is_pair_locked(pair, candle_date=nowtime, side=signal):
-            lock = PairLocks.get_pair_longest_lock(pair, nowtime, signal)
-            if lock:
-                self.log_once(
-                    f"Pair {pair} {lock.side} is locked until "
-                    f"{lock.lock_end_time.strftime(constants.DATETIME_PRINT_FORMAT)} "
-                    f"due to {lock.reason}.",
-                    logger.info,
-                )
-            else:
-                self.log_once(f"Pair {pair} is currently locked.", logger.info)
-            return False
-
-        # get_free_open_trades is checked when signal is found
-        # to prevent opening too many trades within one iteration
-        if not self.get_free_open_trades():
-            logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
-            return False
-
-        stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
-
-        bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
-        if (bid_check_dom.get("enabled", False)) and (
-            bid_check_dom.get("bids_to_ask_delta", 0) > 0
-        ):
-            if self._check_depth_of_market(pair, bid_check_dom, side=signal):
-                return self.execute_entry(
-                    pair,
-                    stake_amount,
-                    enter_tag=enter_tag,
-                    is_short=(signal == SignalDirection.SHORT),
-                )
-            else:
+        if signal:
+            if self.strategy.is_pair_locked(pair, candle_date=nowtime, side=signal):
+                lock = PairLocks.get_pair_longest_lock(pair, nowtime, signal)
+                if lock:
+                    self.log_once(
+                        f"Pair {pair} {lock.side} is locked until "
+                        f"{lock.lock_end_time.strftime(constants.DATETIME_PRINT_FORMAT)} "
+                        f"due to {lock.reason}.",
+                        logger.info,
+                    )
+                else:
+                    self.log_once(f"Pair {pair} is currently locked.", logger.info)
                 return False
 
-        return self.execute_entry(
-            pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
-        )
+            # get_free_open_trades is checked when signal is found
+            # to prevent opening too many trades within one iteration
+            if not self.get_free_open_trades():
+                logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
+                return False
+
+            stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
+
+            bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
+            if (bid_check_dom.get("enabled", False)) and (
+                bid_check_dom.get("bids_to_ask_delta", 0) > 0
+            ):
+                if self._check_depth_of_market(pair, bid_check_dom, side=signal):
+                    return self.execute_entry(
+                        pair,
+                        stake_amount,
+                        enter_tag=enter_tag,
+                        is_short=(signal == SignalDirection.SHORT),
+                    )
+                else:
+                    return False
+
+            return self.execute_entry(
+                pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
+            )
+        else:
+            return False
 
     #
     # Modify positions / DCA logic and methods

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -303,10 +303,8 @@ class FreqtradeBot(LoggingMixin):
                 self.process_open_trade_positions()
 
         # Then looking for entry opportunities
-        if self.state == State.RUNNING:
-            free_trade_slots = self.get_free_open_trades()
-            if free_trade_slots > 0:
-                self.enter_positions(free_trade_slots)
+        if self.state == State.RUNNING and ((free_trade_slots := self.get_free_open_trades()) > 0):
+            self.enter_positions(free_trade_slots)
         self._schedule.run_pending()
         Trade.commit()
         self.rpc.process_msg_queue(self.dataprovider._msg_queue)
@@ -612,7 +610,7 @@ class FreqtradeBot(LoggingMixin):
     # enter positions / open trades logic and methods
     #
 
-    def enter_positions(self, free_trade_slots: int | None = None) -> int:
+    def enter_positions(self, free_trade_slots: int) -> int:
         """
         Tries to execute entry orders for new trades (positions)
 
@@ -654,12 +652,6 @@ class FreqtradeBot(LoggingMixin):
                 self.log_once("Global pairlock active. Not creating new trades.", logger.info)
             return trades_created
 
-        free_trade_slots = (
-            free_trade_slots
-            if free_trade_slots is not None
-            else max(0, self.config["max_open_trades"] - len(open_trades))
-        )
-
         # Create entity and execute trade for each pair from whitelist
         for pair in whitelist:
             if free_trade_slots <= 0:
@@ -688,6 +680,12 @@ class FreqtradeBot(LoggingMixin):
         """
         logger.debug(f"create_trade for pair {pair}")
 
+        # get_free_open_trades is checked before create_trade is called
+        # but it is still used here to prevent opening too many trades within one iteration
+        if not self.get_free_open_trades():
+            logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
+            return False
+
         analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(pair, self.strategy.timeframe)
         nowtime = analyzed_df.iloc[-1]["date"] if len(analyzed_df) > 0 else None
 
@@ -708,12 +706,6 @@ class FreqtradeBot(LoggingMixin):
                     )
                 else:
                     self.log_once(f"Pair {pair} is currently locked.", logger.info)
-                return False
-
-            # get_free_open_trades is checked when signal is found
-            # to prevent opening too many trades within one iteration
-            if not self.get_free_open_trades():
-                logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
                 return False
 
             stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -615,6 +615,7 @@ class FreqtradeBot(LoggingMixin):
         Tries to execute entry orders for new trades (positions)
 
         :param free_trade_slots: Number of available slots for new trades.
+        :return: Number of trades created
         """
         trades_created = 0
 
@@ -623,8 +624,7 @@ class FreqtradeBot(LoggingMixin):
             self.log_once("Active pair whitelist is empty.", logger.info)
             return trades_created
         # Remove pairs for currently opened trades from the whitelist
-        open_trades = Trade.get_open_trades()
-        for trade in open_trades:
+        for trade in Trade.get_open_trades():
             if trade.pair in whitelist:
                 whitelist.remove(trade.pair)
                 logger.debug("Ignoring %s in pair whitelist", trade.pair)
@@ -635,7 +635,6 @@ class FreqtradeBot(LoggingMixin):
                 logger.info,
             )
             return trades_created
-
         if PairLocks.is_global_lock(side="*"):
             # This only checks for total locks (both sides).
             # per-side locks will be evaluated by `is_pair_locked` within create_trade,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -303,8 +303,10 @@ class FreqtradeBot(LoggingMixin):
                 self.process_open_trade_positions()
 
         # Then looking for entry opportunities
-        if self.state == State.RUNNING and self.get_free_open_trades():
-            self.enter_positions()
+        if self.state == State.RUNNING:
+            free_trade_slots = self.get_free_open_trades()
+            if free_trade_slots > 0:
+                self.enter_positions(free_trade_slots)
         self._schedule.run_pending()
         Trade.commit()
         self.rpc.process_msg_queue(self.dataprovider._msg_queue)
@@ -610,9 +612,11 @@ class FreqtradeBot(LoggingMixin):
     # enter positions / open trades logic and methods
     #
 
-    def enter_positions(self) -> int:
+    def enter_positions(self, free_trade_slots: int | None = None) -> int:
         """
         Tries to execute entry orders for new trades (positions)
+
+        :param free_trade_slots: Number of available slots for new trades.
         """
         trades_created = 0
 
@@ -621,7 +625,8 @@ class FreqtradeBot(LoggingMixin):
             self.log_once("Active pair whitelist is empty.", logger.info)
             return trades_created
         # Remove pairs for currently opened trades from the whitelist
-        for trade in Trade.get_open_trades():
+        open_trades = Trade.get_open_trades()
+        for trade in open_trades:
             if trade.pair in whitelist:
                 whitelist.remove(trade.pair)
                 logger.debug("Ignoring %s in pair whitelist", trade.pair)
@@ -632,6 +637,12 @@ class FreqtradeBot(LoggingMixin):
                 logger.info,
             )
             return trades_created
+
+        if free_trade_slots is None:
+            free_trade_slots = max(0, self.config["max_open_trades"] - len(open_trades))
+        if free_trade_slots <= 0:
+            return trades_created
+
         if PairLocks.is_global_lock(side="*"):
             # This only checks for total locks (both sides).
             # per-side locks will be evaluated by `is_pair_locked` within create_trade,
@@ -649,9 +660,13 @@ class FreqtradeBot(LoggingMixin):
             return trades_created
         # Create entity and execute trade for each pair from whitelist
         for pair in whitelist:
+            if free_trade_slots <= 0:
+                break
             try:
                 with self._exit_lock:
-                    trades_created += self.create_trade(pair)
+                    trade_created = self.create_trade(pair)
+                    free_trade_slots -= trade_created
+                    trades_created += trade_created
             except DependencyException as exception:
                 logger.warning("Unable to create trade for %s: %s", pair, exception)
 
@@ -671,12 +686,6 @@ class FreqtradeBot(LoggingMixin):
         """
         logger.debug(f"create_trade for pair {pair}")
 
-        # get_free_open_trades is checked before create_trade is called
-        # but it is still used here to prevent opening too many trades within one iteration
-        if not self.get_free_open_trades():
-            logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
-            return False
-
         analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(pair, self.strategy.timeframe)
         nowtime = analyzed_df.iloc[-1]["date"] if len(analyzed_df) > 0 else None
 
@@ -685,40 +694,47 @@ class FreqtradeBot(LoggingMixin):
             pair, self.strategy.timeframe, analyzed_df
         )
 
-        if signal:
-            if self.strategy.is_pair_locked(pair, candle_date=nowtime, side=signal):
-                lock = PairLocks.get_pair_longest_lock(pair, nowtime, signal)
-                if lock:
-                    self.log_once(
-                        f"Pair {pair} {lock.side} is locked until "
-                        f"{lock.lock_end_time.strftime(constants.DATETIME_PRINT_FORMAT)} "
-                        f"due to {lock.reason}.",
-                        logger.info,
-                    )
-                else:
-                    self.log_once(f"Pair {pair} is currently locked.", logger.info)
-                return False
-            stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
-
-            bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
-            if (bid_check_dom.get("enabled", False)) and (
-                bid_check_dom.get("bids_to_ask_delta", 0) > 0
-            ):
-                if self._check_depth_of_market(pair, bid_check_dom, side=signal):
-                    return self.execute_entry(
-                        pair,
-                        stake_amount,
-                        enter_tag=enter_tag,
-                        is_short=(signal == SignalDirection.SHORT),
-                    )
-                else:
-                    return False
-
-            return self.execute_entry(
-                pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
-            )
-        else:
+        if not signal:
             return False
+
+        if self.strategy.is_pair_locked(pair, candle_date=nowtime, side=signal):
+            lock = PairLocks.get_pair_longest_lock(pair, nowtime, signal)
+            if lock:
+                self.log_once(
+                    f"Pair {pair} {lock.side} is locked until "
+                    f"{lock.lock_end_time.strftime(constants.DATETIME_PRINT_FORMAT)} "
+                    f"due to {lock.reason}.",
+                    logger.info,
+                )
+            else:
+                self.log_once(f"Pair {pair} is currently locked.", logger.info)
+            return False
+
+        # get_free_open_trades is checked when signal is found
+        # to prevent opening too many trades within one iteration
+        if not self.get_free_open_trades():
+            logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
+            return False
+
+        stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
+
+        bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
+        if (bid_check_dom.get("enabled", False)) and (
+            bid_check_dom.get("bids_to_ask_delta", 0) > 0
+        ):
+            if self._check_depth_of_market(pair, bid_check_dom, side=signal):
+                return self.execute_entry(
+                    pair,
+                    stake_amount,
+                    enter_tag=enter_tag,
+                    is_short=(signal == SignalDirection.SHORT),
+                )
+            else:
+                return False
+
+        return self.execute_entry(
+            pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
+        )
 
     #
     # Modify positions / DCA logic and methods

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -638,14 +638,6 @@ class FreqtradeBot(LoggingMixin):
             )
             return trades_created
 
-        free_trade_slots = (
-            free_trade_slots
-            if free_trade_slots is not None
-            else max(0, self.config["max_open_trades"] - len(open_trades))
-        )
-        if free_trade_slots <= 0:
-            return trades_created
-
         if PairLocks.is_global_lock(side="*"):
             # This only checks for total locks (both sides).
             # per-side locks will be evaluated by `is_pair_locked` within create_trade,
@@ -661,15 +653,22 @@ class FreqtradeBot(LoggingMixin):
             else:
                 self.log_once("Global pairlock active. Not creating new trades.", logger.info)
             return trades_created
+
+        free_trade_slots = (
+            free_trade_slots
+            if free_trade_slots is not None
+            else max(0, self.config["max_open_trades"] - len(open_trades))
+        )
+
         # Create entity and execute trade for each pair from whitelist
         for pair in whitelist:
             if free_trade_slots <= 0:
                 break
             try:
                 with self._exit_lock:
-                    trade_created = self.create_trade(pair)
-                    free_trade_slots -= trade_created
-                    trades_created += trade_created
+                    if self.create_trade(pair):
+                        free_trade_slots -= 1
+                        trades_created += 1
             except DependencyException as exception:
                 logger.warning("Unable to create trade for %s: %s", pair, exception)
 

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -264,21 +264,20 @@ def test_total_open_trades_stakes(mocker, default_conf_usdt, ticker_usdt, fee) -
     )
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
-    freqtrade.enter_positions()
-    trade = Trade.session.scalars(select(Trade)).first()
+    freqtrade.enter_positions(2)
+    trade1 = Trade.session.scalars(select(Trade)).first()
 
-    assert trade is not None
-    assert trade.stake_amount == 60.0
-    assert trade.is_open
-    assert trade.open_date is not None
+    assert trade1 is not None
+    assert trade1.stake_amount == 60.0
+    assert trade1.is_open
+    assert trade1.open_date is not None
 
-    freqtrade.enter_positions()
-    trade = Trade.session.scalars(select(Trade).order_by(Trade.id.desc())).first()
+    trade2 = Trade.session.scalars(select(Trade).order_by(Trade.id.desc())).first()
 
-    assert trade is not None
-    assert trade.stake_amount == 60.0
-    assert trade.is_open
-    assert trade.open_date is not None
+    assert trade2 is not None
+    assert trade2.stake_amount == 60.0
+    assert trade2.is_open
+    assert trade2.open_date is not None
 
     assert Trade.total_open_trades_stakes() == 120.0
 
@@ -432,11 +431,11 @@ def test_enter_positions_no_pairs_left(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
 
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(1)
     assert n == positions
     if positions:
         assert not log_has_re(r"No currency pair in active pair whitelist.*", caplog)
-        n = freqtrade.enter_positions()
+        n = freqtrade.enter_positions(0)
         assert n == 0
         assert log_has_re(r"No currency pair in active pair whitelist.*", caplog)
     else:
@@ -458,16 +457,17 @@ def test_enter_positions_global_pairlock(
     )
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(1)
+    assert n == 1
     message = r"Global pairlock active until.* Not creating new trades."
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(0)
     # 0 trades, but it's not because of pairlock.
     assert n == 0
     assert not log_has_re(message, caplog)
     caplog.clear()
 
     PairLocks.lock_pair("*", dt_now() + timedelta(minutes=20), "Just because", side="*")
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(1)
     assert n == 0
     assert log_has_re(message, caplog)
 
@@ -540,7 +540,7 @@ def test_create_trades_multiple_trades(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
 
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(max_open)
     trades = Trade.get_open_trades()
     # Expected trades should be max_open * a modified value
     # depending on the configured tradable_balance
@@ -1158,7 +1158,7 @@ def test_enter_positions(
         "freqtrade.freqtradebot.FreqtradeBot.create_trade",
         MagicMock(return_value=return_value, side_effect=side_effect),
     )
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(1)
     assert n == 0
     assert log_has(log_message, caplog)
     # create_trade should be called once for every pair in the whitelist.
@@ -1494,7 +1494,7 @@ def test_handle_trade(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -1574,7 +1574,7 @@ def test_handle_overlapping_signals(
         patch_get_signal(freqtrade, enter_long=True, exit_long=True)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     # Buy and Sell triggering, so doing nothing ...
     trades = Trade.session.scalars(select(Trade)).all()
@@ -1584,7 +1584,7 @@ def test_handle_overlapping_signals(
 
     # Buy is triggering, so buying ...
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trades = Trade.session.scalars(select(Trade)).all()
     for trade in trades:
         trade.is_short = is_short
@@ -1651,7 +1651,7 @@ def test_handle_trade_roi(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=True)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -1693,7 +1693,7 @@ def test_handle_trade_use_exit_signal(
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -1729,7 +1729,7 @@ def test_close_trade(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create trade and sell it
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -2956,7 +2956,7 @@ def test_execute_trade_exit_up(
     freqtrade.strategy.confirm_trade_exit = MagicMock(return_value=False)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     rpc_mock.reset_mock()
 
     trade = Trade.session.scalars(select(Trade)).first()
@@ -3047,7 +3047,7 @@ def test_execute_trade_exit_down(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -3137,7 +3137,7 @@ def test_execute_trade_exit_custom_exit_price(
     freqtrade.strategy.confirm_trade_exit = MagicMock(return_value=False)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     rpc_mock.reset_mock()
 
     trade = Trade.session.scalars(select(Trade)).first()
@@ -3251,7 +3251,7 @@ def test_execute_trade_exit_market_order(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -3330,7 +3330,7 @@ def test_execute_trade_exit_insufficient_funds_error(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -3410,7 +3410,7 @@ def test_exit_profit_only(
         freqtrade.strategy.ft_stoploss_reached = MagicMock(
             return_value=ExitCheckTuple(exit_type=ExitType.NONE)
         )
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
@@ -3454,7 +3454,7 @@ def test_sell_not_enough_balance(
     patch_get_signal(freqtrade)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     amnt = trade.amount
@@ -3519,7 +3519,7 @@ def test_locked_pairs(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -3541,7 +3541,7 @@ def test_locked_pairs(
 
     # reinit - should buy other pair.
     caplog.clear()
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     direction = "short" if is_short else "long"
 
     assert log_has_re(rf"Pair {trade.pair} {direction} is locked.*", caplog)
@@ -3571,7 +3571,7 @@ def test_ignore_roi_if_entry_signal(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=True)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -3617,7 +3617,7 @@ def test_trailing_stop_loss(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
     assert freqtrade.handle_trade(trade) is False
@@ -3704,7 +3704,7 @@ def test_trailing_stop_loss_positive(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=False)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
@@ -3804,7 +3804,7 @@ def test_disable_ignore_roi_if_entry_signal(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.min_roi_reached = MagicMock(return_value=True)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -4363,7 +4363,7 @@ def test_order_book_depth_of_market(
     whitelist = deepcopy(default_conf_usdt["exchange"]["pair_whitelist"])
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     if is_high_delta:
@@ -4487,7 +4487,7 @@ def test_order_book_exit_pricing(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade
@@ -4551,13 +4551,13 @@ def test_sync_wallet_dry_run(
     patch_get_signal(bot)
     assert bot.wallets.get_free("USDT") == 120.0
 
-    n = bot.enter_positions()
+    n = bot.enter_positions(2)
     assert n == 2
     trades = Trade.session.scalars(select(Trade)).all()
     assert len(trades) == 2
 
     bot.config["max_open_trades"] = 3
-    n = bot.enter_positions()
+    n = bot.enter_positions(1)
     assert n == 0
     assert log_has_re(
         r"Unable to create trade for XRP/USDT: "

--- a/tests/freqtradebot/test_integration.py
+++ b/tests/freqtradebot/test_integration.py
@@ -91,7 +91,7 @@ def test_may_execute_exit_stoploss_on_exchange_multi(default_conf, ticker, fee, 
     patch_get_signal(freqtrade)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(3)
     assert freqtrade.strategy.confirm_trade_entry.call_count == 3
     freqtrade.strategy.confirm_trade_entry.reset_mock()
     assert freqtrade.strategy.confirm_trade_exit.call_count == 0
@@ -183,7 +183,7 @@ def test_forcebuy_last_unlimited(default_conf, ticker, fee, mocker, balance_rati
     patch_get_signal(freqtrade)
 
     # Create 4 trades
-    n = freqtrade.enter_positions()
+    n = freqtrade.enter_positions(5)
     assert n == 4
 
     trades = Trade.session.scalars(select(Trade)).all()
@@ -229,7 +229,7 @@ def test_dca_buying(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
     )
 
     patch_get_signal(freqtrade)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     assert len(Trade.get_trades().all()) == 1
     trade = Trade.get_trades().first()
@@ -300,7 +300,7 @@ def test_dca_short(default_conf_usdt, ticker_usdt, fee, mocker) -> None:
     )
 
     patch_get_signal(freqtrade, enter_long=False, enter_short=True)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     assert len(Trade.get_trades().all()) == 1
     trade = Trade.get_trades().first()
@@ -381,7 +381,7 @@ def test_dca_order_adjust(default_conf_usdt, ticker_usdt, leverage, fee, mocker)
     freqtrade.strategy.leverage = MagicMock(return_value=leverage)
     freqtrade.strategy.minimal_roi = {0: 0.2}
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     assert len(Trade.get_trades().all()) == 1
     trade: Trade = Trade.get_trades().first()
@@ -544,7 +544,7 @@ def test_dca_order_adjust_entry_replace_fails(
     # no order fills.
     mocker.patch(f"{EXMS}._dry_is_price_crossed", side_effect=[False, True])
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(2)
 
     trades = Trade.session.scalars(
         select(Trade)
@@ -629,7 +629,7 @@ def test_dca_exiting(default_conf_usdt, ticker_usdt, fee, mocker, caplog, levera
 
     patch_get_signal(freqtrade)
     freqtrade.strategy.leverage = MagicMock(return_value=leverage)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     assert len(Trade.get_trades().all()) == 1
     trade = Trade.get_trades().first()
@@ -754,7 +754,7 @@ def test_dca_handle_similar_open_order(
     freqtrade.strategy.minimal_roi = {0: 0.2}
 
     # Create trade and initial entry order
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     assert len(Trade.get_trades().all()) == 1
     trade: Trade = Trade.get_trades().first()

--- a/tests/freqtradebot/test_stoploss_on_exchange.py
+++ b/tests/freqtradebot/test_stoploss_on_exchange.py
@@ -47,7 +47,7 @@ def test_add_stoploss_on_exchange(mocker, default_conf_usdt, limit_order, is_sho
 
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -88,7 +88,7 @@ def test_handle_stoploss_on_exchange(
     # should get the stoploss order id immediately
     # and should return false as no trade actually happened
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
     assert trade.is_open
@@ -215,7 +215,7 @@ def test_handle_stoploss_on_exchange_emergency(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
     assert trade.is_open
@@ -293,7 +293,7 @@ def test_handle_stoploss_on_exchange_partial(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -353,7 +353,7 @@ def test_handle_stoploss_on_exchange_partial_cancel_here(
     freqtrade = FreqtradeBot(default_conf_usdt)
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -434,7 +434,7 @@ def test_handle_sle_cancel_cant_recreate(
     )
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
     trade.is_open = True
@@ -486,7 +486,7 @@ def test_create_stoploss_order_invalid_order(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.order_types["stoploss_on_exchange"] = True
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     caplog.clear()
@@ -538,7 +538,7 @@ def test_create_stoploss_order_insufficient_funds(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
     freqtrade.strategy.order_types["stoploss_on_exchange"] = True
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     caplog.clear()
@@ -623,7 +623,7 @@ def test_handle_stoploss_on_exchange_trailing(
 
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -778,7 +778,7 @@ def test_handle_stoploss_on_exchange_trailing_error(
     # setting stoploss_on_exchange_interval to 60 seconds
     freqtrade.strategy.order_types["stoploss_on_exchange_interval"] = 60
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -901,7 +901,7 @@ def test_handle_stoploss_on_exchange_custom_stop(
 
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
     trade.is_open = True
@@ -1020,7 +1020,7 @@ def test_execute_trade_exit_down_stoploss_on_exchange_dry_run(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade.is_short == is_short
@@ -1104,7 +1104,7 @@ def test_execute_trade_exit_sloe_cancel_exception(
 
     freqtrade.strategy.order_types["stoploss_on_exchange"] = True
     patch_get_signal(freqtrade)
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     PairLock.session = MagicMock()
@@ -1159,7 +1159,7 @@ def test_execute_trade_exit_with_stoploss_on_exchange(
     patch_get_signal(freqtrade, enter_short=is_short, enter_long=not is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     trade.is_short = is_short
@@ -1210,7 +1210,7 @@ def test_may_execute_trade_exit_after_stoploss_on_exchange_hit(
     patch_get_signal(freqtrade, enter_long=not is_short, enter_short=is_short)
 
     # Create some test data
-    freqtrade.enter_positions()
+    freqtrade.enter_positions(1)
     freqtrade.manage_open_orders()
     trade = Trade.session.scalars(select(Trade)).first()
     trades = [trade]

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -143,7 +143,7 @@ def test_rpc_trade_status(default_conf, ticker, fee, mocker) -> None:
     with pytest.raises(RPCException, match=r".*no active trade*"):
         rpc._rpc_trade_status()
 
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     # Open order...
     results = rpc._rpc_trade_status()
@@ -247,7 +247,7 @@ def test_rpc_status_table(default_conf, ticker, fee, mocker, time_machine) -> No
     with pytest.raises(RPCException, match=r".*no active trade*"):
         rpc._rpc_status_table(default_conf["stake_currency"], "USD")
     mocker.patch(f"{EXMS}._dry_is_price_crossed", return_value=False)
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     result, headers, fiat_profit_sum, total_sum = rpc._rpc_status_table(
         default_conf["stake_currency"], "USD"
@@ -994,11 +994,11 @@ def test_rpc_force_exit(default_conf, ticker, fee, mocker) -> None:
     msg = rpc._rpc_force_exit("all")
     assert msg == {"result": "Created exit orders for all open trades."}
 
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     msg = rpc._rpc_force_exit("all")
     assert msg == {"result": "Created exit orders for all open trades."}
 
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     msg = rpc._rpc_force_exit("2")
     assert msg == {"result": "Created exit order for trade 2."}
 
@@ -1012,7 +1012,7 @@ def test_rpc_force_exit(default_conf, ticker, fee, mocker) -> None:
     freqtradebot.state = State.RUNNING
     assert cancel_order_mock.call_count == 0
     mocker.patch(f"{EXMS}._dry_is_price_crossed", MagicMock(return_value=False))
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     # make an limit-buy open trade
     trade = Trade.session.scalars(select(Trade).filter(Trade.id == "3")).first()
     filled_amount = trade.amount_requested / 2
@@ -1048,7 +1048,7 @@ def test_rpc_force_exit(default_conf, ticker, fee, mocker) -> None:
     )
 
     freqtradebot.config["max_open_trades"] = 3
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(3)
 
     cancel_order_mock.reset_mock()
     trade = Trade.session.scalars(select(Trade).filter(Trade.id == "3")).first()
@@ -1149,7 +1149,7 @@ def test_enter_tag_performance_handle(default_conf, ticker, fee, mocker) -> None
 
     # Create some test data
     create_mock_trades_usdt(fee)
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     res = rpc._rpc_enter_tag_performance(None)
 
@@ -1319,7 +1319,7 @@ def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     assert counts["current"] == 0
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     counts = rpc._rpc_count()
     assert counts["current"] == 1
 

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -474,7 +474,7 @@ async def test_order_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(3)
 
     mocker.patch("freqtrade.rpc.telegram.MAX_MESSAGE_LENGTH", 500)
 
@@ -584,7 +584,7 @@ async def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(3)
     # Trigger status while we have a fulfilled order for the open trade
     await telegram._status(update=update, context=MagicMock())
 
@@ -655,7 +655,7 @@ async def test_status_table_handle(default_conf, update, ticker, fee, mocker) ->
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     await telegram._status_table(update=update, context=MagicMock())
 
@@ -918,7 +918,7 @@ async def test_telegram_profit_handle(
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     trade = Trade.session.scalars(select(Trade)).first()
 
     context = MagicMock()
@@ -1363,7 +1363,7 @@ async def test_telegram_forceexit_handle(
     patch_get_signal(freqtradebot)
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     trade = Trade.session.scalars(select(Trade)).first()
     assert trade
@@ -1433,7 +1433,7 @@ async def test_telegram_force_exit_down_handle(
     patch_get_signal(freqtradebot)
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
 
     # Decrease the price and sell it
     mocker.patch.multiple(EXMS, fetch_ticker=ticker_sell_down)
@@ -1501,7 +1501,7 @@ async def test_forceexit_all_handle(default_conf, update, ticker, fee, mocker) -
     patch_get_signal(freqtradebot)
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(4)
     msg_mock.reset_mock()
 
     # /forceexit all
@@ -1591,7 +1591,7 @@ async def test_force_exit_no_pair(default_conf, update, ticker, fee, mocker) -> 
     assert msg_mock.call_args_list[0][1]["msg"] == "No open trade found."
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(4)
     msg_mock.reset_mock()
 
     # /forceexit
@@ -1832,7 +1832,7 @@ async def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     freqtradebot.state = State.RUNNING
 
     # Create some test data
-    freqtradebot.enter_positions()
+    freqtradebot.enter_positions(1)
     msg_mock.reset_mock()
     await telegram._count(update=update, context=MagicMock())
 


### PR DESCRIPTION
AI was used to find the issue and review my manually-written changes.

Old code calls `Trade.get_open_trade_count()` too often. Let's say we have 50 pairs on whitelist after removing pairs that are currently having open trade.. The code will call `Trade.get_open_trade_count()` 51 times. Once on `process` and 50 times on `create_trade` no matter if there is any signal or not, or the slot is full after only 10 pairs being checked.

New code call `Trade.get_open_trade_count()` once on `process` and n number of times on `create_trade`, where n is number of not-locked pairs with entry signal, and n can't be more than available trade slot since we have early break when the slot become full.