### PR TITLE
fix: close async ccxt sessions when another event loop is running

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -8,10 +8,11 @@ import inspect
 import logging
 import signal
 from collections.abc import Coroutine, Generator
+from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from math import floor, isnan
-from threading import Lock
+from threading import Lock, Thread
 from typing import Any, Literal, TypeGuard, TypeVar
 from uuid import uuid4
 
@@ -203,6 +204,7 @@ class Exchange:
         # Due to funding fee fetching.
         self._loop_lock = Lock()
         self.loop = self._init_async_loop()
+        self._pending_close_tasks: set[asyncio.Task] = set()
         self._config: Config = config
 
         # Leverage properties
@@ -310,38 +312,92 @@ class Exchange:
         """
         Destructor - clean up async stuff
         """
-        self.close()
+        # Interpreter shutdown / already-closed loops must not raise from __del__.
+        with suppress(Exception):
+            self.close()
+
+    def _ccxt_client_needs_close(self, ccxt_obj: Any) -> bool:
+        if not ccxt_obj or not inspect.iscoroutinefunction(getattr(ccxt_obj, "close", None)):
+            return False
+        return bool(
+            getattr(ccxt_obj, "session", None) or getattr(ccxt_obj, "socks_proxy_sessions", None)
+        )
+
+    def _run_coroutine_sync(self, coro: Coroutine[Any, Any, Any], timeout: float = 10.0) -> None:
+        """
+        Run ``coro`` on this exchange's dedicated loop.
+
+        ``asyncio.run_until_complete`` cannot start that loop while another
+        loop is already running on this thread (API / telegram / asyncio.run).
+        The previous close() path treated that as "do not close", which leaked
+        the ccxt aiohttp session (#13458).
+        """
+        loop = getattr(self, "loop", None)
+        if loop is None or loop.is_closed():
+            try:
+                asyncio.run(coro)
+            except Exception:
+                coro.close()
+                raise
+            return
+
+        if loop.is_running():
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                # Same thread, our loop is running: waiting would deadlock.
+                task = asyncio.create_task(coro)
+                self._pending_close_tasks.add(task)
+                task.add_done_callback(self._pending_close_tasks.discard)
+                return
+            asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=timeout)
+            return
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            with self._loop_lock:
+                loop.run_until_complete(coro)
+            return
+
+        # Another loop is running on this thread; drive ours from a helper thread.
+        error: list[BaseException] = []
+
+        def _runner() -> None:
+            try:
+                with self._loop_lock:
+                    loop.run_until_complete(coro)
+            except BaseException as exc:
+                error.append(exc)
+
+        thread = Thread(target=_runner, name="ft-ccxt-close", daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            raise TimeoutError("Timed out while closing ccxt session.")
+        if error:
+            raise error[0]
+
+    def _close_async_ccxt(self, ccxt_obj: Any, label: str) -> None:
+        if not self._ccxt_client_needs_close(ccxt_obj):
+            return
+        logger.debug("Closing %s ccxt session.", label)
+        try:
+            self._run_coroutine_sync(ccxt_obj.close())
+        except Exception:
+            logger.exception("Exception while closing %s ccxt session", label)
 
     def close(self):
         if self._exchange_ws:
             self._exchange_ws.cleanup()
+            self._exchange_ws = None
 
-        try:
-            generic_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            generic_loop = None
-        loop_running = (getattr(self, "loop", None) and self.loop.is_running()) or (
-            generic_loop is not None and generic_loop.is_running()
-        )
+        self._close_async_ccxt(getattr(self, "_api_async", None), "async")
+        self._close_async_ccxt(getattr(self, "_ws_async", None), "ws")
 
-        if (
-            getattr(self, "_api_async", None)
-            and inspect.iscoroutinefunction(self._api_async.close)
-            and self._api_async.session
-            and not loop_running
-        ):
-            logger.debug("Closing async ccxt session.")
-            self.loop.run_until_complete(self._api_async.close())
-        if (
-            self._ws_async
-            and inspect.iscoroutinefunction(self._ws_async.close)
-            and self._ws_async.session
-            and not loop_running
-        ):
-            logger.debug("Closing ws ccxt session.")
-            self.loop.run_until_complete(self._ws_async.close())
-
-        if self.loop and not self.loop.is_closed():
+        if getattr(self, "loop", None) and not self.loop.is_closed() and not self.loop.is_running():
             self.loop.close()
 
     def _init_async_loop(self) -> asyncio.AbstractEventLoop:

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1,4 +1,6 @@
+import asyncio
 import copy
+import gc
 import logging
 import re
 from copy import deepcopy
@@ -229,6 +231,68 @@ def test_destroy(default_conf, mocker, caplog):
     exchange.close()
     # Prevent the __del__ triggered close (at GC time) from touching the now-closed loop.
     exchange._api_async.session = None
+
+    assert closed
+    assert log_has("Closing async ccxt session.", caplog)
+
+
+def _exchange_with_real_async_ccxt(default_conf):
+    """Build Exchange with a real ccxt.pro client (no network)."""
+    conf = copy.deepcopy(default_conf)
+    conf["exchange"]["name"] = "binance"
+    conf["exchange"]["enable_ws"] = False
+    with (
+        patch(f"{EXMS}.validate_config"),
+        patch(f"{EXMS}.reload_markets"),
+        patch(f"{EXMS}.validate_stakecurrency"),
+    ):
+        return Exchange(conf)
+
+
+def test_close_async_ccxt_session_when_another_loop_running(default_conf, caplog):
+    """
+    #13458: close() used to skip await exchange.close() when *any* loop was
+    running in the current thread, leaking the Binance/ccxt aiohttp session.
+    """
+    caplog.set_level(logging.DEBUG)
+    exchange = _exchange_with_real_async_ccxt(default_conf)
+
+    async def _open():
+        exchange._api_async.open()
+        assert exchange._api_async.session is not None
+
+    exchange.loop.run_until_complete(_open())
+
+    async def _close_from_other_loop():
+        exchange.close()
+
+    asyncio.run(_close_from_other_loop())
+
+    assert exchange._api_async.session is None
+    assert log_has("Closing async ccxt session.", caplog)
+
+    # Drop refs so ccxt __del__ runs; the leaked-session warning must not appear.
+    holders = [exchange, exchange._api_async]
+    holders.clear()
+    gc.collect()
+    assert not any("requires to release all resources" in rec.message for rec in caplog.records)
+
+
+def test_close_async_ccxt_socks_proxy_sessions(default_conf, mocker, caplog):
+    caplog.set_level(logging.DEBUG)
+    exchange = get_patched_exchange(mocker, default_conf)
+    closed = False
+
+    async def _close():
+        nonlocal closed
+        closed = True
+
+    exchange._api_async.close = _close
+    exchange._api_async.session = None
+    exchange._api_async.socks_proxy_sessions = {"socks5://localhost": MagicMock()}
+
+    exchange.close()
+    exchange._api_async.socks_proxy_sessions = None
 
     assert closed
     assert log_has("Closing async ccxt session.", caplog)


### PR DESCRIPTION
## Summary

Fixes #13458.

`Exchange.close()` treated any running asyncio loop in the current thread as a reason to skip `await exchange.close()`. After a scheduled restart, or any caller that already has a loop (API, telegram, `asyncio.run`), the Binance/ccxt aiohttp session stayed open. ccxt's `__del__` then logged:

> binance requires to release all resources with an explicit call to the .close() coroutine.

That still happens on current develop: `self.loop` is idle, but `asyncio.get_running_loop()` succeeds, so close is skipped and the exchange loop is closed anyway. A later `__del__` hits `RuntimeError: Event loop is closed`.

## Change

- Close async/ws ccxt clients whenever `session` or `socks_proxy_sessions` is set.
- If the exchange loop is idle but another loop is running on this thread, run `close()` on a helper thread so we do not nest event loops.
- If the exchange loop is already running on another thread, use `run_coroutine_threadsafe`.
- Do not close the dedicated loop until after the clients are closed.
- Swallow errors in `Exchange.__del__` so interpreter shutdown cannot raise `Event loop is closed`.

## Test plan

- [x] `pytest tests/exchange/test_exchange.py::test_destroy`
- [x] `pytest tests/exchange/test_exchange.py::test_close_async_ccxt_session_when_another_loop_running`
- [x] `pytest tests/exchange/test_exchange.py::test_close_async_ccxt_socks_proxy_sessions`
- [x] `pytest tests/exchange/test_exchange_ws.py tests/freqtradebot/test_freqtradebot.py::test_bot_cleanup`

AI assistance was used for implementation and tests; I reviewed the change.