### PR TITLE
Don't reuse websocket candles before the current candle arrived

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2683,11 +2683,11 @@ class Exchange:
 
             if (
                 candles
-                and (
-                    (len(candles) > 1 and candles[-1][0] >= prev_candle_ts)
-                    # Edgecase on reconnect, where 1 candle is available but it's the current one
-                    or (len(candles) == 1 and candles[-1][0] < candle_ts)
-                )
+                # The cache must already contain the currently forming candle. If it doesn't,
+                # its newest entry is a candle that is still open - get_ohlcv() would return it
+                # with drop_hint=False, so it'd be merged as if it was closed, overwriting the
+                # close of that candle with an intra-candle price.
+                and candles[-1][0] >= candle_ts
                 and last_refresh_time >= half_candle
             ):
                 # Usable result, candle contains the previous candle.

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3057,6 +3057,60 @@ def test_refresh_ohlcv_with_cache(mocker, default_conf, time_machine) -> None:
     assert len(res) == 5
 
 
+def test_try_build_from_websocket(mocker, default_conf, time_machine, caplog) -> None:
+    now = datetime(2024, 11, 1, 10, 0, 1, tzinfo=UTC)
+    time_machine.move_to(now, tick=False)
+    exchange = get_patched_exchange(mocker, default_conf)
+
+    candle_ts = dt_ts(timeframe_to_prev_date("1h", now))
+    prev_candle_ts = dt_ts(date_minus_candles("1h", 1, now))
+    half_candle = candle_ts - (candle_ts - prev_candle_ts) // 2
+
+    ws_mock = MagicMock()
+    exchange._exchange_ws = ws_mock
+    pair_args = ("ETH/BTC", "1h", CandleType.SPOT)
+
+    # Websocket stalled 15 minutes before the candle rolled over, so its newest entry is the
+    # still-forming previous candle. Reusing it would merge an unfinished candle as if it was
+    # closed - get_ohlcv() returns drop_hint=False in that case.
+    ws_mock.get_ohlcv_with_refresh.return_value = (
+        [
+            [prev_candle_ts - 3600 * 1000, 1.0, 2.0, 0.5, 1.5, 100],
+            [prev_candle_ts, 1.5, 2.5, 1.0, 2.0, 50],
+        ],
+        half_candle + 15 * 60 * 1000,
+    )
+    assert exchange._try_build_from_websocket(*pair_args) is None
+    assert log_has_re(r"Couldn't reuse watch for ETH/BTC, 1h.*", caplog)
+
+    # Same cache content, but the websocket has since received the currently forming candle.
+    # The previous candle is closed now, so the cache is usable.
+    caplog.clear()
+    ws_mock.get_ohlcv_with_refresh.return_value = (
+        [
+            [prev_candle_ts, 1.5, 2.5, 1.0, 2.0, 50],
+            [candle_ts, 2.0, 2.1, 1.9, 2.05, 5],
+        ],
+        candle_ts,
+    )
+    assert exchange._try_build_from_websocket(*pair_args) is not None
+    assert not log_has_re(r"Couldn't reuse watch for ETH/BTC, 1h.*", caplog)
+
+    # Current candle present, but the last refresh is older than half a candle.
+    ws_mock.get_ohlcv_with_refresh.return_value = (
+        [
+            [prev_candle_ts, 1.5, 2.5, 1.0, 2.0, 50],
+            [candle_ts, 2.0, 2.1, 1.9, 2.05, 5],
+        ],
+        half_candle - 1,
+    )
+    assert exchange._try_build_from_websocket(*pair_args) is None
+
+    # Empty cache
+    ws_mock.get_ohlcv_with_refresh.return_value = ([], candle_ts)
+    assert exchange._try_build_from_websocket(*pair_args) is None
+
+
 def test_refresh_latest_ohlcv_funding_rate(mocker, default_conf_usdt, caplog) -> None:
     ohlcv = generate_test_data_raw("1h", 24, "2025-01-02 12:00:00+00:00")
     funding_data = [{"timestamp": x[0], "fundingRate": x[1]} for x in ohlcv]


### PR DESCRIPTION
While chasing wrong `close` values on a live bot I ended up in `_try_build_from_websocket`, and I think the reuse condition there is a bit too permissive.

The gate accepts the websocket cache as soon as its newest entry is the *previous* candle:

```python
(len(candles) > 1 and candles[-1][0] >= prev_candle_ts)
```

But `ExchangeWS.get_ohlcv()` decides separately, with `drop_hint = received_ts >= candle_ts`. So if the stream stalls somewhere inside the current candle, the gate still passes — `last_refresh_time >= half_candle` tolerates up to half a candle of staleness — while `drop_hint` comes back `False`. The still-forming candle is then merged as if it were closed.

What makes this hard to notice is the aggregation in `clean_ohlcv_dataframe()`: `{open: first, high: max, low: min, close: last, volume: max}`. On the duplicate timestamp, `max`/`min` keep the correct values that were already in `_klines` from the REST refresh, and only `close` gets replaced by the stale intra-candle price. The resulting row looks perfectly valid — no OHLC sanity check catches it.

### What I ran into

OKX futures, 1h, `enable_ws` left at its default. Comparing `/api/v1/pair_candles` against `fetch_ohlcv` for the 09:00 UTC candle on 2026-07-27:

| pair | exchange close | bot close |
|---|---|---|
| BZ/USDT:USDT | 84.89 | 85.75 |
| SOL/USDT:USDT | 76.45 | 76.24 |
| LINK/USDT:USDT | 8.791 | 8.769 |

`open`, `high`, `low` and `volume` matched the exchange exactly in all three cases, and every wrong close sits inside `[low, high]`, which is consistent with an intra-candle snapshot. The bad close propagates straight into the indicators.

This looks like the same root cause as #11139 — the logs in that issue show `lref=05:59:59, candle_date=06:00:00, drop_hint=False`. The symptom reported there was the obvious zero-volume filler row for the current period. This is the quieter variant, where an already closed candle silently gets its close rewritten.

### The change

Require the cache to already hold the currently forming candle. If it does, the previous candle in the same list is necessarily closed, and `drop_hint` is `True` so the forming one gets dropped. Put differently: the gate now implies `drop_hint`, which I think was the intent all along.

I removed the `len(candles) == 1` reconnect branch, because `candles[-1][0] < candle_ts` is exactly the unsafe case and it also contradicts its own comment ("it's the current one"). Happy to bring it back in some other shape if you'd rather keep it.

There is a tradeoff: on illiquid pairs the first trade of a new candle may arrive a little after the boundary, so those refreshes fall back to REST. That costs one extra REST call, but it never produces bad data.

### Testing

* Added `test_try_build_from_websocket`. There was no unit test for this method before, only the longrun online one. It fails on current `develop` and passes with this change.
* `pytest tests/exchange` — 1771 passed, 18 skipped.
* `ruff check` and `ruff format --check` clean with the pinned 0.15.22, `mypy` clean.

---

*AI assistance disclosure, per CONTRIBUTING: I used an LLM to help trace the code path and to draft this description. I have reviewed the change and can explain it.*
