### PR TITLE
Combine feather and parquet handlers

### DIFF
--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -118,17 +118,17 @@ If the default data-format has been changed during download, then the keys `data
 The following comparisons have been made with the following data, and by using the linux `time` command.
 
 ```
-Found 6 pair / timeframe combinations.
-+----------+-------------+--------+---------------------+---------------------+
-|     Pair |   Timeframe |   Type |                From |                  To |
-|----------+-------------+--------+---------------------+---------------------|
-| BTC/USDT |          5m |   spot | 2017-08-17 04:00:00 | 2022-09-13 19:25:00 |
-| ETH/USDT |          1m |   spot | 2017-08-17 04:00:00 | 2022-09-13 19:26:00 |
-| BTC/USDT |          1m |   spot | 2017-08-17 04:00:00 | 2022-09-13 19:30:00 |
-| XRP/USDT |          5m |   spot | 2018-05-04 08:10:00 | 2022-09-13 19:15:00 |
-| XRP/USDT |          1m |   spot | 2018-05-04 08:11:00 | 2022-09-13 19:22:00 |
-| ETH/USDT |          5m |   spot | 2017-08-17 04:00:00 | 2022-09-13 19:20:00 |
-+----------+-------------+--------+---------------------+---------------------+
+                       Found 6 pair / timeframe combinations.
+┏━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+┃     Pair ┃ Timeframe ┃ Type ┃                From ┃                  To ┃ Candles ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+│ BTC/USDT │        1m │ spot │ 2017-08-17 04:00:00 │ 2026-07-15 04:42:00 │ 4677171 │
+│ BTC/USDT │        5m │ spot │ 2017-08-17 04:00:00 │ 2026-07-15 04:35:00 │  935445 │
+│ ETH/USDT │        1m │ spot │ 2017-08-17 04:00:00 │ 2026-07-15 04:43:00 │ 4677172 │
+│ ETH/USDT │        5m │ spot │ 2017-08-17 04:00:00 │ 2026-07-15 04:35:00 │  935445 │
+│ XRP/USDT │        1m │ spot │ 2018-05-04 08:11:00 │ 2026-07-15 04:44:00 │ 4305252 │
+│ XRP/USDT │        5m │ spot │ 2018-05-04 08:10:00 │ 2026-07-15 04:40:00 │  861055 │
+└──────────┴───────────┴──────┴─────────────────────┴─────────────────────┴─────────┘
 ```
 
 Timings have been taken in a not very scientific way with the following command, which forces reading the data into memory.
@@ -139,14 +139,14 @@ time freqtrade list-data --show-timerange --data-format-ohlcv <dataformat>
 
 |  Format | Size | timing |
 |------------|-------------|-------------|
-| `feather` | 72Mb | 3.5s |
-| `json` | 149Mb | 25.6s |
-| `jsongz` | 39Mb | 27s |
-| `parquet` | 83Mb | 3.8s |
+| `feather` | 115Mb | 1.6s |
+| `json` | 265Mb | 17.1s |
+| `jsongz` | 83Mb | 23.6s |
+| `parquet` | 149Mb | 2.5s |
 
 Size has been taken from the BTC/USDT 1m spot combination for the timerange specified above.
 
-To have a best performance/size mix, we recommend using the default feather format, or parquet.
+To have a best performance/size mix, we recommend using the default **feather** format.
 
 ### Pairs file
 

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -197,7 +197,7 @@ class ArrowDataHandler(IDataHandler):
         """
         raise NotImplementedError()
 
-    def _build_arrow_time_filter(self, timerange: TimeRange | None):
+    def _build_arrow_trades_filter(self, timerange: TimeRange | None):
         """
         Build Arrow predicate filter for timerange filtering.
         Treats 0 as unbounded (no filter on that side).
@@ -244,7 +244,7 @@ class ArrowDataHandler(IDataHandler):
         # Use Arrow dataset with optional timerange filtering, fallback to a full read
         try:
             dataset_reader = dataset.dataset(filename, format=self._get_file_extension())
-            time_filter = self._build_arrow_time_filter(timerange)
+            time_filter = self._build_arrow_trades_filter(timerange)
 
             if time_filter is not None and timerange is not None:
                 tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -152,7 +152,7 @@ class ArrowDataHandler(IDataHandler):
         try:
             dataset_reader = dataset.dataset(filename, format=self._get_file_extension())
             pairdata = dataset_reader.to_table(filter=time_filter).to_pandas()
-        except (ImportError, AttributeError, ValueError) as e:
+        except (ImportError, AttributeError, ValueError, ArrowException) as e:
             # Fallback: load entire file
             logger.warning(f"Unable to use Arrow filtering, loading entire ohlcv file: {e}")
             return self._load_dataframe(filename)

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -207,22 +207,18 @@ class ArrowDataHandler(IDataHandler):
         if not timerange:
             return None
 
-        # Treat 0 as unbounded
-        start_set = bool(timerange.startts and timerange.startts > 0)
-        stop_set = bool(timerange.stopts and timerange.stopts > 0)
-
-        if not (start_set or stop_set):
-            return None
-
         ts_field = dataset.field("timestamp")
         exprs = []
 
-        if start_set:
+        # Treat 0 as unbounded
+        if timerange.startts and timerange.startts > 0:
             exprs.append(ts_field >= timerange.startts)
-        if stop_set:
+        if timerange.stopts and timerange.stopts > 0:
             exprs.append(ts_field <= timerange.stopts)
 
-        if len(exprs) == 1:
+        if not exprs:
+            return None
+        elif len(exprs) == 1:
             return exprs[0]
         else:
             return exprs[0] & exprs[1]

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -1,0 +1,204 @@
+import logging
+from abc import abstractmethod
+from pathlib import Path
+
+from pandas import DataFrame
+from pyarrow import dataset
+
+from freqtrade.configuration import TimeRange
+from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
+from freqtrade.enums import CandleType, TradingMode
+
+from .idatahandler import IDataHandler
+
+
+logger = logging.getLogger(__name__)
+
+
+class ArrowDataHandler(IDataHandler):
+    """
+    Base class for columnar data handlers backed by pyarrow (feather / parquet).
+
+    Subclasses need to implement the format-specific read/write of a single
+    DataFrame (_load_dataframe / _store_dataframe) and _get_file_extension.
+    """
+
+    _columns = DEFAULT_DATAFRAME_COLUMNS
+
+    @abstractmethod
+    def _store_dataframe(self, data: DataFrame, filename: Path) -> None:
+        """
+        Store a DataFrame to disk in the handler's file format.
+        :param data: DataFrame to store (already reset/reordered by the caller)
+        :param filename: Target filename
+        """
+
+    @abstractmethod
+    def _load_dataframe(self, filename: Path) -> DataFrame:
+        """
+        Load a DataFrame from disk in the handler's file format.
+        :param filename: File to load
+        :return: DataFrame as stored on disk
+        """
+
+    def ohlcv_store(
+        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
+    ) -> None:
+        """
+        Store data in the handler's columnar format.
+            format looks as follows:
+            [[<date>,<open>,<high>,<low>,<close>]]
+        :param pair: Pair - used to generate filename
+        :param timeframe: Timeframe - used to generate filename
+        :param data: Dataframe containing OHLCV data
+        :param candle_type: Any of the enum CandleType (must match trading mode!)
+        :return: None
+        """
+        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type)
+        self.create_dir_if_needed(filename)
+
+        self._store_dataframe(data.reset_index(drop=True).loc[:, self._columns], filename)
+
+    def _ohlcv_load(
+        self, pair: str, timeframe: str, timerange: TimeRange | None, candle_type: CandleType
+    ) -> DataFrame:
+        """
+        Internal method used to load data for one pair from disk.
+        Implements the loading and conversion to a Pandas dataframe.
+        Timerange trimming and dataframe validation happens outside of this method.
+        :param pair: Pair to load data
+        :param timeframe: Timeframe (e.g. "5m")
+        :param timerange: Limit data to be loaded to this timerange.
+                        Optionally implemented by subclasses to avoid loading
+                        all data where possible.
+        :param candle_type: Any of the enum CandleType (must match trading mode!)
+        :return: DataFrame with ohlcv data, or empty DataFrame
+        """
+        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type=candle_type)
+        if not filename.exists():
+            # Fallback mode for 1M files
+            filename = self._pair_data_filename(
+                self._datadir, pair, timeframe, candle_type=candle_type, no_timeframe_modify=True
+            )
+            if not filename.exists():
+                return DataFrame(columns=self._columns)
+        try:
+            pairdata = self._load_dataframe(filename)
+            pairdata.columns = self._columns
+            pairdata = pairdata.astype(
+                dtype={
+                    "open": "float",
+                    "high": "float",
+                    "low": "float",
+                    "close": "float",
+                    "volume": "float",
+                }
+            )
+            pairdata["date"] = pairdata["date"].dt.as_unit("ms")
+            return pairdata
+        except Exception as e:
+            logger.exception(
+                f"Error loading data from {filename}. Exception: {e}. Returning empty dataframe."
+            )
+            return DataFrame(columns=self._columns)
+
+    def ohlcv_append(
+        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
+    ) -> None:
+        """
+        Append data to existing data structures
+        :param pair: Pair
+        :param timeframe: Timeframe this ohlcv data is for
+        :param data: Data to append.
+        :param candle_type: Any of the enum CandleType (must match trading mode!)
+        """
+        raise NotImplementedError()
+
+    def _trades_store(self, pair: str, data: DataFrame, trading_mode: TradingMode) -> None:
+        """
+        Store trades data (list of Dicts) to file
+        :param pair: Pair - used for filename
+        :param data: Dataframe containing trades
+                     column sequence as in DEFAULT_TRADES_COLUMNS
+        :param trading_mode: Trading mode to use (used to determine the filename)
+        """
+        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
+        self.create_dir_if_needed(filename)
+        self._store_dataframe(data.reset_index(drop=True), filename)
+
+    def trades_append(self, pair: str, data: DataFrame):
+        """
+        Append data to existing files
+        :param pair: Pair - used for filename
+        :param data: Dataframe containing trades
+                     column sequence as in DEFAULT_TRADES_COLUMNS
+        """
+        raise NotImplementedError()
+
+    def _build_arrow_time_filter(self, timerange: TimeRange | None):
+        """
+        Build Arrow predicate filter for timerange filtering.
+        Treats 0 as unbounded (no filter on that side).
+        :param timerange: TimeRange object with start/stop timestamps
+        :return: Arrow filter expression or None if fully unbounded
+        """
+        if not timerange:
+            return None
+
+        # Treat 0 as unbounded
+        start_set = bool(timerange.startts and timerange.startts > 0)
+        stop_set = bool(timerange.stopts and timerange.stopts > 0)
+
+        if not (start_set or stop_set):
+            return None
+
+        ts_field = dataset.field("timestamp")
+        exprs = []
+
+        if start_set:
+            exprs.append(ts_field >= timerange.startts)
+        if stop_set:
+            exprs.append(ts_field <= timerange.stopts)
+
+        if len(exprs) == 1:
+            return exprs[0]
+        else:
+            return exprs[0] & exprs[1]
+
+    def _trades_load(
+        self, pair: str, trading_mode: TradingMode, timerange: TimeRange | None = None
+    ) -> DataFrame:
+        """
+        Load a pair from file
+        :param pair: Load trades for this pair
+        :param trading_mode: Trading mode to use (used to determine the filename)
+        :param timerange: Timerange to load trades for - filters data to this range if provided
+        :return: Dataframe containing trades
+        """
+        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
+        if not filename.exists():
+            return DataFrame(columns=DEFAULT_TRADES_COLUMNS)
+
+        # Use Arrow dataset with optional timerange filtering, fallback to a full read
+        try:
+            dataset_reader = dataset.dataset(filename, format=self._get_file_extension())
+            time_filter = self._build_arrow_time_filter(timerange)
+
+            if time_filter is not None and timerange is not None:
+                tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()
+                start_desc = timerange.startts if timerange.startts > 0 else "unbounded"
+                stop_desc = timerange.stopts if timerange.stopts > 0 else "unbounded"
+                logger.debug(
+                    f"Loaded {len(tradesdata)} trades for {pair} "
+                    f"(filtered start={start_desc}, stop={stop_desc})"
+                )
+            else:
+                tradesdata = dataset_reader.to_table().to_pandas()
+                logger.debug(f"Loaded {len(tradesdata)} trades for {pair} (unfiltered)")
+
+        except (ImportError, AttributeError, ValueError) as e:
+            # Fallback: load entire file
+            logger.warning(f"Unable to use Arrow filtering, loading entire trades file: {e}")
+            tradesdata = self._load_dataframe(filename)
+
+        return tradesdata

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from pathlib import Path
 
 from pandas import DataFrame
-from pyarrow import dataset
+from pyarrow import ArrowException, dataset
 
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
@@ -241,20 +241,12 @@ class ArrowDataHandler(IDataHandler):
         try:
             dataset_reader = dataset.dataset(filename, format=self._get_file_extension())
             time_filter = self._build_arrow_trades_filter(timerange)
-
-            if time_filter is not None and timerange is not None:
-                tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()
-                start_desc = timerange.startts if timerange.startts > 0 else "unbounded"
-                stop_desc = timerange.stopts if timerange.stopts > 0 else "unbounded"
-                logger.debug(
-                    f"Loaded {len(tradesdata)} trades for {pair} "
-                    f"(filtered start={start_desc}, stop={stop_desc})"
-                )
-            else:
-                tradesdata = dataset_reader.to_table().to_pandas()
-                logger.debug(f"Loaded {len(tradesdata)} trades for {pair} (unfiltered)")
-
-        except (ImportError, AttributeError, ValueError) as e:
+            tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()
+            logger.debug(
+                f"Loaded {len(tradesdata)} trades for {pair} "
+                f"({f'filter: {time_filter}' if time_filter is not None else 'unfiltered'})"
+            )
+        except (ImportError, AttributeError, ValueError, ArrowException) as e:
             # Fallback: load entire file
             logger.warning(f"Unable to use Arrow filtering, loading entire trades file: {e}")
             tradesdata = self._load_dataframe(filename)

--- a/freqtrade/data/history/datahandlers/arrowdatahandler.py
+++ b/freqtrade/data/history/datahandlers/arrowdatahandler.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from datetime import timedelta
 from pathlib import Path
 
 from pandas import DataFrame
@@ -8,6 +9,7 @@ from pyarrow import dataset
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
 from freqtrade.enums import CandleType, TradingMode
+from freqtrade.exchange import timeframe_to_seconds
 
 from .idatahandler import IDataHandler
 
@@ -83,7 +85,7 @@ class ArrowDataHandler(IDataHandler):
             if not filename.exists():
                 return DataFrame(columns=self._columns)
         try:
-            pairdata = self._load_dataframe(filename)
+            pairdata = self._load_ohlcv_dataframe(filename, timeframe, timerange)
             pairdata.columns = self._columns
             pairdata = pairdata.astype(
                 dtype={
@@ -101,6 +103,66 @@ class ArrowDataHandler(IDataHandler):
                 f"Error loading data from {filename}. Exception: {e}. Returning empty dataframe."
             )
             return DataFrame(columns=self._columns)
+
+    def _build_arrow_ohlcv_filter(self, timerange: TimeRange | None, timeframe: str):
+        """
+        Build Arrow predicate filter on the "date" column for ohlcv data.
+
+        Both bounds are widened by one candle. `ohlcv_load` trims the dataframe to the
+        exact timerange afterwards, but inspects the untrimmed dataframe first to warn
+        about missing data and to decide whether the last candle may be incomplete.
+        The extra candle on each side keeps that information intact.
+
+        :param timerange: TimeRange object with start/stop dates
+        :param timeframe: Timeframe of the data (e.g. "5m")
+        :return: Arrow filter expression or None if unbounded
+        """
+        if not timerange:
+            return None
+
+        widen = timedelta(seconds=timeframe_to_seconds(timeframe))
+        date_field = dataset.field("date")
+        exprs = []
+
+        if timerange.starttype == "date" and (startdt := timerange.startdt):
+            exprs.append(date_field >= startdt - widen)
+        if timerange.stoptype == "date" and (stopdt := timerange.stopdt):
+            exprs.append(date_field <= stopdt + widen)
+
+        if not exprs:
+            return None
+        elif len(exprs) == 1:
+            return exprs[0]
+        else:
+            return exprs[0] & exprs[1]
+
+    def _load_ohlcv_dataframe(
+        self, filename: Path, timeframe: str, timerange: TimeRange | None
+    ) -> DataFrame:
+        """
+        Load ohlcv data through Arrow, pushing the timerange filter down where possible
+        to avoid reading candles outside of the requested range.
+        Falls back to reading the full file - callers trim the result either way.
+        :param filename: File to load
+        :param timeframe: Timeframe of the data (e.g. "5m")
+        :param timerange: Timerange to limit the data to
+        :return: DataFrame as stored on disk, limited to (roughly) timerange
+        """
+        time_filter = self._build_arrow_ohlcv_filter(timerange, timeframe)
+        try:
+            dataset_reader = dataset.dataset(filename, format=self._get_file_extension())
+            pairdata = dataset_reader.to_table(filter=time_filter).to_pandas()
+        except (ImportError, AttributeError, ValueError) as e:
+            # Fallback: load entire file
+            logger.warning(f"Unable to use Arrow filtering, loading entire ohlcv file: {e}")
+            return self._load_dataframe(filename)
+
+        if time_filter is not None and pairdata.empty:
+            # No candles in the requested range - reload everything, so callers can tell
+            # "this file has no data at all" apart from "the file has no data for this
+            # timerange" (and can point at the data that is available).
+            return self._load_dataframe(filename)
+        return pairdata
 
     def ohlcv_append(
         self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType

--- a/freqtrade/data/history/datahandlers/featherdatahandler.py
+++ b/freqtrade/data/history/datahandlers/featherdatahandler.py
@@ -1,12 +1,8 @@
-import logging
 from pathlib import Path
 
 from pandas import DataFrame, read_feather
 
 from .arrowdatahandler import ArrowDataHandler
-
-
-logger = logging.getLogger(__name__)
 
 
 class FeatherDataHandler(ArrowDataHandler):

--- a/freqtrade/data/history/datahandlers/featherdatahandler.py
+++ b/freqtrade/data/history/datahandlers/featherdatahandler.py
@@ -1,185 +1,21 @@
 import logging
+from pathlib import Path
 
 from pandas import DataFrame, read_feather
-from pyarrow import dataset
 
-from freqtrade.configuration import TimeRange
-from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
-from freqtrade.enums import CandleType, TradingMode
-
-from .idatahandler import IDataHandler
+from .arrowdatahandler import ArrowDataHandler
 
 
 logger = logging.getLogger(__name__)
 
 
-class FeatherDataHandler(IDataHandler):
-    _columns = DEFAULT_DATAFRAME_COLUMNS
-
-    def ohlcv_store(
-        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
-    ) -> None:
-        """
-        Store data in json format "values".
-            format looks as follows:
-            [[<date>,<open>,<high>,<low>,<close>]]
-        :param pair: Pair - used to generate filename
-        :param timeframe: Timeframe - used to generate filename
-        :param data: Dataframe containing OHLCV data
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        :return: None
-        """
-        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type)
-        self.create_dir_if_needed(filename)
-
-        data.reset_index(drop=True).loc[:, self._columns].to_feather(
-            filename, compression_level=9, compression="lz4"
-        )
-
-    def _ohlcv_load(
-        self, pair: str, timeframe: str, timerange: TimeRange | None, candle_type: CandleType
-    ) -> DataFrame:
-        """
-        Internal method used to load data for one pair from disk.
-        Implements the loading and conversion to a Pandas dataframe.
-        Timerange trimming and dataframe validation happens outside of this method.
-        :param pair: Pair to load data
-        :param timeframe: Timeframe (e.g. "5m")
-        :param timerange: Limit data to be loaded to this timerange.
-                        Optionally implemented by subclasses to avoid loading
-                        all data where possible.
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        :return: DataFrame with ohlcv data, or empty DataFrame
-        """
-        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type=candle_type)
-        if not filename.exists():
-            # Fallback mode for 1M files
-            filename = self._pair_data_filename(
-                self._datadir, pair, timeframe, candle_type=candle_type, no_timeframe_modify=True
-            )
-            if not filename.exists():
-                return DataFrame(columns=self._columns)
-        try:
-            pairdata = read_feather(filename)
-            pairdata.columns = self._columns
-            pairdata = pairdata.astype(
-                dtype={
-                    "open": "float",
-                    "high": "float",
-                    "low": "float",
-                    "close": "float",
-                    "volume": "float",
-                }
-            )
-            pairdata["date"] = pairdata["date"].dt.as_unit("ms")
-            return pairdata
-        except Exception as e:
-            logger.exception(
-                f"Error loading data from {filename}. Exception: {e}. Returning empty dataframe."
-            )
-            return DataFrame(columns=self._columns)
-
-    def ohlcv_append(
-        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
-    ) -> None:
-        """
-        Append data to existing data structures
-        :param pair: Pair
-        :param timeframe: Timeframe this ohlcv data is for
-        :param data: Data to append.
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        """
-        raise NotImplementedError()
-
-    def _trades_store(self, pair: str, data: DataFrame, trading_mode: TradingMode) -> None:
-        """
-        Store trades data (list of Dicts) to file
-        :param pair: Pair - used for filename
-        :param data: Dataframe containing trades
-                     column sequence as in DEFAULT_TRADES_COLUMNS
-        :param trading_mode: Trading mode to use (used to determine the filename)
-        """
-        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
-        self.create_dir_if_needed(filename)
-        data.reset_index(drop=True).to_feather(filename, compression_level=9, compression="lz4")
-
-    def trades_append(self, pair: str, data: DataFrame):
-        """
-        Append data to existing files
-        :param pair: Pair - used for filename
-        :param data: Dataframe containing trades
-                     column sequence as in DEFAULT_TRADES_COLUMNS
-        """
-        raise NotImplementedError()
-
-    def _build_arrow_time_filter(self, timerange: TimeRange | None):
-        """
-        Build Arrow predicate filter for timerange filtering.
-        Treats 0 as unbounded (no filter on that side).
-        :param timerange: TimeRange object with start/stop timestamps
-        :return: Arrow filter expression or None if fully unbounded
-        """
-        if not timerange:
-            return None
-
-        # Treat 0 as unbounded
-        start_set = bool(timerange.startts and timerange.startts > 0)
-        stop_set = bool(timerange.stopts and timerange.stopts > 0)
-
-        if not (start_set or stop_set):
-            return None
-
-        ts_field = dataset.field("timestamp")
-        exprs = []
-
-        if start_set:
-            exprs.append(ts_field >= timerange.startts)
-        if stop_set:
-            exprs.append(ts_field <= timerange.stopts)
-
-        if len(exprs) == 1:
-            return exprs[0]
-        else:
-            return exprs[0] & exprs[1]
-
-    def _trades_load(
-        self, pair: str, trading_mode: TradingMode, timerange: TimeRange | None = None
-    ) -> DataFrame:
-        """
-        Load a pair from file, either .json.gz or .json
-        :param pair: Load trades for this pair
-        :param trading_mode: Trading mode to use (used to determine the filename)
-        :param timerange: Timerange to load trades for - filters data to this range if provided
-        :return: Dataframe containing trades
-        """
-        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
-        if not filename.exists():
-            return DataFrame(columns=DEFAULT_TRADES_COLUMNS)
-
-        # Use Arrow dataset with optional timerange filtering, fallback to read_feather
-        try:
-            dataset_reader = dataset.dataset(filename, format="feather")
-            time_filter = self._build_arrow_time_filter(timerange)
-
-            if time_filter is not None and timerange is not None:
-                tradesdata = dataset_reader.to_table(filter=time_filter).to_pandas()
-                start_desc = timerange.startts if timerange.startts > 0 else "unbounded"
-                stop_desc = timerange.stopts if timerange.stopts > 0 else "unbounded"
-                logger.debug(
-                    f"Loaded {len(tradesdata)} trades for {pair} "
-                    f"(filtered start={start_desc}, stop={stop_desc})"
-                )
-            else:
-                tradesdata = dataset_reader.to_table().to_pandas()
-                logger.debug(f"Loaded {len(tradesdata)} trades for {pair} (unfiltered)")
-
-        except (ImportError, AttributeError, ValueError) as e:
-            # Fallback: load entire file
-            logger.warning(f"Unable to use Arrow filtering, loading entire trades file: {e}")
-            tradesdata = read_feather(filename)
-
-        return tradesdata
-
+class FeatherDataHandler(ArrowDataHandler):
     @classmethod
     def _get_file_extension(cls):
         return "feather"
+
+    def _store_dataframe(self, data: DataFrame, filename: Path) -> None:
+        data.to_feather(filename, compression_level=9, compression="lz4")
+
+    def _load_dataframe(self, filename: Path) -> DataFrame:
+        return read_feather(filename)

--- a/freqtrade/data/history/datahandlers/parquetdatahandler.py
+++ b/freqtrade/data/history/datahandlers/parquetdatahandler.py
@@ -1,12 +1,8 @@
-import logging
 from pathlib import Path
 
 from pandas import DataFrame, read_parquet
 
 from .arrowdatahandler import ArrowDataHandler
-
-
-logger = logging.getLogger(__name__)
 
 
 class ParquetDataHandler(ArrowDataHandler):

--- a/freqtrade/data/history/datahandlers/parquetdatahandler.py
+++ b/freqtrade/data/history/datahandlers/parquetdatahandler.py
@@ -1,133 +1,21 @@
 import logging
+from pathlib import Path
 
 from pandas import DataFrame, read_parquet
 
-from freqtrade.configuration import TimeRange
-from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
-from freqtrade.enums import CandleType, TradingMode
-
-from .idatahandler import IDataHandler
+from .arrowdatahandler import ArrowDataHandler
 
 
 logger = logging.getLogger(__name__)
 
 
-class ParquetDataHandler(IDataHandler):
-    _columns = DEFAULT_DATAFRAME_COLUMNS
-
-    def ohlcv_store(
-        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
-    ) -> None:
-        """
-        Store data in json format "values".
-            format looks as follows:
-            [[<date>,<open>,<high>,<low>,<close>]]
-        :param pair: Pair - used to generate filename
-        :param timeframe: Timeframe - used to generate filename
-        :param data: Dataframe containing OHLCV data
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        :return: None
-        """
-        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type)
-        self.create_dir_if_needed(filename)
-
-        data.reset_index(drop=True).loc[:, self._columns].to_parquet(filename)
-
-    def _ohlcv_load(
-        self, pair: str, timeframe: str, timerange: TimeRange | None, candle_type: CandleType
-    ) -> DataFrame:
-        """
-        Internal method used to load data for one pair from disk.
-        Implements the loading and conversion to a Pandas dataframe.
-        Timerange trimming and dataframe validation happens outside of this method.
-        :param pair: Pair to load data
-        :param timeframe: Timeframe (e.g. "5m")
-        :param timerange: Limit data to be loaded to this timerange.
-                        Optionally implemented by subclasses to avoid loading
-                        all data where possible.
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        :return: DataFrame with ohlcv data, or empty DataFrame
-        """
-        filename = self._pair_data_filename(self._datadir, pair, timeframe, candle_type=candle_type)
-        if not filename.exists():
-            # Fallback mode for 1M files
-            filename = self._pair_data_filename(
-                self._datadir, pair, timeframe, candle_type=candle_type, no_timeframe_modify=True
-            )
-            if not filename.exists():
-                return DataFrame(columns=self._columns)
-        try:
-            pairdata = read_parquet(filename)
-            pairdata.columns = self._columns
-            pairdata = pairdata.astype(
-                dtype={
-                    "open": "float",
-                    "high": "float",
-                    "low": "float",
-                    "close": "float",
-                    "volume": "float",
-                }
-            )
-            pairdata["date"] = pairdata["date"].dt.as_unit("ms")
-            return pairdata
-        except Exception as e:
-            logger.exception(
-                f"Error loading data from {filename}. Exception: {e}. Returning empty dataframe."
-            )
-            return DataFrame(columns=self._columns)
-
-    def ohlcv_append(
-        self, pair: str, timeframe: str, data: DataFrame, candle_type: CandleType
-    ) -> None:
-        """
-        Append data to existing data structures
-        :param pair: Pair
-        :param timeframe: Timeframe this ohlcv data is for
-        :param data: Data to append.
-        :param candle_type: Any of the enum CandleType (must match trading mode!)
-        """
-        raise NotImplementedError()
-
-    def _trades_store(self, pair: str, data: DataFrame, trading_mode: TradingMode) -> None:
-        """
-        Store trades data (list of Dicts) to file
-        :param pair: Pair - used for filename
-        :param data: Dataframe containing trades
-                     column sequence as in DEFAULT_TRADES_COLUMNS
-        :param trading_mode: Trading mode to use (used to determine the filename)
-        """
-        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
-        self.create_dir_if_needed(filename)
-        data.reset_index(drop=True).to_parquet(filename)
-
-    def trades_append(self, pair: str, data: DataFrame):
-        """
-        Append data to existing files
-        :param pair: Pair - used for filename
-        :param data: Dataframe containing trades
-                     column sequence as in DEFAULT_TRADES_COLUMNS
-        """
-        raise NotImplementedError()
-
-    def _trades_load(
-        self, pair: str, trading_mode: TradingMode, timerange: TimeRange | None = None
-    ) -> DataFrame:
-        """
-        Load a pair from file, either .json.gz or .json
-        # TODO: respect timerange ...
-        :param pair: Load trades for this pair
-        :param trading_mode: Trading mode to use (used to determine the filename)
-        :param timerange: Timerange to load trades for - currently not implemented
-        :return: List of trades
-        """
-        filename = self._pair_trades_filename(self._datadir, pair, trading_mode)
-        if not filename.exists():
-            return DataFrame(columns=DEFAULT_TRADES_COLUMNS)
-
-        tradesdata = read_parquet(filename)
-
-        return tradesdata
-
+class ParquetDataHandler(ArrowDataHandler):
     @classmethod
     def _get_file_extension(cls):
         return "parquet"
+
+    def _store_dataframe(self, data: DataFrame, filename: Path) -> None:
+        data.to_parquet(filename)
+
+    def _load_dataframe(self, filename: Path) -> DataFrame:
+        return read_parquet(filename)

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -362,7 +362,12 @@ def test_generic_datahandler_ohlcv_load_and_resave(
     ohlcv = dh1.ohlcv_load("UNITTEST/NONEXIST", timeframe, candle_type=candle_type)
     assert ohlcv.empty
 
-    # Try loading a file that exists but errors
+    # Try loading a file that exists but errors - Arrow fails, so the pandas reader is
+    # used as fallback, which errors as well.
+    mocker.patch(
+        "freqtrade.data.history.datahandlers.arrowdatahandler.dataset.dataset",
+        side_effect=ValueError("Test"),
+    )
     mocker.patch(
         "freqtrade.data.history.datahandlers.featherdatahandler.read_feather",
         side_effect=Exception("Test"),

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -530,16 +530,13 @@ def test_feather_trades_timerange_filter_subset(feather_dh, trades_full, timeran
 
 
 def test_feather_trades_timerange_pushdown_fallback(
-    feather_dh, trades_full, timerange_mid, monkeypatch, caplog
+    feather_dh, trades_full, timerange_mid, mocker, caplog
 ):
     # Pushdown filter should fail, so fallback should load the entire file
-    import freqtrade.data.history.datahandlers.arrowdatahandler as adh
-
-    def raise_err(*args, **kwargs):
-        raise ValueError("fail")
-
-    # Mock the dataset loading to raise an error
-    monkeypatch.setattr(adh.dataset, "dataset", raise_err)
+    mocker.patch(
+        "freqtrade.data.history.datahandlers.arrowdatahandler.dataset.dataset",
+        side_effect=ValueError("fail"),
+    )
 
     with caplog.at_level("WARNING"):
         out = feather_dh.trades_load("XRP/ETH", TradingMode.SPOT, timerange=timerange_mid)

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -528,13 +528,13 @@ def test_feather_trades_timerange_pushdown_fallback(
     feather_dh, trades_full, timerange_mid, monkeypatch, caplog
 ):
     # Pushdown filter should fail, so fallback should load the entire file
-    import freqtrade.data.history.datahandlers.featherdatahandler as fdh
+    import freqtrade.data.history.datahandlers.arrowdatahandler as adh
 
     def raise_err(*args, **kwargs):
         raise ValueError("fail")
 
     # Mock the dataset loading to raise an error
-    monkeypatch.setattr(fdh.dataset, "dataset", raise_err)
+    monkeypatch.setattr(adh.dataset, "dataset", raise_err)
 
     with caplog.at_level("WARNING"):
         out = feather_dh.trades_load("XRP/ETH", TradingMode.SPOT, timerange=timerange_mid)

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -1,7 +1,7 @@
 # pragma pylint: disable=missing-docstring, protected-access, C0103
 
 import re
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -615,3 +615,114 @@ def test_feather_build_arrow_time_filter(feather_dh):
     filter_str = str(filter_closed)
     assert ">=" in filter_str
     assert "<=" in filter_str
+
+
+def test_build_arrow_ohlcv_filter(feather_dh):
+    # No timerange should return None
+    assert feather_dh._build_arrow_ohlcv_filter(None, "5m") is None
+    # Unbounded timerange should return None
+    assert feather_dh._build_arrow_ohlcv_filter(TimeRange(), "5m") is None
+
+    # Open start should return stop filter only - widened by one candle
+    tr_open_start = TimeRange.parse_timerange("-20260119")
+    filter_open_start = str(feather_dh._build_arrow_ohlcv_filter(tr_open_start, "5m"))
+    assert filter_open_start.count("<=") == 1
+    assert filter_open_start.count(">=") == 0
+    assert "2026-01-19 00:05:00" in filter_open_start
+
+    # Open end should return start filter only - widened by one candle
+    tr_open_end = TimeRange.parse_timerange("20260115-")
+    filter_open_end = str(feather_dh._build_arrow_ohlcv_filter(tr_open_end, "5m"))
+    assert filter_open_end.count(">=") == 1
+    assert filter_open_end.count("<=") == 0
+    assert "2026-01-14 23:55:00" in filter_open_end
+
+    # Closed range should combine both, widened by one candle on each side
+    tr_closed = TimeRange.parse_timerange("20260115-20260119")
+    filter_closed = str(feather_dh._build_arrow_ohlcv_filter(tr_closed, "1h"))
+    assert "2026-01-14 23:00:00" in filter_closed
+    assert "2026-01-19 01:00:00" in filter_closed
+
+
+# UNITTEST/BTC 5m spans 2018-01-10 04:55 to 2018-01-30 04:50.
+@pytest.mark.parametrize("datahandler", ["feather", "parquet"])
+@pytest.mark.parametrize(
+    "timerange,same_warnings",
+    [
+        ("20180115-20180119", True),  # aligned to the candle grid
+        ("-20180119", True),  # open start
+        ("20180115-", True),  # open end
+        ("20180101-20180119", True),  # starts before the available data
+        ("20180115-20180201", True),  # ends after the available data
+        ("20250101-20250201", True),  # no data in range at all
+        ("1516003320-1516348980", True),  # not aligned to the candle grid (08:02 / 08:03)
+        # Starts inside the gap punched below, which is wider than the one candle the bounds
+        # are widened by. The pushdown then sees no candle before the requested start and
+        # warns that the data starts late - a full read, seeing the whole file, does not.
+        ("1516082400-1516233600", False),  # 2018-01-16 06:00 (in the gap) - 2018-01-18
+    ],
+)
+def test_ohlcv_load_pushdown_matches_full_read(
+    testdatadir, tmp_path, datahandler, timerange, same_warnings, mocker, caplog
+):
+    # Pushing the timerange filter into Arrow must not change data or warnings.
+    dh = get_datahandler(tmp_path, datahandler)
+    ohlcv = get_datahandler(testdatadir, "feather")._ohlcv_load("UNITTEST/BTC", "5m", None, "spot")
+    # Drop 2018-01-16 00:00 - 12:00, so gaps (exchange downtime) are covered as well.
+    gap = (ohlcv["date"] >= Timestamp("2018-01-16", tz="UTC")) & (
+        ohlcv["date"] < Timestamp("2018-01-16 12:00", tz="UTC")
+    )
+    dh.ohlcv_store("UNITTEST/BTC", "5m", ohlcv[~gap], "spot")
+
+    tr = TimeRange.parse_timerange(timerange)
+
+    caplog.clear()
+    pushdown = dh.ohlcv_load("UNITTEST/BTC", "5m", "spot", timerange=tr)
+    pushdown_logs = sorted(caplog.messages)
+
+    # Disable the pushdown - the full file is read and trimmed by ohlcv_load instead.
+    caplog.clear()
+    mocker.patch.object(dh, "_build_arrow_ohlcv_filter", return_value=None)
+    full_read = dh.ohlcv_load(
+        "UNITTEST/BTC", "5m", "spot", timerange=TimeRange.parse_timerange(timerange)
+    )
+
+    assert_frame_equal(full_read, pushdown, check_exact=True)
+    if same_warnings:
+        assert sorted(caplog.messages) == pushdown_logs
+
+
+@pytest.mark.parametrize("datahandler", ["feather", "parquet"])
+def test_ohlcv_load_pushdown_limits_read(testdatadir, tmp_path, datahandler):
+    # The timerange must actually reach Arrow - _ohlcv_load does not trim by itself.
+    dh = get_datahandler(tmp_path, datahandler)
+    ohlcv = get_datahandler(testdatadir, "feather")._ohlcv_load("UNITTEST/BTC", "5m", None, "spot")
+    dh.ohlcv_store("UNITTEST/BTC", "5m", ohlcv, "spot")
+
+    timerange = TimeRange.parse_timerange("20180115-20180119")
+    full = dh._ohlcv_load("UNITTEST/BTC", "5m", None, "spot")
+    limited = dh._ohlcv_load("UNITTEST/BTC", "5m", timerange, "spot")
+
+    assert len(limited) < len(full)
+    # Bounds are widened by exactly one candle - ohlcv_load trims the rest.
+    assert limited.iloc[0]["date"] == timerange.startdt - timedelta(minutes=5)
+    assert limited.iloc[-1]["date"] == timerange.stopdt + timedelta(minutes=5)
+
+
+def test_ohlcv_load_pushdown_fallback(feather_dh, mocker, caplog):
+    # If Arrow filtering is unavailable, the whole file is read (and trimmed later).
+    tr = TimeRange.parse_timerange("20180115-20180119")
+    expected = feather_dh.ohlcv_load("UNITTEST/BTC", "5m", "spot", timerange=tr)
+
+    mocker.patch(
+        "freqtrade.data.history.datahandlers.arrowdatahandler.dataset.dataset",
+        side_effect=ValueError("fail"),
+    )
+
+    with caplog.at_level("WARNING"):
+        out = feather_dh.ohlcv_load(
+            "UNITTEST/BTC", "5m", "spot", timerange=TimeRange.parse_timerange("20180115-20180119")
+        )
+
+    assert log_has_re("Unable to use Arrow filtering, loading entire ohlcv file.*", caplog)
+    assert_frame_equal(expected, out, check_exact=True)

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from pandas import DataFrame, Timestamp, date_range
+from pandas import DataFrame, Timestamp
 from pandas.testing import assert_frame_equal
 from pyarrow import ArrowNotImplementedError
 

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -583,17 +583,17 @@ def test_feather_trades_timerange_fully_open(feather_dh, trades_full):
     )
 
 
-def test_feather_build_arrow_time_filter(feather_dh):
+def test_feather_build_arrow_trades_filter(feather_dh):
     # None timerange should return None
-    assert feather_dh._build_arrow_time_filter(None) is None
+    assert feather_dh._build_arrow_trades_filter(None) is None
 
     # Fully open (both bounds 0) should return None
     tr_fully_open = TimeRange(None, None, startts=0, stopts=0)
-    assert feather_dh._build_arrow_time_filter(tr_fully_open) is None
+    assert feather_dh._build_arrow_trades_filter(tr_fully_open) is None
 
     # Open start (startts=0) should return stop filter only
     tr_open_start = TimeRange(None, "date", startts=0, stopts=1000)
-    filter_open_start = feather_dh._build_arrow_time_filter(tr_open_start)
+    filter_open_start = feather_dh._build_arrow_trades_filter(tr_open_start)
     assert filter_open_start is not None
     # Should be a single expression (timestamp <= stopts)
     assert str(filter_open_start).count("<=") == 1
@@ -601,7 +601,7 @@ def test_feather_build_arrow_time_filter(feather_dh):
 
     # Open end (stopts=0) should return start filter only
     tr_open_end = TimeRange("date", None, startts=500, stopts=0)
-    filter_open_end = feather_dh._build_arrow_time_filter(tr_open_end)
+    filter_open_end = feather_dh._build_arrow_trades_filter(tr_open_end)
     assert filter_open_end is not None
     # Should be a single expression (timestamp >= startts)
     assert str(filter_open_end).count(">=") == 1
@@ -609,7 +609,7 @@ def test_feather_build_arrow_time_filter(feather_dh):
 
     # Closed range should return combined filter
     tr_closed = TimeRange("date", "date", startts=500, stopts=1000)
-    filter_closed = feather_dh._build_arrow_time_filter(tr_closed)
+    filter_closed = feather_dh._build_arrow_trades_filter(tr_closed)
     assert filter_closed is not None
     # Should contain both >= and <= (combined with &)
     filter_str = str(filter_closed)

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from pandas import DataFrame, Timestamp
+from pandas import DataFrame, Timestamp, date_range
 from pandas.testing import assert_frame_equal
+from pyarrow import ArrowNotImplementedError
 
 from freqtrade.configuration import TimeRange
 from freqtrade.constants import AVAILABLE_DATAHANDLERS
@@ -529,13 +530,14 @@ def test_feather_trades_timerange_filter_subset(feather_dh, trades_full, timeran
     assert len(subset) < len(trades_full)
 
 
+@pytest.mark.parametrize("exception", [ValueError("fail"), ArrowNotImplementedError("fail")])
 def test_feather_trades_timerange_pushdown_fallback(
-    feather_dh, trades_full, timerange_mid, mocker, caplog
+    feather_dh, trades_full, timerange_mid, mocker, caplog, exception
 ):
     # Pushdown filter should fail, so fallback should load the entire file
     mocker.patch(
         "freqtrade.data.history.datahandlers.arrowdatahandler.dataset.dataset",
-        side_effect=ValueError("fail"),
+        side_effect=exception,
     )
 
     with caplog.at_level("WARNING"):
@@ -709,14 +711,24 @@ def test_ohlcv_load_pushdown_limits_read(testdatadir, tmp_path, datahandler):
     assert limited.iloc[-1]["date"] == timerange.stopdt + timedelta(minutes=5)
 
 
-def test_ohlcv_load_pushdown_fallback(feather_dh, mocker, caplog):
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ValueError("fail"),
+        # Arrow raises this when a filter can't be bound to the column - e.g. a tz-aware
+        # bound against a tz-naive date column. It's a NotImplementedError, not a
+        # ValueError, so it only reaches the fallback via ArrowException.
+        ArrowNotImplementedError("fail"),
+    ],
+)
+def test_ohlcv_load_pushdown_fallback(feather_dh, mocker, caplog, exception):
     # If Arrow filtering is unavailable, the whole file is read (and trimmed later).
     tr = TimeRange.parse_timerange("20180115-20180119")
     expected = feather_dh.ohlcv_load("UNITTEST/BTC", "5m", "spot", timerange=tr)
 
     mocker.patch(
         "freqtrade.data.history.datahandlers.arrowdatahandler.dataset.dataset",
-        side_effect=ValueError("fail"),
+        side_effect=exception,
     )
 
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary
Combining parquet and feather handlers makes sense, as they both can use pyarrow under the hood.
this aligns them in functionality - and brings filter pushdown for ohlcv data (which was previously only available for trades data in feather format).

this also revises the recommendation from "feather or parquet" to feather only - as new performance tests show a significant gap between the two *for our usecase* .
