### PR TITLE
fix: respect timerange when loading trades from parquet files

### DIFF
--- a/freqtrade/data/history/datahandlers/featherdatahandler.py
+++ b/freqtrade/data/history/datahandlers/featherdatahandler.py
@@ -112,36 +112,6 @@ class FeatherDataHandler(IDataHandler):
         """
         raise NotImplementedError()
 
-    def _build_arrow_time_filter(self, timerange: TimeRange | None):
-        """
-        Build Arrow predicate filter for timerange filtering.
-        Treats 0 as unbounded (no filter on that side).
-        :param timerange: TimeRange object with start/stop timestamps
-        :return: Arrow filter expression or None if fully unbounded
-        """
-        if not timerange:
-            return None
-
-        # Treat 0 as unbounded
-        start_set = bool(timerange.startts and timerange.startts > 0)
-        stop_set = bool(timerange.stopts and timerange.stopts > 0)
-
-        if not (start_set or stop_set):
-            return None
-
-        ts_field = dataset.field("timestamp")
-        exprs = []
-
-        if start_set:
-            exprs.append(ts_field >= timerange.startts)
-        if stop_set:
-            exprs.append(ts_field <= timerange.stopts)
-
-        if len(exprs) == 1:
-            return exprs[0]
-        else:
-            return exprs[0] & exprs[1]
-
     def _trades_load(
         self, pair: str, trading_mode: TradingMode, timerange: TimeRange | None = None
     ) -> DataFrame:

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from pandas import DataFrame, to_datetime
+from pyarrow import dataset
 
 from freqtrade import misc
 from freqtrade.configuration import TimeRange
@@ -257,6 +258,36 @@ class IDataHandler(ABC):
             filename.unlink()
             return True
         return False
+
+    def _build_arrow_time_filter(self, timerange: TimeRange | None):
+        """
+        Build Arrow predicate filter for timerange filtering.
+        Treats 0 as unbounded (no filter on that side).
+        :param timerange: TimeRange object with start/stop timestamps
+        :return: Arrow filter expression or None if fully unbounded
+        """
+        if not timerange:
+            return None
+
+        # Treat 0 as unbounded
+        start_set = bool(timerange.startts and timerange.startts > 0)
+        stop_set = bool(timerange.stopts and timerange.stopts > 0)
+
+        if not (start_set or stop_set):
+            return None
+
+        ts_field = dataset.field("timestamp")
+        exprs = []
+
+        if start_set:
+            exprs.append(ts_field >= timerange.startts)
+        if stop_set:
+            exprs.append(ts_field <= timerange.stopts)
+
+        if len(exprs) == 1:
+            return exprs[0]
+        else:
+            return exprs[0] & exprs[1]
 
     def trades_load(
         self, pair: str, trading_mode: TradingMode, timerange: TimeRange | None = None

--- a/freqtrade/data/history/datahandlers/parquetdatahandler.py
+++ b/freqtrade/data/history/datahandlers/parquetdatahandler.py
@@ -1,6 +1,7 @@
 import logging
 
 from pandas import DataFrame, read_parquet
+from pyarrow import dataset
 
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
@@ -114,17 +115,36 @@ class ParquetDataHandler(IDataHandler):
     ) -> DataFrame:
         """
         Load a pair from file, either .json.gz or .json
-        # TODO: respect timerange ...
         :param pair: Load trades for this pair
         :param trading_mode: Trading mode to use (used to determine the filename)
-        :param timerange: Timerange to load trades for - currently not implemented
-        :return: List of trades
+        :param timerange: Timerange to load trades for - filters data to this range if provided
+        :return: Dataframe containing trades
         """
         filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
         if not filename.exists():
             return DataFrame(columns=DEFAULT_TRADES_COLUMNS)
 
-        tradesdata = read_parquet(filename)
+        # Use Arrow dataset with optional timerange filtering, fallback to read_parquet
+        try:
+            dataset_reader = dataset.dataset(filename, format="parquet")
+            time_filter = self._build_arrow_time_filter(timerange)
+
+            if time_filter is not None and timerange is not None:
+                tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()
+                start_desc = timerange.startts if timerange.startts > 0 else "unbounded"
+                stop_desc = timerange.stopts if timerange.stopts > 0 else "unbounded"
+                logger.debug(
+                    f"Loaded {len(tradesdata)} trades for {pair} "
+                    f"(filtered start={start_desc}, stop={stop_desc})"
+                )
+            else:
+                tradesdata = dataset_reader.to_table().to_pandas()
+                logger.debug(f"Loaded {len(tradesdata)} trades for {pair} (unfiltered)")
+
+        except (ImportError, AttributeError, ValueError) as e:
+            # Fallback: load entire file
+            logger.warning(f"Unable to use Arrow filtering, loading entire trades file: {e}")
+            tradesdata = read_parquet(filename)
 
         return tradesdata
 

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -386,7 +386,7 @@ def test_datahandler_trades_load(testdatadir, datahandler):
     assert trades.iloc[-1]["cost"] == 0.1986231
 
     trades1 = dh.trades_load("UNITTEST/NONEXIST", TradingMode.SPOT)
-    assert isinstance(trades, DataFrame)
+    assert isinstance(trades1, DataFrame)
     assert trades1.empty
 
 


### PR DESCRIPTION
ParquetDataHandler ignored the timerange parameter when loading trades, while FeatherDataHandler already supported Arrow-based filtering. Move _build_arrow_time_filter to IDataHandler and apply the same filtering logic to parquet trade loads.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
