### PR TITLE
docs: add Shingou sentiment overlay to the community showcase

### DIFF
--- a/docs/includes/showcase.md
+++ b/docs/includes/showcase.md
@@ -9,3 +9,4 @@ This section will highlight a few projects from members of the community.
 - [Freqtrade analysis notebook](https://github.com/froggleston/freqtrade_analysis_notebook) (by Froggleston).
 - [FTUI - Terminal UI for freqtrade](https://github.com/freqtrade/ftui) (by Froggleston).
 - [Bot Academy](https://botacademy.ddns.net/) (by stash86) - Blog about crypto bot projects.
+- [Shingou sentiment overlay](https://github.com/auriontech/shingou-integrations) (by auriontech) - Example strategy using an hourly news-sentiment API as an entry filter and position sizer, plus a typed-event kill switch.


### PR DESCRIPTION
Adds one line to the community showcase for a set of MIT-licensed example strategies that use an hourly news-sentiment API with Freqtrade.

The repo is https://github.com/auriontech/shingou-integrations. It ships a `populate_entry_trend` sentiment filter, a position-sizing variant, and a typed-event kill switch, plus the symbol map between Freqtrade pairs and the API's symbols. The strategies are examples, not a product install, and they run against a free API key.

Happy to reword or drop it if a vendor-backed example is not what the showcase is for.