### PR TITLE
use copy on TimeRange

### DIFF
--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -34,6 +34,15 @@ class TimeRange:
         self.startts: int = startts
         self.stopts: int = stopts
 
+    def copy(self) -> Self:
+        """Return an independent copy of this timerange."""
+        return type(self)(
+            starttype=self.starttype,
+            stoptype=self.stoptype,
+            startts=self.startts,
+            stopts=self.stopts,
+        )
+
     @property
     def startdt(self) -> datetime | None:
         if self.startts:

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -7,7 +7,6 @@ It's subclasses handle and storing data from disk.
 import logging
 import re
 from abc import ABC, abstractmethod
-from copy import copy
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -367,7 +366,7 @@ class IDataHandler(ABC):
         :return: DataFrame with ohlcv data, or empty DataFrame
         """
         # Fix startup period
-        timerange_startup = copy(timerange)
+        timerange_startup = timerange.copy()
         if startup_candles > 0 and timerange_startup:
             timerange_startup.subtract_start(timeframe_to_seconds(timeframe) * startup_candles)
 

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -7,7 +7,7 @@ It's subclasses handle and storing data from disk.
 import logging
 import re
 from abc import ABC, abstractmethod
-from copy import deepcopy
+from copy import copy
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -367,7 +367,7 @@ class IDataHandler(ABC):
         :return: DataFrame with ohlcv data, or empty DataFrame
         """
         # Fix startup period
-        timerange_startup = deepcopy(timerange)
+        timerange_startup = copy(timerange)
         if startup_candles > 0 and timerange_startup:
             timerange_startup.subtract_start(timeframe_to_seconds(timeframe) * startup_candles)
 

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -366,7 +366,7 @@ class IDataHandler(ABC):
         :return: DataFrame with ohlcv data, or empty DataFrame
         """
         # Fix startup period
-        timerange_startup = timerange.copy()
+        timerange_startup = timerange.copy() if timerange else None
         if startup_candles > 0 and timerange_startup:
             timerange_startup.subtract_start(timeframe_to_seconds(timeframe) * startup_candles)
 

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -1,8 +1,8 @@
-import copy
 import inspect
 import logging
 import random
 import shutil
+from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -596,7 +596,7 @@ class FreqaiDataKitchen:
         self.model_filename = f"cb_{coin.lower()}_{timestamp_id}"
 
     def set_all_pairs(self) -> None:
-        self.all_pairs = copy.deepcopy(
+        self.all_pairs = deepcopy(
             self.freqai_config["feature_parameters"].get("include_corr_pairlist", [])
         )
         for pair in self.config.get("exchange", "").get("pair_whitelist"):

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -338,8 +338,8 @@ class FreqaiDataKitchen:
         config_timerange = TimeRange.parse_timerange(self.config["timerange"])
         if config_timerange.stopts == 0:
             config_timerange.stopts = int(datetime.now(tz=UTC).timestamp())
-        timerange_train = copy.deepcopy(full_timerange)
-        timerange_backtest = copy.deepcopy(full_timerange)
+        timerange_train = copy.copy(full_timerange)
+        timerange_backtest = copy.copy(full_timerange)
 
         tr_training_list = []
         tr_backtesting_list = []
@@ -354,7 +354,7 @@ class FreqaiDataKitchen:
 
             first = False
             tr_training_list.append(timerange_train.timerange_str)
-            tr_training_list_timerange.append(copy.deepcopy(timerange_train))
+            tr_training_list_timerange.append(copy.copy(timerange_train))
 
             # associated backtest period
             timerange_backtest.startts = timerange_train.stopts
@@ -364,7 +364,7 @@ class FreqaiDataKitchen:
                 timerange_backtest.stopts = config_timerange.stopts
 
             tr_backtesting_list.append(timerange_backtest.timerange_str)
-            tr_backtesting_list_timerange.append(copy.deepcopy(timerange_backtest))
+            tr_backtesting_list_timerange.append(copy.copy(timerange_backtest))
 
             # ensure we are predicting on exactly same amount of data as requested by user defined
             #  --timerange

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -338,8 +338,8 @@ class FreqaiDataKitchen:
         config_timerange = TimeRange.parse_timerange(self.config["timerange"])
         if config_timerange.stopts == 0:
             config_timerange.stopts = int(datetime.now(tz=UTC).timestamp())
-        timerange_train = copy.copy(full_timerange)
-        timerange_backtest = copy.copy(full_timerange)
+        timerange_train = full_timerange.copy()
+        timerange_backtest = full_timerange.copy()
 
         tr_training_list = []
         tr_backtesting_list = []
@@ -354,7 +354,7 @@ class FreqaiDataKitchen:
 
             first = False
             tr_training_list.append(timerange_train.timerange_str)
-            tr_training_list_timerange.append(copy.copy(timerange_train))
+            tr_training_list_timerange.append(timerange_train.copy())
 
             # associated backtest period
             timerange_backtest.startts = timerange_train.stopts
@@ -364,7 +364,7 @@ class FreqaiDataKitchen:
                 timerange_backtest.stopts = config_timerange.stopts
 
             tr_backtesting_list.append(timerange_backtest.timerange_str)
-            tr_backtesting_list_timerange.append(copy.copy(timerange_backtest))
+            tr_backtesting_list_timerange.append(timerange_backtest.copy())
 
             # ensure we are predicting on exactly same amount of data as requested by user defined
             #  --timerange

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -67,6 +67,30 @@ def test_subtract_start():
     assert x.startts == 1274486400 - 300
 
 
+def test_TimeRange_copy():
+    x = TimeRange("date", "date", 1274486400, 1438214400)
+    y = x.copy()
+
+    # Equal in value, but a distinct object
+    assert y == x
+    assert y is not x
+    assert isinstance(y, TimeRange)
+
+    # Mutating the copy does not affect the original
+    y.subtract_start(300)
+    assert y.startts == 1274486400 - 300
+    assert x.startts == 1274486400
+    assert y != x
+
+    # All fields are copied independently
+    x = TimeRange(None, "date", 0, 1438214400)
+    y = x.copy()
+    assert y.starttype is None
+    assert y.stoptype == "date"
+    assert y.startts == 0
+    assert y.stopts == 1438214400
+
+
 def test_adjust_start_if_necessary():
     min_date = datetime(2017, 11, 14, 21, 15, 00, tzinfo=UTC)
 


### PR DESCRIPTION
We don't need to use deepcopy on TimeRange object.

A test script created by AI
```py
import logging
from copy import copy, deepcopy
from datetime import UTC, datetime
from timeit import repeat

from freqtrade.configuration import TimeRange


IMMUTABLE_FIELD_TYPES = (int, str, type(None))
BENCHMARK_ITERATIONS = 200_000
BENCHMARK_REPEATS = 5


def ensure(condition: bool, message: str) -> None:
    if not condition:
        raise AssertionError(message)


def assert_only_immutable_fields(timerange: TimeRange) -> None:
    """Fail if TimeRange gains state for which a shallow copy may be unsafe."""
    mutable_fields = {
        name: type(value).__name__
        for name, value in vars(timerange).items()
        if not isinstance(value, IMMUTABLE_FIELD_TYPES)
    }
    ensure(
        not mutable_fields,
        f"TimeRange has potentially mutable fields: {mutable_fields}",
    )


def assert_copy_matches_deepcopy(original: TimeRange) -> tuple[TimeRange, TimeRange]:
    shallow = copy(original)
    deep = deepcopy(original)

    ensure(shallow is not original, "copy() returned the original TimeRange instance")
    ensure(deep is not original, "deepcopy() returned the original TimeRange instance")
    ensure(
        vars(shallow) == vars(deep) == vars(original),
        "copy() and deepcopy() did not produce equivalent initial state",
    )
    return shallow, deep


def test_subtract_start() -> None:
    original = TimeRange("date", "date", 1_510_694_100, 1_510_780_500)
    original_state = vars(original).copy()
    assert_only_immutable_fields(original)
    shallow, deep = assert_copy_matches_deepcopy(original)

    shallow.subtract_start(300)
    deep.subtract_start(300)

    ensure(vars(shallow) == vars(deep), "Copies differ after subtract_start()")
    ensure(vars(original) == original_state, "copy() mutation changed the original")


def test_adjust_start_if_necessary() -> None:
    original = TimeRange(None, "date", 0, 1_510_780_500)
    original_state = vars(original).copy()
    assert_only_immutable_fields(original)
    shallow, deep = assert_copy_matches_deepcopy(original)

    min_date = datetime(2017, 11, 14, 21, 15, tzinfo=UTC)
    shallow.adjust_start_if_necessary(300, 20, min_date)
    deep.adjust_start_if_necessary(300, 20, min_date)

    ensure(vars(shallow) == vars(deep), "Copies differ after adjust_start_if_necessary()")
    ensure(vars(original) == original_state, "copy() mutation changed the original")


def benchmark_copy_methods() -> None:
    timerange = TimeRange("date", "date", 1_510_694_100, 1_510_780_500)
    shallow_seconds = min(
        repeat(
            lambda: copy(timerange),
            number=BENCHMARK_ITERATIONS,
            repeat=BENCHMARK_REPEATS,
        )
    )
    deep_seconds = min(
        repeat(
            lambda: deepcopy(timerange),
            number=BENCHMARK_ITERATIONS,
            repeat=BENCHMARK_REPEATS,
        )
    )

    shallow_ns = shallow_seconds / BENCHMARK_ITERATIONS * 1_000_000_000
    deep_ns = deep_seconds / BENCHMARK_ITERATIONS * 1_000_000_000

    print(f"Benchmark (best of {BENCHMARK_REPEATS}, {BENCHMARK_ITERATIONS:,} copies each):")
    print(f"  copy():     {shallow_ns:,.1f} ns/copy")
    print(f"  deepcopy(): {deep_ns:,.1f} ns/copy")
    print(f"  copy() is   {deep_ns / shallow_ns:.2f}x faster")


def main() -> None:
    logging.disable(logging.WARNING)
    test_subtract_start()
    test_adjust_start_if_necessary()
    print("PASS: copy() is equivalent to deepcopy() for the current TimeRange type.")
    benchmark_copy_methods()


if __name__ == "__main__":
    main()
```

The improvement is very minor if we look at the actual number, but as with the original purpose, I'm looking to cut small pieces of time here and there

```
PASS: copy() is equivalent to deepcopy() for the current TimeRange type.
Benchmark (best of 5, 200,000 copies each):
  copy():     747.6 ns/copy
  deepcopy(): 2,805.5 ns/copy
  copy() is   3.75x faster
```