### PR TITLE
Simpler UX for Timerange per hour/minute

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -148,10 +148,24 @@ You can also specify particular date ranges.
 
 The full timerange specification:
 
-- Use data until 2018/01/31: `--timerange=-20180131`
-- Use data since 2018/01/31: `--timerange=20180131-`
-- Use data since 2018/01/31 till 2018/03/01 : `--timerange=20180131-20180301`
-- Use data between POSIX / epoch timestamps 1527595200 1527618600: `--timerange=1527595200-1527618600`
+- Use data until 2026/01/31: `--timerange=-20260131`
+- Use data since 2026/01/31: `--timerange=20260131-`
+- Use data since 2026/01/31 till 2026/03/01 : `--timerange=20260131-20260301`
+- Use data since 2026/01/31 15:30 till 2026/03/01 18:00: `--timerange=20260131T1530-20260301T1800`
+- Use data between POSIX / epoch timestamps 1782086400 1527618600: `--timerange=1782086400-1782144960`
+
+Each side of the timerange is parsed on its own, and can use any of the following formats (all times are in UTC):
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| `yyyymmdd` | `20260131` | Date - equivalent to midnight (00:00) of that day |
+| `yyyymmddThhmm` | `20260131T1530` | Date and time (hours and minutes, 24h clock) |
+| `yyyymmddThhmmss` | `20260131T053045` | Date and time, including seconds |
+| epoch (seconds) | `1782086400` | POSIX timestamp in seconds (10 digits) |
+| epoch (milliseconds) | `1782086400000` | POSIX timestamp in milliseconds (13 digits) |
+
+Formats can be mixed within one timerange - `--timerange=20260131-20260301T1200` is valid.
+Leaving one side empty (`20260131-` or `-20260301`) leaves that end of the range unbounded.
 
 ## Understand the backtesting result
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -152,7 +152,7 @@ The full timerange specification:
 - Use data since 2026/01/31: `--timerange=20260131-`
 - Use data since 2026/01/31 till 2026/03/01 : `--timerange=20260131-20260301`
 - Use data since 2026/01/31 15:30 till 2026/03/01 18:00: `--timerange=20260131T1530-20260301T1800`
-- Use data between POSIX / epoch timestamps 1782086400 1527618600: `--timerange=1782086400-1782144960`
+- Use data between POSIX / epoch timestamps 1782086400 1782144960: `--timerange=1782086400-1782144960`
 
 Each side of the timerange is parsed on its own, and can use any of the following formats (all times are in UTC):
 

--- a/docs/commands/backtesting-analysis.md
+++ b/docs/commands/backtesting-analysis.md
@@ -42,7 +42,9 @@ options:
   --entry-only          Only analyze entry signals.
   --exit-only           Only analyze exit signals.
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --rejected-signals    Analyse rejected signals
   --analysis-to-csv     Save selected analysis tables to individual CSVs
   --analysis-csv-path ANALYSIS_CSV_PATH

--- a/docs/commands/backtesting-analysis.md
+++ b/docs/commands/backtesting-analysis.md
@@ -43,7 +43,7 @@ options:
   --exit-only           Only analyze exit signals.
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --rejected-signals    Analyse rejected signals
   --analysis-to-csv     Save selected analysis tables to individual CSVs

--- a/docs/commands/backtesting.md
+++ b/docs/commands/backtesting.md
@@ -26,7 +26,9 @@ options:
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.
                         (default: `feather`).

--- a/docs/commands/backtesting.md
+++ b/docs/commands/backtesting.md
@@ -27,7 +27,7 @@ options:
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.

--- a/docs/commands/download-data.md
+++ b/docs/commands/download-data.md
@@ -31,7 +31,7 @@ options:
                         you experience issues.
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --dl-trades           Download trades instead of OHLCV data.
   --convert             Convert downloaded trades to OHLCV data. Only

--- a/docs/commands/download-data.md
+++ b/docs/commands/download-data.md
@@ -30,7 +30,9 @@ options:
                         Disable parallel startup download. Only use this if
                         you experience issues.
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --dl-trades           Download trades instead of OHLCV data.
   --convert             Convert downloaded trades to OHLCV data. Only
                         applicable in combination with `--dl-trades`. Will be

--- a/docs/commands/edge.md
+++ b/docs/commands/edge.md
@@ -14,7 +14,7 @@ options:
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.

--- a/docs/commands/edge.md
+++ b/docs/commands/edge.md
@@ -13,7 +13,9 @@ options:
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.
                         (default: `feather`).

--- a/docs/commands/hyperopt.md
+++ b/docs/commands/hyperopt.md
@@ -23,7 +23,7 @@ options:
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.

--- a/docs/commands/hyperopt.md
+++ b/docs/commands/hyperopt.md
@@ -22,7 +22,9 @@ options:
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.
                         (default: `feather`).

--- a/docs/commands/lookahead-analysis.md
+++ b/docs/commands/lookahead-analysis.md
@@ -30,7 +30,7 @@ options:
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.

--- a/docs/commands/lookahead-analysis.md
+++ b/docs/commands/lookahead-analysis.md
@@ -29,7 +29,9 @@ options:
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.
                         (default: `feather`).

--- a/docs/commands/plot-dataframe.md
+++ b/docs/commands/plot-dataframe.md
@@ -45,7 +45,9 @@ options:
                         Assumes either `user_data/backtest_results/` or
                         `--export-directory` as base directory.
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --no-trades           Skip using trades from backtesting file and DB.

--- a/docs/commands/plot-dataframe.md
+++ b/docs/commands/plot-dataframe.md
@@ -46,7 +46,7 @@ options:
                         `--export-directory` as base directory.
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).

--- a/docs/commands/plot-profit.md
+++ b/docs/commands/plot-profit.md
@@ -16,7 +16,9 @@ options:
                         Limit command to these pairs. Pairs are space-
                         separated.
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --export {none,trades,signals}
                         Export backtest results (default: trades).
   --backtest-filename, --export-filename PATH

--- a/docs/commands/plot-profit.md
+++ b/docs/commands/plot-profit.md
@@ -17,7 +17,7 @@ options:
                         separated.
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --export {none,trades,signals}
                         Export backtest results (default: trades).

--- a/docs/commands/recursive-analysis.md
+++ b/docs/commands/recursive-analysis.md
@@ -15,7 +15,9 @@ options:
   -i, --timeframe TIMEFRAME
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
-                        Specify what timerange of data to use.
+                        Limit action to a specific timerange. Format:
+                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.
                         (default: `feather`).

--- a/docs/commands/recursive-analysis.md
+++ b/docs/commands/recursive-analysis.md
@@ -16,7 +16,7 @@ options:
                         Specify timeframe (`1m`, `5m`, `30m`, `1h`, `1d`).
   --timerange TIMERANGE
                         Limit action to a specific timerange. Format:
-                        (`yyyymmdd` or `yyyymmddThhmm - e.g.
+                        (`yyyymmdd` or `yyyymmddThhmm` - e.g.
                         `20240101-20240201T1200`).
   --data-format-ohlcv {json,jsongz,feather,parquet}
                         Storage format for downloaded candle (OHLCV) data.

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -160,7 +160,8 @@ AVAILABLE_CLI_OPTIONS = {
     ),
     "timerange": Arg(
         "--timerange",
-        help="Specify what timerange of data to use.",
+        help="Limit action to a specific timerange. Format: "
+        "(`yyyymmdd` or `yyyymmddThhmm - e.g. `20240101-20240201T1200`).",
     ),
     "max_open_trades": Arg(
         "--max-open-trades",

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -161,7 +161,7 @@ AVAILABLE_CLI_OPTIONS = {
     "timerange": Arg(
         "--timerange",
         help="Limit action to a specific timerange. Format: "
-        "(`yyyymmdd` or `yyyymmddThhmm - e.g. `20240101-20240201T1200`).",
+        "(`yyyymmdd` or `yyyymmddThhmm` - e.g. `20240101-20240201T1200`).",
     ),
     "max_open_trades": Arg(
         "--max-open-trades",

--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -14,6 +14,17 @@ from freqtrade.util import dt_from_ts
 
 logger = logging.getLogger(__name__)
 
+# Supported formats for one side of a timerange.
+# Datetime formats are interpreted as UTC - a format of None means "epoch"
+# (seconds for 10 digits, milliseconds for 13 digits).
+_TIMERANGE_FORMATS: list[tuple[str, str | None]] = [
+    (r"\d{8}", "%Y%m%d"),
+    (r"\d{8}T\d{4}", "%Y%m%dT%H%M"),
+    (r"\d{8}T\d{6}", "%Y%m%dT%H%M%S"),
+    (r"\d{10}", None),
+    (r"\d{13}", None),
+]
+
 
 class TimeRange:
     """
@@ -55,18 +66,31 @@ class TimeRange:
             return dt_from_ts(self.stopts)
         return None
 
+    @staticmethod
+    def _format_dt(dt: datetime) -> str:
+        """
+        Format a datetime with the lowest precision that keeps all information.
+        yyyymmdd for midnight, yyyymmddThhmm otherwise - yyyymmddThhmmss if seconds are set.
+        """
+        if dt.second:
+            return dt.strftime("%Y%m%dT%H%M%S")
+        if dt.hour or dt.minute:
+            return dt.strftime("%Y%m%dT%H%M")
+        return dt.strftime("%Y%m%d")
+
     @property
     def timerange_str(self) -> str:
         """
         Returns a string representation of the timerange as used by parse_timerange.
         Follows the format yyyymmdd-yyyymmdd - leaving out the parts that are not set.
+        Timeranges that are not aligned to midnight use the yyyymmddThhmm[ss] format instead.
         """
         start = ""
         stop = ""
         if startdt := self.startdt:
-            start = startdt.strftime("%Y%m%d")
+            start = self._format_dt(startdt)
         if stopdt := self.stopdt:
-            stop = stopdt.strftime("%Y%m%d")
+            stop = self._format_dt(stopdt)
         return f"{start}-{stop}"
 
     @property
@@ -130,58 +154,46 @@ class TimeRange:
             self.startts = int(min_date.timestamp() + timeframe_secs * startup_candles)
             self.starttype = "date"
 
+    @staticmethod
+    def _parse_timerange_part(text: str) -> int:
+        """
+        Parse one side of a timerange to a timestamp in seconds.
+        :param text: One side of the timerange - an empty string means "unbounded"
+        :return: Timestamp in seconds - 0 if unbounded
+        :raises ValueError: If the value doesn't match any supported format
+        """
+        if not text:
+            return 0
+        for rex, fmt in _TIMERANGE_FORMATS:
+            if not re.fullmatch(rex, text):
+                continue
+            if fmt is None:
+                # Epoch - in seconds (10 digits) or milliseconds (13 digits)
+                return int(text) // 1000 if len(text) == 13 else int(text)
+            return int(datetime.strptime(text, fmt).replace(tzinfo=UTC).timestamp())
+        raise ValueError(f'Invalid timerange value "{text}"')
+
     @classmethod
     def parse_timerange(cls, text: str | None) -> Self:
         """
-        Parse the value of the argument --timerange to determine what is the range desired
+        Parse the value of the argument --timerange to determine what is the range desired.
+        Both sides are parsed independently and may use any of the supported formats:
+        yyyymmdd, yyyymmddThhmm, yyyymmddThhmmss, epoch (seconds) or epoch (milliseconds).
         :param text: value from --timerange
         :return: Start and End range period
         """
         if not text:
             return cls(None, None, 0, 0)
-        syntax = [
-            (r"^-(\d{8})$", (None, "date")),
-            (r"^(\d{8})-$", ("date", None)),
-            (r"^(\d{8})-(\d{8})$", ("date", "date")),
-            (r"^-(\d{10})$", (None, "date")),
-            (r"^(\d{10})-$", ("date", None)),
-            (r"^(\d{10})-(\d{10})$", ("date", "date")),
-            (r"^-(\d{13})$", (None, "date")),
-            (r"^(\d{13})-$", ("date", None)),
-            (r"^(\d{13})-(\d{13})$", ("date", "date")),
-        ]
-        for rex, stype in syntax:
-            # Apply the regular expression to text
-            match = re.match(rex, text)
-            if match:  # Regex has matched
-                rvals = match.groups()
-                index = 0
-                start: int = 0
-                stop: int = 0
-                if stype[0]:
-                    starts = rvals[index]
-                    if stype[0] == "date" and len(starts) == 8:
-                        start = int(
-                            datetime.strptime(starts, "%Y%m%d").replace(tzinfo=UTC).timestamp()
-                        )
-                    elif len(starts) == 13:
-                        start = int(starts) // 1000
-                    else:
-                        start = int(starts)
-                    index += 1
-                if stype[1]:
-                    stops = rvals[index]
-                    if stype[1] == "date" and len(stops) == 8:
-                        stop = int(
-                            datetime.strptime(stops, "%Y%m%d").replace(tzinfo=UTC).timestamp()
-                        )
-                    elif len(stops) == 13:
-                        stop = int(stops) // 1000
-                    else:
-                        stop = int(stops)
-                if start > stop > 0:
-                    raise ConfigurationError(
-                        f'Start date is after stop date for timerange "{text}"'
-                    )
-                return cls(stype[0], stype[1], start, stop)
-        raise ConfigurationError(f'Incorrect syntax for timerange "{text}"')
+        parts = text.split("-")
+        if len(parts) != 2 or not any(parts):
+            raise ConfigurationError(f'Incorrect syntax for timerange "{text}"')
+        starts, stops = parts
+        try:
+            start = cls._parse_timerange_part(starts)
+            stop = cls._parse_timerange_part(stops)
+        except ValueError as e:
+            raise ConfigurationError(f'Incorrect syntax for timerange "{text}"') from e
+
+        if start > stop > 0:
+            raise ConfigurationError(f'Start date is after stop date for timerange "{text}"')
+        return cls("date" if starts else None, "date" if stops else None, start, stop)

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -31,7 +31,8 @@ def test_parse_timerange_incorrect():
     assert isinstance(timerange.stopdt, datetime)
     assert timerange.startdt == datetime.fromtimestamp(1231006505, tz=UTC)
     assert timerange.stopdt == datetime.fromtimestamp(1233360000, tz=UTC)
-    assert timerange.timerange_str == "20090103-20090131"
+    # Non-midnight timestamps round-trip with minute (or second) precision
+    assert timerange.timerange_str == "20090103T181505-20090131"
 
     timerange = TimeRange.parse_timerange("1231006505000-1233360000000")
     assert TimeRange("date", "date", 1231006505, 1233360000) == timerange
@@ -49,6 +50,113 @@ def test_parse_timerange_incorrect():
         OperationalException, match=r"Start date is after stop date for timerange.*"
     ):
         TimeRange.parse_timerange("20100523-20100522")
+
+
+def test_parse_timerange_minutes():
+    timerange = TimeRange.parse_timerange("20100522T1030-")
+    assert TimeRange("date", None, 1274524200, 0) == timerange
+    assert timerange.timerange_str == "20100522T1030-"
+    assert timerange.start_fmt == "2010-05-22 10:30:00"
+
+    timerange = TimeRange.parse_timerange("-20100522T1030")
+    assert TimeRange(None, "date", 0, 1274524200) == timerange
+    assert timerange.timerange_str == "-20100522T1030"
+
+    timerange = TimeRange.parse_timerange("20100522T1030-20150730T2359")
+    assert TimeRange("date", "date", 1274524200, 1438300740) == timerange
+    assert timerange.timerange_str == "20100522T1030-20150730T2359"
+
+    # Seconds are supported, too
+    timerange = TimeRange.parse_timerange("20100522T103045-20150730T235901")
+    assert TimeRange("date", "date", 1274524245, 1438300741) == timerange
+    assert timerange.timerange_str == "20100522T103045-20150730T235901"
+
+    # Midnight keeps the plain date format
+    timerange = TimeRange.parse_timerange("20100522T0000-20150730T0000")
+    assert TimeRange("date", "date", 1274486400, 1438214400) == timerange
+    assert timerange.timerange_str == "20100522-20150730"
+
+    with pytest.raises(
+        OperationalException, match=r"Start date is after stop date for timerange.*"
+    ):
+        TimeRange.parse_timerange("20100522T1030-20100522T1029")
+
+
+@pytest.mark.parametrize(
+    "timerange,expected,expected_str",
+    [
+        (
+            "20100522-20100523T1030",
+            TimeRange("date", "date", 1274486400, 1274610600),
+            "20100522-20100523T1030",
+        ),
+        (
+            "20100522T1030-20100523",
+            TimeRange("date", "date", 1274524200, 1274572800),
+            "20100522T1030-20100523",
+        ),
+        (
+            "1274524200-20100523T1030",
+            TimeRange("date", "date", 1274524200, 1274610600),
+            "20100522T1030-20100523T1030",
+        ),
+        (
+            "20100522T1030-1274610600000",
+            TimeRange("date", "date", 1274524200, 1274610600),
+            "20100522T1030-20100523T1030",
+        ),
+        (
+            "20100522T1030-",
+            TimeRange("date", None, 1274524200, 0),
+            "20100522T1030-",
+        ),
+        (
+            "-20100522T103002",
+            TimeRange(None, "date", 0, 1274524202),
+            "-20100522T103002",
+        ),
+        (
+            "20100522-",
+            TimeRange("date", None, 1274486400, 0),
+            "20100522-",
+        ),
+        (
+            "-20100522",
+            TimeRange(None, "date", 0, 1274486400),
+            "-20100522",
+        ),
+        (
+            "",
+            TimeRange(None, None, 0, 0),
+            "-",
+        ),
+    ],
+)
+def test_parse_timerange_mixed_formats(timerange, expected, expected_str):
+    tr = TimeRange.parse_timerange(timerange)
+    assert tr == expected
+    assert tr.timerange_str == expected_str
+
+
+@pytest.mark.parametrize(
+    "timerange",
+    [
+        "-",
+        "20100522",
+        "20100522-20100523-20100524",
+        "20100522t1030-",
+        "20100522T103-",
+        "20100522T10300-",
+        "20100522T1060-",
+        "20100522T2530-",
+        "20100532T1030-",
+        "20100522 1030-",
+        "20100522T10:30-",
+    ],
+)
+def test_parse_timerange_invalid(timerange):
+    with pytest.raises(OperationalException, match=r"Incorrect syntax for timerange.*"):
+        TimeRange.parse_timerange(timerange)
 
 
 def test_subtract_start():


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Minute/second based timeranges were technically already supported - however only through hard to read epoch timestamps.
This PR adresses this, adding support for timeranges in the following formats:

| Format | Example | Description |
|--------|---------|-------------|
| `yyyymmdd` | `20260131` | Date - equivalent to midnight (00:00) of that day |
| `yyyymmddThhmm` | `20260131T1530` | Date and time (hours and minutes, 24h clock) |
| `yyyymmddThhmmss` | `20260131T053045` | Date and time, including seconds |
| epoch (seconds) | `1782086400` | POSIX timestamp in seconds (10 digits) |
| epoch (milliseconds) | `1782086400000` | POSIX timestamp in milliseconds (13 digits) |

## Quick changelog

- Support human readable timerange timestamps
- Improved tests for new behavior
- update documentation


_AI supported, human reviewed and tested._