### PR TITLE
remove unecessary deepcopy

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -596,7 +596,7 @@ class FreqaiDataKitchen:
         self.model_filename = f"cb_{coin.lower()}_{timestamp_id}"
 
     def set_all_pairs(self) -> None:
-        self.all_pairs = copy.deepcopy(
+        self.all_pairs = copy.copy(
             self.freqai_config["feature_parameters"].get("include_corr_pairlist", [])
         )
         for pair in self.config.get("exchange", "").get("pair_whitelist"):

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -596,8 +596,8 @@ class FreqaiDataKitchen:
         self.model_filename = f"cb_{coin.lower()}_{timestamp_id}"
 
     def set_all_pairs(self) -> None:
-        self.all_pairs = copy.copy(
-            self.freqai_config["feature_parameters"].get("include_corr_pairlist", [])
+        self.all_pairs = (
+            self.freqai_config["feature_parameters"].get("include_corr_pairlist", []).copy()
         )
         for pair in self.config.get("exchange", "").get("pair_whitelist"):
             if pair not in self.all_pairs:

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -616,7 +616,7 @@ class FreqtradeBot(LoggingMixin):
         """
         trades_created = 0
 
-        whitelist = deepcopy(self.active_pair_whitelist)
+        whitelist = self.active_pair_whitelist.copy()
         if not whitelist:
             self.log_once("Active pair whitelist is empty.", logger.info)
             return trades_created

--- a/freqtrade/ft_types/backtest_result_type.py
+++ b/freqtrade/ft_types/backtest_result_type.py
@@ -21,13 +21,11 @@ class BacktestResultType(TypedDict):
 def get_BacktestResultType_default() -> BacktestResultType:
     return cast(
         BacktestResultType,
-        deepcopy(
-            {
-                "metadata": {},
-                "strategy": {},
-                "strategy_comparison": [],
-            }
-        ),
+        {
+            "metadata": {},
+            "strategy": {},
+            "strategy_comparison": [],
+        },
     )
 
 

--- a/freqtrade/ft_types/backtest_result_type.py
+++ b/freqtrade/ft_types/backtest_result_type.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Any, cast
 
 from pandas import DataFrame

--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -106,7 +106,7 @@ class AgeFilter(IPairList):
         since_ms = dt_ts(dt_floor_day(dt_now()) + timedelta(days=since_days))
         candles = self._exchange.refresh_latest_ohlcv(needed_pairs, since_ms=since_ms, cache=False)
         if self._enabled:
-            for p in deepcopy(pairlist):
+            for p in pairlist.copy():
                 daily_candles = (
                     candles[(p, "1d", self._def_candletype)]
                     if (p, "1d", self._def_candletype) in candles

--- a/freqtrade/plugins/pairlist/AgeFilter.py
+++ b/freqtrade/plugins/pairlist/AgeFilter.py
@@ -3,7 +3,6 @@ Minimum age (days listed) pair list filter
 """
 
 import logging
-from copy import deepcopy
 from datetime import timedelta
 
 from pandas import DataFrame

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -4,7 +4,6 @@ PairList Handler base class
 
 import logging
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from enum import StrEnum
 from typing import Any, Literal, TypedDict
 

--- a/freqtrade/plugins/pairlist/IPairList.py
+++ b/freqtrade/plugins/pairlist/IPairList.py
@@ -201,7 +201,7 @@ class IPairList(LoggingMixin, ABC):
         """
         if self._enabled:
             # Copy list since we're modifying this list
-            for p in deepcopy(pairlist):
+            for p in pairlist.copy():
                 # Filter out assets
                 if not self._validate_pair(p, tickers[p] if p in tickers else None):
                     pairlist.remove(p)

--- a/freqtrade/plugins/pairlist/StaticPairList.py
+++ b/freqtrade/plugins/pairlist/StaticPairList.py
@@ -5,7 +5,6 @@ Provides pair white list as it configured in config
 """
 
 import logging
-from copy import deepcopy
 
 from cachetools import LRUCache
 

--- a/freqtrade/plugins/pairlist/StaticPairList.py
+++ b/freqtrade/plugins/pairlist/StaticPairList.py
@@ -82,7 +82,7 @@ class StaticPairList(IPairList):
         :param tickers: Tickers (from exchange.get_tickers). May be cached.
         :return: new whitelist
         """
-        pairlist_ = deepcopy(pairlist)
+        pairlist_ = pairlist.copy()
         for pair in self._config["exchange"]["pair_whitelist"]:
             if pair not in pairlist_:
                 pairlist_.append(pair)


### PR DESCRIPTION
there are some unnecessary deepcopy used, especially used on
- list of strings
- when creating new dict

script below was created by AI to benchmark and make sure using .copy() is safe for those 2 types of usage

```py
from __future__ import annotations

import argparse
import statistics
import timeit
from collections.abc import Callable
from copy import deepcopy


def measure(timer: timeit.Timer, iterations: int) -> float:
    """Return total seconds for the requested number of iterations."""
    return timer.timeit(number=iterations)


def calibrated_iterations(timer: timeit.Timer, target_seconds: float) -> int:
    """Choose an iteration count that makes a sample approximately target_seconds long."""
    iterations = 1
    elapsed = 0.0
    while elapsed < 0.05 and iterations < 10_000_000:
        elapsed = measure(timer, iterations)
        if elapsed < 0.05:
            iterations *= 10
    return max(1, min(10_000_000, round(iterations * target_seconds / elapsed)))


def format_duration(seconds: float) -> str:
    magnitude = abs(seconds)
    if magnitude < 1e-6:
        return f"{seconds * 1e9:.1f} ns"
    if magnitude < 1e-3:
        return f"{seconds * 1e6:.2f} us"
    if magnitude < 1:
        return f"{seconds * 1e3:.2f} ms"
    return f"{seconds:.2f} s"


def verify_copy_isolation(name: str, copy_function: Callable[[list[str]], list[str]]) -> None:
    """Verify that structural mutations do not leak between a list and its copy."""
    initial = ["BTC/USDT", "ETH/USDT", "SOL/USDT"]

    original = initial.copy()
    copied = copy_function(original)
    original.remove("ETH/USDT")
    if copied != initial:
        raise RuntimeError(f"{name}: modifying the original affected its copy")

    original = initial.copy()
    copied = copy_function(original)
    copied.append("XRP/USDT")
    if original != initial:
        raise RuntimeError(f"{name}: modifying the copy affected the original")


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument(
        "--sizes",
        type=int,
        nargs="+",
        default=[10, 50, 100, 1000],
        help="list sizes to benchmark (default: 10 50 100 1000)",
    )
    parser.add_argument(
        "--repeat",
        type=int,
        default=7,
        help="timing samples per implementation (default: 7)",
    )
    parser.add_argument(
        "--iterations",
        type=int,
        help="copies per sample; by default this is calibrated for each list size",
    )
    parser.add_argument(
        "--target-time",
        type=float,
        default=0.2,
        help="target seconds per auto-calibrated sample (default: 0.2)",
    )
    args = parser.parse_args()
    if any(size < 0 for size in args.sizes):
        parser.error("--sizes values must be non-negative")
    if args.repeat < 1:
        parser.error("--repeat must be at least 1")
    if args.iterations is not None and args.iterations < 1:
        parser.error("--iterations must be at least 1")
    if args.target_time <= 0:
        parser.error("--target-time must be positive")
    return args


def main() -> None:
    args = parse_args()
    verify_copy_isolation("deepcopy", deepcopy)
    verify_copy_isolation("list.copy", list.copy)

    print("Isolation checks passed for mutations to both the original and the copy.")
    print(f"Median of {args.repeat} samples; values are unique strings")
    print(
        f"{'items':>8}  {'copies/sample':>13}  {'deepcopy':>12}  {'list.copy':>12}  "
        f"{'time saved':>12}  {'saved':>8}  {'speedup':>8}"
    )

    for size in args.sizes:
        values = [f"PAIR-{index}/USDT" for index in range(size)]
        timer_globals = {"deepcopy": deepcopy, "values": values}
        deep_timer = timeit.Timer("deepcopy(values)", globals=timer_globals)
        shallow_timer = timeit.Timer("values.copy()", globals=timer_globals)

        deep_result = deepcopy(values)
        shallow_result = values.copy()
        if deep_result != shallow_result or deep_result is values or shallow_result is values:
            raise RuntimeError("copy verification failed")

        iterations = args.iterations or calibrated_iterations(deep_timer, args.target_time)
        deep_samples: list[float] = []
        shallow_samples: list[float] = []
        for sample in range(args.repeat):
            # Alternate order to reduce thermal/frequency bias.
            if sample % 2:
                shallow_samples.append(measure(shallow_timer, iterations))
                deep_samples.append(measure(deep_timer, iterations))
            else:
                deep_samples.append(measure(deep_timer, iterations))
                shallow_samples.append(measure(shallow_timer, iterations))

        deep_per_copy = statistics.median(deep_samples) / iterations
        shallow_per_copy = statistics.median(shallow_samples) / iterations
        saved_per_copy = deep_per_copy - shallow_per_copy
        saved_percent = saved_per_copy / deep_per_copy * 100
        speedup = deep_per_copy / shallow_per_copy
        print(
            f"{size:8,d}  {iterations:13,d}  {format_duration(deep_per_copy):>12}  "
            f"{format_duration(shallow_per_copy):>12}  {format_duration(saved_per_copy):>12}  "
            f"{saved_percent:7.2f}%  {speedup:7.2f}x"
        )


if __name__ == "__main__":
    main()
```

The result of `python benchmark_list_copy.py --sizes 10 50 100 1000 --repeat 9` was
```
Isolation checks passed for mutations to both the original and the copy.
Median of 9 samples; values are unique strings
   items  copies/sample      deepcopy     list.copy    time saved     saved   speedup
      10        113,204       1.64 us       25.4 ns       1.62 us    98.45%    64.61x
      50         27,736       6.95 us       65.7 ns       6.88 us    99.06%   105.85x
     100         14,969      13.00 us       94.8 ns      12.90 us    99.27%   137.14x
   1,000          1,629     122.66 us      925.1 ns     121.74 us    99.25%   132.60x
```