### PR TITLE
rank already-signaled entry candidates

### DIFF
--- a/docs/strategy-callbacks.md
+++ b/docs/strategy-callbacks.md
@@ -15,6 +15,7 @@ Currently available callbacks:
 * [`custom_roi()`](#custom-roi)
 * [`custom_entry_price()` and `custom_exit_price()`](#custom-order-price-rules)
 * [`check_entry_timeout()` and `check_exit_timeout()`](#custom-order-timeout-rules)
+* [`entry_candidate_priority()`](#entry-candidate-priority)
 * [`confirm_trade_entry()`](#trade-entry-buy-order-confirmation)
 * [`confirm_trade_exit()`](#trade-exit-sell-order-confirmation)
 * [`adjust_trade_position()`](#adjust-trade-position)
@@ -788,6 +789,32 @@ class AwesomeStrategy(IStrategy):
 
 Confirm trade entry / exits.
 This are the last methods that will be called before an order is placed.
+
+### Entry candidate priority
+
+`entry_candidate_priority()` ranks entry signals that compete for the available
+trade slots in one bot loop. Higher values are considered first. Equal values
+keep the pairlist order, which is the default behavior.
+
+The callback is called after exit processing and before any new entry order is
+created. It is called in live/dry-run operation and during backtesting. Return
+a finite number and use only information available at `current_time`.
+
+``` python
+class AwesomeStrategy(IStrategy):
+
+    # ... populate_* methods calculate atr_pct and quote_volume
+
+    def entry_candidate_priority(self, pair: str, current_time: datetime,
+                                 side: str, entry_tag: str | None, **kwargs) -> float:
+        dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+        last_candle = dataframe.iloc[-1]
+        # Examples: return last_candle["quote_volume"] or -last_candle["atr_pct"]
+        return float(last_candle["quote_volume"])
+```
+
+Do not make network requests or recalculate indicators here. A ranking callback
+chooses among existing signals; it does not create an entry signal.
 
 ### Trade entry (buy order) confirmation
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -6,10 +6,10 @@ import logging
 import traceback
 from copy import deepcopy
 from datetime import UTC, datetime, time, timedelta
-from math import isclose
+from math import isclose, isfinite
 from threading import Lock
 from time import sleep
-from typing import Any
+from typing import Any, NamedTuple
 
 from schedule import Scheduler
 
@@ -68,6 +68,13 @@ from freqtrade.wallets import Wallets
 
 
 logger = logging.getLogger(__name__)
+
+
+class EntryCandidate(NamedTuple):
+    pair: str
+    signal: SignalDirection
+    enter_tag: str | None
+    current_time: datetime | None
 
 
 class FreqtradeBot(LoggingMixin):
@@ -664,17 +671,22 @@ class FreqtradeBot(LoggingMixin):
                 self.log_once("Global pairlock active. Not creating new trades.", logger.info)
             return trades_created
 
-        # Create entity and execute trade for each pair from whitelist
-        for pair in whitelist:
+        candidates = [
+            candidate for pair in whitelist if (candidate := self.get_entry_candidate(pair))
+        ]
+        candidates.sort(key=self._entry_candidate_priority, reverse=True)
+
+        # Create entity and execute trade for each ranked candidate.
+        for candidate in candidates:
             if free_trade_slots <= 0:
                 break
             try:
                 with self._exit_lock:
-                    if self.create_trade(pair):
+                    if self.execute_entry_candidate(candidate):
                         free_trade_slots -= 1
                         trades_created += 1
             except DependencyException as exception:
-                logger.warning("Unable to create trade for %s: %s", pair, exception)
+                logger.warning("Unable to create trade for %s: %s", candidate.pair, exception)
 
         if not trades_created:
             logger.debug("Found no enter signals for whitelisted currencies. Trying again...")
@@ -698,6 +710,11 @@ class FreqtradeBot(LoggingMixin):
             logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
             return False
 
+        candidate = self.get_entry_candidate(pair)
+        return self.execute_entry_candidate(candidate) if candidate else False
+
+    def get_entry_candidate(self, pair: str) -> EntryCandidate | None:
+        """Return an actionable entry signal without creating an order."""
         analyzed_df, _ = self.dataprovider.get_analyzed_dataframe(pair, self.strategy.timeframe)
         nowtime = analyzed_df.iloc[-1]["date"] if len(analyzed_df) > 0 else None
 
@@ -718,29 +735,52 @@ class FreqtradeBot(LoggingMixin):
                     )
                 else:
                     self.log_once(f"Pair {pair} is currently locked.", logger.info)
-                return False
+                return None
 
-            stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
+            return EntryCandidate(pair, signal, enter_tag, nowtime)
+        return None
 
-            bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
-            if (bid_check_dom.get("enabled", False)) and (
-                bid_check_dom.get("bids_to_ask_delta", 0) > 0
-            ):
-                if self._check_depth_of_market(pair, bid_check_dom, side=signal):
-                    return self.execute_entry(
-                        pair,
-                        stake_amount,
-                        enter_tag=enter_tag,
-                        is_short=(signal == SignalDirection.SHORT),
-                    )
-                else:
-                    return False
+    def _entry_candidate_priority(self, candidate: EntryCandidate) -> float:
+        priority = strategy_safe_wrapper(
+            self.strategy.entry_candidate_priority, default_retval=0.0
+        )(
+            pair=candidate.pair,
+            current_time=candidate.current_time,
+            side=candidate.signal,
+            entry_tag=candidate.enter_tag,
+        )
+        if isinstance(priority, (int, float)) and isfinite(priority):
+            return priority
+        logger.warning(
+            "Ignoring non-finite entry candidate priority for %s: %r", candidate.pair, priority
+        )
+        return 0.0
 
-            return self.execute_entry(
-                pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
-            )
-        else:
+    def execute_entry_candidate(self, candidate: EntryCandidate) -> bool:
+        """Create an order for a candidate already selected by the scheduler."""
+        pair, signal, enter_tag, _ = candidate
+        if not self.get_free_open_trades():
+            logger.debug(f"Can't open a new trade for {pair}: max number of trades is reached.")
             return False
+
+        stake_amount = self.wallets.get_trade_stake_amount(pair, self.config["max_open_trades"])
+
+        bid_check_dom = self.config.get("entry_pricing", {}).get("check_depth_of_market", {})
+        if (bid_check_dom.get("enabled", False)) and (
+            bid_check_dom.get("bids_to_ask_delta", 0) > 0
+        ):
+            if self._check_depth_of_market(pair, bid_check_dom, side=signal):
+                return self.execute_entry(
+                    pair,
+                    stake_amount,
+                    enter_tag=enter_tag,
+                    is_short=(signal == SignalDirection.SHORT),
+                )
+            return False
+
+        return self.execute_entry(
+            pair, stake_amount, enter_tag=enter_tag, is_short=(signal == SignalDirection.SHORT)
+        )
 
     #
     # Modify positions / DCA logic and methods

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import datetime, timedelta
+from math import isfinite
 from typing import TYPE_CHECKING
 
 from numpy import isnan, nan
@@ -1322,6 +1323,58 @@ class Backtesting:
             return "short"
         return None
 
+    def _rank_entry_pairs(
+        self,
+        pairs: list[str],
+        candidates: dict[str, tuple[LongShort, str | None]],
+        current_time: datetime,
+    ) -> list[str]:
+        """Put same-candle entry candidates in strategy priority order.
+
+        ``sorted`` is stable, so the default priority preserves pairlist order.
+        """
+
+        def priority(item: tuple[str, tuple[LongShort, str | None]]) -> float:
+            pair, (side, enter_tag) = item
+            value = strategy_safe_wrapper(
+                self.strategy.entry_candidate_priority, default_retval=0.0
+            )(
+                pair=pair,
+                current_time=current_time,
+                side=side,
+                entry_tag=enter_tag,
+            )
+            if isinstance(value, (int, float)) and isfinite(value):
+                return value
+            logger.warning("Ignoring non-finite entry candidate priority for %s: %r", pair, value)
+            return 0.0
+
+        ranked = [pair for pair, _ in sorted(candidates.items(), key=priority, reverse=True)]
+        ranked_set = set(ranked)
+        return ranked + [pair for pair in pairs if pair not in ranked_set]
+
+    def _prepare_main_candles(
+        self,
+        current_time: datetime,
+        pairs: list[str],
+        data: dict[str, list[tuple]],
+        indexes: dict,
+    ) -> tuple[dict[str, tuple], list[str]]:
+        """Advance all pairs to the current candle, then rank entry candidates."""
+        main_rows: dict[str, tuple] = {}
+        candidates: dict[str, tuple[LongShort, str | None]] = {}
+        for pair in pairs:
+            row_index = self._sync_pair_index(data, pair, indexes[pair], current_time)
+            row = self.validate_row(data, pair, row_index, current_time)
+            if not row:
+                continue
+            indexes[pair] = row_index + 1
+            main_rows[pair] = row
+            self.dataprovider._set_dataframe_max_index(pair, self.required_startup + row_index + 1)
+            if trade_dir := self.check_for_trade_entry(row):
+                candidates[pair] = (trade_dir, row[ENTER_TAG_IDX])
+        return main_rows, self._rank_entry_pairs(pairs, candidates, current_time)
+
     def run_protections(self, pair: str, current_time: datetime, side: LongShort):
         if self.enable_protections:
             self.protections.stop_per_pair(pair, current_time, side, self.starting_balance)
@@ -1675,8 +1728,12 @@ class Backtesting:
             pairs_with_open_trades = [t.pair for t in LocalTrade.bt_trades_open]
             self._capture_wallet(current_time, self.strategy.config["stake_currency"], 1)
 
+            # Make all current main candles visible before ranking candidates. This
+            # gives a strategy the same completed-candle view for every pair.
+            main_rows, loop_pairs = self._prepare_main_candles(current_time, pairs, data, indexes)
+
             for current_time_det, is_first, has_detail, idx, pair in self._time_pair_generator_det(
-                current_time, pairs
+                current_time, loop_pairs
             ):
                 # Loop for each detail candle (if necessary) and pair
                 # Yields only the main date if no detail timeframe is set.
@@ -1685,17 +1742,10 @@ class Backtesting:
                 trade_dir: LongShort | None = None
                 if is_first:
                     # Main candle
-                    row_index = self._sync_pair_index(data, pair, indexes[pair], current_time)
-                    row = self.validate_row(data, pair, row_index, current_time)
-                    if not row:
+                    row = main_rows.get(pair)
+                    if row is None:
                         continue
-
-                    row_index += 1
-                    indexes[pair] = row_index
                     is_last_row = current_time == end_date
-                    self.dataprovider._set_dataframe_max_index(
-                        pair, self.required_startup + row_index
-                    )
                     trade_dir = self.check_for_trade_entry(row)
                     pair_tradedir_cache[pair] = trade_dir
                     self._capture_wallet(current_time, pair.split("/")[0], row[OPEN_IDX])

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -392,6 +392,33 @@ class IStrategy(ABC, HyperStrategyMixin):
         """
         return True
 
+    def entry_candidate_priority(
+        self,
+        pair: str,
+        current_time: datetime | None,
+        side: str,
+        entry_tag: str | None,
+        **kwargs,
+    ) -> float:
+        """
+        Return the priority of an entry candidate when several candidates compete for slots.
+
+        Candidates with a higher value are considered first. Equal values keep the
+        order supplied by the pairlist, which is the default behavior.
+
+        This callback must only use data available at ``current_time``. It is called
+        once for every actionable entry signal before an entry order is created.
+        It may therefore be used to rank candidates by values calculated in
+        ``populate_indicators`` (for example, volume or ATR).
+
+        :param pair: Pair of the entry candidate.
+        :param current_time: Timestamp of the signal candle.
+        :param side: 'long' or 'short'.
+        :param entry_tag: Optional entry tag from the signal candle.
+        :return: Higher candidates are considered first. The default is 0.
+        """
+        return 0.0
+
     def confirm_trade_exit(
         self,
         pair: str,

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -30,7 +30,7 @@ from freqtrade.exceptions import (
     PricingError,
     TemporaryError,
 )
-from freqtrade.freqtradebot import FreqtradeBot
+from freqtrade.freqtradebot import EntryCandidate, FreqtradeBot
 from freqtrade.persistence import Order, PairLocks, Trade
 from freqtrade.plugins.protections.iprotection import ProtectionReturn
 from freqtrade.util.datetime_helpers import dt_now, dt_utc
@@ -1154,15 +1154,38 @@ def test_enter_positions(
     caplog.set_level(logging.DEBUG)
     freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
 
+    mocker.patch(
+        "freqtrade.freqtradebot.FreqtradeBot.get_entry_candidate",
+        MagicMock(return_value=EntryCandidate("ETH/USDT", SignalDirection.LONG, None, None)),
+    )
     mock_ct = mocker.patch(
-        "freqtrade.freqtradebot.FreqtradeBot.create_trade",
+        "freqtrade.freqtradebot.FreqtradeBot.execute_entry_candidate",
         MagicMock(return_value=return_value, side_effect=side_effect),
     )
     n = freqtrade.enter_positions(1)
     assert n == 0
     assert log_has(log_message, caplog)
-    # create_trade should be called once for every pair in the whitelist.
+    # All candidates are considered when no entry is created.
     assert mock_ct.call_count == len(default_conf_usdt["exchange"]["pair_whitelist"])
+
+
+def test_enter_positions_uses_entry_candidate_priority(mocker, default_conf_usdt) -> None:
+    freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
+    first, second = default_conf_usdt["exchange"]["pair_whitelist"][:2]
+    candidates = {
+        first: EntryCandidate(first, SignalDirection.LONG, None, None),
+        second: EntryCandidate(second, SignalDirection.LONG, None, None),
+    }
+    mocker.patch.object(
+        freqtrade, "get_entry_candidate", side_effect=lambda pair: candidates.get(pair)
+    )
+    freqtrade.strategy.entry_candidate_priority = MagicMock(
+        side_effect=lambda pair, **kwargs: 1.0 if pair == second else 0.0
+    )
+    execute = mocker.patch.object(freqtrade, "execute_entry_candidate", return_value=True)
+
+    assert freqtrade.enter_positions(1) == 1
+    assert execute.call_args.args[0].pair == second
 
 
 @pytest.mark.usefixtures("init_persistence")

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -54,6 +54,28 @@ def trim_dictlist(dict_list, num):
     return new
 
 
+def test_rank_entry_pairs_uses_strategy_priority_and_keeps_ties_stable() -> None:
+    backtesting = Backtesting.__new__(Backtesting)
+    backtesting.strategy = MagicMock()
+    backtesting.strategy.entry_candidate_priority.side_effect = lambda pair, **kwargs: {
+        "B/USDT": 2.0,
+        "C/USDT": 1.0,
+    }.get(pair, 0.0)
+    pairs = ["A/USDT", "B/USDT", "C/USDT", "D/USDT"]
+    candidates = {"A/USDT": ("long", None), "B/USDT": ("long", None), "C/USDT": ("short", "x")}
+
+    assert backtesting._rank_entry_pairs(pairs, candidates, datetime.now(UTC)) == [
+        "B/USDT",
+        "C/USDT",
+        "A/USDT",
+        "D/USDT",
+    ]
+
+    backtesting.strategy.entry_candidate_priority.return_value = 0.0
+    backtesting.strategy.entry_candidate_priority.side_effect = None
+    assert backtesting._rank_entry_pairs(pairs, candidates, datetime.now(UTC)) == pairs
+
+
 def load_data_test(what, testdatadir):
     timerange = TimeRange.parse_timerange("1510694220-1510700340")
     data = history.load_pair_history(


### PR DESCRIPTION
## Summary

Adds an optional `IStrategy.entry_candidate_priority()` callback for ranking entry signals that compete for limited open-trade slots.

- Higher finite scores are considered first.
- Equal scores keep the active pairlist order, preserving default behavior.
- Live/dry-run collect actionable signals, rank them, then create orders.
- Backtesting advances all current main-candle dataframe indexes before it ranks candidates, so every candidate has the same completed-candle view.

Closes #13449. Related: #6030.

## Explicit non-goals

- This does not mutate the pairlist or add pairs.
- This does not change the intentional same-candle exit/entry processing model in #9817.
- This is not a claim that any score improves profitability.

## Validation

- `pre-commit run --files ...` passed: schema extraction, mypy, ruff, formatting, end-of-file, line endings, AST, codespell, and zizmor.
- `pytest --confcutdir=tests/optimize tests/optimize/test_backtesting.py::test_rank_entry_pairs_uses_strategy_priority_and_keeps_ties_stable -q` passed.
- A manual 200-USDT / 2-slot Binance futures fixture verified default pairlist admission (AVAX) and higher-score admission (BCH) at the same replacement candle.

The targeted `tests/freqtradebot` run is blocked before test collection by the local shared environment: its `torch` namespace has neither `torch._logging` nor `torch.Tensor`, which then breaks the repository test fixture and SciPy import. This PR does not modify those dependencies.