### PR TITLE
use "api_key" instead of "key" for more clarity

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1273,8 +1273,16 @@
           "description": "Name of the exchange.",
           "type": "string"
         },
+        "api_key": {
+          "description": "API key for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__API_KEY",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "key": {
-          "description": "API key for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__KEY",
+          "description": "API key for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__KEYDeprecated, use api_key instead.",
           "type": [
             "string",
             "null"

--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1278,16 +1278,14 @@
           "type": [
             "string",
             "null"
-          ],
-          "default": null
+          ]
         },
         "key": {
-          "description": "API key for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__KEYDeprecated, use api_key instead.",
+          "description": "API key for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__KEY Deprecated, use api_key instead.",
           "type": [
             "string",
             "null"
-          ],
-          "default": null
+          ]
         },
         "secret": {
           "description": "API secret for the exchange. Recommended to be set via environment variable FREQTRADE__EXCHANGE__SECRET",

--- a/config_examples/config_binance.example.json
+++ b/config_examples/config_binance.example.json
@@ -31,7 +31,7 @@
     },
     "exchange": {
         "name": "binance",
-        "key": "your_exchange_key",
+        "api_key": "your_exchange_api_key",
         "secret": "your_exchange_secret",
         "ccxt_config": {},
         "ccxt_async_config": {

--- a/config_examples/config_freqai.example.json
+++ b/config_examples/config_freqai.example.json
@@ -17,8 +17,8 @@
     },
     "exchange": {
         "name": "binance",
-        "key": "",
-        "secret": "",
+        "api_key": "your_exchange_api_key",
+        "secret": "your_exchange_secret",
         "ccxt_config": {},
         "ccxt_async_config": {},
         "pair_whitelist": [

--- a/config_examples/config_full.example.json
+++ b/config_examples/config_full.example.json
@@ -113,7 +113,7 @@
         "name": "binance",
         "api_key": "your_exchange_api_key",
         "secret": "your_exchange_secret",
-        "password": "your_exchange_password_if_necessary",
+        "password": "",
         "log_responses": false,
         // "unknown_fee_rate": 1,
         "ccxt_config": {},

--- a/config_examples/config_full.example.json
+++ b/config_examples/config_full.example.json
@@ -111,9 +111,9 @@
     ],
     "exchange": {
         "name": "binance",
-        "key": "your_exchange_key",
+        "api_key": "your_exchange_api_key",
         "secret": "your_exchange_secret",
-        "password": "",
+        "password": "your_exchange_password_if_necessary",
         "log_responses": false,
         // "unknown_fee_rate": 1,
         "ccxt_config": {},

--- a/config_examples/config_kraken.example.json
+++ b/config_examples/config_kraken.example.json
@@ -31,8 +31,8 @@
     },
     "exchange": {
         "name": "kraken",
-        "key": "your_exchange_key",
-        "secret": "your_exchange_key",
+        "api_key": "your_exchange_api_key",
+        "secret": "your_exchange_secret",
         "ccxt_config": {},
         "ccxt_async_config": {
         },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -699,7 +699,7 @@ creating trades on the exchange.
 ```json
 "exchange": {
     "name": "binance",
-    "key": "key",
+    "api_key": "api_key",
     "secret": "secret",
     ...
 }
@@ -749,7 +749,7 @@ API Keys are usually only required for live trading (trading for real money, bot
 {
     "exchange": {
         "name": "binance",
-        "key": "af8ddd35195e9dc500b9a6f799f6f5c93d89193b",
+        "api_key": "af8ddd35195e9dc500b9a6f799f6f5c93d89193b",
         "secret": "08a9dc6db3d7b53e1acebd9275677f4b0a04f1a5",
         //"password": "", // Optional, not needed by all exchanges)
         // ...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `max_entry_position_adjustment` | Maximum additional order(s) for each open trade on top of the first entry Order. Set it to `-1` for unlimited additional orders. [More information here](strategy-callbacks.md#adjust-trade-position). <br> [Strategy Override](#parameters-in-the-strategy). <br>*Defaults to `-1`.*<br> **Datatype:** Positive Integer or -1
 | | **Exchange**
 | `exchange.name` | **Required.** Name of the exchange class to use. <br> **Datatype:** String
-| `exchange.key` | API key to use for the exchange. Only required when you are in production mode.<br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
+| `exchange.api_key` | API key to use for the exchange. Only required when you are in production mode.<br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
 | `exchange.secret` | API secret to use for the exchange. Only required when you are in production mode.<br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
 | `exchange.password` | API password to use for the exchange. Only required when you are in production mode and for exchanges that use password for API requests.<br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String
 | `exchange.uid` | API uid to use for the exchange. Only required when you are in production mode and for exchanges that use uid for API requests.<br>**Keep it in secret, do not disclose publicly.** <br> **Datatype:** String

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -25,7 +25,7 @@ A exchange configuration for "binance" would look as follows:
 ```json
 "exchange": {
     "name": "binance",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret",
     "ccxt_config": {},
     "ccxt_async_config": {},
@@ -40,7 +40,7 @@ In case of problems related to rate-limits (usually DDOS Exceptions in your logs
 ```json
 "exchange": {
     "name": "kraken",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret",
     "ccxt_config": {"enableRateLimit": true},
     "ccxt_async_config": {
@@ -95,7 +95,7 @@ They can however also be configured via configuration file. Since json doesn't s
 
 ``` json
 // ...
- "key": "<someapikey>",
+ "api_key": "<someapikey>",
  "secret": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBABACAFQA<...>s8KX8=\n-----END PRIVATE KEY-----"
 // ...
 ```
@@ -224,7 +224,7 @@ Kraken Futures uses the exchange id `krakenfutures` and supports isolated future
 ```jsonc
 "exchange": {
     "name": "krakenfutures",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret"
 },
 "trading_mode": "futures",
@@ -250,7 +250,7 @@ Kucoin requires a passphrase for each api key, you will therefore need to add th
 ```json
 "exchange": {
     "name": "kucoin",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret",
     "password": "your_exchange_api_key_password",
     // ...
@@ -283,7 +283,7 @@ OKX requires a passphrase for each api key, you will therefore need to add this 
 ```json
 "exchange": {
     "name": "okx",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret",
     "password": "your_exchange_api_key_password",
     // ...
@@ -364,7 +364,7 @@ Bitget requires a passphrase for each api key, you will therefore need to add th
 ```json
 "exchange": {
     "name": "bitget",
-    "key": "your_exchange_key",
+    "api_key": "your_exchange_api_key",
     "secret": "your_exchange_secret",
     "password": "your_exchange_api_key_password",
     // ...
@@ -511,7 +511,7 @@ If your account is required to use an operatorId, you can set it in the configur
 ``` json
 "exchange": {
         "name": "bitvavo",
-        "key": "",
+        "api_key": "",
         "secret": "",
         "ccxt_config": {
             "options": {

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -70,7 +70,7 @@ Your combined configuration is:
   "stake_currency": "USDT",
   "exchange": {
     "name": "binance",
-    "key": "REDACTED",
+    "api_key": "REDACTED",
     "secret": "REDACTED",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -941,15 +941,13 @@ CONF_SCHEMA = {
                         f"API key for the exchange. {__VIA_ENV} FREQTRADE__EXCHANGE__API_KEY"
                     ),
                     "type": ["string", "null"],
-                    "default": None,
                 },
                 "key": {
                     "description": (
                         f"API key for the exchange. {__VIA_ENV} FREQTRADE__EXCHANGE__KEY"
-                        "Deprecated, use api_key instead."
+                        " Deprecated, use api_key instead."
                     ),
                     "type": ["string", "null"],
-                    "default": None,
                 },
                 "secret": {
                     "description": (

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -936,9 +936,17 @@ CONF_SCHEMA = {
             "type": "object",
             "properties": {
                 "name": {"description": "Name of the exchange.", "type": "string"},
+                "api_key": {
+                    "description": (
+                        f"API key for the exchange. {__VIA_ENV} FREQTRADE__EXCHANGE__API_KEY"
+                    ),
+                    "type": ["string", "null"],
+                    "default": None,
+                },
                 "key": {
                     "description": (
                         f"API key for the exchange. {__VIA_ENV} FREQTRADE__EXCHANGE__KEY"
+                        "Deprecated, use api_key instead."
                     ),
                     "type": ["string", "null"],
                     "default": None,

--- a/freqtrade/configuration/deploy_config.py
+++ b/freqtrade/configuration/deploy_config.py
@@ -137,8 +137,8 @@ def ask_user_config() -> dict[str, Any]:
         },
         {
             "type": "password",
-            "name": "exchange_key",
-            "message": "Insert Exchange Key",
+            "name": "exchange_api_key",
+            "message": "Insert Exchange API Key",
             "when": lambda x: not x["dry_run"],
         },
         {
@@ -149,7 +149,7 @@ def ask_user_config() -> dict[str, Any]:
         },
         {
             "type": "password",
-            "name": "exchange_key_password",
+            "name": "exchange_api_key_password",
             "message": "Insert Exchange API Key password",
             "when": lambda x: not x["dry_run"] and x["exchange_name"] in ("kucoin", "okx"),
         },

--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -196,7 +196,7 @@ MINIMAL_CONFIG = {
     "dry_run": True,
     "exchange": {
         "name": "",
-        "key": None,
+        "api_key": None,
         "secret": None,
         "pair_whitelist": [],
         "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_binance.j2
+++ b/freqtrade/templates/subtemplates/exchange_binance.j2
@@ -1,6 +1,6 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_bittrex.j2
+++ b/freqtrade/templates/subtemplates/exchange_bittrex.j2
@@ -7,7 +7,7 @@
 },
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_gateio.j2
+++ b/freqtrade/templates/subtemplates/exchange_gateio.j2
@@ -1,6 +1,6 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "unknown_fee_rate": 1,
     "ccxt_config": {},

--- a/freqtrade/templates/subtemplates/exchange_generic.j2
+++ b/freqtrade/templates/subtemplates/exchange_generic.j2
@@ -1,6 +1,6 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_huobi.j2
+++ b/freqtrade/templates/subtemplates/exchange_huobi.j2
@@ -1,6 +1,6 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_kraken.j2
+++ b/freqtrade/templates/subtemplates/exchange_kraken.j2
@@ -1,7 +1,7 @@
 "download_trades": true,
 "exchange": {
     "name": "kraken",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
     "ccxt_config": {},
     "ccxt_async_config": {},

--- a/freqtrade/templates/subtemplates/exchange_kucoin.j2
+++ b/freqtrade/templates/subtemplates/exchange_kucoin.j2
@@ -1,8 +1,8 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
-    "password": "{{ exchange_key_password }}",
+    "password": "{{ exchange_api_key_password }}",
     "ccxt_config": {},
     "ccxt_async_config": {},
     "pair_whitelist": [

--- a/freqtrade/templates/subtemplates/exchange_okex.j2
+++ b/freqtrade/templates/subtemplates/exchange_okex.j2
@@ -1,8 +1,8 @@
 "exchange": {
     "name": "{{ exchange_name | lower }}",
-    "key": "{{ exchange_key }}",
+    "api_key": "{{ exchange_api_key }}",
     "secret": "{{ exchange_secret }}",
-    "password": "{{ exchange_key_password }}",
+    "password": "{{ exchange_api_key_password }}",
     "ccxt_config": {},
     "ccxt_async_config": {},
     "pair_whitelist": [

--- a/tests/commands/test_build_config.py
+++ b/tests/commands/test_build_config.py
@@ -75,6 +75,7 @@ def test_start_new_config(mocker, caplog, exchange):
         parse_mode=rapidjson.PM_COMMENTS | rapidjson.PM_TRAILING_COMMAS,
     )
     assert result["exchange"]["name"] == exchange
+    assert result["exchange"]["api_key"] == "sampleKey"
     assert result["timeframe"] == "15m"
 
 

--- a/tests/commands/test_build_config.py
+++ b/tests/commands/test_build_config.py
@@ -51,7 +51,7 @@ def test_start_new_config(mocker, caplog, exchange):
         "trading_mode": "spot",
         "margin_mode": "",
         "exchange_name": exchange,
-        "exchange_key": "sampleKey",
+        "exchange_api_key": "sampleKey",
         "exchange_secret": "Samplesecret",
         "telegram": False,
         "telegram_token": "asdf1244",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,7 +639,7 @@ def get_default_conf(testdatadir):
         },
         "exchange": {
             "name": "binance",
-            "key": "key",
+            "api_key": "key",
             "enable_ws": False,
             "secret": "secret",
             "pair_whitelist": ["ETH/BTC", "LTC/BTC", "XRP/BTC", "NEO/BTC"],
@@ -685,7 +685,7 @@ def get_default_conf_usdt(testdatadir):
             "exchange": {
                 "name": "binance",
                 "enabled": True,
-                "key": "key",
+                "api_key": "key",
                 "enable_ws": False,
                 "secret": "secret",
                 "pair_whitelist": [

--- a/tests/exchange_online/conftest.py
+++ b/tests/exchange_online/conftest.py
@@ -773,7 +773,7 @@ EXCHANGES_SPOT = [exch for exch, params in EXCHANGES.items() if not params.get("
 def exchange_conf():
     config = get_default_conf_usdt((Path(__file__).parent / "testdata").resolve())
     config["exchange"]["pair_whitelist"] = []
-    config["exchange"]["apiKey"] = None
+    config["exchange"]["api_key"] = None
     config["exchange"]["secret"] = None
     config["dry_run"] = False
     config["entry_pricing"]["use_order_book"] = True

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -188,15 +188,15 @@ def test_load_strategy_no_keys(default_conf_usdt, mocker, runmode, caplog) -> No
     strategy_config = freqtrade.strategy.config
     assert id(strategy_config["exchange"]) == id(conf["exchange"])
     # Keys have been removed and are not passed to the exchange
-    assert strategy_config["exchange"]["key"] is None
+    assert strategy_config["exchange"]["api_key"] is None
     assert strategy_config["exchange"]["secret"] is None
 
     assert erm.call_count == 1
     ex_conf = erm.call_args_list[0][1]["exchange_config"]
     assert id(ex_conf) != id(conf["exchange"])
     # Keys are still present
-    assert ex_conf["key"] is not None
-    assert ex_conf["key"] == default_conf_usdt["exchange"]["key"]
+    assert ex_conf["api_key"] is not None
+    assert ex_conf["api_key"] == default_conf_usdt["exchange"]["api_key"]
     assert ex_conf["secret"] is not None
     assert ex_conf["secret"] == default_conf_usdt["exchange"]["secret"]
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1591,19 +1591,19 @@ def test_setup_freqai_backtesting(mocker, default_conf) -> None:
 
 
 def test_sanitize_config(default_conf_usdt):
-    assert default_conf_usdt["exchange"]["key"] != "REDACTED"
+    assert default_conf_usdt["exchange"]["api_key"] != "REDACTED"
     res = sanitize_config(default_conf_usdt)
     # Didn't modify original dict
-    assert default_conf_usdt["exchange"]["key"] != "REDACTED"
+    assert default_conf_usdt["exchange"]["api_key"] != "REDACTED"
     assert "accountId" not in default_conf_usdt["exchange"]
 
-    assert res["exchange"]["key"] == "REDACTED"
+    assert res["exchange"]["api_key"] == "REDACTED"
     assert res["exchange"]["secret"] == "REDACTED"
     # Didn't add a non-existing key
     assert "accountId" not in res["exchange"]
 
     res = sanitize_config(default_conf_usdt, show_sensitive=True)
-    assert res["exchange"]["key"] == default_conf_usdt["exchange"]["key"]
+    assert res["exchange"]["api_key"] == default_conf_usdt["exchange"]["api_key"]
     assert res["exchange"]["secret"] == default_conf_usdt["exchange"]["secret"]
 
 
@@ -1611,11 +1611,11 @@ def test_remove_exchange_credentials(default_conf) -> None:
     conf = deepcopy(default_conf)
     remove_exchange_credentials(conf["exchange"], False)
 
-    assert conf["exchange"]["key"] is not None
+    assert conf["exchange"]["api_key"] is not None
     assert conf["exchange"]["secret"] is not None
 
     remove_exchange_credentials(conf["exchange"], True)
-    assert conf["exchange"]["key"] is None
+    assert conf["exchange"]["api_key"] is None
     assert conf["exchange"]["secret"] is None
     assert conf["exchange"].get("password") is None
     assert conf["exchange"].get("uid") is None

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1118,7 +1118,6 @@ def test_load_config_stoploss_exchange_limit_ratio(all_conf) -> None:
 @pytest.mark.parametrize(
     "base,key,expected",
     [
-        ("exchange", "api_key", None),
         ("exchange", "secret", None),
         ("exchange", "password", None),
     ],

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -169,7 +169,7 @@ def test_load_config_max_open_trades_zero(default_conf, mocker, caplog) -> None:
 def test_load_config_combine_dicts(default_conf, mocker, caplog) -> None:
     conf1 = deepcopy(default_conf)
     conf2 = deepcopy(default_conf)
-    del conf1["exchange"]["key"]
+    del conf1["exchange"]["api_key"]
     del conf1["exchange"]["secret"]
     del conf2["exchange"]["name"]
     conf2["exchange"]["pair_whitelist"] += ["NANO/BTC"]
@@ -192,7 +192,7 @@ def test_load_config_combine_dicts(default_conf, mocker, caplog) -> None:
 
     exchange_conf = default_conf["exchange"]
     assert validated_conf["exchange"]["name"] == exchange_conf["name"]
-    assert validated_conf["exchange"]["key"] == exchange_conf["key"]
+    assert validated_conf["exchange"]["api_key"] == exchange_conf["api_key"]
     assert validated_conf["exchange"]["secret"] == exchange_conf["secret"]
     assert validated_conf["exchange"]["pair_whitelist"] != conf1["exchange"]["pair_whitelist"]
     assert validated_conf["exchange"]["pair_whitelist"] == conf2["exchange"]["pair_whitelist"]
@@ -203,7 +203,7 @@ def test_load_config_combine_dicts(default_conf, mocker, caplog) -> None:
 def test_from_config(default_conf, mocker, caplog) -> None:
     conf1 = deepcopy(default_conf)
     conf2 = deepcopy(default_conf)
-    del conf1["exchange"]["key"]
+    del conf1["exchange"]["api_key"]
     del conf1["exchange"]["secret"]
     del conf2["exchange"]["name"]
     conf2["exchange"]["pair_whitelist"] += ["NANO/BTC"]
@@ -218,7 +218,7 @@ def test_from_config(default_conf, mocker, caplog) -> None:
 
     exchange_conf = default_conf["exchange"]
     assert validated_conf["exchange"]["name"] == exchange_conf["name"]
-    assert validated_conf["exchange"]["key"] == exchange_conf["key"]
+    assert validated_conf["exchange"]["api_key"] == exchange_conf["api_key"]
     assert validated_conf["exchange"]["secret"] == exchange_conf["secret"]
     assert validated_conf["exchange"]["pair_whitelist"] != conf1["exchange"]["pair_whitelist"]
     assert validated_conf["exchange"]["pair_whitelist"] == conf2["exchange"]["pair_whitelist"]
@@ -1116,31 +1116,29 @@ def test_load_config_stoploss_exchange_limit_ratio(all_conf) -> None:
 
 
 @pytest.mark.parametrize(
-    "keys",
+    "base,key,expected",
     [
-        ("exchange", "key", None),
+        ("exchange", "api_key", None),
         ("exchange", "secret", None),
         ("exchange", "password", None),
     ],
 )
-def test_load_config_default_subkeys(all_conf, keys) -> None:
+def test_load_config_default_subkeys(all_conf, base, key, expected) -> None:
     """
     Test for parameters with default values in sub-paths
     so they can be omitted in the config and the default value
     should is added to the config.
     """
-    # Get first level key
-    key = keys[0]
     # get second level key
-    subkey = keys[1]
+    subkey = key
 
-    del all_conf[key][subkey]
+    del all_conf[base][subkey]
 
-    assert subkey not in all_conf[key]
+    assert subkey not in all_conf[base]
 
     validate_config_schema(all_conf)
-    assert subkey in all_conf[key]
-    assert all_conf[key][subkey] == keys[2]
+    assert subkey in all_conf[base]
+    assert all_conf[base][subkey] == expected
 
 
 def test_pairlist_resolving():

--- a/tests/testdata/testconfigs/main_test_config.json
+++ b/tests/testdata/testconfigs/main_test_config.json
@@ -30,7 +30,7 @@
     },
     "exchange": {
         "name": "binance",
-        "key": "your_exchange_key",
+        "api_key": "your_exchange_api_key",
         "secret": "your_exchange_secret",
         "ccxt_config": {},
         "ccxt_async_config": {},

--- a/tests/testdata/testconfigs/test_base_config.json
+++ b/tests/testdata/testconfigs/test_base_config.json
@@ -3,7 +3,7 @@
     "dry_run": false,
     "exchange": {
         "name": "",
-        "key": "",
+        "api_key": "",
         "secret": "",
         "pair_whitelist": [],
         "ccxt_async_config": {


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Update terminology, docs and tests to use api_key instead of "key".

"key" is still supported - but deprecated.