### PR TITLE
Fix strip_trailing_zeros corrupting integer strings

### DIFF
--- a/freqtrade/util/formatters.py
+++ b/freqtrade/util/formatters.py
@@ -20,6 +20,8 @@ def strip_trailing_zeros(value: str) -> str:
     :param value: Value to be stripped
     :return: Stripped value
     """
+    if "." not in value:
+        return value
     return value.rstrip("0").rstrip(".")
 
 

--- a/tests/util/test_formatters.py
+++ b/tests/util/test_formatters.py
@@ -55,6 +55,11 @@ def test_round_value():
     assert round_value(0.1274512123, 5) == "0.12745"
     assert round_value(222.2, 3, True) == "222.200"
     assert round_value(222.2, 0, True) == "222"
+    # decimals=0 without keep_trailing_zeros must not strip integer digits
+    assert round_value(222.2, 0) == "222"
+    assert round_value(1200, 0) == "1200"
+    assert round_value(1500, 0) == "1500"
+    assert round_value(0, 0) == "0"
     assert round_value(float("nan"), 0, True) == "N/A"
     assert round_value(float("nan"), 10, True) == "N/A"
     assert round_value(None, 10, True) == "N/A"


### PR DESCRIPTION
## Summary

`round_value(value, 0)` returns wrong output because `strip_trailing_zeros` strips zeros from integer strings that have no decimal point. Self-found, no existing issue.

## Quick changelog

- `util/formatters.strip_trailing_zeros`: only strip trailing zeros when a decimal point is present
- added `round_value(..., 0)` cases to `test_round_value`

## What's new?

`strip_trailing_zeros(value)` does `value.rstrip("0").rstrip(".")`. When the string has no decimal point it removes significant digits:

```
round_value(1200, 0)  ->  "12"   (expected "1200")
round_value(1500, 0)  ->  "15"   (expected "1500")
round_value(0, 0)     ->  ""     (expected "0")
```

`round_value` documents and tests `decimals=0` (there is a `keep_trailing_zeros=True` case in `test_round_value`), so this is a supported input. The fix only strips when a `.` is present, so every decimal-containing value is unchanged and existing behaviour is preserved. Added tests for the `decimals=0` path.

AI assistance (Claude) was used for this change; I reviewed it and verified it against the formatter test suite myself