### PR TITLE
feat(okx): support stop-market orders

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -275,6 +275,9 @@ Kucoin accounts may use `KCS` for fees, and if a trade happens to be on `KCS`, f
 
 ## OKX
 
+!!! Tip "Stoploss on Exchange"
+    OKX supports `stoploss_on_exchange` with both stop-limit and stop-market orders on spot and futures markets. You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to select the stoploss order type.
+
 OKX requires a passphrase for each api key, you will therefore need to add this key into the configuration so your exchange section looks as follows:
 
 ```json
@@ -297,9 +300,6 @@ Using the wrong exchange will result in the error "OKX Error 50119: API key does
     OKX Futures has the concept of "position mode" - which can be "Buy/Sell" or long/short (hedge mode).
     Freqtrade supports both modes (we recommend to use Buy/Sell mode) - but changing the mode mid-trading is not supported and will lead to exceptions and failures to place trades.
     OKX also only provides MARK candles for the past ~3 months. Backtesting futures prior to that date will therefore lead to slight deviations, as funding-fees cannot be calculated correctly without this data.
-
-!!! Tip "Stoploss on Exchange"
-    OKX supports `stoploss_on_exchange` with both stop-limit and stop-market orders on spot and futures markets. You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to select the stoploss order type.
 
 ## Gate.io
 

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -298,6 +298,9 @@ Using the wrong exchange will result in the error "OKX Error 50119: API key does
     Freqtrade supports both modes (we recommend to use Buy/Sell mode) - but changing the mode mid-trading is not supported and will lead to exceptions and failures to place trades.
     OKX also only provides MARK candles for the past ~3 months. Backtesting futures prior to that date will therefore lead to slight deviations, as funding-fees cannot be calculated correctly without this data.
 
+!!! Tip "Stoploss on Exchange"
+    OKX supports `stoploss_on_exchange` with stop-limit orders on spot markets. Futures markets support both stop-limit and stop-market orders. You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to select the stoploss order type.
+
 ## Gate.io
 
 !!! Tip "Stoploss on Exchange"

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -299,7 +299,7 @@ Using the wrong exchange will result in the error "OKX Error 50119: API key does
     OKX also only provides MARK candles for the past ~3 months. Backtesting futures prior to that date will therefore lead to slight deviations, as funding-fees cannot be calculated correctly without this data.
 
 !!! Tip "Stoploss on Exchange"
-    OKX supports `stoploss_on_exchange` with stop-limit orders on spot markets. Futures markets support both stop-limit and stop-market orders. You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to select the stoploss order type.
+    OKX supports `stoploss_on_exchange` with both stop-limit and stop-market orders on spot and futures markets. You can use either `"limit"` or `"market"` in the `order_types.stoploss` configuration setting to select the stoploss order type.
 
 ## Gate.io
 

--- a/docs/includes/exchange-features.md
+++ b/docs/includes/exchange-features.md
@@ -18,7 +18,7 @@
 | [Hyperliquid](exchanges.md#hyperliquid) | futures | isolated, cross | limit |
 | [Kraken](exchanges.md#kraken) | spot | | market, limit |
 | [Kraken](exchanges.md#kraken-futures) | futures | isolated | market, limit |
-| [OKX](exchanges.md#okx) | spot | | limit |
+| [OKX](exchanges.md#okx) | spot | | market, limit |
 | [OKX](exchanges.md#okx) | futures | isolated | market, limit |
 | [Bitvavo](exchanges.md#bitvavo) | spot | | ❌ (not available) |
 | [Kucoin](exchanges.md#kucoin) | spot | | market, limit |

--- a/docs/includes/exchange-features.md
+++ b/docs/includes/exchange-features.md
@@ -19,6 +19,6 @@
 | [Kraken](exchanges.md#kraken) | spot | | market, limit |
 | [Kraken](exchanges.md#kraken-futures) | futures | isolated | market, limit |
 | [OKX](exchanges.md#okx) | spot | | limit |
-| [OKX](exchanges.md#okx) | futures | isolated | limit |
+| [OKX](exchanges.md#okx) | futures | isolated | market, limit |
 | [Bitvavo](exchanges.md#bitvavo) | spot | | ❌ (not available) |
 | [Kucoin](exchanges.md#kucoin) | spot | | market, limit |

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -36,6 +36,7 @@ class Okx(Exchange):
     }
     _ft_has_futures: FtHas = {
         "tickers_have_quoteVolume": False,
+        "stoploss_order_types": {"limit": "limit", "market": "market"},
         "stop_price_type_field": "slTriggerPxType",
         "stop_price_type_value_mapping": {
             PriceType.LAST: "last",

--- a/freqtrade/exchange/okx.py
+++ b/freqtrade/exchange/okx.py
@@ -28,7 +28,7 @@ class Okx(Exchange):
 
     _ft_has: FtHas = {
         "ohlcv_candle_limit": 100,  # Warning, special case with data prior to X months
-        "stoploss_order_types": {"limit": "limit"},
+        "stoploss_order_types": {"limit": "limit", "market": "market"},
         "stoploss_on_exchange": True,
         "stoploss_query_requires_stop_flag": True,
         "trades_has_history": False,  # Endpoint doesn't have a "since" parameter
@@ -36,7 +36,6 @@ class Okx(Exchange):
     }
     _ft_has_futures: FtHas = {
         "tickers_have_quoteVolume": False,
-        "stoploss_order_types": {"limit": "limit", "market": "market"},
         "stop_price_type_field": "slTriggerPxType",
         "stop_price_type_value_mapping": {
             PriceType.LAST: "last",
@@ -190,7 +189,9 @@ class Okx(Exchange):
 
     def _get_stop_params(self, side: BuySell, ordertype: str, stop_price: float) -> dict:
         params = super()._get_stop_params(side, ordertype, stop_price)
-        if self.trading_mode == TradingMode.FUTURES and self.margin_mode:
+        if self.trading_mode == TradingMode.SPOT:
+            params["tdMode"] = "cash"
+        elif self.trading_mode == TradingMode.FUTURES and self.margin_mode:
             params["tdMode"] = self.margin_mode.value
             params["posSide"] = self._get_posSide(side, True)
         return params

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -684,16 +684,6 @@ def test_stoploss_cancel_okx(mocker, default_conf):
 
 
 def test__get_stop_params_okx(mocker, default_conf):
-    default_conf["trading_mode"] = "futures"
-    default_conf["margin_mode"] = "isolated"
-    exchange = get_patched_exchange(mocker, default_conf, exchange="okx")
-    params = exchange._get_stop_params("sell", "market", 1500)
-
-    assert params["tdMode"] == "isolated"
-    assert params["posSide"] == "net"
-
-
-def test_create_stoploss_order_market_okx(mocker, default_conf):
     api_mock = MagicMock()
     api_mock.create_order = MagicMock(return_value={"id": "order-id", "info": {}})
     default_conf["dry_run"] = False
@@ -704,6 +694,10 @@ def test_create_stoploss_order_market_okx(mocker, default_conf):
     mocker.patch(f"{EXMS}.price_to_precision", lambda s, x, y, **kwargs: y)
 
     exchange = get_patched_exchange(mocker, default_conf, api_mock, exchange="okx")
+    params = exchange._get_stop_params("sell", "market", 1500)
+
+    assert params["tdMode"] == "isolated"
+    assert params["posSide"] == "net"
     exchange.create_stoploss(
         pair="ETH/USDT:USDT",
         amount=1,
@@ -712,8 +706,6 @@ def test_create_stoploss_order_market_okx(mocker, default_conf):
         side="sell",
         leverage=2.0,
     )
-    # Avoid destructor logs leaking into unrelated caplog assertions under xdist.
-    exchange.close()
 
     api_mock.create_order.assert_called_once_with(
         symbol="ETH/USDT:USDT",

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -712,6 +712,7 @@ def test_create_stoploss_order_market_okx(mocker, default_conf):
         side="sell",
         leverage=2.0,
     )
+    exchange.close()
 
     api_mock.create_order.assert_called_once_with(
         symbol="ETH/USDT:USDT",

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -712,6 +712,7 @@ def test_create_stoploss_order_market_okx(mocker, default_conf):
         side="sell",
         leverage=2.0,
     )
+    # Avoid destructor logs leaking into unrelated caplog assertions under xdist.
     exchange.close()
 
     api_mock.create_order.assert_called_once_with(

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -8,8 +8,20 @@ from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import RetryableOrderError, TemporaryError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import timeframe_to_minutes
+from freqtrade.exchange.okx import Okx
 from tests.conftest import EXMS, get_patched_exchange, log_has
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
+
+
+def test_okx_stoploss_order_types():
+    spot_options = Okx.combine_ft_has(include_futures=False)
+    futures_options = Okx.combine_ft_has(include_futures=True)
+
+    assert spot_options["stoploss_order_types"] == {"limit": "limit"}
+    assert futures_options["stoploss_order_types"] == {
+        "limit": "limit",
+        "market": "market",
+    }
 
 
 def test_okx_ohlcv_candle_limit(default_conf, mocker):
@@ -679,6 +691,42 @@ def test__get_stop_params_okx(mocker, default_conf):
 
     assert params["tdMode"] == "isolated"
     assert params["posSide"] == "net"
+
+
+def test_create_stoploss_order_market_okx(mocker, default_conf):
+    api_mock = MagicMock()
+    api_mock.create_order = MagicMock(return_value={"id": "order-id", "info": {}})
+    default_conf["dry_run"] = False
+    default_conf["trading_mode"] = TradingMode.FUTURES
+    default_conf["margin_mode"] = MarginMode.ISOLATED
+
+    mocker.patch(f"{EXMS}.amount_to_precision", lambda s, x, y: y)
+    mocker.patch(f"{EXMS}.price_to_precision", lambda s, x, y, **kwargs: y)
+
+    exchange = get_patched_exchange(mocker, default_conf, api_mock, exchange="okx")
+    exchange.create_stoploss(
+        pair="ETH/USDT:USDT",
+        amount=1,
+        stop_price=1500,
+        order_types={"stoploss": "market", "stoploss_price_type": "mark"},
+        side="sell",
+        leverage=2.0,
+    )
+
+    api_mock.create_order.assert_called_once_with(
+        symbol="ETH/USDT:USDT",
+        type="market",
+        side="sell",
+        amount=0.1,
+        price=None,
+        params={
+            "stopLossPrice": 1500,
+            "tdMode": "isolated",
+            "posSide": "net",
+            "reduceOnly": True,
+            "slTriggerPxType": "mark",
+        },
+    )
 
 
 def test_fetch_orders_okx(default_conf, mocker, limit_order):

--- a/tests/exchange/test_okx.py
+++ b/tests/exchange/test_okx.py
@@ -8,20 +8,8 @@ from freqtrade.enums import CandleType, MarginMode, TradingMode
 from freqtrade.exceptions import RetryableOrderError, TemporaryError
 from freqtrade.exchange.common import API_RETRY_COUNT
 from freqtrade.exchange.exchange import timeframe_to_minutes
-from freqtrade.exchange.okx import Okx
 from tests.conftest import EXMS, get_patched_exchange, log_has
 from tests.exchange.test_exchange import ccxt_exceptionhandlers
-
-
-def test_okx_stoploss_order_types():
-    spot_options = Okx.combine_ft_has(include_futures=False)
-    futures_options = Okx.combine_ft_has(include_futures=True)
-
-    assert spot_options["stoploss_order_types"] == {"limit": "limit"}
-    assert futures_options["stoploss_order_types"] == {
-        "limit": "limit",
-        "market": "market",
-    }
 
 
 def test_okx_ohlcv_candle_limit(default_conf, mocker):
@@ -683,44 +671,24 @@ def test_stoploss_cancel_okx(mocker, default_conf):
     assert args[2] == {"stop": True}
 
 
-def test__get_stop_params_okx(mocker, default_conf):
-    api_mock = MagicMock()
-    api_mock.create_order = MagicMock(return_value={"id": "order-id", "info": {}})
-    default_conf["dry_run"] = False
-    default_conf["trading_mode"] = TradingMode.FUTURES
-    default_conf["margin_mode"] = MarginMode.ISOLATED
-
-    mocker.patch(f"{EXMS}.amount_to_precision", lambda s, x, y: y)
-    mocker.patch(f"{EXMS}.price_to_precision", lambda s, x, y, **kwargs: y)
-
-    exchange = get_patched_exchange(mocker, default_conf, api_mock, exchange="okx")
+@pytest.mark.parametrize(
+    "trading_mode,margin_mode,expected",
+    [
+        (TradingMode.SPOT, MarginMode.NONE, {"stopLossPrice": 1500, "tdMode": "cash"}),
+        (
+            TradingMode.FUTURES,
+            MarginMode.ISOLATED,
+            {"stopLossPrice": 1500, "tdMode": "isolated", "posSide": "net"},
+        ),
+    ],
+)
+def test__get_stop_params_okx(mocker, default_conf, trading_mode, margin_mode, expected):
+    default_conf["trading_mode"] = trading_mode
+    default_conf["margin_mode"] = margin_mode
+    exchange = get_patched_exchange(mocker, default_conf, exchange="okx")
     params = exchange._get_stop_params("sell", "market", 1500)
 
-    assert params["tdMode"] == "isolated"
-    assert params["posSide"] == "net"
-    exchange.create_stoploss(
-        pair="ETH/USDT:USDT",
-        amount=1,
-        stop_price=1500,
-        order_types={"stoploss": "market", "stoploss_price_type": "mark"},
-        side="sell",
-        leverage=2.0,
-    )
-
-    api_mock.create_order.assert_called_once_with(
-        symbol="ETH/USDT:USDT",
-        type="market",
-        side="sell",
-        amount=0.1,
-        price=None,
-        params={
-            "stopLossPrice": 1500,
-            "tdMode": "isolated",
-            "posSide": "net",
-            "reduceOnly": True,
-            "slTriggerPxType": "mark",
-        },
-    )
+    assert params == expected
 
 
 def test_fetch_orders_okx(default_conf, mocker, limit_order):


### PR DESCRIPTION
## Summary

- enable stop-market orders for OKX spot and futures
- send `tdMode=cash` for spot stop orders
- update the OKX feature matrix and documentation

## Motivation

OKX supports market-on-trigger conditional stops, and CCXT sends `slOrdPx=-1` for a market stop. Freqtrade currently advertises only limit stops for OKX, so `order_types.stoploss=market` is mapped back to a stop-limit order.

Spot algo orders also need `tdMode=cash`. Without it, CCXT used `cross` on the tested account and OKX rejected the request with `50014` (`ccy` missing).

## Validation

- `python -m pytest tests/exchange/test_okx.py -q`: 22 passed
- `python -m pytest tests/exchange/test_okx.py tests/exchange/test_exchange.py -q`: 1440 passed, 18 skipped
- changed-file pre-commit hooks: passed
- `python -m mkdocs build --strict`: passed
- editor diagnostics and `git diff --check`: clean

Authenticated OKX Demo checks:

- futures: live conditional order with `slOrdPx=-1`, mark trigger, and `reduceOnly=true`
- spot: live conditional order with `tdMode=cash`, `slOrdPx=-1`, and last-price trigger

Both test orders were canceled and the account was left with no pending conditional orders. The Spot test did not change BTC or USDT balances.

## AI assistance

GitHub Copilot assisted with investigation and drafting. I reviewed the patch and ran the validation above.