### PR TITLE
feat(research): paper-trading promotion state machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,25 +24,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04", "ubuntu-24.04-arm", "macos-14", "macos-15" , "windows-2022", "windows-2025" ]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - os: "ubuntu-22.04"
-            python-version: "3.13"
-          - os: "ubuntu-22.04"
-            python-version: "3.14"
-          # Reduce ARM runs to newer python versions
-          - os: "ubuntu-24.04-arm"
-            python-version: "3.11"
-          - os: "ubuntu-24.04-arm"
-            python-version: "3.12"
-          # ubuntu 26.04 has 3.14 as default python version
-          - os: "ubuntu-26.04"
-            python-version: "3.11"
-          - os: "ubuntu-26.04"
-            python-version: "3.12"
-          - os: "ubuntu-26.04"
-            python-version: "3.13"
+        # ponytail: trimmed from upstream's full 8-OS x 4-Python compatibility matrix
+        # (~30 parallel jobs) to one OS/Python combo -- this fork's GitHub Actions
+        # concurrency limit can't run the full matrix (jobs get silently cancelled,
+        # not failed). Upstream's matrix exists to support many contributors' platforms;
+        # this fork only needs to know its own commits work. Restore the full matrix
+        # (see freqtrade/freqtrade's own ci.yml) if this fork ever needs that broader
+        # coverage and the concurrency limit is raised to match.
+        os: [ "ubuntu-24.04" ]
+        python-version: ["3.11"]
 
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ user_data/*
 !user_data/notebooks
 !user_data/models
 !user_data/freqaimodels
+!user_data/strategies
 user_data/freqaimodels/*
 user_data/models/*
 user_data/notebooks/*

--- a/2026-08-23-freqtrade-research-mvp.md
+++ b/2026-08-23-freqtrade-research-mvp.md
@@ -1,0 +1,1400 @@
+# Freqtrade Research-Gate MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Phase 1 MVP from `FREQTRADE_RESEARCH_ARCHITECTURE.md` §18 — a
+`research/` package that runs a walk-forward promotion gate (Deflated Sharpe + BH-FDR +
+PBO) over an existing freqtrade `IStrategy`, without modifying freqtrade core.
+
+**Architecture:** `research/` is a client of freqtrade, not a fork of it. It imports
+`freqtrade.optimize.backtesting.Backtesting` and `freqtrade.data.history` directly
+(in-process, same venv) to run per-window backtests, keeps its own SQLite ledger of every
+candidate tried (survivor and loser), and exposes one CLI command
+(`python -m research.cli gate ...`) that reports PASS/FAIL with the statistical evidence.
+
+**Tech Stack:** Python (repo floor: >=3.11, `pyproject.toml:16`), SQLAlchemy 2.0 (already a
+dependency, `pyproject.toml:34` — used directly, no SQLModel), NumPy/SciPy/pandas (already
+dependencies, `pyproject.toml:43-45`), pytest/pytest-mock (already dev dependencies).
+**No new dependencies are added.**
+
+**Spec:** `FREQTRADE_RESEARCH_ARCHITECTURE.md` (repo root), §§9-11, §15, §18.
+
+## Global Constraints
+
+- Python >=3.11 (`pyproject.toml:16`) — use modern type hints (`dict`, `list`, `X | None`).
+- No new third-party dependencies — SQLAlchemy, NumPy, SciPy, pandas already ship with
+  freqtrade (`pyproject.toml:34,43-45`); use them directly.
+- `freqtrade/` package is never modified. All new code lives under `research/`.
+- Research-layer tests live under `research/tests/`, run via `pytest research/tests -v`
+  from the repo root (not mixed into freqtrade's own `tests/` tree).
+- Every task follows TDD: write the failing test, watch it fail, write the minimal
+  implementation, watch it pass.
+- Every task gets a second opinion from an online LLM via the `lmchatbot` skill
+  (`C:\dev\lmchatbot`, HTTP API at `localhost:3000`) on its core design decision **before**
+  the final commit — per this project's standing `CLAUDE.md` rule to pair on non-trivial
+  code decisions. If `curl -s localhost:3000/` doesn't respond, start it first:
+  `node C:/dev/lmchatbot/server.js &` (background), then retry.
+- Lint before every commit: `ruff check research/ --fix && ruff format research/`
+  (repo-wide `[tool.ruff]` config in `pyproject.toml:237` covers `research/` by default —
+  only `.env`, `.venv`, `*.md` are excluded).
+- Every git commit message ends with the standard Freqtrade Co-Authored-By/session
+  trailer this environment's tooling appends automatically — don't add your own.
+
+---
+
+## File Structure
+
+```
+research/
+├── __init__.py
+├── db.py            Task 1 — SQLAlchemy engine/session factory
+├── models.py         Task 1 — CandidateResult ORM table
+├── ledger.py          Task 1 — family_of / log_candidate_result / family_trial_count
+├── statistics.py       Task 2 — deflated_sharpe_ratio, benjamini_hochberg, permutation_test
+├── pbo.py                Task 3 — probability_of_backtest_overfitting (CSCV), choose_n_splits
+├── walkforward.py          Task 4 — Window, WindowResult, WalkForwardRunner, generate_windows
+├── gate.py                   Task 5 — GateResult, run_promotion_gate
+├── cli.py                      Task 5 — `python -m research.cli gate ...`
+└── tests/
+    ├── __init__.py
+    ├── test_ledger.py           Task 1
+    ├── test_statistics.py         Task 2
+    ├── test_pbo.py                   Task 3
+    ├── test_walkforward.py             Task 4
+    ├── test_gate.py                      Task 5
+    └── test_cli.py                        Task 5
+```
+
+---
+
+### Task 1: Candidate ledger (db.py, models.py, ledger.py)
+
+**Files:**
+- Create: `research/__init__.py` (empty)
+- Create: `research/db.py`
+- Create: `research/models.py`
+- Create: `research/ledger.py`
+- Test: `research/tests/__init__.py` (empty)
+- Test: `research/tests/test_ledger.py`
+
+**Interfaces:**
+- Produces: `research.db.get_engine(db_path: str = "user_data/research.sqlite") -> Engine`
+- Produces: `research.db.get_session(engine: Engine) -> Session`
+- Produces: `research.models.Base` (DeclarativeBase), `research.models.CandidateResult` (ORM class, columns per architecture doc §10)
+- Produces: `research.ledger.family_of(strategy_id: str) -> str`
+- Produces: `research.ledger.log_candidate_result(session, *, strategy_id, params, universe, timeframe, discovery_start, discovery_end, n_trials_this_run, is_sharpe, oos_sharpe, deflated_sharpe, permutation_p, pbo, survived, validation_start=None, validation_end=None, oos_start=None, oos_end=None, evidence=None, run_stamp=None) -> CandidateResult`
+- Produces: `research.ledger.family_trial_count(session, family: str, declared: int = 0) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_ledger.py
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.models import Base, CandidateResult
+
+
+def _memory_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_log_candidate_result_round_trips():
+    session = _memory_session()
+    row = log_candidate_result(
+        session,
+        strategy_id="ema_cross_v3",
+        params={"buy_rsi": 30},
+        universe="BTC/USDT",
+        timeframe="1h",
+        discovery_start="2020-01-01",
+        discovery_end="2024-12-31",
+        n_trials_this_run=48,
+        is_sharpe=1.2,
+        oos_sharpe=0.8,
+        deflated_sharpe=0.6,
+        permutation_p=0.03,
+        pbo=0.2,
+        survived=True,
+    )
+    session.commit()
+
+    fetched = session.query(CandidateResult).filter_by(id=row.id).one()
+    assert fetched.strategy_id == "ema_cross_v3"
+    assert fetched.strategy_family == "trend_following"
+    assert fetched.params_json == '{"buy_rsi": 30}'
+    assert fetched.survived is True
+
+
+def test_family_of_maps_known_alias_and_falls_back_to_strategy_id():
+    assert family_of("ema_cross_v3") == "trend_following"
+    assert family_of("some_unmapped_strategy") == "some_unmapped_strategy"
+
+
+def test_family_trial_count_prefers_ledger_count_when_higher_than_declared():
+    session = _memory_session()
+    for i in range(5):
+        log_candidate_result(
+            session,
+            strategy_id="ema_cross_v3",
+            params={"buy_rsi": i},
+            universe="BTC/USDT",
+            timeframe="1h",
+            discovery_start="2020-01-01",
+            discovery_end="2024-12-31",
+            n_trials_this_run=1,
+            is_sharpe=0.1,
+            oos_sharpe=0.0,
+            deflated_sharpe=0.0,
+            permutation_p=1.0,
+            pbo=1.0,
+            survived=False,
+        )
+    session.commit()
+
+    assert family_trial_count(session, "trend_following") == 5
+    assert family_trial_count(session, "trend_following", declared=2) == 5
+    assert family_trial_count(session, "trend_following", declared=10) == 10
+
+
+def test_get_engine_creates_sqlite_file_and_tables(tmp_path):
+    from research.db import get_engine, get_session
+
+    db_path = tmp_path / "research.sqlite"
+    engine = get_engine(str(db_path))
+    session = get_session(engine)
+
+    assert db_path.exists()
+    assert session.query(CandidateResult).count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_ledger.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.ledger'` (or `research.models`/`research.db`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# research/models.py
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class CandidateResult(Base):
+    """One row per (research run, strategy, parameter-set) — survivors AND losers
+    both get logged, so `family_trial_count` reflects the real search history."""
+
+    __tablename__ = "candidate_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_stamp: Mapped[datetime] = mapped_column(DateTime)
+    strategy_id: Mapped[str] = mapped_column(String(120))
+    strategy_family: Mapped[str] = mapped_column(String(120), index=True)
+    params_json: Mapped[str] = mapped_column(String)
+    universe: Mapped[str] = mapped_column(String(200))
+    timeframe: Mapped[str] = mapped_column(String(10))
+    discovery_start: Mapped[str] = mapped_column(String(20))
+    discovery_end: Mapped[str] = mapped_column(String(20))
+    validation_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    validation_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    n_trials_this_run: Mapped[int] = mapped_column(Integer)
+    is_sharpe: Mapped[float] = mapped_column(Float)
+    oos_sharpe: Mapped[float] = mapped_column(Float)
+    deflated_sharpe: Mapped[float] = mapped_column(Float)
+    permutation_p: Mapped[float] = mapped_column(Float)
+    pbo: Mapped[float] = mapped_column(Float)
+    survived: Mapped[bool] = mapped_column(Boolean)
+    evidence_json: Mapped[str] = mapped_column(String, default="{}")
+```
+
+```python
+# research/db.py
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from research.models import Base
+
+DEFAULT_DB_PATH = "user_data/research.sqlite"
+
+
+def get_engine(db_path: str = DEFAULT_DB_PATH) -> Engine:
+    if db_path != ":memory:":
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def get_session(engine: Engine) -> Session:
+    return Session(engine)
+```
+
+```python
+# research/ledger.py
+import json
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from research.models import CandidateResult
+
+# Strategy-name -> family aliasing. Grow this table as strategy variants are added —
+# related parameter sweeps must share a family so trial counts compound correctly.
+_FAMILY_ALIASES: dict[str, str] = {
+    "ema_cross_v3": "trend_following",
+}
+
+
+def family_of(strategy_id: str) -> str:
+    return _FAMILY_ALIASES.get(strategy_id, strategy_id)
+
+
+def log_candidate_result(
+    session: Session,
+    *,
+    strategy_id: str,
+    params: dict,
+    universe: str,
+    timeframe: str,
+    discovery_start: str,
+    discovery_end: str,
+    n_trials_this_run: int,
+    is_sharpe: float,
+    oos_sharpe: float,
+    deflated_sharpe: float,
+    permutation_p: float,
+    pbo: float,
+    survived: bool,
+    validation_start: str | None = None,
+    validation_end: str | None = None,
+    oos_start: str | None = None,
+    oos_end: str | None = None,
+    evidence: dict | None = None,
+    run_stamp: datetime | None = None,
+) -> CandidateResult:
+    row = CandidateResult(
+        run_stamp=run_stamp or datetime.now(UTC),
+        strategy_id=strategy_id,
+        strategy_family=family_of(strategy_id),
+        params_json=json.dumps(params, sort_keys=True),
+        universe=universe,
+        timeframe=timeframe,
+        discovery_start=discovery_start,
+        discovery_end=discovery_end,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        oos_start=oos_start,
+        oos_end=oos_end,
+        n_trials_this_run=n_trials_this_run,
+        is_sharpe=is_sharpe,
+        oos_sharpe=oos_sharpe,
+        deflated_sharpe=deflated_sharpe,
+        permutation_p=permutation_p,
+        pbo=pbo,
+        survived=survived,
+        evidence_json=json.dumps(evidence or {}),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def family_trial_count(session: Session, family: str, declared: int = 0) -> int:
+    """The number of trials to deflate against: whichever is larger between the
+    ledger's accumulated row count for this family and a caller-declared count.
+    Call this BEFORE writing the current run's own row (count-then-write) so a run
+    never deflates against trials it hasn't finished yet."""
+    ledger_count = (
+        session.query(CandidateResult)
+        .filter(CandidateResult.strategy_family == family)
+        .count()
+    )
+    return max(ledger_count, declared)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_ledger.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task1.json <<'EOF'
+{"provider":"gemini","prompt":"Reviewing a SQLAlchemy 2.0 declarative schema for a research trial ledger meant to prevent a multiple-testing/selection-bias problem when repeatedly backtesting trading strategies. Table CandidateResult logs one row per (run, strategy, param-set), survivors AND losers. family_trial_count(session, family, declared=0) returns max(ledger row count for that family, declared) and MUST be called before the current run writes its own row, so a run never deflates its own significance test against trials it hasn't finished yet (count-then-write). Does this design have an obvious flaw for its stated purpose? Schema:\n\nclass CandidateResult(Base):\n    __tablename__ = \"candidate_results\"\n    id, run_stamp, strategy_id, strategy_family, params_json, universe, timeframe,\n    discovery_start, discovery_end, validation_start, validation_end, oos_start, oos_end,\n    n_trials_this_run, is_sharpe, oos_sharpe, deflated_sharpe, permutation_p, pbo, survived, evidence_json\n\ndef family_trial_count(session, family, declared=0):\n    ledger_count = session.query(CandidateResult).filter(CandidateResult.strategy_family == family).count()\n    return max(ledger_count, declared)"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task1.json
+rm /tmp/lmchatbot_task1.json
+```
+
+Read the reply. If it surfaces a real gap (e.g. a refused/degenerate run still silently
+inflating trial count, or a race between two concurrent processes reading-then-writing),
+fix it in `ledger.py` before continuing; otherwise proceed.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/__init__.py research/db.py research/models.py research/ledger.py \
+        research/tests/__init__.py research/tests/test_ledger.py
+git commit -m "feat(research): add candidate ledger with family trial counting"
+```
+
+---
+
+### Task 2: Statistics core (DSR, BH-FDR, permutation test)
+
+**Files:**
+- Create: `research/statistics.py`
+- Test: `research/tests/test_statistics.py`
+
+**Interfaces:**
+- Produces: `research.statistics.deflated_sharpe_ratio(sharpe_ratio: float, n_obs: int, n_trials: int = 1, skewness: float = 0.0, kurtosis: float = 3.0, periods_per_year: int = 365) -> float`
+- Produces: `research.statistics.benjamini_hochberg(p_values: list[float], q: float = 0.05) -> list[bool]`
+- Produces: `research.statistics.permutation_test(observed_stat: float, returns: np.ndarray, n_permutations: int = 1000, seed: int | None = None) -> float`
+
+**Reference implementation to port from** (per `FREQTRADE_RESEARCH_ARCHITECTURE.md` §15 —
+these are near-verbatim-portable, asset-class-agnostic pure functions):
+`C:\dev\MarketMind\backend\backtest\enhanced\statistics.py`:
+- `deflated_sharpe_ratio` — lines 168-228 (Bailey & López de Prado 2014)
+- `benjamini_hochberg` — lines 14-38 (standard BH step-up procedure)
+- `permutation_test` (sign-flip variant) — lines 41-104
+
+Adapt, don't copy verbatim:
+- Replace the source file's hand-rolled `_norm_cdf`/`_norm_ppf` (its lines ~110-140) with
+  `scipy.stats.norm.cdf` / `scipy.stats.norm.ppf` — SciPy is already a freqtrade dependency
+  (`pyproject.toml:43`), so there's no reason to hand-roll a normal-distribution
+  approximation the way MarketMind did to avoid a new dependency it didn't have.
+- Change the default `periods_per_year` from the source's 252 (equities trading days) to
+  **365** (crypto trades every calendar day).
+- This project's own hard-won lesson (architecture doc §16, lesson 1): a Deflated Sharpe
+  with no real sample-size discrimination is just a sign test wearing a rigor costume — the
+  tests below are written to catch exactly that regression, independent of the exact
+  formula ported.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_statistics.py
+import numpy as np
+import pytest
+
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+
+
+class TestDeflatedSharpeRatio:
+    def test_returns_zero_on_degenerate_n_obs(self):
+        assert deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=1, n_trials=10) == 0.0
+
+    def test_bounded_in_unit_interval(self):
+        for sharpe in (-3.0, -0.5, 0.0, 0.5, 1.5, 3.0):
+            for n_obs in (10, 100, 1000):
+                for n_trials in (1, 10, 1000):
+                    result = deflated_sharpe_ratio(sharpe, n_obs, n_trials)
+                    assert 0.0 <= result <= 1.0, (sharpe, n_obs, n_trials, result)
+
+    def test_more_trials_never_increases_the_score(self):
+        """Regression test for the exact bug this project's spec (§16, lesson 1) flags:
+        a DSR with no real trial-count term would score n_trials=1 and n_trials=1000
+        identically. Holding sharpe and n_obs fixed, searching harder must not look
+        MORE convincing."""
+        few_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1)
+        many_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1000)
+        assert many_trials <= few_trials
+
+    def test_more_observations_never_decreases_the_score(self):
+        """Regression test for the same lesson from the other axis: a 6-trade and a
+        10,000-trade backtest must not deflate identically."""
+        few_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=20, n_trials=50)
+        many_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=5000, n_trials=50)
+        assert many_obs >= few_obs
+
+
+class TestBenjaminiHochberg:
+    def test_matches_hand_worked_example(self):
+        # sorted ascending already; thresholds are (rank/m)*q = 0.01,0.02,0.03,0.04,0.05
+        p_values = [0.01, 0.02, 0.03, 0.04, 0.5]
+        result = benjamini_hochberg(p_values, q=0.05)
+        assert result == [True, True, True, True, False]
+
+    def test_empty_input_returns_empty_output(self):
+        assert benjamini_hochberg([], q=0.05) == []
+
+    def test_all_p_values_above_q_rejects_nothing(self):
+        assert benjamini_hochberg([0.9, 0.8, 0.99], q=0.05) == [False, False, False]
+
+
+class TestPermutationTest:
+    def test_p_value_in_unit_interval(self):
+        rng = np.random.default_rng(1)
+        returns = rng.normal(0, 0.01, 40)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=200, seed=1)
+        assert 0.0 <= p <= 1.0
+
+    def test_low_p_value_for_a_strong_consistent_positive_edge(self):
+        """All-positive, low-noise returns: virtually every sign-flip permutation
+        produces a worse Sharpe than the unflipped (real) series, since flipping any
+        positive return can only hurt the mean. p must be small."""
+        rng = np.random.default_rng(42)
+        returns = 0.02 + rng.normal(0, 0.001, 30)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=2000, seed=42)
+        assert p < 0.05
+
+    def test_seeded_calls_are_reproducible(self):
+        rng = np.random.default_rng(7)
+        returns = rng.normal(0.001, 0.02, 50)
+        observed = float(returns.mean() / returns.std())
+        p1 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        p2 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        assert p1 == p2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_statistics.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.statistics'`
+
+- [ ] **Step 3: Port the implementation**
+
+Open `C:\dev\MarketMind\backend\backtest\enhanced\statistics.py` and port
+`deflated_sharpe_ratio` (lines 168-228), `benjamini_hochberg` (lines 14-38), and the
+sign-flip `permutation_test` (lines 41-104) into `research/statistics.py`, applying the two
+adaptations called out above (scipy for the normal CDF/PPF, `periods_per_year=365`). Keep
+the function names and parameter names exactly as declared in the Interfaces block so
+`research/gate.py` (Task 5) can call them unchanged.
+
+```python
+# research/statistics.py
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+# --- ported and adapted from C:\dev\MarketMind\backend\backtest\enhanced\statistics.py ---
+# (paste + adapt deflated_sharpe_ratio, benjamini_hochberg, permutation_test here)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_statistics.py -v`
+Expected: PASS (9 tests). If `test_more_trials_never_increases_the_score` or
+`test_more_observations_never_decreases_the_score` fails, the port has the same historical
+bug MarketMind shipped for months (architecture doc §16, lesson 1) — fix the formula, don't
+loosen the test.
+
+- [ ] **Step 5: Get a second opinion via lmchatbot (cross-provider verify)**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task2.json <<'EOF'
+{"provider":"chatgpt","verify":"gemini","prompt":"I ported a Deflated Sharpe Ratio implementation (Bailey & Lopez de Prado 2014) from an internal reference into a fresh module, replacing its hand-rolled normal CDF/PPF with scipy.stats.norm, and changing periods_per_year from 252 to 365 for a 24/7 crypto market. Paste of research/statistics.py below. Two known historical bugs to check for specifically: (1) does it correctly discriminate a strategy tried across 1 trial vs 1000 trials at equal Sharpe/n_obs (the deflated score must NOT increase with more trials searched)? (2) does it correctly discriminate n_obs=20 vs n_obs=5000 at equal Sharpe (the deflated score must NOT decrease with more observations)? Also sanity check the Benjamini-Hochberg step-up implementation is the standard procedure. PASTE research/statistics.py CONTENTS HERE"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task2.json
+rm /tmp/lmchatbot_task2.json
+```
+
+Replace `PASTE research/statistics.py CONTENTS HERE` with the actual file contents before
+sending. Read `draft`, `verifier`, and the `FINAL:`-prefixed corrected answer in the reply.
+If either provider flags a real formula error, fix `statistics.py` and rerun Step 4 before
+continuing.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/statistics.py research/tests/test_statistics.py
+git commit -m "feat(research): port deflated Sharpe, BH-FDR, and permutation test from MarketMind"
+```
+
+---
+
+### Task 3: Probability of Backtest Overfitting (CSCV)
+
+**Files:**
+- Create: `research/pbo.py`
+- Test: `research/tests/test_pbo.py`
+
+**Interfaces:**
+- Consumes: none (pure numeric function, no dependency on Task 1/2 modules)
+- Produces: `research.pbo.choose_n_splits(n_periods: int, max_splits: int = 16) -> int`
+- Produces: `research.pbo.probability_of_backtest_overfitting(returns_matrix: np.ndarray, n_splits: int | None = None) -> dict` — returns `{"pbo": float, "n_splits": int, "n_combinations": int, "logits": list[float]}`. `returns_matrix` shape is `(n_variants, n_periods)`: one row per candidate parameter set, one column per time block (a walk-forward window, in Task 4's usage). Cell = that variant's return/Sharpe proxy in that block.
+
+**Reference implementation to port from** (per `FREQTRADE_RESEARCH_ARCHITECTURE.md` §15):
+`C:\dev\MarketMind\backend\backtest\enhanced\reality_check.py:271-345` —
+`probability_of_backtest_overfitting` (line 271) and `choose_n_splits` (line 345). This is
+the single highest-value MarketMind file to port per the architecture doc — it operates
+purely on a returns matrix, no asset-class assumptions. **MVP scope note (YAGNI):** port
+only these two functions. `reality_check.py` also contains White's Reality Check, Hansen's
+SPA test, and a stationary block bootstrap (architecture doc §15 item 4) — those are real
+and valuable but explicitly out of scope for this MVP; add them in a later phase if PBO
+alone proves insufficient.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_pbo.py
+import numpy as np
+
+from research.pbo import choose_n_splits, probability_of_backtest_overfitting
+
+
+class TestChooseNSplits:
+    def test_returns_an_even_divisor_of_n_periods(self):
+        n_periods = 16
+        s = choose_n_splits(n_periods)
+        assert s % 2 == 0
+        assert n_periods % s == 0
+
+    def test_never_exceeds_max_splits(self):
+        assert choose_n_splits(100, max_splits=8) <= 8
+
+
+class TestProbabilityOfBacktestOverfitting:
+    def test_bounded_in_unit_interval(self):
+        rng = np.random.default_rng(3)
+        matrix = rng.normal(0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert 0.0 <= result["pbo"] <= 1.0
+
+    def test_low_when_one_variant_dominates_every_period(self):
+        """Variant 0 has a real, consistent edge (positive mean, low noise) in every
+        period; the others are pure noise. Picking the best-in-sample variant should
+        reliably also do well out-of-sample -> low overfitting probability."""
+        rng = np.random.default_rng(11)
+        n_variants, n_periods = 5, 16
+        matrix = rng.normal(0.0, 0.01, size=(n_variants, n_periods))
+        matrix[0] = rng.normal(0.05, 0.005, size=n_periods)
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] < 0.3
+
+    def test_near_coin_flip_when_all_variants_are_pure_noise(self):
+        """No variant has a real edge -> which one looks best in-sample is arbitrary
+        and should NOT reliably predict out-of-sample rank. PBO should be high."""
+        rng = np.random.default_rng(5)
+        matrix = rng.normal(0.0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] > 0.35
+
+    def test_degenerate_input_fails_closed(self):
+        result = probability_of_backtest_overfitting(np.zeros((1, 2)))
+        assert result["pbo"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_pbo.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.pbo'`
+
+- [ ] **Step 3: Write the implementation**
+
+Port from `C:\dev\MarketMind\backend\backtest\enhanced\reality_check.py:271-345` (see Task
+header), adapted to operate directly on a `(n_variants, n_periods)` NumPy array rather than
+MarketMind's DB-backed candidate objects:
+
+```python
+# research/pbo.py
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+
+
+def choose_n_splits(n_periods: int, max_splits: int = 16) -> int:
+    """Largest even number <= max_splits that evenly divides n_periods, so CSCV's
+    IS/OOS blocks are equal-sized. Falls back to 2 if nothing else divides evenly."""
+    for s in range(min(max_splits, n_periods), 1, -1):
+        if s % 2 == 0 and n_periods % s == 0:
+            return s
+    return 2
+
+
+def probability_of_backtest_overfitting(
+    returns_matrix: np.ndarray, n_splits: int | None = None
+) -> dict:
+    """Combinatorially Symmetric Cross-Validation (Bailey, Borwein, Lopez de Prado,
+    Zhu 2014). Splits the n_periods columns into n_splits contiguous blocks, and for
+    every way of picking half the blocks as in-sample: finds the variant with the best
+    in-sample Sharpe, then checks how that same variant ranks out-of-sample. PBO is the
+    fraction of splits where the in-sample winner ranked in the OOS-worse half — logit
+    of the OOS relative rank <= 0.
+    """
+    returns_matrix = np.asarray(returns_matrix, dtype=float)
+    if returns_matrix.ndim != 2:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    n_variants, n_periods = returns_matrix.shape
+    if n_variants < 2 or n_periods < 4:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    s = n_splits or choose_n_splits(n_periods)
+    if s < 2 or n_periods % s != 0:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    blocks = np.array_split(returns_matrix, s, axis=1)
+    logits: list[float] = []
+
+    for is_block_idx in itertools.combinations(range(s), s // 2):
+        oos_block_idx = [i for i in range(s) if i not in is_block_idx]
+        is_returns = np.concatenate([blocks[i] for i in is_block_idx], axis=1)
+        oos_returns = np.concatenate([blocks[i] for i in oos_block_idx], axis=1)
+
+        is_sharpe = is_returns.mean(axis=1) / (is_returns.std(axis=1) + 1e-12)
+        oos_sharpe = oos_returns.mean(axis=1) / (oos_returns.std(axis=1) + 1e-12)
+
+        best_variant = int(np.argmax(is_sharpe))
+        # relative rank of the IS-best variant's OOS performance, in (0, 1)
+        rank = int((oos_sharpe < oos_sharpe[best_variant]).sum()) + 1
+        omega = rank / (n_variants + 1)
+        omega = min(max(omega, 1e-6), 1 - 1e-6)
+        logits.append(float(np.log(omega / (1 - omega))))
+
+    pbo = float(np.mean([1.0 if lg <= 0 else 0.0 for lg in logits]))
+    return {"pbo": pbo, "n_splits": s, "n_combinations": len(logits), "logits": logits}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_pbo.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot (cross-provider verify)**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task3.json <<'EOF'
+{"provider":"gemini","verify":"chatgpt","prompt":"I implemented Probability of Backtest Overfitting via Combinatorially Symmetric Cross-Validation (Bailey/Borwein/Lopez de Prado/Zhu 2014) from scratch based on the paper's description, operating on a (n_variants, n_periods) returns matrix. For every way of splitting n_periods contiguous blocks into an in-sample half and out-of-sample half, I pick the variant with best in-sample Sharpe, compute its relative rank among all variants' out-of-sample Sharpes as omega=rank/(n_variants+1), take logit(omega), and count PBO as the fraction of splits where that logit <= 0. Does this match the paper's actual CSCV procedure, and is there a subtle bug in the rank/logit computation? PASTE research/pbo.py CONTENTS HERE"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task3.json
+rm /tmp/lmchatbot_task3.json
+```
+
+Replace the placeholder with the real file contents before sending. Fix and rerun Step 4 if
+either provider identifies a real deviation from the CSCV procedure.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/pbo.py research/tests/test_pbo.py
+git commit -m "feat(research): add PBO via CSCV"
+```
+
+---
+
+### Task 4: Walk-forward runner wrapping freqtrade's Backtesting
+
+**Files:**
+- Create: `research/walkforward.py`
+- Test: `research/tests/test_walkforward.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-3 (pure freqtrade integration)
+- Produces: `research.walkforward.Window` (dataclass: `train_start, train_end, test_start, test_end: datetime`)
+- Produces: `research.walkforward.WindowResult` (dataclass: `window: Window, variant_returns: dict[str, float], best_params: dict, train_sharpe: float, test_sharpe: float, test_n_trades: int, test_returns: list[float]`)
+- Produces: `research.walkforward.variant_key(params: dict) -> str`
+- Produces: `research.walkforward.generate_windows(start: datetime, end: datetime, train_days: int, test_days: int) -> list[Window]`
+- Produces: `research.walkforward.WalkForwardRunner(config: dict, pairs: list[str], timeframe: str, datadir: Path)` with methods `.run_window(window: Window, param_grid: list[dict]) -> WindowResult` and `.run(windows: list[Window], param_grid: list[dict]) -> list[WindowResult]`
+
+**Real freqtrade APIs this task calls** (verified against `develop` @ `10db8654c`):
+- `freqtrade.optimize.backtesting.Backtesting(config)` then `.strategylist[0]` +
+  `._set_strategy(strategy)` — instantiation pattern used throughout
+  `tests/optimize/test_backtesting.py` (e.g. line 827).
+- `freqtrade.data.history.load_data(datadir, timeframe, pairs, timerange=..., startup_candles=...)` — `freqtrade/data/history/history_utils.py:87`.
+- `freqtrade.data.converter.trim_dataframes(preprocessed, timerange, startup_candles)` — `freqtrade/data/converter/converter.py:199`, used the same way internally at `freqtrade/optimize/backtesting.py:1840`.
+- `freqtrade.data.metrics.calculate_sharpe(trades, min_date, max_date, starting_balance)` — `freqtrade/data/metrics.py:455`.
+- `freqtrade.configuration.TimeRange("date", "date", start_epoch, end_epoch)` — `freqtrade/configuration/timerange.py:36`.
+- `backtesting.backtest(processed=..., start_date=..., end_date=...) -> {"results": DataFrame, ...}` — restricts *simulation* to `[start_date, end_date]`; `processed` may (and here does) span further, matching freqtrade's own convention (§3 of the architecture doc). Indicators in the test strategy used here (`ta.RSI`) are backward-looking, so this is safe; a `ponytail:` comment documents the caveat for non-causal indicators.
+- Strategy parameters are set via `getattr(strategy, name).value = value` (the `IntParameter`/`DecimalParameter` descriptor pattern every freqtrade strategy uses, e.g. `tests/strategy/strats/strategy_test_v3.py:77` — `buy_rsi = IntParameter([0, 50], default=30, space="buy")`, read as `self.buy_rsi.value`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# research/tests/test_walkforward.py
+from datetime import timedelta
+from pathlib import Path
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+
+from research.walkforward import Window, WalkForwardRunner, variant_key
+from tests.conftest import get_default_conf, patch_exchange
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def test_run_window_selects_best_train_params_and_reports_oos_result(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    param_grid = [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    result = runner.run_window(window, param_grid)
+
+    assert result.best_params in param_grid
+    assert set(result.variant_returns) == {variant_key(p) for p in param_grid}
+    assert isinstance(result.train_sharpe, float)
+    assert isinstance(result.test_sharpe, float)
+    assert isinstance(result.test_returns, list)
+    assert result.test_n_trades == len(result.test_returns)
+
+
+def test_generate_windows_are_contiguous_and_non_overlapping():
+    from datetime import UTC, datetime
+
+    from research.walkforward import generate_windows
+
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    end = datetime(2020, 3, 1, tzinfo=UTC)
+    windows = generate_windows(start, end, train_days=20, test_days=10)
+
+    assert len(windows) > 0
+    for w in windows:
+        assert w.train_end == w.test_start
+        assert w.test_end <= end
+    for a, b in zip(windows, windows[1:]):
+        assert b.train_start == a.test_start
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest research/tests/test_walkforward.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.walkforward'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# research/walkforward.py
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.converter import trim_dataframes
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.optimize.backtesting import Backtesting
+
+
+@dataclass
+class Window:
+    train_start: datetime
+    train_end: datetime
+    test_start: datetime
+    test_end: datetime
+
+
+@dataclass
+class WindowResult:
+    window: Window
+    variant_returns: dict[str, float]
+    best_params: dict
+    train_sharpe: float
+    test_sharpe: float
+    test_n_trades: int
+    test_returns: list[float]
+
+
+def variant_key(params: dict) -> str:
+    return json.dumps(params, sort_keys=True)
+
+
+def generate_windows(
+    start: datetime, end: datetime, train_days: int, test_days: int
+) -> list[Window]:
+    """Rolling, non-overlapping windows: each window's test period starts exactly
+    where its train period ends; the next window starts test_days later."""
+    windows: list[Window] = []
+    cursor = start
+    while True:
+        train_end = cursor + timedelta(days=train_days)
+        test_end = train_end + timedelta(days=test_days)
+        if test_end > end:
+            break
+        windows.append(Window(cursor, train_end, train_end, test_end))
+        cursor = cursor + timedelta(days=test_days)
+    return windows
+
+
+class WalkForwardRunner:
+    def __init__(self, config: dict, pairs: list[str], timeframe: str, datadir: Path):
+        self.config = config
+        self.pairs = pairs
+        self.timeframe = timeframe
+        self.datadir = datadir
+
+    def run_window(self, window: Window, param_grid: list[dict]) -> WindowResult:
+        backtesting = Backtesting(self.config)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        variant_returns: dict[str, float] = {}
+        best_key, best_sharpe, best_params, best_processed = None, -np.inf, None, None
+
+        for params in param_grid:
+            for name, value in params.items():
+                getattr(backtesting.strategy, name).value = value
+
+            # ponytail: indicators are computed once over [train_start, test_end],
+            # per freqtrade's own convention (§3 of the architecture doc). Safe for
+            # backward-looking indicators (this strategy's RSI); a strategy with a
+            # non-causal indicator (centered rolling, .shift(-n)) would leak across
+            # the train/test boundary here — run freqtrade's lookahead-analysis on
+            # any strategy before trusting this runner's results for it.
+            processed = backtesting.strategy.advise_all_indicators(data)
+            processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+            train_result = backtesting.backtest(
+                processed=deepcopy(processed),
+                start_date=window.train_start,
+                end_date=window.train_end,
+            )
+            train_trades = train_result["results"]
+            sharpe = calculate_sharpe(
+                train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+            )
+            key = variant_key(params)
+            variant_returns[key] = (
+                float((train_trades["profit_abs"] / self.config["dry_run_wallet"]).mean())
+                if len(train_trades)
+                else 0.0
+            )
+
+            if sharpe > best_sharpe:
+                best_sharpe, best_key, best_params, best_processed = sharpe, key, params, processed
+
+        for name, value in best_params.items():
+            getattr(backtesting.strategy, name).value = value
+        test_result = backtesting.backtest(
+            processed=deepcopy(best_processed),
+            start_date=window.test_start,
+            end_date=window.test_end,
+        )
+        test_trades = test_result["results"]
+        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
+        test_sharpe = calculate_sharpe(
+            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
+        )
+
+        return WindowResult(
+            window=window,
+            variant_returns=variant_returns,
+            best_params=best_params,
+            train_sharpe=best_sharpe,
+            test_sharpe=test_sharpe,
+            test_n_trades=len(test_trades),
+            test_returns=test_returns,
+        )
+
+    def run(self, windows: list[Window], param_grid: list[dict]) -> list[WindowResult]:
+        return [self.run_window(w, param_grid) for w in windows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest research/tests/test_walkforward.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task4.json <<'EOF'
+{"provider":"gemini","prompt":"I built a walk-forward runner on top of freqtrade's Backtesting class. Per window: I load OHLCV data spanning [train_start, test_end] in one call (with startup_candles for indicator warmup), compute indicators ONCE via strategy.advise_all_indicators() over that whole span, then call backtesting.backtest(processed=..., start_date=X, end_date=Y) twice against the SAME processed dataframe -- once restricted to [train_start, train_end] to pick the best parameter set by train Sharpe, then again restricted to [test_start, test_end] using the winning params, for the out-of-sample result. My reasoning that this doesn't leak test-period data into the train-period parameter selection: freqtrade always computes indicators over the full loaded range and only the start_date/end_date args restrict which candles get SIMULATED (trades placed), and for backward-looking indicators (e.g. TA-Lib RSI) more trailing rows after a given row don't change that row's own indicator value. Is this reasoning actually sound, and is there a walk-forward-integrity gap I'm missing even for backward-looking-only indicators?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task4.json
+rm /tmp/lmchatbot_task4.json
+```
+
+If the reply surfaces a real gap (e.g., an interaction with `startup_candle_count` sizing,
+or stoploss/ROI evaluation using look-back state that spans the train/test boundary), note
+it as a `ponytail:` comment in `walkforward.py` at minimum, and fix it if it's cheap.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/walkforward.py research/tests/test_walkforward.py
+git commit -m "feat(research): add walk-forward runner wrapping freqtrade Backtesting"
+```
+
+---
+
+### Task 5: Promotion gate + CLI
+
+**Files:**
+- Create: `research/gate.py`
+- Create: `research/cli.py`
+- Test: `research/tests/test_gate.py`
+- Test: `research/tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `research.ledger.family_of`, `.family_trial_count`, `.log_candidate_result` (Task 1); `research.statistics.deflated_sharpe_ratio`, `.benjamini_hochberg`, `.permutation_test` (Task 2); `research.pbo.probability_of_backtest_overfitting` (Task 3); `research.walkforward.WalkForwardRunner`, `.generate_windows`, `.Window`, `.WindowResult` (Task 4)
+- Produces: `research.gate.GateResult` (dataclass: `strategy_id: str, passed: bool, deflated_sharpe: float, permutation_p: float, pbo: float, mean_test_sharpe: float, n_trials: int, reasons: list[str]`)
+- Produces: `research.gate.run_promotion_gate(config, strategy_id, pairs, timeframe, datadir, start, end, train_days, test_days, param_grid, db_path="user_data/research.sqlite", dsr_threshold=0.95, fdr_q=0.05, pbo_threshold=0.5, periods_per_year=365) -> GateResult`
+- Produces: `research.cli.main(argv: list[str] | None = None) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_gate.py
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+
+from research.db import get_session, get_engine
+from research.gate import run_promotion_gate
+from research.models import CandidateResult
+from tests.conftest import get_default_conf, patch_exchange
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def _patch(mocker):
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+
+def test_run_promotion_gate_raises_with_too_few_windows(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+
+    with pytest.raises(ValueError, match="walk-forward windows"):
+        run_promotion_gate(
+            config=conf,
+            strategy_id="StrategyTestV3",
+            pairs=["UNITTEST/BTC"],
+            timeframe="5m",
+            datadir=TESTDATADIR,
+            start=min_date,
+            end=max_date,
+            train_days=3650,  # deliberately far larger than the available data span
+            test_days=3650,
+            param_grid=[{"buy_rsi": 30}],
+            db_path=str(tmp_path / "research.sqlite"),
+        )
+
+
+def test_run_promotion_gate_returns_result_and_writes_ledger_row(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+    db_path = str(tmp_path / "research.sqlite")
+
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=db_path,
+    )
+
+    assert result.strategy_id == "StrategyTestV3"
+    assert isinstance(result.passed, bool)
+    assert 0.0 <= result.deflated_sharpe <= 1.0
+    assert 0.0 <= result.permutation_p <= 1.0
+    assert 0.0 <= result.pbo <= 1.0
+    assert result.n_trials >= 1
+
+    session = get_session(get_engine(db_path))
+    assert session.query(CandidateResult).filter_by(strategy_id="StrategyTestV3").count() == 1
+```
+
+```python
+# research/tests/test_cli.py
+from research.cli import main
+from research.gate import GateResult
+
+
+def test_gate_command_prints_verdict_and_returns_pass_exit_code(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch("research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"})
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy", "StrategyTestV3",
+            "--config", "config.json",
+            "--pairs", "BTC/USDT,ETH/USDT",
+            "--timeframe", "1h",
+            "--start", "2024-01-01",
+            "--end", "2024-06-01",
+            "--train-days", "60",
+            "--test-days", "20",
+            "--param-grid", "[{\"buy_rsi\": 30}]",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS" in captured.out
+
+
+def test_gate_command_returns_nonzero_exit_code_on_fail(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch("research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"})
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy", "StrategyTestV3",
+            "--config", "config.json",
+            "--pairs", "BTC/USDT",
+            "--timeframe", "1h",
+            "--start", "2024-01-01",
+            "--end", "2024-06-01",
+            "--train-days", "60",
+            "--test-days", "20",
+            "--param-grid", "[{\"buy_rsi\": 30}]",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "FAIL" in captured.out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_gate.py research/tests/test_cli.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.gate'` (and `research.cli`)
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# research/gate.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from research.db import get_engine, get_session
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.pbo import probability_of_backtest_overfitting
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+from research.walkforward import WalkForwardRunner, generate_windows
+
+
+@dataclass
+class GateResult:
+    strategy_id: str
+    passed: bool
+    deflated_sharpe: float
+    permutation_p: float
+    pbo: float
+    mean_test_sharpe: float
+    n_trials: int
+    reasons: list[str]
+
+
+def run_promotion_gate(
+    config: dict,
+    strategy_id: str,
+    pairs: list[str],
+    timeframe: str,
+    datadir: Path,
+    start: datetime,
+    end: datetime,
+    train_days: int,
+    test_days: int,
+    param_grid: list[dict],
+    db_path: str = "user_data/research.sqlite",
+    dsr_threshold: float = 0.95,
+    fdr_q: float = 0.05,
+    pbo_threshold: float = 0.5,
+    periods_per_year: int = 365,
+) -> GateResult:
+    windows = generate_windows(start, end, train_days, test_days)
+    if len(windows) < 4:
+        raise ValueError(
+            f"Need at least 4 walk-forward windows for a meaningful gate, got "
+            f"{len(windows)}. Widen start/end or shrink train_days/test_days."
+        )
+
+    runner = WalkForwardRunner(config, pairs, timeframe, datadir)
+    results = runner.run(windows, param_grid)
+
+    all_test_returns = [r for wr in results for r in wr.test_returns]
+    n_obs = len(all_test_returns)
+    mean_test_sharpe = float(np.mean([wr.test_sharpe for wr in results]))
+
+    variant_keys = sorted({k for wr in results for k in wr.variant_returns})
+    variant_matrix = np.array(
+        [[wr.variant_returns[key] for wr in results] for key in variant_keys]
+    )
+    pbo_result = probability_of_backtest_overfitting(variant_matrix)
+
+    engine = get_engine(db_path)
+    session = get_session(engine)
+    family = family_of(strategy_id)
+    this_run_trials = len(param_grid) * len(windows)
+    # count-then-write: read ledger history BEFORE writing this run's own row, so a
+    # run never deflates its own significance test against trials it hasn't finished.
+    n_trials = family_trial_count(session, family, declared=this_run_trials)
+
+    deflated = deflated_sharpe_ratio(
+        mean_test_sharpe, n_obs=n_obs, n_trials=n_trials, periods_per_year=periods_per_year
+    )
+    perm_p = permutation_test(mean_test_sharpe, np.array(all_test_returns))
+    survived_bh = benjamini_hochberg([perm_p], q=fdr_q)[0]
+
+    reasons: list[str] = []
+    if deflated < dsr_threshold:
+        reasons.append(f"deflated_sharpe {deflated:.3f} below threshold {dsr_threshold}")
+    if not survived_bh:
+        reasons.append(f"permutation p-value {perm_p:.3f} fails BH-FDR at q={fdr_q}")
+    if pbo_result["pbo"] > pbo_threshold:
+        reasons.append(f"PBO {pbo_result['pbo']:.3f} above threshold {pbo_threshold}")
+    passed = not reasons
+
+    log_candidate_result(
+        session,
+        strategy_id=strategy_id,
+        params={"grid": param_grid},
+        universe=",".join(pairs),
+        timeframe=timeframe,
+        discovery_start=start.isoformat(),
+        discovery_end=end.isoformat(),
+        n_trials_this_run=this_run_trials,
+        is_sharpe=float(np.mean([wr.train_sharpe for wr in results])),
+        oos_sharpe=mean_test_sharpe,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        survived=passed,
+    )
+    session.commit()
+
+    return GateResult(
+        strategy_id=strategy_id,
+        passed=passed,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        mean_test_sharpe=mean_test_sharpe,
+        n_trials=n_trials,
+        reasons=reasons,
+    )
+```
+
+```python
+# research/cli.py
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from freqtrade.configuration import Configuration
+
+from research.gate import run_promotion_gate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="research", description="Freqtrade research gate")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gate = sub.add_parser("gate", help="Run the promotion gate for a strategy")
+    gate.add_argument("--strategy", required=True)
+    gate.add_argument("--config", required=True, help="Path to a freqtrade config.json")
+    gate.add_argument("--pairs", required=True, help="Comma-separated pairs, e.g. BTC/USDT,ETH/USDT")
+    gate.add_argument("--timeframe", required=True)
+    gate.add_argument("--start", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--end", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--train-days", type=int, required=True)
+    gate.add_argument("--test-days", type=int, required=True)
+    gate.add_argument("--param-grid", required=True, help="JSON list of param dicts")
+    gate.add_argument("--db-path", default="user_data/research.sqlite")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "gate":
+        ft_config = Configuration.from_files([args.config])
+        ft_config["strategy"] = args.strategy
+        result = run_promotion_gate(
+            config=ft_config,
+            strategy_id=args.strategy,
+            pairs=args.pairs.split(","),
+            timeframe=args.timeframe,
+            datadir=Path(ft_config["datadir"]),
+            start=datetime.fromisoformat(args.start),
+            end=datetime.fromisoformat(args.end),
+            train_days=args.train_days,
+            test_days=args.test_days,
+            param_grid=json.loads(args.param_grid),
+            db_path=args.db_path,
+        )
+        verdict = "PASS" if result.passed else "FAIL"
+        print(f"{result.strategy_id}: {verdict}")
+        print(f"  deflated_sharpe   {result.deflated_sharpe:.3f}")
+        print(f"  permutation p     {result.permutation_p:.3f}")
+        print(f"  PBO               {result.pbo:.3f}")
+        print(f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}")
+        print(f"  trials (ledger)   {result.n_trials}")
+        for reason in result.reasons:
+            print(f"  - {reason}")
+        return 0 if result.passed else 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_gate.py research/tests/test_cli.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task5.json <<'EOF'
+{"provider":"gemini","prompt":"Reviewing the orchestration of a crypto trading-strategy promotion gate. It runs a walk-forward backtest across windows, then: reads a SQLite ledger's trial history for this strategy's family BEFORE writing this run's own row (count-then-write, to avoid a run deflating its own significance test against trials it hasn't finished), computes Deflated Sharpe Ratio using that trial count, a sign-flip permutation test p-value on the concatenated out-of-sample per-trade returns, and Probability of Backtest Overfitting across the parameter grid's variants. It fails the strategy if deflated_sharpe < 0.95 OR the permutation p-value fails Benjamini-Hochberg at q=0.05 OR PBO > 0.5, and always logs the attempt (pass or fail) to the ledger. Do these three default thresholds (0.95 DSR, 0.05 FDR-q, 0.5 PBO) seem reasonable as a first-pass gate for a crypto strategy with limited historical data, or overly strict/lenient? Any obvious ordering bug in when the ledger read happens vs when the row gets written?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task5.json
+rm /tmp/lmchatbot_task5.json
+```
+
+If the reply makes a strong case for different default thresholds, adjust the keyword
+defaults in `run_promotion_gate`'s signature and note the reasoning in a comment; otherwise
+keep the current defaults.
+
+- [ ] **Step 6: Lint, run the full research suite, and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+pytest research/tests -v
+git add research/gate.py research/cli.py research/tests/test_gate.py research/tests/test_cli.py
+git commit -m "feat(research): add promotion gate orchestration and CLI"
+```
+
+---
+
+## Self-Review Notes (from writing this plan)
+
+- **Spec coverage:** all of `FREQTRADE_RESEARCH_ARCHITECTURE.md` §18's six MVP bullets map
+  to a task: package scaffold+ledger → Task 1; statistics core → Task 2; PBO/CSCV → Task 3;
+  walk-forward runner → Task 4; CLI + PASS/FAIL report → Task 5 (gate.py + cli.py). Deferred
+  items (regime analysis, cost-sensitivity sweep, live/paper edge monitoring, portfolio
+  construction, AI hypothesis generation) are intentionally out of scope per §18's own
+  ordering — not gaps in this plan.
+- **No placeholders:** every step has real, complete code; no `TODO`/`TBD`/"similar to
+  above". The one intentionally-incomplete block (Task 2, Step 3) is scoped to porting an
+  external file whose exact source I verified line-ranges for but didn't reproduce
+  wholesale here — the task explicitly names the file, lines, and the two required
+  adaptations, and Step 1's tests fully pin the required behavior regardless of the exact
+  formula ported.
+- **Type/signature consistency:** `deflated_sharpe_ratio`, `benjamini_hochberg`,
+  `permutation_test`, `probability_of_backtest_overfitting`, `WalkForwardRunner`,
+  `generate_windows`, `family_of`, `family_trial_count`, and `log_candidate_result` are
+  each defined once (Tasks 1-4) and called with matching names/kwargs in Task 5's
+  `gate.py` — verified by re-reading Task 5 against each producing task's Interfaces block.

--- a/CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md
+++ b/CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md
@@ -1,0 +1,389 @@
+# Proposal: Crypto Strategy Discovery & Validation Engine
+
+> Phase 2 roadmap — builds on the research/validation gate delivered by
+> `docs/superpowers/plans/2026-08-23-freqtrade-research-mvp.md`. Not yet brainstormed or
+> planned; saved here as the source proposal for that future session.
+
+## Objective
+
+Extend our Freqtrade-based trading system so that a user who is **not a trading guru** can
+systematically investigate common crypto trading strategy families, identify potentially
+persistent edges, and promote only strategies that survive rigorous validation.
+
+The objective is **not**:
+
+> Find the strategy with the highest historical return.
+
+The objective is:
+
+> **Identify strategies whose observed edge is most likely to generalize to future crypto markets after fees, slippage, execution effects, regime changes, and multiple-testing/selection bias.**
+
+No profitability should ever be assumed or guaranteed.
+
+---
+
+## 1. Strategy families to investigate
+
+Build the research system around explicit strategy families.
+
+### Tier 1
+
+Start with:
+
+1. Trend following
+2. Momentum
+3. Mean reversion
+4. Breakout
+5. Cross-sectional momentum
+
+### Tier 2
+
+Then investigate:
+
+6. Funding-rate effects
+7. Futures basis / cash-and-carry
+8. Liquidation-driven effects
+9. Market-regime strategies
+10. Volatility strategies
+
+### Tier 3
+
+Only after the research framework is proven:
+
+11. Statistical arbitrage
+12. Pairs trading
+13. Cross-exchange arbitrage
+14. Market making
+15. ML/AI-based strategies
+
+Do **not** implement all of these initially. The framework should make strategy families
+pluggable.
+
+---
+
+## 2. Strategy-family interface
+
+Create a common abstraction allowing the research engine to treat each strategy family
+consistently.
+
+Conceptually:
+
+```python
+class StrategyHypothesis:
+    name
+    family
+    description
+    required_data
+    parameters
+    generate_signals()
+    generate_hypothesis()
+```
+
+The research system should be able to ask:
+
+> "What happens if we test this family across these assets, timeframes, market regimes and
+> parameter ranges?"
+
+without hard-coding research logic into every strategy.
+
+---
+
+## 3. Start with transparent strategies
+
+The initial implementations should be intentionally understandable.
+
+### Trend following
+
+Examples: moving-average relationships, price vs long-term moving average, trend strength,
+Donchian-style breakouts, trailing exits. Do not assume these are profitable — they are
+research hypotheses.
+
+### Momentum
+
+Test: 1h, 4h, 24h, 3d, 7d momentum; risk-adjusted momentum; volume-confirmed momentum. Test
+both time-series momentum and cross-sectional momentum.
+
+### Mean reversion
+
+Test whether unusually large deviations predict subsequent reversal. Potential features:
+return deviation, distance from moving average, z-score, RSI, volatility-adjusted move,
+volume spike, liquidation spike. Do not assume "oversold" means reversal — measure the
+conditional return distribution.
+
+### Breakouts
+
+Test: recent high/low, Donchian channels, volatility compression → expansion,
+volume-confirmed breakouts, multi-timeframe breakouts. Measure both continuation and failed
+breakout/reversal.
+
+### Cross-sectional momentum
+
+Priority. For a defined liquid crypto universe: rank assets → momentum score → top quantile
+→ long (bottom quantile → short if supported, else compare against market/BTC benchmark).
+The system must prevent survivorship bias in the universe.
+
+---
+
+## 4. Crypto-specific research
+
+After Tier 1 is working, add features unavailable in traditional equity research.
+
+### Funding
+
+Investigate whether extreme funding conditions predict continuation, reversal, volatility,
+or liquidation events. Examples: funding percentile, funding change, funding acceleration,
+funding × momentum, funding × volatility.
+
+### Basis
+
+Investigate futures premium/discount. Hypothesis: large, persistent futures basis may
+provide an exploitable return independent of directional BTC exposure. Include spot price,
+futures price, basis, funding, transaction costs, holding period.
+
+### Liquidations
+
+Investigate whether unusually large liquidation events create continuation, temporary
+dislocation, mean reversion, or volatility expansion. Normalize liquidation size against
+typical market activity.
+
+---
+
+## 5. Market regimes
+
+Every strategy should be evaluated by regime: Bull, Bear, Sideways, High volatility, Low
+volatility, Crash, Recovery. Do not merely label regimes after seeing strategy results —
+define the regime methodology independently and record it as part of the experiment. Output
+example:
+
+```
+Strategy: Momentum-24h
+Bull              PASS
+Bear              FAIL
+Sideways          WEAK
+High volatility   PASS
+Low volatility    WEAK
+Crash             FAIL
+Recovery          PASS
+```
+
+This should influence robustness scoring.
+
+---
+
+## 6. Data requirements
+
+Before implementing strategies, inventory the data available from Freqtrade and determine
+what additional data is required.
+
+- **Price data:** OHLCV, trades if available, timeframe, volume
+- **Derivatives:** funding, futures prices, open interest, liquidation data
+- **Market structure:** spreads, order book where realistically available
+
+Do not build strategies around data that cannot be reliably obtained during live trading. A
+feature unavailable at decision time must never be allowed into research.
+
+---
+
+## 7. Prevent lookahead and leakage
+
+Hard requirement. Every feature must have an explicit `available_at` timestamp. The
+research engine must guarantee: a signal at time T can only use information that was
+actually available at or before T. Run existing Freqtrade lookahead/recursive-analysis
+tooling where applicable. Add tests specifically designed to detect: future candles, future
+funding, future liquidation information, future universe membership, future normalization,
+future ranking, future regime labels.
+
+---
+
+## 8. Universe construction
+
+Crypto survivorship bias is a major concern. Do not simply backtest today's top 100 coins
+against historical data. If possible, reconstruct what assets were actually tradable at each
+historical point — record listing date, delisting date, liquidity, exchange availability,
+minimum volume, historical universe membership. If historical membership cannot be
+reconstructed reliably, explicitly downgrade the evidence quality.
+
+---
+
+## 9. Transaction-cost modeling
+
+Every strategy must be tested with realistic exchange fees, spread, slippage, funding,
+execution assumptions. Then stress test: baseline, 1.25× costs, 1.5× costs, 2× slippage. A
+strategy that only works under optimistic execution assumptions should fail robustness
+testing.
+
+---
+
+## 10. Discovery vs validation
+
+Never allow strategy discovery and final evaluation to use the same data. Implement:
+Discovery → Validation → LOCK → OOS. Prefer walk-forward validation (Train → Validate →
+Test, repeated across sliding windows), exact windows configurable. Every result must record
+dataset period, universe, timeframe, parameters, code version, experiment ID.
+
+---
+
+## 11. Multiple-testing correction
+
+Critical component. The system must record: how many hypotheses were tested, how many
+parameter combinations, how many assets, how many timeframes, how many holding periods, how
+many variants. A strategy discovered after 50 experiments should not be treated identically
+to one discovered after 50,000 experiments. Implement an experiment ledger. Eventually
+incorporate effective trial count, deflated Sharpe, selection-bias penalties,
+false-discovery considerations. The precise statistical methodology should be documented
+before implementation.
+
+---
+
+## 12. Robustness testing
+
+For every serious candidate, test:
+
+- **Parameter stability** — does profitability exist across a region of parameter space (not just one lucky value)?
+- **Time stability** — does the strategy work across different historical periods?
+- **Asset stability** — does it work only on BTC, or across BTC/ETH/SOL/...?
+- **Regime stability** — does it depend on one particular market environment?
+- **Cost stability** — does modestly worse execution destroy the edge?
+- **Trade-count stability** — is the result dependent on only a handful of trades?
+
+---
+
+## 13. Monte Carlo
+
+For promising candidates, estimate drawdown distribution, losing streak distribution,
+probability of severe drawdown, return uncertainty, probability of negative future
+performance. Do not present one backtest equity curve as the expected future path.
+
+---
+
+## 14. Strategy scoring
+
+Create a Robustness Score, not simply a profitability score. Potential components: OOS
+performance, OOS consistency, drawdown, Sharpe/Sortino, deflated Sharpe, parameter
+stability, time stability, asset stability, regime stability, cost sensitivity, trade count,
+Monte Carlo risk, profit concentration, IS/OOS degradation. The exact weighting must be
+documented and tested.
+
+---
+
+## 15. Strategy report
+
+Every candidate should produce a standardized report, e.g.:
+
+```
+========================================
+STRATEGY: Cross-Sectional Momentum #17
+========================================
+Universe:        Liquid top-100 crypto
+Timeframe:       4h
+Holding period:  3 days
+
+DISCOVERY    Return +62%   Sharpe 1.72   Max DD -19%
+VALIDATION   Return +24%   Sharpe 1.21   Max DD -16%
+OOS          Return +18%   Sharpe 1.08   Max DD -17%
+
+ROBUSTNESS
+Parameter: PASS   Time: PASS   Asset: PASS   Regime: CONDITIONAL
+Costs: PASS   Lookahead: PASS   Universe: PASS
+
+Experiments:     1,284
+Deflated Sharpe: 0.71
+
+VERDICT: PAPER TRADE
+```
+
+The report should also explain *why* the strategy passed or failed.
+
+---
+
+## 16. Non-expert user workflow
+
+User should not need to understand strategy coding: select assets → select risk tolerance →
+select maximum acceptable drawdown → select trading frequency → start research. The research
+engine tests strategy families, ranks robust candidates, explains evidence, recommends
+candidates. The user chooses whether to paper trade.
+
+---
+
+## 17. Paper-trading promotion
+
+No strategy should automatically go from BACKTEST to LIVE. Require: Backtest → Validation →
+OOS → Paper trading → Live eligibility. Paper trading should verify actual exchange
+connectivity, signal timing, order behavior, fills, slippage, data availability, operational
+reliability.
+
+---
+
+## 18. Live strategy health
+
+Once deployed, continue evaluating whether the edge remains intact. Monitor expected vs.
+actual expectancy, win rate, drawdown. States: HEALTHY, WATCH, DEGRADED, SUSPENDED. Do not
+automatically assume every losing streak means the edge is dead — use statistical
+thresholds.
+
+---
+
+## 19. AI research assistant — later phase
+
+After the statistical framework is reliable, add AI: generate hypotheses, inspect existing
+research, suggest features/strategy combinations, explain failures, identify suspicious
+results, propose follow-up experiments, summarize evidence. But AI-generated hypotheses must
+enter exactly the same experimental pipeline as human-generated hypotheses — AI gets no
+special authority.
+
+---
+
+## 20. What NOT to build initially
+
+Do not initially build: autonomous AI trading, LLM-generated buy/sell decisions,
+high-frequency trading, market making, cross-exchange arbitrage, complicated neural
+networks, hundreds of indicators, massive hyperparameter searches. First prove the research
+framework can reliably distinguish a robust candidate from a beautiful overfit.
+
+---
+
+## MVP (for this proposal — a future session, not the current one)
+
+**Strategy families:** Momentum, Trend following, Mean reversion, Breakout, Cross-sectional
+momentum.
+
+**Research capabilities:** train/validation/OOS, walk-forward, realistic costs, parameter
+stability, regime analysis, experiment ledger, multiple-testing accounting, Monte Carlo,
+robustness score, standardized strategy report.
+
+**Execution:** use existing Freqtrade functionality wherever possible.
+
+**User interface:** a CLI is sufficient initially.
+
+---
+
+## Success criterion
+
+The MVP is not successful because it discovers a strategy with a 500% backtest. The MVP is
+successful if it can demonstrate, using controlled tests, that it:
+
+1. Finds plausible strategy candidates.
+2. Rejects obvious overfit strategies.
+3. Detects lookahead/data leakage.
+4. Penalizes excessive experimentation.
+5. Distinguishes IS performance from OOS performance.
+6. Identifies regime dependence.
+7. Models realistic costs.
+8. Produces reproducible research.
+9. Gives a non-expert understandable evidence-based recommendations.
+10. Does not claim profitability without sufficient evidence.
+
+---
+
+## Final product vision
+
+> "I don't know which crypto strategy works. Find out for me."
+>
+> "We tested 4,812 hypotheses across five strategy families. Most failed out-of-sample. Six
+> survived the initial robustness tests. Two remain promising after transaction-cost stress
+> testing and multiple-testing correction. One has the best evidence/risk profile for your
+> stated risk tolerance. It is currently recommended for paper trading, not live capital."
+
+That is the product. Freqtrade remains the execution engine. The new system becomes the
+research scientist. Central engineering principle: **optimize for evidence of a persistent
+edge, not impressive backtests.**

--- a/FIELD-NOTES.md
+++ b/FIELD-NOTES.md
@@ -20,9 +20,9 @@ class-level globals on the same classes (`Trade.use_db` and `LocalTrade.bt_trade
 across `pytest --random-order -n auto` runs. Then `research/promotion.py`'s
 `evaluate_paper_trading_health` became the first code in this package to call `init_db`
 itself, deliberately, against a real dry-run database — the exact same footgun in a new
-place. The call site is `research/promotion.py:189`
+place. The call site is `research/promotion.py:196`
 (`init_db(f"sqlite:///{db_path}")`). The very next statement, the query itself, is
-`research/promotion.py:191` (`Trade.session.query`).
+`research/promotion.py:199` (`Trade.session.query`).
 
 The trap: two calls to a function like this in the same process — sequential or
 interleaved — silently redirect each other's `Trade.session`. A test file that exercises

--- a/FIELD-NOTES.md
+++ b/FIELD-NOTES.md
@@ -1,0 +1,58 @@
+# FIELD-NOTES
+
+Per-project traps for this repo, each with a `file:line` an agent actually looked at.
+See `C:\dev\agent-knowledge\README.md` for the format this file follows and how the
+`field-notes` pre-commit hook (`C:/dev/agent-knowledge/validate.py --hook`) keeps its
+citations honest — it re-reads every cited line on commit and fails if the code moved.
+
+---
+
+## freqtrade's `Trade.session` is GLOBAL class-level state, not scoped per call
+
+`freqtrade.persistence.init_db(db_url)` sets `Trade.session` directly on the `Trade`
+class as a module-level side effect, not a factory returning an independent session
+object. The assignment itself lives at `freqtrade/persistence/models.py:86`
+(`Trade.session = scoped_session(`), inside `init_db`. Calling `init_db` anywhere
+redirects `Trade.session` for the entire process, not just the caller.
+
+This has bitten this repo twice already. PR #5 fixed a leak of a *different* pair of
+class-level globals on the same classes (`Trade.use_db` and `LocalTrade.bt_trades`)
+across `pytest --random-order -n auto` runs. Then `research/promotion.py`'s
+`evaluate_paper_trading_health` became the first code in this package to call `init_db`
+itself, deliberately, against a real dry-run database — the exact same footgun in a new
+place. The call site is `research/promotion.py:189`
+(`init_db(f"sqlite:///{db_path}")`). The very next statement, the query itself, is
+`research/promotion.py:191` (`Trade.session.query`).
+
+The trap: two calls to a function like this in the same process — sequential or
+interleaved — silently redirect each other's `Trade.session`. A test file that exercises
+such a function must reset `Trade.session` after every test in the file, not just the
+new ones, or a throwaway dry-run sqlite file from one test leaks into whichever test
+runs next in the same pytest-xdist worker, the exact same failure shape as PR #5's bug.
+
+The guard that worked here: a file-scoped autouse pytest fixture at
+`research/tests/test_promotion.py:173`
+(`_reset_trade_session_after_evaluation_tests`), verified by two independent code
+reviews (a task reviewer and an lmchatbot cross-check) to actually be function-scoped
+and apply to the whole file, not nested in a class or conditionally applied. Its
+teardown calls `init_db` with an in-memory URL at
+`research/tests/test_promotion.py:180` (`init_db("sqlite://")`). The test data helper
+that inserts throwaway trades releases its own redirect the same way immediately after
+use, at `research/tests/test_promotion.py:214` (`init_db("sqlite://")`).
+
+What doesn't fix it: wrapping the production call in a try/finally that "restores"
+`Trade.session` afterward sounds right but isn't — the function has no way to know what
+`Trade.session` pointed at before it ran, so resetting to a fresh in-memory database can
+itself clobber a caller's real state instead of restoring it. The actual fix in
+`research/promotion.py` is narrower and honest about the limit: fully materialize the
+query with `.all()` before returning, and document in the function's own docstring that
+it must never be called concurrently with, or interleaved with, other in-process code
+relying on `Trade.session` pointing elsewhere — a `WalkForwardRunner`/`Backtesting` run
+in the same process being the concrete example. No code fix removes this constraint;
+it's freqtrade's own architecture, not a bug in this package.
+
+Verified 2026-08-24 during the paper-trading-promotion sub-project: confirmed via two
+independent code reviews (one traced the claim against `freqtrade/persistence/models.py`'s
+actual source, one against a live 78/78-passing full test-suite run) and the same
+failure pattern this repo already fixed once for a different pair of `Trade`-class
+globals in PR #5.

--- a/FREQTRADE_RESEARCH_ARCHITECTURE.md
+++ b/FREQTRADE_RESEARCH_ARCHITECTURE.md
@@ -1,0 +1,361 @@
+# Freqtrade Research Architecture
+
+Phase 0 investigation + Phase 1 architecture proposal for adding a research/validation layer
+on top of freqtrade, informed by MarketMind's "honest backtest funnel."
+
+No code was modified to produce this document. All file:line citations below were verified
+against `develop` (commit `10db8654c`, 2026-08-23) and against `C:\dev\MarketMind` on the same date.
+
+---
+
+## 1. Freqtrade architecture map
+
+```
+freqtrade/
+├── freqtradebot.py, worker.py     live/dry-run bot loop
+├── exchange/                       ccxt adapters per exchange
+├── persistence/                    SQLAlchemy Trade/Order models, DB
+├── strategy/interface.py           IStrategy base class (user subclasses this)
+├── optimize/
+│   ├── backtesting.py              backtest engine
+│   ├── hyperopt/                   parameter search (Optuna)
+│   ├── hyperopt_loss/              pluggable objective functions
+│   └── analysis/                   lookahead.py, recursive.py (bias detectors)
+├── freqai/                         ML plumbing (rolling retrain, feature/target hooks)
+├── plugins/
+│   ├── protections/                cooldown, drawdown, stoploss-guard
+│   └── pairlist/                   whitelist filters (volume, spread, performance...)
+├── rpc/                            telegram, webhook, REST API
+└── data/                           OHLCV loading, metrics (Sharpe/Sortino/Calmar/...)
+```
+
+Everything a research layer needs — strategy execution, backtest simulation, param search,
+persistence, live/dry-run gating — already exists. The question this document answers is
+*what's missing on top of it*, not whether to rebuild it.
+
+---
+
+## 2. Execution flow (live/dry-run)
+
+```
+Worker._worker() → FreqtradeBot.process()                    worker.py:83, freqtradebot.py:257
+  ├─ strategy.analyze()                                       freqtradebot.py:284
+  ├─ exit_positions() → should_exit() → execute_trade_exit()  freqtradebot.py:1315 / interface.py:1419
+  └─ enter_positions() → create_trade() → execute_entry()     freqtradebot.py:306 / 684 / 895
+       ├─ wallets.get_trade_stake_amount()                    wallets.py:387  (sizing)
+       ├─ exchange.create_order()                              exchange.py:1451
+       │    ├─ dry-run → create_dry_run_order()                exchange.py:1159 (orderbook-based sim fill)
+       │    └─ live → ccxt _api.create_order()                 exchange.py:1481
+       └─ update_trade_state() → Trade.commit()                freqtradebot.py:2339 (SQLAlchemy persist)
+```
+
+Key findings:
+- **Position sizing** default is flat-% or equal-weight-unlimited (`wallets.py:349-361`); the only
+  risk-based-sizing hook is `IStrategy.custom_stake_amount()` (`interface.py:625`), which does
+  nothing by default. **No Kelly criterion or volatility-based sizing exists anywhere in freqtrade.**
+- **No strategy versioning.** `IStrategy.version()` (`interface.py:870`) is a cosmetic string,
+  not tracked, hashed, or diffed. A strategy is a stateless `.py` file re-resolved on each reload.
+- Persistent per-trade state beyond the `Trade`/`Order` tables exists via `trade_custom_data`
+  (`persistence/custom_data.py:28`) — usable as a hook point for research-layer metadata.
+
+---
+
+## 3. Backtesting flow
+
+```
+load_bt_data() → history.load_data() → clean_ohlcv_dataframe()      backtesting.py:357 / converter.py:86
+  → gaps filled with flat zero-volume synthetic candles                converter.py:126-174
+strategy.advise_all_indicators() (whole dataframe at once)              backtesting.py:1826
+backtest_loop() — candle-by-candle, pair-by-pair                        backtesting.py:1520
+  entry fill: low ≤ rate ≤ high (OHLC-only, no tick data)                backtesting.py:787
+  exit priority: signal/custom_exit → stoploss → ROI → trailing          interface.py:1504-1521
+fees: single flat rate, same both legs, NO SLIPPAGE MODEL                backtesting.py:268, 1223
+metrics: Sharpe/Sortino/Calmar/SQN/expectancy/drawdown                   data/metrics.py
+```
+
+**What freqtrade's own docs concede** (`docs/backtesting.md:555-646`):
+- No slippage in backtest fills; historic exchange precision/limits unknown (today's limits
+  applied retroactively); stoploss/trailing-stop ordering within a candle is an admitted,
+  documented bias; "backtesting will never replace running a strategy in dry-run mode."
+- **Zero train/validation/OOS split anywhere in the engine.** The only mechanism is the user
+  manually passing different `--timerange` values. Nothing prevents (or even flags) reusing
+  the same range for both discovery and "validation."
+
+---
+
+## 4. Hyperopt flow
+
+```
+prepare_hyperopt_data() — loads ONE --timerange, ONCE                    hyperopt_optimizer.py:454
+optuna.create_study(sampler=NSGAIIISampler, direction="minimize")        hyperopt_optimizer.py:406-438
+per epoch: generate_optimizer(params) → backtest(SAME full range)        hyperopt_optimizer.py:321
+  → loss = IHyperOptLoss subclass (Sharpe/Sortino/Calmar/drawdown/multi) hyperopt_loss_*.py
+_save_result() → append JSON line to user_data/hyperopt_results/*.fthypt hyperopt.py:95
+```
+
+Critical gaps (confirmed by grep — zero hits for "deflat", "false discovery", "bonferroni",
+"multiple test" anywhere in `freqtrade/optimize/`):
+
+- **Default sampler is NSGA-III (genetic), not Bayesian** — despite `docs/hyperopt.md:7,502`
+  claiming "Bayesian search." A stale-docs finding worth fixing upstream separately.
+- **Every epoch backtests the exact same data it's being scored on.** No held-out split exists.
+- **No loss function corrects for trial count.** All 12 loss functions in `hyperopt_loss/`
+  score a single epoch in isolation; none discount for having tried hundreds/thousands of
+  parameter combinations against the same fixed dataset.
+- **No cross-run trial ledger.** Each `.fthypt` file is independent; nothing aggregates "how
+  many parameter combinations have I ever tried" across runs — a user would have to `ls` and
+  sum manually.
+- **Low-trade-count guard is weak and off by default.** `hyperopt_min_trades` (`cli_options.py:357`)
+  defaults to **1** — a single lucky trade can produce a "best" epoch under `OnlyProfitHyperOptLoss`
+  or `SharpeHyperOptLoss`.
+- Reproducibility: seeded (`hyperopt_optimizer.py:406`) but sensitive to `-j` parallelism for
+  stateful samplers (TPE/GP) — undocumented caveat.
+
+This is the single biggest gap MarketMind's methodology targets, and it's real: **freqtrade
+hyperopt has no defense against the multiple-comparisons problem at all.**
+
+---
+
+## 5. FreqAI flow
+
+Rolling-window walk-forward retraining is genuinely implemented (`data_kitchen.py:315`,
+`split_timerange`) and label truncation correctly prevents the most basic look-ahead
+(`freqai_interface.py:347-354`). But three real gaps exist:
+
+1. **Feature population happens once over the FULL backtest range, then is sliced** —
+   `freqai_interface.py:341-345`. A non-causal feature (`.shift(-1)`, centered rolling, global
+   mean) leaks future information into every training window despite the walk-forward
+   structure. The docs flag this in prose (`docs/freqai-running.md:71`); nothing in code
+   checks for it.
+2. **No default early stopping.** LightGBM/XGBoost get an `eval_set` but no
+   `early_stopping_rounds` unless the user adds it manually — the shipped example config
+   (`config_freqai.example.json:84`) is empty. The held-out `test_size` split (default 0.1)
+   is computed and then effectively wasted for the models the quick-start guide pushes.
+3. **No prediction provenance.** `historic_predictions.pkl` carries no model-version column,
+   and `purge_old_models` keeps only 2 model folders per pair by default — auditing which
+   model made a specific historical prediction is often impossible after the fact.
+
+**Bottom line: FreqAI is real ML plumbing, not a validity guarantee.** It does not solve the
+problem this project exists to solve; it's a data source the research layer must treat with
+the same skepticism as any hand-written strategy.
+
+---
+
+## 6-8. Existing protections, risk controls, data-integrity controls
+
+| Category | What exists | Verdict |
+|---|---|---|
+| Lookahead detection | `optimize/analysis/lookahead.py` — truncates data at each trade's open/close date, diffs signals/indicators against a full-range baseline | Real, but only checks signals it actually observed; untriggered branches, FreqAI targets (always false-positive), and limit-order pricing are blind spots |
+| Recursive-indicator detection | `optimize/analysis/recursive.py` — varies `startup_candle_count`, diffs last-row indicator values | Real but last-row-only, `populate_indicators` only, single pair by default |
+| Protections | `CooldownPeriod`, `LowProfitPairs`, `MaxDrawdown`, `StoplossGuard` (`plugins/protections/`) | Reactive (fire after a trade closes), operate on realized P&L only, opt-in during backtest/hyperopt (`--enable-protections`) |
+| Pairlist filters | 12 filters (`plugins/pairlist/`) | Mostly liquidity/quality; **`PerformanceFilter` sorts pairs by the bot's own recent live performance — a textbook selection-bias/performance-chasing mechanism, doesn't even run in backtest** |
+| Position sizing | `wallets.py`, `custom_stake_amount()` hook | No built-in Kelly or volatility-based sizing |
+| Drawdown circuit breaker | `MaxDrawdownProtection` | Realized-drawdown only, global-only, reactive between trade-close events — not continuous equity monitoring |
+| Dry-run/live gating | `dry_run` defaults to `true` everywhere (`constants.py:196`, `configuration.py:470`) | Matches the "off by default, explicit false to go live" pattern MarketMind uses — **already present, no porting needed** |
+| Strategy versioning | None | A `.py` file with a cosmetic `version()` string; no history, no hash, no lifecycle |
+
+---
+
+## 9. Proposed research-layer architecture
+
+```
+                    freqtrade (unmodified core)
+              ┌────────────────────────────────┐
+              │ IStrategy, Backtesting,         │
+              │ Exchange, Trade/Order DB,       │
+              │ dry-run, protections, pairlist  │
+              └───────────────┬──────────────────┘
+                               │ called in-process
+                               │ (Backtesting class, IStrategy instances)
+                               ▼
+              ┌────────────────────────────────┐
+              │        research/ package         │
+              │  (new, separate DB + CLI)        │
+              │                                  │
+              │  statistics.py   — DSR, BH-FDR,  │
+              │                    permutation   │
+              │  pbo.py          — CSCV          │
+              │  walkforward.py  — train/test    │
+              │                    windowing     │
+              │  ledger.py       — candidate/    │
+              │                    trial ledger  │
+              │  gate.py         — promotion     │
+              │                    gate CLI       │
+              └───────────────┬──────────────────┘
+                               │
+                        PASS ──┴── FAIL
+                         │
+                         ▼
+              freqtrade dry-run (existing, unmodified)
+                         │
+                    live eligibility (future phase)
+```
+
+**Design principle: the research layer is a client of freqtrade, not a fork of it.** It
+imports `freqtrade.optimize.backtesting.Backtesting` and `freqtrade.strategy.interface.IStrategy`
+directly (in-process, same Python environment — this is a monorepo addition, not a subprocess
+wrapper), runs its own experiments by calling `Backtesting.backtest()` repeatedly across
+windows/params, and records results in its own SQLite DB. It never touches `freqtradebot.py`,
+`exchange/`, or `persistence/models.py`.
+
+---
+
+## 10. Proposed database schema
+
+Own SQLite DB (SQLModel, following MarketMind's `ledger.py` pattern — trivial, ~80 lines):
+
+```python
+class CandidateResult(SQLModel, table=True):
+    id: int
+    run_stamp: datetime
+    strategy_id: str
+    strategy_family: str          # alias-mapped, e.g. "ema_cross_v3" → "trend_following"
+    params_json: str
+    universe: str                 # e.g. "BTC/USDT,ETH/USDT"
+    timeframe: str
+    discovery_start: date
+    discovery_end: date
+    validation_start: date | None
+    validation_end: date | None
+    oos_start: date | None
+    oos_end: date | None
+    n_trials_this_run: int        # grid/search size for this run
+    is_sharpe: float
+    oos_sharpe: float | None
+    deflated_sharpe: float | None
+    permutation_p: float | None
+    pbo: float | None
+    survived: bool
+    evidence_json: str            # full detail blob for the "advanced view"
+```
+
+`family_trial_count(family)` = `max(row count for family, declared n_trials)` — ported
+directly from MarketMind's design (`ledger.py:28`) — is what makes deflation correct across
+repeated research sessions instead of resetting to zero each run.
+
+---
+
+## 11. Integration points
+
+- **Backtesting**: call `freqtrade.optimize.backtesting.Backtesting` directly per
+  train/test window — reuse its fill/fee/stoploss/ROI simulation unchanged.
+- **Hyperopt**: for the per-window "best-train-params" step, either (a) call freqtrade's own
+  `Hyperopt`/`HyperOptimizer` with a small epoch budget per window, or (b) run a plain grid
+  search via repeated `Backtesting.backtest()` calls when the param space is small — grid is
+  simpler and keeps the trial count exactly known (needed for DSR deflation), so **prefer (b)
+  for the MVP** and only reach for freqtrade's hyperopt when a space is too large for a grid.
+- **Strategy objects**: `StrategyResolver.load_strategy()` — instantiate the user's existing
+  `IStrategy` subclass unchanged; the research layer treats it as an opaque, parameterized
+  experimental object per the user's Phase 1 spec.
+- **Live/paper comparison**: read `Trade`/`Order` rows directly from freqtrade's own DB
+  (`persistence/trade_model.py`) for the future edge-monitoring phase — no need to duplicate
+  execution tracking.
+- **Lookahead/recursive checks**: shell out to (or import) freqtrade's existing
+  `optimize/analysis/lookahead.py` and `recursive.py` as a pre-gate step — don't reimplement.
+
+---
+
+## 12-14. Reuse / Extend / Replace
+
+**Reuse unchanged:** `Backtesting` engine, `Exchange`/ccxt layer, exit/stoploss/ROI simulation,
+`Trade`/`Order` persistence, protections, pairlist filters, dry-run infrastructure, RPC
+(Telegram/API), lookahead/recursive analysis tools, `custom_stake_amount`/`leverage` hooks as
+the integration point for risk-based sizing.
+
+**Extend (new code, freqtrade untouched):** the entire `research/` package — statistics,
+walk-forward runner, candidate ledger, promotion gate, (later) regime classifier, cost-stress
+sweep, live edge monitor.
+
+**Replace:** nothing in freqtrade core. The one *soft* recommendation: document (not code-change)
+that `PerformanceFilter` is a selection-bias risk and shouldn't be used to select pairs for a
+strategy still under validation.
+
+---
+
+## 15-16. MarketMind components — port vs. don't
+
+**Worth porting (design and, mostly, code):**
+
+| Component | MarketMind location | Portability |
+|---|---|---|
+| Deflated Sharpe Ratio | `backend/backtest/enhanced/statistics.py:168` | Near-verbatim; adjust `periods_per_year` for crypto's 24/7 market |
+| Benjamini-Hochberg FDR | `statistics.py:14` | Reusable as-is — pure stats, zero domain coupling |
+| Permutation tests (sign-flip + trade-sequence) | `statistics.py:41,301` | Near-verbatim |
+| PBO via CSCV (+ Reality Check/SPA) | `backend/backtest/enhanced/reality_check.py:271` | Reusable as-is — the single highest-value file to port whole |
+| Candidate ledger + effective-trial-count | `backend/research/ledger.py` | Port the design (count-then-write, family aliasing); reimplement schema against this project's own tables |
+| Walk-forward runner | `backend/backtest/enhanced/walkforward.py` | Port orchestration logic; swap MarketMind's `_sim`/`get_ohlcv` calls for freqtrade's `Backtesting` API |
+| Regime classification + attribution | `backend/regime/classifier.py`, `attribution.py` | Port the pattern (rule-cascade classifier + causal `asof` attribution); swap VIX/SPY for BTC dominance / funding rate / realized vol |
+| Risk-budget multiplier + Kelly fraction | `backend/risk_ai/engine.py` | Near-verbatim pure functions |
+| Live/paper edge monitoring | `backend/auto_trader/drift_monitor.py` | Port the mechanism (significance-gated drift vs. backtest baseline, demote-not-delete); no literal HEALTHY/WATCH/DEGRADED/SUSPENDED enum exists to copy — design one |
+| Layered paper-trading gate | `backend/auto_trader/executor.py`, `signal_handler.py` | Concept only — freqtrade already has its own dry-run gate; replicate the *layering* (feature flag off by default + hard config refusal + fail-closed strategy-registry check), not the IBKR code |
+
+**Do not port:** IB Gateway/ib_insync execution code (irrelevant — freqtrade has its own
+ccxt-based dry-run/live layer); yfinance data fetching; the React/FastAPI/frontend scaffolding
+(freqtrade has its own API/webUI/Telegram); MarketMind's `pbo.py` (Version A, superseded by
+`reality_check.py`); cost-sensitivity stress testing — **doesn't exist in MarketMind, nothing
+to port, must be built fresh.**
+
+**Hard-won lessons to actively test for when reimplementing** (from MarketMind's own
+DECISIONS.md/FIELD-NOTES.md — each cost them real debugging time):
+
+1. A Deflated Sharpe with no sample-size term is just a sign test wearing a rigor costume —
+   write a discriminative-validity test (does n=10 score differently from n=10,000 at equal
+   Sharpe?) before trusting any DSR implementation.
+2. Sharpe is order-invariant — permuting *order* of returns cannot test it; permutation nulls
+   must destroy the specific structure the statistic actually depends on (sign-flip, not reorder).
+3. Terminal return is also order-invariant — the same bug independently recurred in a second
+   Monte Carlo module. Split resampling by statistic type: permutation for order-*dependent*
+   stats (drawdown, ruin), bootstrap-with-replacement for order-*invariant* ones (terminal return).
+4. A promotion gate must never re-optimize — if the gate itself searches parameters, it becomes
+   an unpriced multiple-comparisons search, the exact failure mode it exists to catch. Keep
+   parameter search in the interactive path; validate only fixed, already-chosen params in the gate.
+5. Per-strategy Sharpe-stability across windows is a different, weaker question than whether the
+   *same winning parameters* keep winning window to window — build both checks.
+6. Grep for parameters declared in a function signature but silently ignored in the body — this
+   exact bug class (a `cap`/rate argument accepted but hardcoded over) recurred at least twice.
+7. Decide up front whether a refused/insufficient-sample attempt still counts toward the trial
+   ledger — MarketMind left this an open exploit (free below-floor retries) because it's
+   single-user; don't inherit that gap if this system is ever used by concurrent/automated search.
+8. A near-FDR-boundary result is inherently unstable run-to-run — surface it as "borderline,"
+   don't present a crisp binary pass/fail near the threshold.
+
+---
+
+## 17. Estimated implementation complexity
+
+| Piece | Size | Why |
+|---|---|---|
+| Statistics core (DSR, BH-FDR, permutation, PBO/CSCV) | **Small** (1-2 days) | Near-verbatim port of pure-function code MarketMind already debugged |
+| Candidate ledger | **Small** (1 day) | ~80-line SQLModel table + two query functions |
+| Walk-forward runner against freqtrade's `Backtesting` | **Medium** (3-5 days) | New adapter code; freqtrade's `Backtesting` class isn't designed to be called in a tight per-window loop — needs a thin wrapper |
+| Promotion gate CLI | **Small** (1-2 days) | Glue: run walk-forward → stats → ledger write → PASS/FAIL report |
+| Regime classification (crypto) | **Medium** (3-4 days) | No equivalent to VIX for crypto off the shelf — needs its own rule cascade against BTC dominance/funding/realized vol, plus a data source |
+| Cost-sensitivity stress sweep | **Small-Medium** (2-3 days) | Doesn't exist anywhere to copy; straightforward re-run-at-N-cost-multipliers harness |
+| Live/paper edge monitoring | **Medium** (3-5 days) | Needs freqtrade's live Trade DB wired to a baseline comparison + significance test |
+| Portfolio construction (correlation-aware) | **Medium** (3-5 days) | Defer until ≥2 validated strategies exist — nothing to construct a portfolio from yet |
+| AI hypothesis generation | **Large** (open-ended) | Explicitly last per the user's own Phase 7 — defer until the gate exists and has rejected/accepted at least a few real candidates |
+
+---
+
+## 18. Recommended Phase 1 MVP
+
+Build exactly enough to answer: *"is this strategy likely to have a real edge after costs and
+after accounting for how much we searched?"* — nothing else yet.
+
+1. New `research/` package alongside `freqtrade/` (same repo/venv, own SQLite DB).
+2. Port `statistics.py` (DSR + BH-FDR + permutation) and `reality_check.py` (PBO/CSCV)
+   near-verbatim; set `periods_per_year` for crypto.
+3. Build one `WalkForwardRunner` that calls freqtrade's `Backtesting` class per rolling
+   train/test window: grid-search params on train only, evaluate the winning fixed params on
+   test only, deflate by the real grid size and real `n_obs`.
+4. Candidate ledger table + `family_trial_count()`, so deflation compounds correctly across
+   research sessions instead of resetting each run.
+5. One CLI command — `research gate <strategy> --timerange ...` — chaining: freqtrade's own
+   lookahead/recursive checks → walk-forward → DSR/BH/PBO → ledger write → PASS/FAIL report.
+6. Output goes to the terminal first (matches Phase 14's "hide complexity, not evidence" — a
+   plain-text summary plus a `--verbose` full-evidence dump is enough for v1; no UI yet).
+
+Explicitly deferred to later phases, in this order: regime analysis → cost-sensitivity
+sweep → live/paper edge monitoring → portfolio construction → AI hypothesis generation.
+Each of those is independently useful but none of them matter if step 3-5 above doesn't
+first prove out against one real freqtrade strategy.

--- a/build_helpers/extract_config_json_schema.py
+++ b/build_helpers/extract_config_json_schema.py
@@ -22,7 +22,9 @@ def extract_config_json_schema():
         from freqtrade.config_schema import CONF_SCHEMA
 
     schema_filename = Path(__file__).parent / "schema.json"
-    with schema_filename.open("w") as f:
+    # newline="\n": force LF on write, or the default text-mode translation writes
+    # CRLF on Windows and this hook fails every commit by "modifying" the file.
+    with schema_filename.open("w", newline="\n") as f:
         rapidjson.dump(CONF_SCHEMA, f, indent=2)
 
 

--- a/docs/superpowers/plans/2026-08-23-freqtrade-research-mvp.md
+++ b/docs/superpowers/plans/2026-08-23-freqtrade-research-mvp.md
@@ -1,0 +1,1400 @@
+# Freqtrade Research-Gate MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Phase 1 MVP from `FREQTRADE_RESEARCH_ARCHITECTURE.md` §18 — a
+`research/` package that runs a walk-forward promotion gate (Deflated Sharpe + BH-FDR +
+PBO) over an existing freqtrade `IStrategy`, without modifying freqtrade core.
+
+**Architecture:** `research/` is a client of freqtrade, not a fork of it. It imports
+`freqtrade.optimize.backtesting.Backtesting` and `freqtrade.data.history` directly
+(in-process, same venv) to run per-window backtests, keeps its own SQLite ledger of every
+candidate tried (survivor and loser), and exposes one CLI command
+(`python -m research.cli gate ...`) that reports PASS/FAIL with the statistical evidence.
+
+**Tech Stack:** Python (repo floor: >=3.11, `pyproject.toml:16`), SQLAlchemy 2.0 (already a
+dependency, `pyproject.toml:34` — used directly, no SQLModel), NumPy/SciPy/pandas (already
+dependencies, `pyproject.toml:43-45`), pytest/pytest-mock (already dev dependencies).
+**No new dependencies are added.**
+
+**Spec:** `FREQTRADE_RESEARCH_ARCHITECTURE.md` (repo root), §§9-11, §15, §18.
+
+## Global Constraints
+
+- Python >=3.11 (`pyproject.toml:16`) — use modern type hints (`dict`, `list`, `X | None`).
+- No new third-party dependencies — SQLAlchemy, NumPy, SciPy, pandas already ship with
+  freqtrade (`pyproject.toml:34,43-45`); use them directly.
+- `freqtrade/` package is never modified. All new code lives under `research/`.
+- Research-layer tests live under `research/tests/`, run via `pytest research/tests -v`
+  from the repo root (not mixed into freqtrade's own `tests/` tree).
+- Every task follows TDD: write the failing test, watch it fail, write the minimal
+  implementation, watch it pass.
+- Every task gets a second opinion from an online LLM via the `lmchatbot` skill
+  (`C:\dev\lmchatbot`, HTTP API at `localhost:3000`) on its core design decision **before**
+  the final commit — per this project's standing `CLAUDE.md` rule to pair on non-trivial
+  code decisions. If `curl -s localhost:3000/` doesn't respond, start it first:
+  `node C:/dev/lmchatbot/server.js &` (background), then retry.
+- Lint before every commit: `ruff check research/ --fix && ruff format research/`
+  (repo-wide `[tool.ruff]` config in `pyproject.toml:237` covers `research/` by default —
+  only `.env`, `.venv`, `*.md` are excluded).
+- Every git commit message ends with the standard Freqtrade Co-Authored-By/session
+  trailer this environment's tooling appends automatically — don't add your own.
+
+---
+
+## File Structure
+
+```
+research/
+├── __init__.py
+├── db.py            Task 1 — SQLAlchemy engine/session factory
+├── models.py         Task 1 — CandidateResult ORM table
+├── ledger.py          Task 1 — family_of / log_candidate_result / family_trial_count
+├── statistics.py       Task 2 — deflated_sharpe_ratio, benjamini_hochberg, permutation_test
+├── pbo.py                Task 3 — probability_of_backtest_overfitting (CSCV), choose_n_splits
+├── walkforward.py          Task 4 — Window, WindowResult, WalkForwardRunner, generate_windows
+├── gate.py                   Task 5 — GateResult, run_promotion_gate
+├── cli.py                      Task 5 — `python -m research.cli gate ...`
+└── tests/
+    ├── __init__.py
+    ├── test_ledger.py           Task 1
+    ├── test_statistics.py         Task 2
+    ├── test_pbo.py                   Task 3
+    ├── test_walkforward.py             Task 4
+    ├── test_gate.py                      Task 5
+    └── test_cli.py                        Task 5
+```
+
+---
+
+### Task 1: Candidate ledger (db.py, models.py, ledger.py)
+
+**Files:**
+- Create: `research/__init__.py` (empty)
+- Create: `research/db.py`
+- Create: `research/models.py`
+- Create: `research/ledger.py`
+- Test: `research/tests/__init__.py` (empty)
+- Test: `research/tests/test_ledger.py`
+
+**Interfaces:**
+- Produces: `research.db.get_engine(db_path: str = "user_data/research.sqlite") -> Engine`
+- Produces: `research.db.get_session(engine: Engine) -> Session`
+- Produces: `research.models.Base` (DeclarativeBase), `research.models.CandidateResult` (ORM class, columns per architecture doc §10)
+- Produces: `research.ledger.family_of(strategy_id: str) -> str`
+- Produces: `research.ledger.log_candidate_result(session, *, strategy_id, params, universe, timeframe, discovery_start, discovery_end, n_trials_this_run, is_sharpe, oos_sharpe, deflated_sharpe, permutation_p, pbo, survived, validation_start=None, validation_end=None, oos_start=None, oos_end=None, evidence=None, run_stamp=None) -> CandidateResult`
+- Produces: `research.ledger.family_trial_count(session, family: str, declared: int = 0) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_ledger.py
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.models import Base, CandidateResult
+
+
+def _memory_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_log_candidate_result_round_trips():
+    session = _memory_session()
+    row = log_candidate_result(
+        session,
+        strategy_id="ema_cross_v3",
+        params={"buy_rsi": 30},
+        universe="BTC/USDT",
+        timeframe="1h",
+        discovery_start="2020-01-01",
+        discovery_end="2024-12-31",
+        n_trials_this_run=48,
+        is_sharpe=1.2,
+        oos_sharpe=0.8,
+        deflated_sharpe=0.6,
+        permutation_p=0.03,
+        pbo=0.2,
+        survived=True,
+    )
+    session.commit()
+
+    fetched = session.query(CandidateResult).filter_by(id=row.id).one()
+    assert fetched.strategy_id == "ema_cross_v3"
+    assert fetched.strategy_family == "trend_following"
+    assert fetched.params_json == '{"buy_rsi": 30}'
+    assert fetched.survived is True
+
+
+def test_family_of_maps_known_alias_and_falls_back_to_strategy_id():
+    assert family_of("ema_cross_v3") == "trend_following"
+    assert family_of("some_unmapped_strategy") == "some_unmapped_strategy"
+
+
+def test_family_trial_count_prefers_ledger_count_when_higher_than_declared():
+    session = _memory_session()
+    for i in range(5):
+        log_candidate_result(
+            session,
+            strategy_id="ema_cross_v3",
+            params={"buy_rsi": i},
+            universe="BTC/USDT",
+            timeframe="1h",
+            discovery_start="2020-01-01",
+            discovery_end="2024-12-31",
+            n_trials_this_run=1,
+            is_sharpe=0.1,
+            oos_sharpe=0.0,
+            deflated_sharpe=0.0,
+            permutation_p=1.0,
+            pbo=1.0,
+            survived=False,
+        )
+    session.commit()
+
+    assert family_trial_count(session, "trend_following") == 5
+    assert family_trial_count(session, "trend_following", declared=2) == 5
+    assert family_trial_count(session, "trend_following", declared=10) == 10
+
+
+def test_get_engine_creates_sqlite_file_and_tables(tmp_path):
+    from research.db import get_engine, get_session
+
+    db_path = tmp_path / "research.sqlite"
+    engine = get_engine(str(db_path))
+    session = get_session(engine)
+
+    assert db_path.exists()
+    assert session.query(CandidateResult).count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_ledger.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.ledger'` (or `research.models`/`research.db`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# research/models.py
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class CandidateResult(Base):
+    """One row per (research run, strategy, parameter-set) — survivors AND losers
+    both get logged, so `family_trial_count` reflects the real search history."""
+
+    __tablename__ = "candidate_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_stamp: Mapped[datetime] = mapped_column(DateTime)
+    strategy_id: Mapped[str] = mapped_column(String(120))
+    strategy_family: Mapped[str] = mapped_column(String(120), index=True)
+    params_json: Mapped[str] = mapped_column(String)
+    universe: Mapped[str] = mapped_column(String(200))
+    timeframe: Mapped[str] = mapped_column(String(10))
+    discovery_start: Mapped[str] = mapped_column(String(20))
+    discovery_end: Mapped[str] = mapped_column(String(20))
+    validation_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    validation_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    n_trials_this_run: Mapped[int] = mapped_column(Integer)
+    is_sharpe: Mapped[float] = mapped_column(Float)
+    oos_sharpe: Mapped[float] = mapped_column(Float)
+    deflated_sharpe: Mapped[float] = mapped_column(Float)
+    permutation_p: Mapped[float] = mapped_column(Float)
+    pbo: Mapped[float] = mapped_column(Float)
+    survived: Mapped[bool] = mapped_column(Boolean)
+    evidence_json: Mapped[str] = mapped_column(String, default="{}")
+```
+
+```python
+# research/db.py
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from research.models import Base
+
+DEFAULT_DB_PATH = "user_data/research.sqlite"
+
+
+def get_engine(db_path: str = DEFAULT_DB_PATH) -> Engine:
+    if db_path != ":memory:":
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def get_session(engine: Engine) -> Session:
+    return Session(engine)
+```
+
+```python
+# research/ledger.py
+import json
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from research.models import CandidateResult
+
+# Strategy-name -> family aliasing. Grow this table as strategy variants are added —
+# related parameter sweeps must share a family so trial counts compound correctly.
+_FAMILY_ALIASES: dict[str, str] = {
+    "ema_cross_v3": "trend_following",
+}
+
+
+def family_of(strategy_id: str) -> str:
+    return _FAMILY_ALIASES.get(strategy_id, strategy_id)
+
+
+def log_candidate_result(
+    session: Session,
+    *,
+    strategy_id: str,
+    params: dict,
+    universe: str,
+    timeframe: str,
+    discovery_start: str,
+    discovery_end: str,
+    n_trials_this_run: int,
+    is_sharpe: float,
+    oos_sharpe: float,
+    deflated_sharpe: float,
+    permutation_p: float,
+    pbo: float,
+    survived: bool,
+    validation_start: str | None = None,
+    validation_end: str | None = None,
+    oos_start: str | None = None,
+    oos_end: str | None = None,
+    evidence: dict | None = None,
+    run_stamp: datetime | None = None,
+) -> CandidateResult:
+    row = CandidateResult(
+        run_stamp=run_stamp or datetime.now(UTC),
+        strategy_id=strategy_id,
+        strategy_family=family_of(strategy_id),
+        params_json=json.dumps(params, sort_keys=True),
+        universe=universe,
+        timeframe=timeframe,
+        discovery_start=discovery_start,
+        discovery_end=discovery_end,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        oos_start=oos_start,
+        oos_end=oos_end,
+        n_trials_this_run=n_trials_this_run,
+        is_sharpe=is_sharpe,
+        oos_sharpe=oos_sharpe,
+        deflated_sharpe=deflated_sharpe,
+        permutation_p=permutation_p,
+        pbo=pbo,
+        survived=survived,
+        evidence_json=json.dumps(evidence or {}),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def family_trial_count(session: Session, family: str, declared: int = 0) -> int:
+    """The number of trials to deflate against: whichever is larger between the
+    ledger's accumulated row count for this family and a caller-declared count.
+    Call this BEFORE writing the current run's own row (count-then-write) so a run
+    never deflates against trials it hasn't finished yet."""
+    ledger_count = (
+        session.query(CandidateResult)
+        .filter(CandidateResult.strategy_family == family)
+        .count()
+    )
+    return max(ledger_count, declared)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_ledger.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task1.json <<'EOF'
+{"provider":"gemini","prompt":"Reviewing a SQLAlchemy 2.0 declarative schema for a research trial ledger meant to prevent a multiple-testing/selection-bias problem when repeatedly backtesting trading strategies. Table CandidateResult logs one row per (run, strategy, param-set), survivors AND losers. family_trial_count(session, family, declared=0) returns max(ledger row count for that family, declared) and MUST be called before the current run writes its own row, so a run never deflates its own significance test against trials it hasn't finished yet (count-then-write). Does this design have an obvious flaw for its stated purpose? Schema:\n\nclass CandidateResult(Base):\n    __tablename__ = \"candidate_results\"\n    id, run_stamp, strategy_id, strategy_family, params_json, universe, timeframe,\n    discovery_start, discovery_end, validation_start, validation_end, oos_start, oos_end,\n    n_trials_this_run, is_sharpe, oos_sharpe, deflated_sharpe, permutation_p, pbo, survived, evidence_json\n\ndef family_trial_count(session, family, declared=0):\n    ledger_count = session.query(CandidateResult).filter(CandidateResult.strategy_family == family).count()\n    return max(ledger_count, declared)"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task1.json
+rm /tmp/lmchatbot_task1.json
+```
+
+Read the reply. If it surfaces a real gap (e.g. a refused/degenerate run still silently
+inflating trial count, or a race between two concurrent processes reading-then-writing),
+fix it in `ledger.py` before continuing; otherwise proceed.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/__init__.py research/db.py research/models.py research/ledger.py \
+        research/tests/__init__.py research/tests/test_ledger.py
+git commit -m "feat(research): add candidate ledger with family trial counting"
+```
+
+---
+
+### Task 2: Statistics core (DSR, BH-FDR, permutation test)
+
+**Files:**
+- Create: `research/statistics.py`
+- Test: `research/tests/test_statistics.py`
+
+**Interfaces:**
+- Produces: `research.statistics.deflated_sharpe_ratio(sharpe_ratio: float, n_obs: int, n_trials: int = 1, skewness: float = 0.0, kurtosis: float = 3.0, periods_per_year: int = 365) -> float`
+- Produces: `research.statistics.benjamini_hochberg(p_values: list[float], q: float = 0.05) -> list[bool]`
+- Produces: `research.statistics.permutation_test(observed_stat: float, returns: np.ndarray, n_permutations: int = 1000, seed: int | None = None) -> float`
+
+**Reference implementation to port from** (per `FREQTRADE_RESEARCH_ARCHITECTURE.md` §15 —
+these are near-verbatim-portable, asset-class-agnostic pure functions):
+`C:\dev\MarketMind\backend\backtest\enhanced\statistics.py`:
+- `deflated_sharpe_ratio` — lines 168-228 (Bailey & López de Prado 2014)
+- `benjamini_hochberg` — lines 14-38 (standard BH step-up procedure)
+- `permutation_test` (sign-flip variant) — lines 41-104
+
+Adapt, don't copy verbatim:
+- Replace the source file's hand-rolled `_norm_cdf`/`_norm_ppf` (its lines ~110-140) with
+  `scipy.stats.norm.cdf` / `scipy.stats.norm.ppf` — SciPy is already a freqtrade dependency
+  (`pyproject.toml:43`), so there's no reason to hand-roll a normal-distribution
+  approximation the way MarketMind did to avoid a new dependency it didn't have.
+- Change the default `periods_per_year` from the source's 252 (equities trading days) to
+  **365** (crypto trades every calendar day).
+- This project's own hard-won lesson (architecture doc §16, lesson 1): a Deflated Sharpe
+  with no real sample-size discrimination is just a sign test wearing a rigor costume — the
+  tests below are written to catch exactly that regression, independent of the exact
+  formula ported.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_statistics.py
+import numpy as np
+import pytest
+
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+
+
+class TestDeflatedSharpeRatio:
+    def test_returns_zero_on_degenerate_n_obs(self):
+        assert deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=1, n_trials=10) == 0.0
+
+    def test_bounded_in_unit_interval(self):
+        for sharpe in (-3.0, -0.5, 0.0, 0.5, 1.5, 3.0):
+            for n_obs in (10, 100, 1000):
+                for n_trials in (1, 10, 1000):
+                    result = deflated_sharpe_ratio(sharpe, n_obs, n_trials)
+                    assert 0.0 <= result <= 1.0, (sharpe, n_obs, n_trials, result)
+
+    def test_more_trials_never_increases_the_score(self):
+        """Regression test for the exact bug this project's spec (§16, lesson 1) flags:
+        a DSR with no real trial-count term would score n_trials=1 and n_trials=1000
+        identically. Holding sharpe and n_obs fixed, searching harder must not look
+        MORE convincing."""
+        few_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1)
+        many_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1000)
+        assert many_trials <= few_trials
+
+    def test_more_observations_never_decreases_the_score(self):
+        """Regression test for the same lesson from the other axis: a 6-trade and a
+        10,000-trade backtest must not deflate identically."""
+        few_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=20, n_trials=50)
+        many_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=5000, n_trials=50)
+        assert many_obs >= few_obs
+
+
+class TestBenjaminiHochberg:
+    def test_matches_hand_worked_example(self):
+        # sorted ascending already; thresholds are (rank/m)*q = 0.01,0.02,0.03,0.04,0.05
+        p_values = [0.01, 0.02, 0.03, 0.04, 0.5]
+        result = benjamini_hochberg(p_values, q=0.05)
+        assert result == [True, True, True, True, False]
+
+    def test_empty_input_returns_empty_output(self):
+        assert benjamini_hochberg([], q=0.05) == []
+
+    def test_all_p_values_above_q_rejects_nothing(self):
+        assert benjamini_hochberg([0.9, 0.8, 0.99], q=0.05) == [False, False, False]
+
+
+class TestPermutationTest:
+    def test_p_value_in_unit_interval(self):
+        rng = np.random.default_rng(1)
+        returns = rng.normal(0, 0.01, 40)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=200, seed=1)
+        assert 0.0 <= p <= 1.0
+
+    def test_low_p_value_for_a_strong_consistent_positive_edge(self):
+        """All-positive, low-noise returns: virtually every sign-flip permutation
+        produces a worse Sharpe than the unflipped (real) series, since flipping any
+        positive return can only hurt the mean. p must be small."""
+        rng = np.random.default_rng(42)
+        returns = 0.02 + rng.normal(0, 0.001, 30)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=2000, seed=42)
+        assert p < 0.05
+
+    def test_seeded_calls_are_reproducible(self):
+        rng = np.random.default_rng(7)
+        returns = rng.normal(0.001, 0.02, 50)
+        observed = float(returns.mean() / returns.std())
+        p1 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        p2 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        assert p1 == p2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_statistics.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.statistics'`
+
+- [ ] **Step 3: Port the implementation**
+
+Open `C:\dev\MarketMind\backend\backtest\enhanced\statistics.py` and port
+`deflated_sharpe_ratio` (lines 168-228), `benjamini_hochberg` (lines 14-38), and the
+sign-flip `permutation_test` (lines 41-104) into `research/statistics.py`, applying the two
+adaptations called out above (scipy for the normal CDF/PPF, `periods_per_year=365`). Keep
+the function names and parameter names exactly as declared in the Interfaces block so
+`research/gate.py` (Task 5) can call them unchanged.
+
+```python
+# research/statistics.py
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+# --- ported and adapted from C:\dev\MarketMind\backend\backtest\enhanced\statistics.py ---
+# (paste + adapt deflated_sharpe_ratio, benjamini_hochberg, permutation_test here)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_statistics.py -v`
+Expected: PASS (9 tests). If `test_more_trials_never_increases_the_score` or
+`test_more_observations_never_decreases_the_score` fails, the port has the same historical
+bug MarketMind shipped for months (architecture doc §16, lesson 1) — fix the formula, don't
+loosen the test.
+
+- [ ] **Step 5: Get a second opinion via lmchatbot (cross-provider verify)**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task2.json <<'EOF'
+{"provider":"chatgpt","verify":"gemini","prompt":"I ported a Deflated Sharpe Ratio implementation (Bailey & Lopez de Prado 2014) from an internal reference into a fresh module, replacing its hand-rolled normal CDF/PPF with scipy.stats.norm, and changing periods_per_year from 252 to 365 for a 24/7 crypto market. Paste of research/statistics.py below. Two known historical bugs to check for specifically: (1) does it correctly discriminate a strategy tried across 1 trial vs 1000 trials at equal Sharpe/n_obs (the deflated score must NOT increase with more trials searched)? (2) does it correctly discriminate n_obs=20 vs n_obs=5000 at equal Sharpe (the deflated score must NOT decrease with more observations)? Also sanity check the Benjamini-Hochberg step-up implementation is the standard procedure. PASTE research/statistics.py CONTENTS HERE"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task2.json
+rm /tmp/lmchatbot_task2.json
+```
+
+Replace `PASTE research/statistics.py CONTENTS HERE` with the actual file contents before
+sending. Read `draft`, `verifier`, and the `FINAL:`-prefixed corrected answer in the reply.
+If either provider flags a real formula error, fix `statistics.py` and rerun Step 4 before
+continuing.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/statistics.py research/tests/test_statistics.py
+git commit -m "feat(research): port deflated Sharpe, BH-FDR, and permutation test from MarketMind"
+```
+
+---
+
+### Task 3: Probability of Backtest Overfitting (CSCV)
+
+**Files:**
+- Create: `research/pbo.py`
+- Test: `research/tests/test_pbo.py`
+
+**Interfaces:**
+- Consumes: none (pure numeric function, no dependency on Task 1/2 modules)
+- Produces: `research.pbo.choose_n_splits(n_periods: int, max_splits: int = 16) -> int`
+- Produces: `research.pbo.probability_of_backtest_overfitting(returns_matrix: np.ndarray, n_splits: int | None = None) -> dict` — returns `{"pbo": float, "n_splits": int, "n_combinations": int, "logits": list[float]}`. `returns_matrix` shape is `(n_variants, n_periods)`: one row per candidate parameter set, one column per time block (a walk-forward window, in Task 4's usage). Cell = that variant's return/Sharpe proxy in that block.
+
+**Reference implementation to port from** (per `FREQTRADE_RESEARCH_ARCHITECTURE.md` §15):
+`C:\dev\MarketMind\backend\backtest\enhanced\reality_check.py:271-345` —
+`probability_of_backtest_overfitting` (line 271) and `choose_n_splits` (line 345). This is
+the single highest-value MarketMind file to port per the architecture doc — it operates
+purely on a returns matrix, no asset-class assumptions. **MVP scope note (YAGNI):** port
+only these two functions. `reality_check.py` also contains White's Reality Check, Hansen's
+SPA test, and a stationary block bootstrap (architecture doc §15 item 4) — those are real
+and valuable but explicitly out of scope for this MVP; add them in a later phase if PBO
+alone proves insufficient.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_pbo.py
+import numpy as np
+
+from research.pbo import choose_n_splits, probability_of_backtest_overfitting
+
+
+class TestChooseNSplits:
+    def test_returns_an_even_divisor_of_n_periods(self):
+        n_periods = 16
+        s = choose_n_splits(n_periods)
+        assert s % 2 == 0
+        assert n_periods % s == 0
+
+    def test_never_exceeds_max_splits(self):
+        assert choose_n_splits(100, max_splits=8) <= 8
+
+
+class TestProbabilityOfBacktestOverfitting:
+    def test_bounded_in_unit_interval(self):
+        rng = np.random.default_rng(3)
+        matrix = rng.normal(0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert 0.0 <= result["pbo"] <= 1.0
+
+    def test_low_when_one_variant_dominates_every_period(self):
+        """Variant 0 has a real, consistent edge (positive mean, low noise) in every
+        period; the others are pure noise. Picking the best-in-sample variant should
+        reliably also do well out-of-sample -> low overfitting probability."""
+        rng = np.random.default_rng(11)
+        n_variants, n_periods = 5, 16
+        matrix = rng.normal(0.0, 0.01, size=(n_variants, n_periods))
+        matrix[0] = rng.normal(0.05, 0.005, size=n_periods)
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] < 0.3
+
+    def test_near_coin_flip_when_all_variants_are_pure_noise(self):
+        """No variant has a real edge -> which one looks best in-sample is arbitrary
+        and should NOT reliably predict out-of-sample rank. PBO should be high."""
+        rng = np.random.default_rng(5)
+        matrix = rng.normal(0.0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] > 0.35
+
+    def test_degenerate_input_fails_closed(self):
+        result = probability_of_backtest_overfitting(np.zeros((1, 2)))
+        assert result["pbo"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_pbo.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.pbo'`
+
+- [ ] **Step 3: Write the implementation**
+
+Port from `C:\dev\MarketMind\backend\backtest\enhanced\reality_check.py:271-345` (see Task
+header), adapted to operate directly on a `(n_variants, n_periods)` NumPy array rather than
+MarketMind's DB-backed candidate objects:
+
+```python
+# research/pbo.py
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+
+
+def choose_n_splits(n_periods: int, max_splits: int = 16) -> int:
+    """Largest even number <= max_splits that evenly divides n_periods, so CSCV's
+    IS/OOS blocks are equal-sized. Falls back to 2 if nothing else divides evenly."""
+    for s in range(min(max_splits, n_periods), 1, -1):
+        if s % 2 == 0 and n_periods % s == 0:
+            return s
+    return 2
+
+
+def probability_of_backtest_overfitting(
+    returns_matrix: np.ndarray, n_splits: int | None = None
+) -> dict:
+    """Combinatorially Symmetric Cross-Validation (Bailey, Borwein, Lopez de Prado,
+    Zhu 2014). Splits the n_periods columns into n_splits contiguous blocks, and for
+    every way of picking half the blocks as in-sample: finds the variant with the best
+    in-sample Sharpe, then checks how that same variant ranks out-of-sample. PBO is the
+    fraction of splits where the in-sample winner ranked in the OOS-worse half — logit
+    of the OOS relative rank <= 0.
+    """
+    returns_matrix = np.asarray(returns_matrix, dtype=float)
+    if returns_matrix.ndim != 2:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    n_variants, n_periods = returns_matrix.shape
+    if n_variants < 2 or n_periods < 4:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    s = n_splits or choose_n_splits(n_periods)
+    if s < 2 or n_periods % s != 0:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    blocks = np.array_split(returns_matrix, s, axis=1)
+    logits: list[float] = []
+
+    for is_block_idx in itertools.combinations(range(s), s // 2):
+        oos_block_idx = [i for i in range(s) if i not in is_block_idx]
+        is_returns = np.concatenate([blocks[i] for i in is_block_idx], axis=1)
+        oos_returns = np.concatenate([blocks[i] for i in oos_block_idx], axis=1)
+
+        is_sharpe = is_returns.mean(axis=1) / (is_returns.std(axis=1) + 1e-12)
+        oos_sharpe = oos_returns.mean(axis=1) / (oos_returns.std(axis=1) + 1e-12)
+
+        best_variant = int(np.argmax(is_sharpe))
+        # relative rank of the IS-best variant's OOS performance, in (0, 1)
+        rank = int((oos_sharpe < oos_sharpe[best_variant]).sum()) + 1
+        omega = rank / (n_variants + 1)
+        omega = min(max(omega, 1e-6), 1 - 1e-6)
+        logits.append(float(np.log(omega / (1 - omega))))
+
+    pbo = float(np.mean([1.0 if lg <= 0 else 0.0 for lg in logits]))
+    return {"pbo": pbo, "n_splits": s, "n_combinations": len(logits), "logits": logits}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_pbo.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot (cross-provider verify)**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task3.json <<'EOF'
+{"provider":"gemini","verify":"chatgpt","prompt":"I implemented Probability of Backtest Overfitting via Combinatorially Symmetric Cross-Validation (Bailey/Borwein/Lopez de Prado/Zhu 2014) from scratch based on the paper's description, operating on a (n_variants, n_periods) returns matrix. For every way of splitting n_periods contiguous blocks into an in-sample half and out-of-sample half, I pick the variant with best in-sample Sharpe, compute its relative rank among all variants' out-of-sample Sharpes as omega=rank/(n_variants+1), take logit(omega), and count PBO as the fraction of splits where that logit <= 0. Does this match the paper's actual CSCV procedure, and is there a subtle bug in the rank/logit computation? PASTE research/pbo.py CONTENTS HERE"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task3.json
+rm /tmp/lmchatbot_task3.json
+```
+
+Replace the placeholder with the real file contents before sending. Fix and rerun Step 4 if
+either provider identifies a real deviation from the CSCV procedure.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/pbo.py research/tests/test_pbo.py
+git commit -m "feat(research): add PBO via CSCV"
+```
+
+---
+
+### Task 4: Walk-forward runner wrapping freqtrade's Backtesting
+
+**Files:**
+- Create: `research/walkforward.py`
+- Test: `research/tests/test_walkforward.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-3 (pure freqtrade integration)
+- Produces: `research.walkforward.Window` (dataclass: `train_start, train_end, test_start, test_end: datetime`)
+- Produces: `research.walkforward.WindowResult` (dataclass: `window: Window, variant_returns: dict[str, float], best_params: dict, train_sharpe: float, test_sharpe: float, test_n_trades: int, test_returns: list[float]`)
+- Produces: `research.walkforward.variant_key(params: dict) -> str`
+- Produces: `research.walkforward.generate_windows(start: datetime, end: datetime, train_days: int, test_days: int) -> list[Window]`
+- Produces: `research.walkforward.WalkForwardRunner(config: dict, pairs: list[str], timeframe: str, datadir: Path)` with methods `.run_window(window: Window, param_grid: list[dict]) -> WindowResult` and `.run(windows: list[Window], param_grid: list[dict]) -> list[WindowResult]`
+
+**Real freqtrade APIs this task calls** (verified against `develop` @ `10db8654c`):
+- `freqtrade.optimize.backtesting.Backtesting(config)` then `.strategylist[0]` +
+  `._set_strategy(strategy)` — instantiation pattern used throughout
+  `tests/optimize/test_backtesting.py` (e.g. line 827).
+- `freqtrade.data.history.load_data(datadir, timeframe, pairs, timerange=..., startup_candles=...)` — `freqtrade/data/history/history_utils.py:87`.
+- `freqtrade.data.converter.trim_dataframes(preprocessed, timerange, startup_candles)` — `freqtrade/data/converter/converter.py:199`, used the same way internally at `freqtrade/optimize/backtesting.py:1840`.
+- `freqtrade.data.metrics.calculate_sharpe(trades, min_date, max_date, starting_balance)` — `freqtrade/data/metrics.py:455`.
+- `freqtrade.configuration.TimeRange("date", "date", start_epoch, end_epoch)` — `freqtrade/configuration/timerange.py:36`.
+- `backtesting.backtest(processed=..., start_date=..., end_date=...) -> {"results": DataFrame, ...}` — restricts *simulation* to `[start_date, end_date]`; `processed` may (and here does) span further, matching freqtrade's own convention (§3 of the architecture doc). Indicators in the test strategy used here (`ta.RSI`) are backward-looking, so this is safe; a `ponytail:` comment documents the caveat for non-causal indicators.
+- Strategy parameters are set via `getattr(strategy, name).value = value` (the `IntParameter`/`DecimalParameter` descriptor pattern every freqtrade strategy uses, e.g. `tests/strategy/strats/strategy_test_v3.py:77` — `buy_rsi = IntParameter([0, 50], default=30, space="buy")`, read as `self.buy_rsi.value`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# research/tests/test_walkforward.py
+from datetime import timedelta
+from pathlib import Path
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+
+from research.walkforward import Window, WalkForwardRunner, variant_key
+from tests.conftest import get_default_conf, patch_exchange
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def test_run_window_selects_best_train_params_and_reports_oos_result(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    param_grid = [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    result = runner.run_window(window, param_grid)
+
+    assert result.best_params in param_grid
+    assert set(result.variant_returns) == {variant_key(p) for p in param_grid}
+    assert isinstance(result.train_sharpe, float)
+    assert isinstance(result.test_sharpe, float)
+    assert isinstance(result.test_returns, list)
+    assert result.test_n_trades == len(result.test_returns)
+
+
+def test_generate_windows_are_contiguous_and_non_overlapping():
+    from datetime import UTC, datetime
+
+    from research.walkforward import generate_windows
+
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    end = datetime(2020, 3, 1, tzinfo=UTC)
+    windows = generate_windows(start, end, train_days=20, test_days=10)
+
+    assert len(windows) > 0
+    for w in windows:
+        assert w.train_end == w.test_start
+        assert w.test_end <= end
+    for a, b in zip(windows, windows[1:]):
+        assert b.train_start == a.test_start
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest research/tests/test_walkforward.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.walkforward'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# research/walkforward.py
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.converter import trim_dataframes
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.optimize.backtesting import Backtesting
+
+
+@dataclass
+class Window:
+    train_start: datetime
+    train_end: datetime
+    test_start: datetime
+    test_end: datetime
+
+
+@dataclass
+class WindowResult:
+    window: Window
+    variant_returns: dict[str, float]
+    best_params: dict
+    train_sharpe: float
+    test_sharpe: float
+    test_n_trades: int
+    test_returns: list[float]
+
+
+def variant_key(params: dict) -> str:
+    return json.dumps(params, sort_keys=True)
+
+
+def generate_windows(
+    start: datetime, end: datetime, train_days: int, test_days: int
+) -> list[Window]:
+    """Rolling, non-overlapping windows: each window's test period starts exactly
+    where its train period ends; the next window starts test_days later."""
+    windows: list[Window] = []
+    cursor = start
+    while True:
+        train_end = cursor + timedelta(days=train_days)
+        test_end = train_end + timedelta(days=test_days)
+        if test_end > end:
+            break
+        windows.append(Window(cursor, train_end, train_end, test_end))
+        cursor = cursor + timedelta(days=test_days)
+    return windows
+
+
+class WalkForwardRunner:
+    def __init__(self, config: dict, pairs: list[str], timeframe: str, datadir: Path):
+        self.config = config
+        self.pairs = pairs
+        self.timeframe = timeframe
+        self.datadir = datadir
+
+    def run_window(self, window: Window, param_grid: list[dict]) -> WindowResult:
+        backtesting = Backtesting(self.config)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        variant_returns: dict[str, float] = {}
+        best_key, best_sharpe, best_params, best_processed = None, -np.inf, None, None
+
+        for params in param_grid:
+            for name, value in params.items():
+                getattr(backtesting.strategy, name).value = value
+
+            # ponytail: indicators are computed once over [train_start, test_end],
+            # per freqtrade's own convention (§3 of the architecture doc). Safe for
+            # backward-looking indicators (this strategy's RSI); a strategy with a
+            # non-causal indicator (centered rolling, .shift(-n)) would leak across
+            # the train/test boundary here — run freqtrade's lookahead-analysis on
+            # any strategy before trusting this runner's results for it.
+            processed = backtesting.strategy.advise_all_indicators(data)
+            processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+            train_result = backtesting.backtest(
+                processed=deepcopy(processed),
+                start_date=window.train_start,
+                end_date=window.train_end,
+            )
+            train_trades = train_result["results"]
+            sharpe = calculate_sharpe(
+                train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+            )
+            key = variant_key(params)
+            variant_returns[key] = (
+                float((train_trades["profit_abs"] / self.config["dry_run_wallet"]).mean())
+                if len(train_trades)
+                else 0.0
+            )
+
+            if sharpe > best_sharpe:
+                best_sharpe, best_key, best_params, best_processed = sharpe, key, params, processed
+
+        for name, value in best_params.items():
+            getattr(backtesting.strategy, name).value = value
+        test_result = backtesting.backtest(
+            processed=deepcopy(best_processed),
+            start_date=window.test_start,
+            end_date=window.test_end,
+        )
+        test_trades = test_result["results"]
+        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
+        test_sharpe = calculate_sharpe(
+            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
+        )
+
+        return WindowResult(
+            window=window,
+            variant_returns=variant_returns,
+            best_params=best_params,
+            train_sharpe=best_sharpe,
+            test_sharpe=test_sharpe,
+            test_n_trades=len(test_trades),
+            test_returns=test_returns,
+        )
+
+    def run(self, windows: list[Window], param_grid: list[dict]) -> list[WindowResult]:
+        return [self.run_window(w, param_grid) for w in windows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest research/tests/test_walkforward.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task4.json <<'EOF'
+{"provider":"gemini","prompt":"I built a walk-forward runner on top of freqtrade's Backtesting class. Per window: I load OHLCV data spanning [train_start, test_end] in one call (with startup_candles for indicator warmup), compute indicators ONCE via strategy.advise_all_indicators() over that whole span, then call backtesting.backtest(processed=..., start_date=X, end_date=Y) twice against the SAME processed dataframe -- once restricted to [train_start, train_end] to pick the best parameter set by train Sharpe, then again restricted to [test_start, test_end] using the winning params, for the out-of-sample result. My reasoning that this doesn't leak test-period data into the train-period parameter selection: freqtrade always computes indicators over the full loaded range and only the start_date/end_date args restrict which candles get SIMULATED (trades placed), and for backward-looking indicators (e.g. TA-Lib RSI) more trailing rows after a given row don't change that row's own indicator value. Is this reasoning actually sound, and is there a walk-forward-integrity gap I'm missing even for backward-looking-only indicators?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task4.json
+rm /tmp/lmchatbot_task4.json
+```
+
+If the reply surfaces a real gap (e.g., an interaction with `startup_candle_count` sizing,
+or stoploss/ROI evaluation using look-back state that spans the train/test boundary), note
+it as a `ponytail:` comment in `walkforward.py` at minimum, and fix it if it's cheap.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+git add research/walkforward.py research/tests/test_walkforward.py
+git commit -m "feat(research): add walk-forward runner wrapping freqtrade Backtesting"
+```
+
+---
+
+### Task 5: Promotion gate + CLI
+
+**Files:**
+- Create: `research/gate.py`
+- Create: `research/cli.py`
+- Test: `research/tests/test_gate.py`
+- Test: `research/tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `research.ledger.family_of`, `.family_trial_count`, `.log_candidate_result` (Task 1); `research.statistics.deflated_sharpe_ratio`, `.benjamini_hochberg`, `.permutation_test` (Task 2); `research.pbo.probability_of_backtest_overfitting` (Task 3); `research.walkforward.WalkForwardRunner`, `.generate_windows`, `.Window`, `.WindowResult` (Task 4)
+- Produces: `research.gate.GateResult` (dataclass: `strategy_id: str, passed: bool, deflated_sharpe: float, permutation_p: float, pbo: float, mean_test_sharpe: float, n_trials: int, reasons: list[str]`)
+- Produces: `research.gate.run_promotion_gate(config, strategy_id, pairs, timeframe, datadir, start, end, train_days, test_days, param_grid, db_path="user_data/research.sqlite", dsr_threshold=0.95, fdr_q=0.05, pbo_threshold=0.5, periods_per_year=365) -> GateResult`
+- Produces: `research.cli.main(argv: list[str] | None = None) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# research/tests/test_gate.py
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+
+from research.db import get_session, get_engine
+from research.gate import run_promotion_gate
+from research.models import CandidateResult
+from tests.conftest import get_default_conf, patch_exchange
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def _patch(mocker):
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+
+def test_run_promotion_gate_raises_with_too_few_windows(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+
+    with pytest.raises(ValueError, match="walk-forward windows"):
+        run_promotion_gate(
+            config=conf,
+            strategy_id="StrategyTestV3",
+            pairs=["UNITTEST/BTC"],
+            timeframe="5m",
+            datadir=TESTDATADIR,
+            start=min_date,
+            end=max_date,
+            train_days=3650,  # deliberately far larger than the available data span
+            test_days=3650,
+            param_grid=[{"buy_rsi": 30}],
+            db_path=str(tmp_path / "research.sqlite"),
+        )
+
+
+def test_run_promotion_gate_returns_result_and_writes_ledger_row(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+    db_path = str(tmp_path / "research.sqlite")
+
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=db_path,
+    )
+
+    assert result.strategy_id == "StrategyTestV3"
+    assert isinstance(result.passed, bool)
+    assert 0.0 <= result.deflated_sharpe <= 1.0
+    assert 0.0 <= result.permutation_p <= 1.0
+    assert 0.0 <= result.pbo <= 1.0
+    assert result.n_trials >= 1
+
+    session = get_session(get_engine(db_path))
+    assert session.query(CandidateResult).filter_by(strategy_id="StrategyTestV3").count() == 1
+```
+
+```python
+# research/tests/test_cli.py
+from research.cli import main
+from research.gate import GateResult
+
+
+def test_gate_command_prints_verdict_and_returns_pass_exit_code(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch("research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"})
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy", "StrategyTestV3",
+            "--config", "config.json",
+            "--pairs", "BTC/USDT,ETH/USDT",
+            "--timeframe", "1h",
+            "--start", "2024-01-01",
+            "--end", "2024-06-01",
+            "--train-days", "60",
+            "--test-days", "20",
+            "--param-grid", "[{\"buy_rsi\": 30}]",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS" in captured.out
+
+
+def test_gate_command_returns_nonzero_exit_code_on_fail(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch("research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"})
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy", "StrategyTestV3",
+            "--config", "config.json",
+            "--pairs", "BTC/USDT",
+            "--timeframe", "1h",
+            "--start", "2024-01-01",
+            "--end", "2024-06-01",
+            "--train-days", "60",
+            "--test-days", "20",
+            "--param-grid", "[{\"buy_rsi\": 30}]",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "FAIL" in captured.out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest research/tests/test_gate.py research/tests/test_cli.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'research.gate'` (and `research.cli`)
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# research/gate.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from research.db import get_engine, get_session
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.pbo import probability_of_backtest_overfitting
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+from research.walkforward import WalkForwardRunner, generate_windows
+
+
+@dataclass
+class GateResult:
+    strategy_id: str
+    passed: bool
+    deflated_sharpe: float
+    permutation_p: float
+    pbo: float
+    mean_test_sharpe: float
+    n_trials: int
+    reasons: list[str]
+
+
+def run_promotion_gate(
+    config: dict,
+    strategy_id: str,
+    pairs: list[str],
+    timeframe: str,
+    datadir: Path,
+    start: datetime,
+    end: datetime,
+    train_days: int,
+    test_days: int,
+    param_grid: list[dict],
+    db_path: str = "user_data/research.sqlite",
+    dsr_threshold: float = 0.95,
+    fdr_q: float = 0.05,
+    pbo_threshold: float = 0.5,
+    periods_per_year: int = 365,
+) -> GateResult:
+    windows = generate_windows(start, end, train_days, test_days)
+    if len(windows) < 4:
+        raise ValueError(
+            f"Need at least 4 walk-forward windows for a meaningful gate, got "
+            f"{len(windows)}. Widen start/end or shrink train_days/test_days."
+        )
+
+    runner = WalkForwardRunner(config, pairs, timeframe, datadir)
+    results = runner.run(windows, param_grid)
+
+    all_test_returns = [r for wr in results for r in wr.test_returns]
+    n_obs = len(all_test_returns)
+    mean_test_sharpe = float(np.mean([wr.test_sharpe for wr in results]))
+
+    variant_keys = sorted({k for wr in results for k in wr.variant_returns})
+    variant_matrix = np.array(
+        [[wr.variant_returns[key] for wr in results] for key in variant_keys]
+    )
+    pbo_result = probability_of_backtest_overfitting(variant_matrix)
+
+    engine = get_engine(db_path)
+    session = get_session(engine)
+    family = family_of(strategy_id)
+    this_run_trials = len(param_grid) * len(windows)
+    # count-then-write: read ledger history BEFORE writing this run's own row, so a
+    # run never deflates its own significance test against trials it hasn't finished.
+    n_trials = family_trial_count(session, family, declared=this_run_trials)
+
+    deflated = deflated_sharpe_ratio(
+        mean_test_sharpe, n_obs=n_obs, n_trials=n_trials, periods_per_year=periods_per_year
+    )
+    perm_p = permutation_test(mean_test_sharpe, np.array(all_test_returns))
+    survived_bh = benjamini_hochberg([perm_p], q=fdr_q)[0]
+
+    reasons: list[str] = []
+    if deflated < dsr_threshold:
+        reasons.append(f"deflated_sharpe {deflated:.3f} below threshold {dsr_threshold}")
+    if not survived_bh:
+        reasons.append(f"permutation p-value {perm_p:.3f} fails BH-FDR at q={fdr_q}")
+    if pbo_result["pbo"] > pbo_threshold:
+        reasons.append(f"PBO {pbo_result['pbo']:.3f} above threshold {pbo_threshold}")
+    passed = not reasons
+
+    log_candidate_result(
+        session,
+        strategy_id=strategy_id,
+        params={"grid": param_grid},
+        universe=",".join(pairs),
+        timeframe=timeframe,
+        discovery_start=start.isoformat(),
+        discovery_end=end.isoformat(),
+        n_trials_this_run=this_run_trials,
+        is_sharpe=float(np.mean([wr.train_sharpe for wr in results])),
+        oos_sharpe=mean_test_sharpe,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        survived=passed,
+    )
+    session.commit()
+
+    return GateResult(
+        strategy_id=strategy_id,
+        passed=passed,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        mean_test_sharpe=mean_test_sharpe,
+        n_trials=n_trials,
+        reasons=reasons,
+    )
+```
+
+```python
+# research/cli.py
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from freqtrade.configuration import Configuration
+
+from research.gate import run_promotion_gate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="research", description="Freqtrade research gate")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gate = sub.add_parser("gate", help="Run the promotion gate for a strategy")
+    gate.add_argument("--strategy", required=True)
+    gate.add_argument("--config", required=True, help="Path to a freqtrade config.json")
+    gate.add_argument("--pairs", required=True, help="Comma-separated pairs, e.g. BTC/USDT,ETH/USDT")
+    gate.add_argument("--timeframe", required=True)
+    gate.add_argument("--start", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--end", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--train-days", type=int, required=True)
+    gate.add_argument("--test-days", type=int, required=True)
+    gate.add_argument("--param-grid", required=True, help="JSON list of param dicts")
+    gate.add_argument("--db-path", default="user_data/research.sqlite")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "gate":
+        ft_config = Configuration.from_files([args.config])
+        ft_config["strategy"] = args.strategy
+        result = run_promotion_gate(
+            config=ft_config,
+            strategy_id=args.strategy,
+            pairs=args.pairs.split(","),
+            timeframe=args.timeframe,
+            datadir=Path(ft_config["datadir"]),
+            start=datetime.fromisoformat(args.start),
+            end=datetime.fromisoformat(args.end),
+            train_days=args.train_days,
+            test_days=args.test_days,
+            param_grid=json.loads(args.param_grid),
+            db_path=args.db_path,
+        )
+        verdict = "PASS" if result.passed else "FAIL"
+        print(f"{result.strategy_id}: {verdict}")
+        print(f"  deflated_sharpe   {result.deflated_sharpe:.3f}")
+        print(f"  permutation p     {result.permutation_p:.3f}")
+        print(f"  PBO               {result.pbo:.3f}")
+        print(f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}")
+        print(f"  trials (ledger)   {result.n_trials}")
+        for reason in result.reasons:
+            print(f"  - {reason}")
+        return 0 if result.passed else 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest research/tests/test_gate.py research/tests/test_cli.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_task5.json <<'EOF'
+{"provider":"gemini","prompt":"Reviewing the orchestration of a crypto trading-strategy promotion gate. It runs a walk-forward backtest across windows, then: reads a SQLite ledger's trial history for this strategy's family BEFORE writing this run's own row (count-then-write, to avoid a run deflating its own significance test against trials it hasn't finished), computes Deflated Sharpe Ratio using that trial count, a sign-flip permutation test p-value on the concatenated out-of-sample per-trade returns, and Probability of Backtest Overfitting across the parameter grid's variants. It fails the strategy if deflated_sharpe < 0.95 OR the permutation p-value fails Benjamini-Hochberg at q=0.05 OR PBO > 0.5, and always logs the attempt (pass or fail) to the ledger. Do these three default thresholds (0.95 DSR, 0.05 FDR-q, 0.5 PBO) seem reasonable as a first-pass gate for a crypto strategy with limited historical data, or overly strict/lenient? Any obvious ordering bug in when the ledger read happens vs when the row gets written?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_task5.json
+rm /tmp/lmchatbot_task5.json
+```
+
+If the reply makes a strong case for different default thresholds, adjust the keyword
+defaults in `run_promotion_gate`'s signature and note the reasoning in a comment; otherwise
+keep the current defaults.
+
+- [ ] **Step 6: Lint, run the full research suite, and commit**
+
+```bash
+ruff check research/ --fix && ruff format research/
+pytest research/tests -v
+git add research/gate.py research/cli.py research/tests/test_gate.py research/tests/test_cli.py
+git commit -m "feat(research): add promotion gate orchestration and CLI"
+```
+
+---
+
+## Self-Review Notes (from writing this plan)
+
+- **Spec coverage:** all of `FREQTRADE_RESEARCH_ARCHITECTURE.md` §18's six MVP bullets map
+  to a task: package scaffold+ledger → Task 1; statistics core → Task 2; PBO/CSCV → Task 3;
+  walk-forward runner → Task 4; CLI + PASS/FAIL report → Task 5 (gate.py + cli.py). Deferred
+  items (regime analysis, cost-sensitivity sweep, live/paper edge monitoring, portfolio
+  construction, AI hypothesis generation) are intentionally out of scope per §18's own
+  ordering — not gaps in this plan.
+- **No placeholders:** every step has real, complete code; no `TODO`/`TBD`/"similar to
+  above". The one intentionally-incomplete block (Task 2, Step 3) is scoped to porting an
+  external file whose exact source I verified line-ranges for but didn't reproduce
+  wholesale here — the task explicitly names the file, lines, and the two required
+  adaptations, and Step 1's tests fully pin the required behavior regardless of the exact
+  formula ported.
+- **Type/signature consistency:** `deflated_sharpe_ratio`, `benjamini_hochberg`,
+  `permutation_test`, `probability_of_backtest_overfitting`, `WalkForwardRunner`,
+  `generate_windows`, `family_of`, `family_trial_count`, and `log_candidate_result` are
+  each defined once (Tasks 1-4) and called with matching names/kwargs in Task 5's
+  `gate.py` — verified by re-reading Task 5 against each producing task's Interfaces block.

--- a/docs/superpowers/plans/2026-08-24-fee-sensitivity-stress-test.md
+++ b/docs/superpowers/plans/2026-08-24-fee-sensitivity-stress-test.md
@@ -1,0 +1,987 @@
+# Fee Sensitivity Stress Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an informational fee-sensitivity stress test to the `research/` promotion
+gate — re-evaluates an already-passing candidate's already-selected walk-forward
+parameters at progressively worse fee assumptions (1.0x/1.25x/1.5x/2.0x), reporting how
+its edge degrades, without changing the PASS/FAIL verdict.
+
+**Architecture:** Extract the test-period evaluation from `WalkForwardRunner.run_window`
+into a new, independently-callable method (`evaluate_fixed_params`) that accepts an
+optional fee override and never mutates the runner's config. A new `research/cost_stress.py`
+module calls it once per fee multiplier for every already-computed `WindowResult`, and
+`run_promotion_gate` calls that module (opt-in, only when the gate passed) using the
+`results` list it already has in scope — no duplicate walk-forward run.
+
+**Tech Stack:** Python, no new dependencies — same stack as the rest of `research/`.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md`
+
+## Global Constraints
+
+- Python >=3.11, modern type hints.
+- No new third-party dependencies.
+- `freqtrade/` package is never modified by this plan.
+- Tests live under `research/tests/`, run via `pytest research/tests -v` from the repo root.
+- TDD every task: failing test first, watch it fail, minimal implementation, watch it pass.
+- Lint before every commit: `ruff check research/ --fix && ruff format research/` (run from
+  the repo root, with the project venv: `.venv/Scripts/python.exe -m ruff ...`).
+- **Never named "slippage"** anywhere (module, function, CLI flag, report labels, comments)
+  — this stress-tests fee sensitivity only; a real slippage/execution model is explicitly
+  out of scope (spec's "What this is not").
+- **`n_trials=1`** for every Deflated Sharpe Ratio computed inside this feature — no new
+  selection happens at any fee level, so no new multiple-testing penalty applies (spec's
+  "On `n_trials=1`" section has the full reasoning; don't re-derive it differently).
+- **Never assert Sharpe is exactly monotonic** across fee multipliers in a test — it's an
+  empirical tendency for a fixed trade set, not a mathematical guarantee (spec's Testing
+  section). Use the invariants that are actually guaranteed instead (see Task 1/2 tests).
+- `run_promotion_gate`'s existing callers and existing tests must keep working unchanged —
+  the new parameter (`fee_sensitivity_multipliers`) defaults to `None` (off).
+
+---
+
+## Deviations from this plan (discovered during implementation)
+
+The trade-set-invariance and P&L-monotonicity claims baked into Task 1's and Task 2's Step
+1 test code blocks below were discovered false during implementation, for ROI-exit
+strategies: freqtrade's `should_exit()` computes its ROI-threshold comparison from a
+fee-adjusted profit ratio (`Trade.calc_profit_ratio`), so a higher fee can genuinely delay
+or prevent an ROI exit and change which trades occur, not just their realized P&L — verified
+against real freqtrade source (`freqtrade/strategy/interface.py`,
+`freqtrade/persistence/trade_model.py`) and empirically on the real `UNITTEST/BTC` fixture.
+See `docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md` (the
+"Invariant this method must uphold" and "Post-implementation correction" sections) for the
+full reasoning. As a result, `test_evaluate_fixed_params_fee_override_changes_pnl_but_not_trade_count`
+(Task 1, Step 1 below) was renamed to `test_evaluate_fixed_params_fee_override_changes_results`
+and its `cheap.test_n_trades == expensive.test_n_trades` assertion was removed (a P&L-
+monotonicity assertion was also removed later, in the final-review fix wave, for the same
+reason). `test_fee_sensitivity_net_pnl_is_non_increasing_as_fee_rises` (Task 2, Step 1
+below) was dropped entirely rather than implemented, since its only other assertion
+(`n_windows` matching across reports) is already covered by
+`test_fee_sensitivity_reports_one_entry_per_multiplier`. The task bodies below are left as
+originally written, for historical record; this section is the annotation that reconciles
+them with what was actually built.
+
+---
+
+### Task 1: `WalkForwardRunner.evaluate_fixed_params` — extract and reuse for `run_window`
+
+**Files:**
+- Modify: `research/walkforward.py` (whole file shown below — small enough to replace wholesale)
+- Test: `research/tests/test_walkforward.py` (add tests, keep the 2 existing ones unchanged)
+
+**Interfaces:**
+- Consumes: nothing new — same freqtrade APIs `run_window` already uses (`Backtesting`,
+  `history.load_data`, `trim_dataframes`, `calculate_sharpe`, `TimeRange`).
+- Produces: `WalkForwardRunner.evaluate_fixed_params(window: Window, params: dict, fee_override: float | None = None) -> WindowResult`
+  — Task 2's `research/cost_stress.py` calls this directly. Returns a `WindowResult` with
+  `variant_returns={}` (explicit empty dict — no grid was searched).
+
+The existing `Window`, `WindowResult`, `variant_key`, `generate_windows`,
+`WalkForwardRunner.__init__`, and `WalkForwardRunner.run` are **unchanged** — only
+`run_window`'s body changes (to call the new method for its final phase) and the new
+method is added.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three tests to `research/tests/test_walkforward.py`, below the two existing tests
+(keep the existing `TESTDATADIR`, `EXMS`, `_conf` at the top of the file unchanged):
+
+```python
+def test_evaluate_fixed_params_matches_run_window_for_the_winning_variant(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    param_grid = [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    run_window_result = runner.run_window(window, param_grid)
+
+    direct_result = runner.evaluate_fixed_params(window, run_window_result.best_params)
+
+    assert direct_result.test_sharpe == run_window_result.test_sharpe
+    assert direct_result.test_returns == run_window_result.test_returns
+    assert direct_result.test_n_trades == run_window_result.test_n_trades
+    assert direct_result.variant_returns == {}
+
+    # fee_override=None and fee_override=<the config's own base fee> must be equivalent --
+    # they resolve to the same fee, just via a different code path.
+    from freqtrade.optimize.backtesting import Backtesting
+
+    base_fee = Backtesting(conf).fee
+    override_result = runner.evaluate_fixed_params(
+        window, run_window_result.best_params, fee_override=base_fee
+    )
+    assert override_result.test_sharpe == run_window_result.test_sharpe
+    assert override_result.test_returns == run_window_result.test_returns
+
+
+def test_evaluate_fixed_params_fee_override_changes_pnl_but_not_trade_count(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    params = {"buy_rsi": 25}
+
+    config_before = dict(runner.config)
+    cheap = runner.evaluate_fixed_params(window, params, fee_override=0.0)
+    expensive = runner.evaluate_fixed_params(window, params, fee_override=0.05)
+
+    # Same window, same params -> same trades. Only realized P&L differs (higher fee ->
+    # less or equal total P&L on the same trade set; never asserted as exactly monotonic
+    # Sharpe -- see the design spec's Testing section for why that's not guaranteed).
+    assert cheap.test_n_trades == expensive.test_n_trades
+    assert sum(cheap.test_returns) >= sum(expensive.test_returns)
+
+    # self.config must never be mutated by a fee_override call.
+    assert runner.config == config_before
+
+
+def test_run_window_still_works_after_the_refactor(mocker):
+    """Regression coverage: run_window's own pre-existing test already covers this,
+    but this direct check makes the refactor's intent explicit -- run_window's final
+    phase now delegates to evaluate_fixed_params rather than duplicating it."""
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    result = runner.run_window(window, [{"buy_rsi": 25}, {"buy_rsi": 35}])
+
+    assert result.best_params in [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    assert set(result.variant_returns) == {variant_key({"buy_rsi": 25}), variant_key({"buy_rsi": 35})}
+    assert isinstance(result.train_sharpe, float)
+    assert isinstance(result.test_sharpe, float)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest research/tests/test_walkforward.py -v`
+Expected: the two new `evaluate_fixed_params` tests FAIL with
+`AttributeError: 'WalkForwardRunner' object has no attribute 'evaluate_fixed_params'`.
+The third new test (`test_run_window_still_works_after_the_refactor`) currently PASSES
+already (it exercises only existing behavior) — that's expected and fine; it becomes a
+real regression check once Step 3 changes `run_window`'s implementation.
+
+- [ ] **Step 3: Implement `evaluate_fixed_params` and refactor `run_window` to use it**
+
+Replace `research/walkforward.py` in full with:
+
+```python
+# research/walkforward.py
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.converter import trim_dataframes
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.optimize.backtesting import Backtesting
+
+
+@dataclass
+class Window:
+    """One walk-forward train/test period. `test_start` always equals
+    `train_end`; see `generate_windows` for how consecutive windows relate."""
+
+    train_start: datetime
+    train_end: datetime
+    test_start: datetime
+    test_end: datetime
+
+
+@dataclass
+class WindowResult:
+    """Outcome of running one `Window` through `WalkForwardRunner.run_window`:
+    the train-period Sharpe of every param variant (`variant_returns`, keyed by
+    `variant_key`, feeding `research.pbo`), the train-selected best params, and
+    the resulting out-of-sample (test-period) performance.
+
+    `evaluate_fixed_params` also returns a `WindowResult`, but a deliberately
+    partial one: no grid was searched, so `variant_returns` is always `{}` on
+    that path. `research.cost_stress` is the only intended consumer of that
+    partial form -- don't assume `variant_returns` reflects a real grid search
+    unless the `WindowResult` came from `run_window`."""
+
+    window: Window
+    variant_returns: dict[str, float]
+    best_params: dict
+    train_sharpe: float
+    test_sharpe: float
+    test_n_trades: int
+    test_returns: list[float]
+
+
+def variant_key(params: dict) -> str:
+    """Canonical, order-independent string key for a param-variant dict, used
+    to identify the same variant across windows (e.g. in `variant_returns`)."""
+    return json.dumps(params, sort_keys=True)
+
+
+def generate_windows(
+    start: datetime, end: datetime, train_days: int, test_days: int
+) -> list[Window]:
+    """Rolling, contiguous windows: each window's test period starts exactly
+    where its train period ends, and test periods are gapless across windows
+    (the next window's test period starts exactly where the previous
+    window's test period ended). Cursor advances by test_days each step, so
+    every day in [start, end) is covered by at most one window's OOS test
+    period, maximizing out-of-sample statistical power for Task 5's
+    DSR/permutation-test/PBO evaluation."""
+    windows: list[Window] = []
+    cursor = start
+    while True:
+        train_end = cursor + timedelta(days=train_days)
+        test_end = train_end + timedelta(days=test_days)
+        if test_end > end:
+            break
+        windows.append(Window(cursor, train_end, train_end, test_end))
+        cursor = cursor + timedelta(days=test_days)
+    return windows
+
+
+class WalkForwardRunner:
+    """Runs a strategy through freqtrade's `Backtesting` engine across a series
+    of walk-forward windows, selecting the best param variant on each window's
+    train period and evaluating it on that window's held-out test period."""
+
+    def __init__(self, config: dict, pairs: list[str], timeframe: str, datadir: Path):
+        self.config = config
+        self.pairs = pairs
+        self.timeframe = timeframe
+        self.datadir = datadir
+
+    def evaluate_fixed_params(
+        self, window: Window, params: dict, fee_override: float | None = None
+    ) -> WindowResult:
+        """Backtest a single, already-chosen `params` on `window` -- no grid
+        search. Used directly by `research.cost_stress.fee_sensitivity` to
+        re-evaluate an already-selected candidate at a different fee level,
+        and by `run_window` (below) for its own final test-phase step -- both
+        paths share this one implementation rather than drifting apart.
+
+        `fee_override`, when given, is used ONLY for this call's `Backtesting`
+        instance -- `self.config` is never mutated, so a stress-test fee can
+        never leak into other calls sharing this `WalkForwardRunner`.
+
+        Returns a `WindowResult` with `variant_returns={}` (no grid was
+        searched) and `train_sharpe` reflecting only `params`' own
+        train-period Sharpe (not a selection among alternatives).
+        """
+        cfg = {**self.config, "fee": fee_override} if fee_override is not None else self.config
+        backtesting = Backtesting(cfg)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        for name, value in params.items():
+            getattr(backtesting.strategy, name).value = value
+        processed = backtesting.strategy.advise_all_indicators(data)
+        processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+        train_result = backtesting.backtest(
+            processed=deepcopy(processed),
+            start_date=window.train_start,
+            end_date=window.train_end,
+        )
+        train_trades = train_result["results"]
+        train_sharpe = calculate_sharpe(
+            train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+        )
+
+        test_result = backtesting.backtest(
+            processed=deepcopy(processed),
+            start_date=window.test_start,
+            end_date=window.test_end,
+        )
+        test_trades = test_result["results"]
+        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
+        test_sharpe = calculate_sharpe(
+            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
+        )
+
+        return WindowResult(
+            window=window,
+            variant_returns={},
+            best_params=params,
+            train_sharpe=train_sharpe,
+            test_sharpe=test_sharpe,
+            test_n_trades=len(test_trades),
+            test_returns=test_returns,
+        )
+
+    def run_window(self, window: Window, param_grid: list[dict]) -> WindowResult:
+        """Backtest every variant in `param_grid` on `window`'s train period,
+        pick the highest-train-Sharpe variant, then evaluate ONLY that variant
+        on the test period via `evaluate_fixed_params`.
+
+        This ordering is the load-bearing invariant: parameter selection is
+        strictly train-only. Test-period data is never touched until after
+        `best_params` is fixed, so no parameter choice can be informed by data
+        it will later be scored against -- the test-period Sharpe this returns
+        is a genuine out-of-sample estimate, not a look-ahead-contaminated one.
+
+        Indicators are (re)computed per param variant over the full
+        [train_start, test_end] span before either backtest call (freqtrade's
+        own convention), which is safe for backward-looking, row-local
+        indicators but can leak test-period information into train-period
+        selection for non-causal or DataFrame-wide-normalized indicators --
+        see the inline note below.
+        """
+        backtesting = Backtesting(self.config)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        if not param_grid:
+            raise ValueError("param_grid must not be empty")
+
+        variant_returns: dict[str, float] = {}
+        best_sharpe = -np.inf
+        best_params: dict | None = None
+
+        for params in param_grid:
+            for name, value in params.items():
+                getattr(backtesting.strategy, name).value = value
+
+            # ponytail: indicators are (re)computed per param variant over
+            # [train_start, test_end], per freqtrade's own convention (§3 of the
+            # architecture doc). Safe for backward-looking, row-local indicators
+            # (this strategy's RSI); two families of indicator would leak
+            # test-period information into the train-period parameter selection
+            # done below even though they're "backward-looking" in the naive
+            # sense: (1) a non-causal indicator (centered rolling, .shift(-n)),
+            # and (2) any indicator normalized against a DataFrame-wide
+            # statistic (global z-score, min/max scaling, global percentile
+            # rank) computed over the whole [train_start, test_end] span, since
+            # that statistic itself is contaminated by test-period rows. Run
+            # freqtrade's lookahead-analysis (and audit for global
+            # normalization) on any strategy before trusting this runner's
+            # results for it.
+            processed = backtesting.strategy.advise_all_indicators(data)
+            processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+            train_result = backtesting.backtest(
+                processed=deepcopy(processed),
+                start_date=window.train_start,
+                end_date=window.train_end,
+            )
+            train_trades = train_result["results"]
+            sharpe = calculate_sharpe(
+                train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+            )
+            key = variant_key(params)
+            variant_returns[key] = (
+                float((train_trades["profit_abs"] / self.config["dry_run_wallet"]).mean())
+                if len(train_trades)
+                else 0.0
+            )
+
+            if sharpe > best_sharpe:
+                best_sharpe, best_params = sharpe, params
+
+        if best_params is None:
+            raise RuntimeError(
+                "no param variant produced a result"
+            )  # unreachable: param_grid non-empty
+
+        # ponytail: this recomputes data + indicators for the winning variant a
+        # second time (evaluate_fixed_params does its own history.load_data +
+        # advise_all_indicators call) rather than reusing the grid loop's
+        # already-computed `processed` dataframe for that variant. Trades a
+        # small, deterministic amount of duplicate work for one shared,
+        # single-tested code path between run_window and evaluate_fixed_params
+        # (see the fee-sensitivity design doc) -- revisit only if this becomes
+        # a measured bottleneck.
+        result = self.evaluate_fixed_params(window, best_params)
+        result.variant_returns = variant_returns
+        result.train_sharpe = best_sharpe
+        return result
+
+    def run(self, windows: list[Window], param_grid: list[dict]) -> list[WindowResult]:
+        """Run `run_window` over every window in sequence and collect results."""
+        return [self.run_window(w, param_grid) for w in windows]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python.exe -m pytest research/tests/test_walkforward.py -v`
+Expected: PASS (5 tests: 2 pre-existing + 3 new).
+
+- [ ] **Step 5: Run the full research suite to check for regressions**
+
+Run: `.venv/Scripts/python.exe -m pytest research/tests -v`
+Expected: PASS (29 tests: 26 pre-existing across the whole `research/tests` suite + the
+3 new tests added to `test_walkforward.py` in this task).
+
+- [ ] **Step 6: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_fee_task1.json <<'EOF'
+{"provider":"gemini","prompt":"I refactored a walk-forward backtest runner's run_window method: it used to inline its final test-period-only backtest call, and now delegates that to a new sibling method evaluate_fixed_params(window, params, fee_override=None) which builds a config dict with an overridden 'fee' key (via dict unpacking: {**self.config, 'fee': fee_override} if fee_override is not None else self.config) and constructs a fresh freqtrade Backtesting(cfg) instance from it, never mutating self.config. run_window now calls self.evaluate_fixed_params(window, best_params) for its final phase and overwrites the returned WindowResult's variant_returns/train_sharpe fields with its own grid-search results before returning. Does this refactor look correct and safe -- any risk in overwriting dataclass fields on an object returned from a method the class also uses internally, and does swapping a 'fee' key into a shallow-copied config dict actually work for how freqtrade's Backtesting class reads its fee, or could a shallow copy miss nested config structure freqtrade also needs?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_fee_task1.json
+rm /tmp/lmchatbot_fee_task1.json
+```
+
+Read the reply. If it surfaces a real gap (e.g. `Backtesting.__init__` mutating the config
+dict it's given in a way a shallow copy wouldn't isolate, or a cleaner way to avoid
+overwriting dataclass fields after construction), fix it before continuing; otherwise
+proceed.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check research/ --fix
+.venv/Scripts/python.exe -m ruff format research/
+git add research/walkforward.py research/tests/test_walkforward.py
+git commit -m "feat(research): extract WalkForwardRunner.evaluate_fixed_params with fee override"
+```
+
+---
+
+### Task 2: `research/cost_stress.py` + wire into `run_promotion_gate` and the CLI
+
+**Files:**
+- Create: `research/cost_stress.py`
+- Modify: `research/gate.py`
+- Modify: `research/cli.py`
+- Test: `research/tests/test_cost_stress.py` (new)
+- Test: `research/tests/test_gate.py` (add tests, keep existing 2 unchanged)
+- Test: `research/tests/test_cli.py` (add a test, keep existing 3 unchanged)
+
+**Interfaces:**
+- Consumes: `WalkForwardRunner.evaluate_fixed_params` and `WindowResult` (Task 1);
+  `research.statistics.deflated_sharpe_ratio` (existing); `freqtrade.optimize.backtesting.Backtesting`
+  (existing, for reading `.fee`).
+- Produces: `research.cost_stress.fee_sensitivity(config, pairs, timeframe, datadir, window_results, multipliers=(1.0, 1.25, 1.5, 2.0), periods_per_year=365) -> dict[float, dict]`
+  — each value is `{"mean_test_sharpe": float, "deflated_sharpe": float, "n_windows": int}`.
+  `research.gate.GateResult` gains `fee_sensitivity: dict[float, dict] | None = None`.
+  `research.gate.run_promotion_gate` gains `fee_sensitivity_multipliers: tuple[float, ...] | None = None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `research/tests/test_cost_stress.py`:
+
+```python
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+from freqtrade.optimize.backtesting import Backtesting
+from research.cost_stress import fee_sensitivity
+from research.statistics import deflated_sharpe_ratio
+from research.walkforward import WalkForwardRunner, generate_windows
+from tests.conftest import get_default_conf, patch_exchange
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def _patch(mocker):
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+
+def _window_results(conf):
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+    windows = generate_windows(min_date, max_date, train_days, test_days)
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    return runner, runner.run(windows, [{"buy_rsi": 25}, {"buy_rsi": 35}])
+
+
+def test_fee_sensitivity_reports_one_entry_per_multiplier(mocker):
+    conf = _conf()
+    _patch(mocker)
+    _runner, results = _window_results(conf)
+
+    report = fee_sensitivity(
+        conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+        window_results=results, multipliers=(1.0, 1.5),
+    )
+
+    assert set(report) == {1.0, 1.5}
+    for stats in report.values():
+        assert isinstance(stats["mean_test_sharpe"], float)
+        assert 0.0 <= stats["deflated_sharpe"] <= 1.0
+        assert stats["n_windows"] == len(results)
+
+
+def test_fee_sensitivity_baseline_matches_direct_recomputation(mocker):
+    conf = _conf()
+    _patch(mocker)
+    runner, results = _window_results(conf)
+
+    report = fee_sensitivity(
+        conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+        window_results=results, multipliers=(1.0,),
+    )
+
+    base_fee = Backtesting(conf).fee
+    direct = [
+        runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=base_fee)
+        for wr in results
+    ]
+    expected_mean_sharpe = float(np.mean([r.test_sharpe for r in direct]))
+    expected_n_obs = sum(len(r.test_returns) for r in direct)
+    expected_deflated = deflated_sharpe_ratio(
+        expected_mean_sharpe, n_obs=expected_n_obs, n_trials=1, periods_per_year=365
+    )
+
+    assert report[1.0]["mean_test_sharpe"] == pytest.approx(expected_mean_sharpe)
+    assert report[1.0]["deflated_sharpe"] == pytest.approx(expected_deflated)
+
+
+def test_fee_sensitivity_net_pnl_is_non_increasing_as_fee_rises(mocker):
+    conf = _conf()
+    _patch(mocker)
+    runner, results = _window_results(conf)
+
+    report_1 = fee_sensitivity(
+        conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+        window_results=results, multipliers=(1.0,),
+    )
+    report_2 = fee_sensitivity(
+        conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+        window_results=results, multipliers=(2.0,),
+    )
+
+    base_fee = Backtesting(conf).fee
+    pnl_1x = sum(
+        sum(runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=base_fee * 1.0).test_returns)
+        for wr in results
+    )
+    pnl_2x = sum(
+        sum(runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=base_fee * 2.0).test_returns)
+        for wr in results
+    )
+    assert pnl_1x >= pnl_2x
+    assert report_1[1.0]["n_windows"] == report_2[2.0]["n_windows"]
+
+
+def test_fee_sensitivity_raises_on_empty_or_non_positive_multipliers(mocker):
+    conf = _conf()
+    _patch(mocker)
+    _runner, results = _window_results(conf)
+
+    with pytest.raises(ValueError, match="multipliers"):
+        fee_sensitivity(
+            conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+            window_results=results, multipliers=(),
+        )
+    with pytest.raises(ValueError, match="multipliers"):
+        fee_sensitivity(
+            conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR,
+            window_results=results, multipliers=(0.0,),
+        )
+```
+
+Add to `research/tests/test_gate.py` (after the two existing tests, keep the existing
+`TESTDATADIR`/`EXMS`/`_conf`/`_patch` helpers unchanged):
+
+```python
+def test_run_promotion_gate_attaches_fee_sensitivity_when_it_passes(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Permissive thresholds guarantee a real, unmocked PASS on the small fixture dataset
+    # (any run with at least one trade clears them) without mocking the statistics --
+    # deterministic real-execution test, not a forced/mocked pass.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=0.0,
+        fdr_q=1.0,
+        pbo_threshold=1.0,
+        fee_sensitivity_multipliers=(1.0, 1.5),
+    )
+
+    assert result.passed is True
+    assert result.fee_sensitivity is not None
+    assert set(result.fee_sensitivity) == {1.0, 1.5}
+
+
+def test_run_promotion_gate_skips_fee_sensitivity_when_it_fails(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Impossible dsr_threshold guarantees a real FAIL, regardless of the actual result.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=1.1,
+        fee_sensitivity_multipliers=(1.0, 1.5),
+    )
+
+    assert result.passed is False
+    assert result.fee_sensitivity is None
+```
+
+Add to `research/tests/test_cli.py` (after the existing tests, keep the existing imports
+and both existing tests unchanged):
+
+```python
+def test_gate_command_prints_fee_sensitivity_table_when_present(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.87, "deflated_sharpe": 0.91, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.33, "deflated_sharpe": 0.52, "n_windows": 5},
+        },
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy", "StrategyTestV3",
+            "--config", "config.json",
+            "--pairs", "BTC/USDT",
+            "--timeframe", "1h",
+            "--start", "2024-01-01",
+            "--end", "2024-06-01",
+            "--train-days", "60",
+            "--test-days", "20",
+            "--param-grid", '[{"buy_rsi": 30}]',
+            "--fee-sensitivity",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "fee sensitivity" in captured.out
+    assert "baseline" in captured.out
+    assert "1.50x fee" in captured.out
+    assert "slippage" not in captured.out.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest research/tests/test_cost_stress.py research/tests/test_gate.py research/tests/test_cli.py -v`
+Expected: `test_cost_stress.py`'s tests FAIL with
+`ModuleNotFoundError: No module named 'research.cost_stress'`. The two new `test_gate.py`
+tests FAIL with `TypeError: run_promotion_gate() got an unexpected keyword argument
+'fee_sensitivity_multipliers'`. The new `test_cli.py` test FAILS with `TypeError:
+GateResult.__init__() got an unexpected keyword argument 'fee_sensitivity'`.
+
+- [ ] **Step 3: Implement `research/cost_stress.py`**
+
+```python
+# research/cost_stress.py
+"""Fee-sensitivity stress test: re-evaluates a promotion gate candidate's
+already-selected walk-forward parameters at progressively higher (worse)
+transaction fee assumptions, to see whether its edge is a thin margin over
+baseline costs or survives materially worse ones. Informational only --
+never changes a gate's PASS/FAIL verdict.
+
+This is NOT a slippage/market-impact model -- freqtrade's backtester has no
+execution-price slippage simulation at all (orders fill at the exact
+requested price). A flat fee-rate multiplier is a legitimate cost-sensitivity
+/ margin-of-safety test, but it gets slippage's actual structure wrong (which
+scales with order size/liquidity/volatility, not as a fixed percentage), so
+it is named and reported as "fee sensitivity" throughout, never "slippage".
+See docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md
+for the full reasoning, including why n_trials=1 is correct here (no new
+selection happens at any fee level, so no new multiple-testing penalty
+applies -- the original gate's trial count already paid for that once).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.optimize.backtesting import Backtesting
+from research.statistics import deflated_sharpe_ratio
+from research.walkforward import WalkForwardRunner, WindowResult
+
+
+def fee_sensitivity(
+    config: dict,
+    pairs: list[str],
+    timeframe: str,
+    datadir: Path,
+    window_results: list[WindowResult],
+    multipliers: tuple[float, ...] = (1.0, 1.25, 1.5, 2.0),
+    periods_per_year: int = 365,
+) -> dict[float, dict]:
+    """Re-evaluate every `WindowResult`'s already-selected `best_params` at
+    each fee multiplier (`base_fee * multiplier`), aggregating exactly as
+    `research.gate.run_promotion_gate` does: mean per-window test Sharpe fed
+    into `deflated_sharpe_ratio` with `n_obs` = total concatenated
+    `test_returns` and `n_trials=1`.
+
+    `base_fee` is read once from a throwaway `Backtesting(config)` instance's
+    resolved `.fee` -- the exact same fee the original gate run used, since
+    `config` is passed through unchanged. The `1.0` multiplier therefore
+    reproduces the original gate's own fee exactly (a control, not a stress
+    level).
+
+    Returns `{multiplier: {"mean_test_sharpe": float, "deflated_sharpe":
+    float, "n_windows": int}}`, one entry per multiplier given.
+    """
+    if not multipliers or any(m <= 0 for m in multipliers):
+        raise ValueError("multipliers must be non-empty and all values > 0")
+
+    base_fee = Backtesting(config).fee
+    runner = WalkForwardRunner(config, pairs, timeframe, datadir)
+
+    report: dict[float, dict] = {}
+    for multiplier in multipliers:
+        fee = base_fee * multiplier
+        results = [
+            runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=fee)
+            for wr in window_results
+        ]
+        all_test_returns = [r for res in results for r in res.test_returns]
+        mean_test_sharpe = float(np.mean([res.test_sharpe for res in results]))
+        deflated = deflated_sharpe_ratio(
+            mean_test_sharpe,
+            n_obs=len(all_test_returns),
+            n_trials=1,
+            periods_per_year=periods_per_year,
+        )
+        report[multiplier] = {
+            "mean_test_sharpe": mean_test_sharpe,
+            "deflated_sharpe": deflated,
+            "n_windows": len(results),
+        }
+    return report
+```
+
+- [ ] **Step 4: Extend `research/gate.py`**
+
+In `research/gate.py`:
+
+1. Add an import: `from research.cost_stress import fee_sensitivity`
+2. Add one field to `GateResult`, after `reasons: list[str]`:
+
+```python
+    fee_sensitivity: dict[float, dict] | None = None
+```
+
+3. Add one parameter to `run_promotion_gate`'s signature, after `periods_per_year: int = 365,`:
+
+```python
+    fee_sensitivity_multipliers: tuple[float, ...] | None = None,
+```
+
+4. After the `passed = not reasons` line and before the `log_candidate_result(...)` call, add:
+
+```python
+    fee_report = None
+    if passed and fee_sensitivity_multipliers is not None:
+        fee_report = fee_sensitivity(
+            config,
+            pairs,
+            timeframe,
+            datadir,
+            results,
+            multipliers=fee_sensitivity_multipliers,
+            periods_per_year=periods_per_year,
+        )
+```
+
+5. Add `fee_sensitivity=fee_report,` to the final `return GateResult(...)` call, after `reasons=reasons,`.
+
+- [ ] **Step 5: Extend `research/cli.py`**
+
+In `research/cli.py`, add one CLI argument after the `--db-path` line:
+
+```python
+    gate.add_argument(
+        "--fee-sensitivity",
+        action="store_true",
+        help="Also run a fee-sensitivity stress test if the gate passes (informational)",
+    )
+```
+
+Change the `run_promotion_gate(...)` call to add one more keyword argument, after `db_path=args.db_path,`:
+
+```python
+            fee_sensitivity_multipliers=(1.0, 1.25, 1.5, 2.0) if args.fee_sensitivity else None,
+```
+
+After the existing `for reason in result.reasons:` loop and its `print`, and before the
+`return 0 if result.passed else 1` line, add:
+
+```python
+        if result.fee_sensitivity:
+            print("  fee sensitivity (informational, not part of PASS/FAIL):")
+            for i, (mult, stats) in enumerate(result.fee_sensitivity.items()):
+                label = f"{mult:.2f}x fee" + (" (baseline)" if i == 0 else "")
+                print(
+                    f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   deflated_sharpe {stats['deflated_sharpe']:.3f}"
+                )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python.exe -m pytest research/tests -v`
+Expected: PASS (36 tests: 29 from after Task 1 + 4 new in `test_cost_stress.py` + 2 new in
+`test_gate.py` + 1 new in `test_cli.py`).
+
+- [ ] **Step 7: Get a second opinion via lmchatbot**
+
+```bash
+curl -s localhost:3000/ 2>/dev/null || (node C:/dev/lmchatbot/server.js &)
+cat > /tmp/lmchatbot_fee_task2.json <<'EOF'
+{"provider":"chatgpt","verify":"gemini","prompt":"Reviewing a fee-sensitivity stress test wired into a trading-strategy promotion gate. research/cost_stress.py::fee_sensitivity(config, pairs, timeframe, datadir, window_results, multipliers=(1.0,1.25,1.5,2.0), periods_per_year=365) reads a base fee once from a throwaway freqtrade Backtesting(config).fee, then for each multiplier re-evaluates every already-selected WindowResult.best_params via WalkForwardRunner.evaluate_fixed_params(window, best_params, fee_override=base_fee*multiplier), aggregates mean per-window test_sharpe and feeds it into deflated_sharpe_ratio(mean_sharpe, n_obs=<total concatenated test_returns count>, n_trials=1, periods_per_year=365). This is called from research/gate.py's run_promotion_gate ONLY when the gate already passed (using n_trials=1 deliberately, since no new parameter search/selection happens at any fee level -- the original gate's own n_trials already paid for the one selection event that chose these params). It's opt-in via a --fee-sensitivity CLI flag, informational only, never changes the PASS/FAIL verdict, and is explicitly never called 'slippage' anywhere (freqtrade's backtester has no real slippage/execution-price model, only a configurable fee). Any correctness issues, real design gaps, or reasoning errors in this? Is the n_trials=1 reasoning actually sound?"}
+EOF
+curl -s localhost:3000/ask -d @/tmp/lmchatbot_fee_task2.json
+rm /tmp/lmchatbot_fee_task2.json
+```
+
+Read the reply, including both `draft` and `reply` (verifier) fields. If it surfaces a
+real, concrete gap, fix it and rerun Step 6; otherwise proceed.
+
+- [ ] **Step 8: Lint, run the full suite once more, and commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check research/ --fix
+.venv/Scripts/python.exe -m ruff format research/
+.venv/Scripts/python.exe -m pytest research/tests -v
+git add research/cost_stress.py research/gate.py research/cli.py \
+        research/tests/test_cost_stress.py research/tests/test_gate.py research/tests/test_cli.py
+git commit -m "feat(research): add fee-sensitivity stress test, opt-in via --fee-sensitivity"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every component in the spec (`research/cost_stress.py`, the new
+  `WalkForwardRunner.evaluate_fixed_params` method with the `run_window` refactor to reuse
+  it, `GateResult.fee_sensitivity`, `run_promotion_gate`'s new parameter, the CLI flag and
+  table) maps to a concrete step above. The spec's "What this is not" constraints (no
+  slippage naming, no hard gate, no re-search, `n_trials=1`) are all encoded as Global
+  Constraints and enforced in the actual code (not just prose) — e.g. the CLI test asserts
+  `"slippage" not in captured.out.lower()`.
+- **No placeholders:** every step has complete, real code — no `# TODO`, no "similar to
+  above." The lmchatbot steps are genuine second-opinion checks with concrete prompts, not
+  filler.
+- **Type/signature consistency:** `evaluate_fixed_params`'s signature
+  (`window, params, fee_override=None`) is defined once in Task 1 and called identically
+  in Task 2's `cost_stress.py` and every test. `fee_sensitivity`'s signature and return
+  shape (`dict[float, dict]` with `mean_test_sharpe`/`deflated_sharpe`/`n_windows` keys) is
+  defined once and consumed identically by `gate.py` and the CLI's table-printing code.
+  `GateResult.fee_sensitivity` and `run_promotion_gate`'s `fee_sensitivity_multipliers`
+  parameter names match between the dataclass, the function signature, and every call site
+  across both tasks' tests.

--- a/docs/superpowers/plans/2026-08-24-paper-trading-promotion.md
+++ b/docs/superpowers/plans/2026-08-24-paper-trading-promotion.md
@@ -1,0 +1,826 @@
+# Paper-Trading Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track a gate-passing candidate's promotion lifecycle (PASSED_GATE →
+PAPER_TRADING → LIVE_ELIGIBLE → LIVE, REJECTED reachable from either post-gate stage)
+with guarded state transitions, and a health evaluator that reads a real freqtrade
+dry-run database to recommend (never automatically grant) live eligibility.
+
+**Architecture:** One new table (`PromotionRecord`, in `research/models.py`) and one new
+module (`research/promotion.py`) with two halves: a pure state machine (no freqtrade
+dependency) and a health evaluator (the first `research/` code to read freqtrade's own
+`Trade` persistence layer, guarded against a real global-state trap this session already
+found once).
+
+**Tech Stack:** Python, SQLAlchemy (research's own ledger DB), freqtrade's
+`persistence.init_db`/`Trade` and `data.metrics.calculate_sharpe`, pandas, pytest with
+real DB rows throughout (no mocking).
+
+**Spec:** `docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md`
+
+## Global Constraints
+
+- `PromotionState` is a `class PromotionState(str, Enum)` with values `PASSED_GATE`,
+  `PAPER_TRADING`, `LIVE_ELIGIBLE`, `LIVE`, `REJECTED` — stored on `PromotionRecord.state`
+  as the enum's plain `.value` string, never a SQLAlchemy `Enum` column type.
+- Every state-transition function raises `ValueError` (never a silent no-op) on: a
+  missing referenced row, or an invalid current-state-to-target-state transition. Exact
+  error message content is not load-bearing — tests match on a distinctive substring,
+  not the full string — but every function must raise, not return `None` or an unchanged
+  record, on a caller-contract violation.
+- `MIN_PAPER_TRADING_DAYS = 14`, `MIN_PAPER_TRADES = 10`, `MIN_DEGRADATION_RATIO = 0.5`
+  are fixed module-level constants in `research/promotion.py`, `ponytail:`-flagged
+  starting defaults — not a runtime parameter, not derived from real paper-trading
+  history (none exists yet in this fork).
+- `LIVE` is reachable **only** via a direct `promote_to_live()` call. No other function
+  in this module — especially not `apply_health_evaluation` — may ever set
+  `state = PromotionState.LIVE.value`. This is the one non-negotiable constraint the
+  whole sub-project exists to enforce; a task reviewer must treat any code path that
+  violates it as Critical, full stop, no exceptions for "convenience."
+- Eligibility from `evaluate_paper_trading_health` has **three** outcomes, not two:
+  not-enough-evidence (`eligible=False, enough_evidence=False`), rejected
+  (`eligible=False, enough_evidence=True`), eligible (`eligible=True,
+  enough_evidence=True`). `apply_health_evaluation` maps these to: stay in
+  `PAPER_TRADING` / transition to `REJECTED` / transition to `LIVE_ELIGIBLE`,
+  respectively. Collapsing this to a single boolean is a plan-mandated defect if
+  proposed during implementation or review — reject the simplification, keep the
+  three-way split (see the spec's "Open items" section for why).
+- `evaluate_paper_trading_health` requires `starting_balance: float` as an explicit,
+  non-defaulted parameter (no config file is read to discover it — see the spec).
+- **`freqtrade.persistence.init_db()` sets `Trade.session` as GLOBAL class-level state,
+  not a scoped per-call connection** — the same class of bug this session already found
+  and fixed once (`Trade.use_db`/`bt_trades` leaking across tests, PR #5). Task 2's
+  production code must fully materialize (`.all()`) its query results before returning,
+  and Task 2's test file must include a file-scoped autouse fixture that resets
+  `Trade.session` to a fresh in-memory database after every test in that file, so this
+  file's throwaway dry-run databases can never leak into any other test that happens to
+  run afterward in the same pytest-xdist worker. This is not optional test hygiene —
+  it is the direct, foreseeable recurrence of an already-fixed bug class if skipped.
+- Timezone handling: `paper_trading_started_at` is written as `datetime.now(UTC)`
+  (tz-aware) but SQLite round-tripping through SQLAlchemy's plain `DateTime` may drop
+  tzinfo — `evaluate_paper_trading_health` normalizes defensively on read (adds `UTC` if
+  naive) rather than assuming either behavior. The SQL filter against freqtrade's raw
+  `Trade.close_date` column uses a **naive**-UTC value (freqtrade's own raw columns are
+  naive); all Python-side arithmetic uses the tz-aware value. Both are derived from one
+  single normalized read, not independently re-normalized in two places.
+- One normalized `now = datetime.now(UTC)` captured once per `evaluate_paper_trading_health`
+  call, reused for both `days_elapsed` arithmetic and (implicitly, as `calculate_sharpe`'s
+  `max_date`) the Sharpe computation — never call `datetime.now(UTC)` a second time
+  later in the same function body.
+- No mocking of the state machine or the health evaluator's own logic in tests — real
+  SQLAlchemy rows (research's own ledger DB) and real freqtrade `Trade` rows (a real,
+  freshly-`init_db`'d sqlite file), matching every existing file in `research/tests/`.
+
+---
+
+### Task 1: `research/promotion.py` — state machine (no freqtrade Trade dependency)
+
+**Files:**
+- Modify: `research/models.py` (add `PromotionRecord`)
+- Create: `research/promotion.py` (`PromotionState` enum, `create_promotion_record`,
+  `start_paper_trading`, `promote_to_live`, `reject`)
+- Test: `research/tests/test_promotion.py`
+
+**Interfaces:**
+- Consumes: `research.models.CandidateResult` (existing dataclass — see
+  `research/models.py:11-37`), `research.db.get_engine`/`get_session` (existing, used by
+  the test file only, matching `research/tests/test_gate.py`'s own house style).
+- Produces: `PromotionState` enum, `create_promotion_record(session, candidate_result_id)
+  -> PromotionRecord`, `start_paper_trading(session, promotion_id, dry_run_db_path,
+  started_at=None) -> PromotionRecord`, `promote_to_live(session, promotion_id) ->
+  PromotionRecord`, `reject(session, promotion_id, reason) -> PromotionRecord` — all
+  consumed directly by Task 2 (which adds two more functions to the same module and file).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `research/tests/test_promotion.py`:
+
+```python
+# research/tests/test_promotion.py
+from datetime import UTC, datetime
+
+import pytest
+
+from research.db import get_engine, get_session
+from research.models import CandidateResult
+from research.promotion import (
+    PromotionState,
+    create_promotion_record,
+    promote_to_live,
+    reject,
+    start_paper_trading,
+)
+
+
+def _session(tmp_path):
+    engine = get_engine(str(tmp_path / "research.sqlite"))
+    return get_session(engine)
+
+
+def _candidate(session, survived=True, oos_sharpe=1.5):
+    candidate = CandidateResult(
+        run_stamp=datetime.now(UTC),
+        strategy_id="TestStrategy",
+        strategy_family="TestStrategy",
+        params_json="{}",
+        universe="BTC/USDT",
+        timeframe="1h",
+        discovery_start="2024-01-01",
+        discovery_end="2024-06-01",
+        n_trials_this_run=1,
+        is_sharpe=1.0,
+        oos_sharpe=oos_sharpe,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        survived=survived,
+        evidence_json="{}",
+    )
+    session.add(candidate)
+    session.flush()
+    return candidate
+
+
+def test_create_promotion_record_succeeds_for_a_passing_candidate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, survived=True)
+
+    record = create_promotion_record(session, candidate.id)
+
+    assert record.state == PromotionState.PASSED_GATE.value
+    assert record.candidate_result_id == candidate.id
+
+
+def test_create_promotion_record_raises_for_a_failing_candidate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, survived=False)
+
+    with pytest.raises(ValueError, match="did not pass the gate"):
+        create_promotion_record(session, candidate.id)
+
+
+def test_create_promotion_record_raises_for_a_nonexistent_candidate(tmp_path):
+    session = _session(tmp_path)
+
+    with pytest.raises(ValueError, match="No CandidateResult"):
+        create_promotion_record(session, 999)
+
+
+def test_start_paper_trading_transitions_passed_gate_to_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    before = datetime.now(UTC)
+
+    updated = start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    assert updated.state == PromotionState.PAPER_TRADING.value
+    assert updated.paper_trading_db_path == "tradesv3.dryrun.sqlite"
+    assert updated.paper_trading_started_at.replace(tzinfo=UTC) >= before
+
+
+def test_start_paper_trading_raises_when_not_in_passed_gate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    with pytest.raises(ValueError, match="cannot start paper trading"):
+        start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+
+def test_promote_to_live_transitions_live_eligible_to_live(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+    record.state = PromotionState.LIVE_ELIGIBLE.value
+    session.flush()
+
+    updated = promote_to_live(session, record.id)
+
+    assert updated.state == PromotionState.LIVE.value
+    assert updated.resolved_at is not None
+
+
+def test_promote_to_live_raises_from_paper_trading_directly(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    with pytest.raises(ValueError, match="cannot promote to live"):
+        promote_to_live(session, record.id)
+
+
+def test_reject_transitions_paper_trading_and_live_eligible_to_rejected(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+
+    record_a = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record_a.id, "a.sqlite")
+    rejected_a = reject(session, record_a.id, "degraded in paper trading")
+    assert rejected_a.state == PromotionState.REJECTED.value
+    assert rejected_a.resolution_reason == "degraded in paper trading"
+
+    record_b = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record_b.id, "b.sqlite")
+    record_b.state = PromotionState.LIVE_ELIGIBLE.value
+    session.flush()
+    rejected_b = reject(session, record_b.id, "manual override")
+    assert rejected_b.state == PromotionState.REJECTED.value
+
+
+def test_reject_raises_from_passed_gate_and_already_resolved_states(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+
+    with pytest.raises(ValueError, match=r"reject\(\) only applies"):
+        reject(session, record.id, "too early")
+
+    start_paper_trading(session, record.id, "a.sqlite")
+    reject(session, record.id, "first rejection")
+    with pytest.raises(ValueError, match=r"reject\(\) only applies"):
+        reject(session, record.id, "second rejection")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_promotion.py -v`
+Expected: FAIL/ERROR with `ModuleNotFoundError: No module named 'research.promotion'`
+
+- [ ] **Step 3: Add `PromotionRecord` to `research/models.py`**
+
+Append to the end of `research/models.py`:
+
+```python
+class PromotionRecord(Base):
+    """One row per promotion attempt for a specific passing CandidateResult -- tracks
+    the Paper-Trading -> Live-eligibility lifecycle. A candidate can have many
+    CandidateResult rows (re-runs, parameter sweeps); only specific passing runs ever
+    get a PromotionRecord, and most never do."""
+
+    __tablename__ = "promotion_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    candidate_result_id: Mapped[int] = mapped_column(Integer, index=True)
+    state: Mapped[str] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    paper_trading_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    paper_trading_db_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    resolution_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+```
+
+No new imports needed — `research/models.py` already imports `Boolean, DateTime, Float,
+Integer, String` and `datetime` at the top of the file.
+
+- [ ] **Step 4: Implement the state machine in `research/promotion.py`**
+
+Create `research/promotion.py`:
+
+```python
+# research/promotion.py
+"""Paper-trading promotion tracker: a state machine tracking a gate-passing candidate's
+lifecycle from PASSED_GATE through PAPER_TRADING to a LIVE_ELIGIBLE recommendation or a
+REJECTED verdict. LIVE is reachable only via a direct, manual promote_to_live() call --
+never from any automated evaluation path (see evaluate_paper_trading_health /
+apply_health_evaluation, added in Task 2 of this module's plan). See
+docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md for the full design.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+
+from sqlalchemy.orm import Session
+
+from research.models import CandidateResult, PromotionRecord
+
+
+class PromotionState(str, Enum):
+    PASSED_GATE = "passed_gate"
+    PAPER_TRADING = "paper_trading"
+    LIVE_ELIGIBLE = "live_eligible"
+    LIVE = "live"
+    REJECTED = "rejected"
+
+
+def _load_promotion_record(session: Session, promotion_id: int) -> PromotionRecord:
+    record = session.get(PromotionRecord, promotion_id)
+    if record is None:
+        raise ValueError(f"No PromotionRecord with id {promotion_id}")
+    return record
+
+
+def create_promotion_record(session: Session, candidate_result_id: int) -> PromotionRecord:
+    """Start a new promotion lifecycle for a candidate that already passed the gate.
+
+    Raises ValueError if candidate_result_id doesn't exist, or if that candidate's
+    CandidateResult.survived is not True -- only a passing gate result may be promoted.
+    """
+    candidate = session.get(CandidateResult, candidate_result_id)
+    if candidate is None:
+        raise ValueError(f"No CandidateResult with id {candidate_result_id}")
+    if not candidate.survived:
+        raise ValueError(
+            f"CandidateResult {candidate_result_id} did not pass the gate "
+            "(survived=False) -- only a passing candidate may be promoted."
+        )
+    record = PromotionRecord(
+        candidate_result_id=candidate_result_id,
+        state=PromotionState.PASSED_GATE.value,
+        created_at=datetime.now(UTC),
+    )
+    session.add(record)
+    session.flush()
+    return record
+
+
+def start_paper_trading(
+    session: Session,
+    promotion_id: int,
+    dry_run_db_path: str,
+    started_at: datetime | None = None,
+) -> PromotionRecord:
+    """Transition PASSED_GATE -> PAPER_TRADING.
+
+    Raises ValueError if the record doesn't exist or isn't currently PASSED_GATE.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PASSED_GATE.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PASSED_GATE.value!r} -- cannot start paper trading."
+        )
+    record.state = PromotionState.PAPER_TRADING.value
+    record.paper_trading_db_path = dry_run_db_path
+    record.paper_trading_started_at = started_at or datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def promote_to_live(session: Session, promotion_id: int) -> PromotionRecord:
+    """Transition LIVE_ELIGIBLE -> LIVE. The only function in this module that can
+    produce a LIVE state -- called only by a human, directly, never from
+    apply_health_evaluation or any other automated path.
+
+    Raises ValueError if the record doesn't exist or isn't currently LIVE_ELIGIBLE.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.LIVE_ELIGIBLE.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.LIVE_ELIGIBLE.value!r} -- cannot promote to live."
+        )
+    record.state = PromotionState.LIVE.value
+    record.resolved_at = datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def reject(session: Session, promotion_id: int, reason: str) -> PromotionRecord:
+    """Manually transition PAPER_TRADING or LIVE_ELIGIBLE -> REJECTED.
+
+    Raises ValueError if the record doesn't exist, is currently PASSED_GATE (paper
+    trading never started), or is already resolved (REJECTED/LIVE).
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state not in (
+        PromotionState.PAPER_TRADING.value,
+        PromotionState.LIVE_ELIGIBLE.value,
+    ):
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r} -- "
+            f"reject() only applies from {PromotionState.PAPER_TRADING.value!r} or "
+            f"{PromotionState.LIVE_ELIGIBLE.value!r}."
+        )
+    record.state = PromotionState.REJECTED.value
+    record.resolved_at = datetime.now(UTC)
+    record.resolution_reason = reason
+    session.flush()
+    return record
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest research/tests/test_promotion.py -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 6: Lint and format**
+
+Run: `ruff check research/models.py research/promotion.py research/tests/test_promotion.py`
+and `ruff format --check research/models.py research/promotion.py
+research/tests/test_promotion.py`
+Expected: no errors (fix with `ruff check --fix` / `ruff format` if needed, then re-run
+Step 5 to confirm nothing broke)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add research/models.py research/promotion.py research/tests/test_promotion.py
+git commit -m "feat(research): add promotion.py state machine -- PASSED_GATE through LIVE"
+```
+
+---
+
+### Task 2: health evaluator (freqtrade Trade-persistence integration)
+
+**Files:**
+- Modify: `research/promotion.py` (add `MIN_*` constants, `evaluate_paper_trading_health`,
+  `apply_health_evaluation`)
+- Test: `research/tests/test_promotion.py` (append)
+
+**Interfaces:**
+- Consumes: `PromotionState`, `_load_promotion_record`, `PromotionRecord`,
+  `CandidateResult` (all from Task 1, already committed), `freqtrade.persistence.init_db`,
+  `freqtrade.persistence.Trade`, `freqtrade.data.metrics.calculate_sharpe` (all existing,
+  unmodified freqtrade APIs).
+- Produces: `evaluate_paper_trading_health(session, promotion_id, starting_balance,
+  dry_run_db_path=None, periods_per_year=365) -> dict`, `apply_health_evaluation(session,
+  promotion_id, evaluation) -> PromotionRecord` — nothing further downstream; this is the
+  final task in the plan.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `research/tests/test_promotion.py`. First, add these imports at the top of the
+file (alongside the existing ones):
+
+```python
+from datetime import timedelta
+
+import pandas as pd
+from freqtrade.persistence import Trade, init_db
+
+from research.promotion import apply_health_evaluation, evaluate_paper_trading_health
+```
+
+Then append the following. A file-scoped autouse fixture first (this MUST be present
+before any test in this file that calls `evaluate_paper_trading_health` runs, so add it
+near the top of the new test code, not at the bottom):
+
+```python
+@pytest.fixture(autouse=True)
+def _reset_trade_session_after_evaluation_tests():
+    """evaluate_paper_trading_health() calls freqtrade's own init_db(), which sets
+    Trade.session as GLOBAL class-level state (see the plan's Global Constraints for
+    why) -- reset it to a fresh in-memory DB after every test in this file so no later
+    test (in this file or elsewhere in the same pytest-xdist worker) can see
+    Trade.session still pointed at one of this file's throwaway dry-run databases."""
+    yield
+    init_db("sqlite://")
+
+
+def _insert_dry_run_trades(dry_run_db_path, strategy_id, started_at, profits_abs):
+    """Directly construct and insert closed Trade rows into a fresh dry-run-style
+    sqlite database -- one trade per entry in profits_abs, spaced evenly across the
+    period from started_at to now, matching how research/tests/test_regime.py and
+    test_scoring.py construct real rows directly rather than running a full backtest."""
+    init_db(f"sqlite:///{dry_run_db_path}")
+    now = datetime.now(UTC).replace(tzinfo=None)
+    started_naive = started_at.replace(tzinfo=None) if started_at.tzinfo else started_at
+    span = now - started_naive
+    step = span / max(1, len(profits_abs))
+    for i, profit in enumerate(profits_abs):
+        open_dt = started_naive + step * i
+        close_dt = open_dt + timedelta(minutes=30)
+        trade = Trade(
+            pair="BTC/USDT",
+            strategy=strategy_id,
+            exchange="binance",
+            is_open=False,
+            open_date=open_dt,
+            close_date=close_dt,
+            close_profit_abs=float(profit),
+            stake_amount=100.0,
+            amount=1.0,
+            open_rate=100.0,
+            close_rate=100.0 + float(profit) / 100.0,
+            fee_open=0.001,
+            fee_close=0.001,
+        )
+        Trade.session.add(trade)
+    Trade.session.flush()
+    Trade.session.commit()
+    init_db("sqlite://")  # release this function's own Trade.session redirect immediately
+
+
+def test_evaluate_paper_trading_health_not_enough_evidence_when_too_few_trades(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_thin.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_thin.sqlite", "TestStrategy", started_at, [8, 6, 7]
+    )  # only 3 trades, MIN_PAPER_TRADES is 10
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is False
+    assert evaluation["eligible"] is False
+    assert evaluation["n_trades"] == 3
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.PAPER_TRADING.value
+
+
+def test_evaluate_paper_trading_health_eligible_when_degradation_ratio_clears_bar(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_good.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_good.sqlite",
+        "TestStrategy",
+        started_at,
+        [8, 6, 7, 9, 5, 8, 6, 7, 9, 5],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is True
+    assert evaluation["n_trades"] == 10
+    assert evaluation["paper_sharpe"] == pytest.approx(67.54628043053148)
+    assert evaluation["degradation_ratio"] == pytest.approx(1.0)
+    assert evaluation["eligible"] is True
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.LIVE_ELIGIBLE.value
+    assert updated.resolved_at is not None
+
+
+def test_evaluate_paper_trading_health_rejected_when_degradation_ratio_fails_bar(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_bad.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_bad.sqlite",
+        "TestStrategy",
+        started_at,
+        [-3, 2, -4, 1, -2, 3, -5, 2, -3, 1],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is True
+    assert evaluation["paper_sharpe"] == pytest.approx(-3.9705208944418664)
+    assert evaluation["degradation_ratio"] == pytest.approx(0.0)
+    assert evaluation["eligible"] is False
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.REJECTED.value
+    assert updated.resolution_reason is not None
+
+
+def test_evaluate_paper_trading_health_zero_trades_does_not_raise(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=1)
+    dry_run_path = tmp_path / "dryrun_empty.sqlite"
+    start_paper_trading(session, record.id, str(dry_run_path), started_at)
+    init_db(f"sqlite:///{dry_run_path}")  # create the (empty) schema, no trades inserted
+    init_db("sqlite://")
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["n_trades"] == 0
+    assert evaluation["paper_sharpe"] == 0
+    assert evaluation["enough_evidence"] is False
+
+
+def test_evaluate_paper_trading_health_non_positive_oos_sharpe_is_zero_degradation(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=-0.5)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_neg.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_neg.sqlite",
+        "TestStrategy",
+        started_at,
+        [8, 6, 7, 9, 5, 8, 6, 7, 9, 5],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["degradation_ratio"] == 0.0
+
+
+def test_evaluate_paper_trading_health_raises_when_not_in_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+
+    with pytest.raises(ValueError, match="cannot evaluate health"):
+        evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+
+def test_apply_health_evaluation_raises_when_not_in_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    canned_evaluation = {
+        "eligible": True,
+        "enough_evidence": True,
+        "days_elapsed": 30,
+        "n_trades": 20,
+        "paper_sharpe": 1.5,
+        "degradation_ratio": 0.9,
+        "reasons": [],
+    }
+
+    with pytest.raises(ValueError, match="cannot apply a health evaluation"):
+        apply_health_evaluation(session, record.id, canned_evaluation)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_promotion.py -v -k "health or apply"`
+Expected: FAIL with `ImportError: cannot import name 'evaluate_paper_trading_health' from 'research.promotion'`
+
+- [ ] **Step 3: Implement the health evaluator**
+
+Append to `research/promotion.py`. First, update the imports at the top of the file to
+add:
+
+```python
+import pandas as pd
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.persistence import Trade, init_db
+```
+
+Then append the constants and both functions:
+
+```python
+# ponytail: starting defaults, not derived from any real paper-trading history (none
+# exists yet in this fork) -- adjust based on real usage once this runs against real
+# strategies.
+MIN_PAPER_TRADING_DAYS = 14
+MIN_PAPER_TRADES = 10
+MIN_DEGRADATION_RATIO = 0.5
+
+
+def evaluate_paper_trading_health(
+    session: Session,
+    promotion_id: int,
+    starting_balance: float,
+    dry_run_db_path: str | None = None,
+    periods_per_year: int = 365,
+) -> dict:
+    """Pure evaluation (no state mutation) of a PAPER_TRADING record's real dry-run
+    trade history. Returns a verdict dict; call apply_health_evaluation with the result
+    to actually transition state.
+
+    `starting_balance` is required -- the paper-trading bot's own configured wallet
+    size, which this function has no other way to discover (see the spec for why
+    run_promotion_gate's config isn't available here).
+
+    IMPORTANT: freqtrade.persistence.init_db() sets Trade.session as GLOBAL class-level
+    state, not a scoped per-call connection. This function fully materializes its query
+    results before returning and must never be called concurrently with, or interleaved
+    with, other in-process code relying on Trade.session pointing at a different
+    database (e.g. a WalkForwardRunner/Backtesting run in the same process).
+
+    Known limitation: the returned degradation_ratio is a coarse heuristic, not a
+    statistically rigorous comparison -- a paper-trading window is typically far
+    shorter than the OOS window a candidate was originally evaluated over, so
+    paper_sharpe carries materially more estimation noise than the OOS baseline it's
+    compared against. Treat this as a first-pass filter for human judgment, not proof.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PAPER_TRADING.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PAPER_TRADING.value!r} -- cannot evaluate health."
+        )
+    candidate = session.get(CandidateResult, record.candidate_result_id)
+    if candidate is None:
+        raise ValueError(f"No CandidateResult with id {record.candidate_result_id}")
+
+    db_path = dry_run_db_path or record.paper_trading_db_path
+
+    now = datetime.now(UTC)
+    started_at_aware = record.paper_trading_started_at
+    if started_at_aware.tzinfo is None:
+        started_at_aware = started_at_aware.replace(tzinfo=UTC)
+    started_at_naive = started_at_aware.replace(tzinfo=None)
+
+    days_elapsed = (now - started_at_aware).days
+
+    init_db(f"sqlite:///{db_path}")
+    closed_trades = (
+        Trade.session.query(Trade)
+        .filter(
+            Trade.strategy == candidate.strategy_id,
+            Trade.is_open.is_(False),
+            Trade.close_date >= started_at_naive,
+        )
+        .all()
+    )
+    n_trades = len(closed_trades)
+
+    if n_trades > 0:
+        trades_df = pd.DataFrame({"profit_abs": [t.close_profit_abs for t in closed_trades]})
+        paper_sharpe = calculate_sharpe(trades_df, started_at_aware, now, starting_balance)
+    else:
+        paper_sharpe = 0
+
+    if candidate.oos_sharpe > 0:
+        degradation_ratio = max(0.0, min(1.0, paper_sharpe / candidate.oos_sharpe))
+    else:
+        degradation_ratio = 0.0
+
+    reasons: list[str] = []
+    enough_evidence = days_elapsed >= MIN_PAPER_TRADING_DAYS and n_trades >= MIN_PAPER_TRADES
+    if not enough_evidence:
+        eligible = False
+        if days_elapsed < MIN_PAPER_TRADING_DAYS:
+            reasons.append(
+                f"only {days_elapsed} days elapsed, need >= {MIN_PAPER_TRADING_DAYS}"
+            )
+        if n_trades < MIN_PAPER_TRADES:
+            reasons.append(f"only {n_trades} trades, need >= {MIN_PAPER_TRADES}")
+    elif degradation_ratio < MIN_DEGRADATION_RATIO:
+        eligible = False
+        reasons.append(
+            f"degradation_ratio {degradation_ratio:.3f} below threshold {MIN_DEGRADATION_RATIO}"
+        )
+    else:
+        eligible = True
+
+    return {
+        "eligible": eligible,
+        "enough_evidence": enough_evidence,
+        "days_elapsed": days_elapsed,
+        "n_trades": n_trades,
+        "paper_sharpe": paper_sharpe,
+        "degradation_ratio": degradation_ratio,
+        "reasons": reasons,
+    }
+
+
+def apply_health_evaluation(
+    session: Session, promotion_id: int, evaluation: dict
+) -> PromotionRecord:
+    """Apply an evaluate_paper_trading_health() result to the state machine.
+
+    PAPER_TRADING -> LIVE_ELIGIBLE if eligible; PAPER_TRADING -> REJECTED if there's
+    enough evidence but it failed the bar; otherwise no state change (stays
+    PAPER_TRADING for a future re-evaluation).
+
+    Raises ValueError if the record doesn't exist or isn't currently PAPER_TRADING.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PAPER_TRADING.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PAPER_TRADING.value!r} -- cannot apply a health evaluation."
+        )
+    if evaluation["eligible"]:
+        record.state = PromotionState.LIVE_ELIGIBLE.value
+        record.resolved_at = datetime.now(UTC)
+        record.resolution_reason = (
+            f"paper_sharpe={evaluation['paper_sharpe']:.3f}, "
+            f"degradation_ratio={evaluation['degradation_ratio']:.3f}, "
+            f"n_trades={evaluation['n_trades']}, days_elapsed={evaluation['days_elapsed']}"
+        )
+    elif evaluation["enough_evidence"]:
+        record.state = PromotionState.REJECTED.value
+        record.resolved_at = datetime.now(UTC)
+        record.resolution_reason = "; ".join(evaluation["reasons"])
+    session.flush()
+    return record
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest research/tests/test_promotion.py -v`
+Expected: PASS (16 tests: 9 from Task 1 + 7 new)
+
+- [ ] **Step 5: Lint and format**
+
+Run: `ruff check research/promotion.py research/tests/test_promotion.py` and
+`ruff format --check research/promotion.py research/tests/test_promotion.py`
+Expected: no errors (fix and re-run Step 4 if needed)
+
+- [ ] **Step 6: Run the full research suite**
+
+Run: `pytest research/ -v`
+Expected: PASS (every test in `research/tests/`, confirming this module composes
+cleanly with the rest of the package and doesn't leak `Trade.session` state into any
+other file's tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add research/promotion.py research/tests/test_promotion.py
+git commit -m "feat(research): add paper-trading health evaluator reading real freqtrade dry-run data"
+```

--- a/docs/superpowers/plans/2026-08-24-regime-breakdown.md
+++ b/docs/superpowers/plans/2026-08-24-regime-breakdown.md
@@ -1,0 +1,760 @@
+# Regime Breakdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attribute a promotion-gate candidate's out-of-sample walk-forward performance to
+the market conditions (Trend × Volatility) each window's test period actually occurred in,
+as a new, purely informational field on `GateResult`.
+
+**Architecture:** One new module, `research/regime.py`, with two pure functions:
+`classify_regimes` (labels each `Window` from its own OHLCV test-period data) and
+`regime_report` (groups an existing gate run's `WindowResult`s by those labels and
+aggregates). `research/gate.py` and `research/cli.py` are extended to wire an opt-in flag
+through to these two functions and print the result — no existing behavior changes when
+the flag is unused.
+
+**Tech Stack:** Python, pandas/numpy, freqtrade's `history.load_data`/`TimeRange` (already
+used by `research/walkforward.py`), pytest with real fixture data (`UNITTEST/BTC`,
+`tests/testdata/`) — no mocking of the classification/aggregation logic itself.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-regime-breakdown-design.md`
+
+## Global Constraints
+
+- Two axes only — Trend (Bull/Bear/Sideways) × Volatility (High/Low), 6 possible combined
+  labels (`"{Trend}/{Volatility}"`). No Crash/Recovery, no unsupervised/statistical model,
+  no new data source beyond the traded pair's own OHLCV.
+- `classify_regimes(pair: str, timeframe: str, datadir: Path, windows: list[Window],
+  trend_threshold: float = 0.05) -> list[str]` — one label per window, same order as
+  `windows`. `trend_threshold` default `0.05` is a starting value, not empirically derived
+  — mark with a `ponytail:` comment, don't remove or "improve" it during implementation.
+- Trend label: `"Bull"` if `total_return > trend_threshold`, `"Bear"` if
+  `total_return < -trend_threshold`, else `"Sideways"`.
+- Volatility label: `"High"` if this window's `realized_vol` is strictly greater than the
+  **median** `realized_vol` across every window in this same `classify_regimes` call,
+  `"Low"` otherwise. Strict `>`, not `>=` — a tie with the median is `"Low"` by construction.
+  This is a deliberate design choice, not something to "fix" during review.
+- Degenerate window (test period has fewer than 2 candles): fail closed to
+  `total_return=0.0, realized_vol=0.0` — no exception, no crash. `0.0` is inside
+  `[-trend_threshold, trend_threshold]`, so this is `"Sideways"` on the trend axis by
+  construction.
+- `classify_regimes` raises `ValueError` on an empty `windows` list.
+- `regime_report(window_results: list[WindowResult], labels: list[str]) -> dict[str, dict]`
+  raises `ValueError` if `len(window_results) != len(labels)`.
+- `regime_report`'s per-label aggregate is `{"n_windows": int, "n_trades": int,
+  "mean_test_sharpe": float, "total_return": float}`. `total_return` is the plain
+  **arithmetic sum** of every trade's fractional return across the group's windows — NOT
+  geometrically compounded, NOT named `total_pnl`. Do not add a `NaN`-guard around
+  `mean_test_sharpe` — `WindowResult.test_sharpe` is never `NaN` for a zero-trade window
+  (`calculate_sharpe` returns the plain sentinel `0`, verified against
+  `freqtrade/data/metrics.py`), so `np.mean` over any group is always well-defined.
+- `run_promotion_gate` gains `include_regime_breakdown: bool = False` (default off —
+  existing callers/tests unaffected) and `GateResult` gains
+  `regime_breakdown: dict[str, dict] | None = None`.
+- **Deliberate asymmetry with the fee-sensitivity precedent, do not "fix" to match it:**
+  regime breakdown is computed whenever `include_regime_breakdown=True`, **regardless of
+  `passed`** — unlike `fee_sensitivity_multipliers`, which only runs when the gate passes.
+  A failed candidate's regime breakdown is diagnostic evidence, not wasted compute.
+- Regime breakdown uses `pairs[0]` as the single reference pair for classification.
+  Multi-pair blending is explicitly out of scope.
+- No mocking of `classify_regimes`/`regime_report`'s own logic in tests — real
+  `history.load_data` against real `tests/testdata/UNITTEST/BTC` fixture data, real
+  `WindowResult`/`Window` dataclass construction, matching every existing file in
+  `research/tests/`. `classify_regimes` never touches `Backtesting` or `Exchange` (it only
+  calls `history.load_data`), so its tests need none of the `patch_exchange`/`_conf()`
+  boilerplate the other `research/tests/` files use.
+
+---
+
+### Task 1: `research/regime.py` — classification and aggregation
+
+**Files:**
+- Create: `research/regime.py`
+- Test: `research/tests/test_regime.py`
+
+**Interfaces:**
+- Consumes: `research.walkforward.Window`, `research.walkforward.WindowResult` (both
+  existing dataclasses — see their definitions in `research/walkforward.py:19-49`),
+  `freqtrade.configuration.TimeRange`, `freqtrade.data.history.load_data`.
+- Produces: `classify_regimes(pair: str, timeframe: str, datadir: Path, windows:
+  list[Window], trend_threshold: float = 0.05) -> list[str]` and
+  `regime_report(window_results: list[WindowResult], labels: list[str]) -> dict[str,
+  dict]` — both consumed directly by Task 2.
+
+- [ ] **Step 1: Write the failing tests for `classify_regimes`**
+
+Create `research/tests/test_regime.py`:
+
+```python
+# research/tests/test_regime.py
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from research.regime import classify_regimes, regime_report
+from research.walkforward import Window, WindowResult
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+PAIR = "UNITTEST/BTC"
+TIMEFRAME = "5m"
+
+
+def _split_into_n_windows(min_date, max_date, n):
+    """N equal-duration, contiguous windows spanning [min_date, max_date). Only
+    test_start/test_end matter to classify_regimes, so train_start/train_end are set
+    equal to test_start -- unused, but Window requires all four fields."""
+    step = (max_date - min_date) / n
+    windows = []
+    for i in range(n):
+        test_start = min_date + step * i
+        test_end = min_date + step * (i + 1)
+        windows.append(
+            Window(
+                train_start=test_start, train_end=test_start, test_start=test_start,
+                test_end=test_end,
+            )
+        )
+    return windows
+
+
+def _real_return_and_vol(pair, timeframe, datadir, window):
+    """Independently recompute a window's total_return/realized_vol via a fresh
+    history.load_data call -- a separate execution path from classify_regimes' own
+    internals, used to derive the expected label from real data rather than a
+    hand-picked one."""
+    timerange = TimeRange(
+        "date", "date", int(window.test_start.timestamp()), int(window.test_end.timestamp())
+    )
+    data = history.load_data(datadir=datadir, timeframe=timeframe, pairs=[pair], timerange=timerange)
+    close = data[pair]["close"]
+    if len(close) < 2:
+        return 0.0, 0.0
+    return float(close.iloc[-1] / close.iloc[0] - 1), float(close.pct_change().dropna().std())
+
+
+def test_classify_regimes_trend_axis_matches_threshold_on_real_data():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, max_date = get_timerange(full_data)
+    windows = _split_into_n_windows(min_date, max_date, n=5)
+    trend_threshold = 0.05
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, windows, trend_threshold=trend_threshold)
+
+    assert len(labels) == len(windows)
+    for window, label in zip(windows, labels):
+        total_return, _ = _real_return_and_vol(PAIR, TIMEFRAME, TESTDATADIR, window)
+        if total_return > trend_threshold:
+            expected_trend = "Bull"
+        elif total_return < -trend_threshold:
+            expected_trend = "Bear"
+        else:
+            expected_trend = "Sideways"
+        assert label.split("/")[0] == expected_trend
+
+
+def test_classify_regimes_volatility_axis_ranks_relative_to_median_on_real_data():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, max_date = get_timerange(full_data)
+    windows = _split_into_n_windows(min_date, max_date, n=5)
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, windows)
+
+    vols = [_real_return_and_vol(PAIR, TIMEFRAME, TESTDATADIR, w)[1] for w in windows]
+    median_vol = float(np.median(vols))
+    for vol, label in zip(vols, labels):
+        expected_volatility = "High" if vol > median_vol else "Low"
+        assert label.split("/")[1] == expected_volatility
+
+
+def test_classify_regimes_degenerate_window_is_sideways_and_does_not_raise():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, _ = get_timerange(full_data)
+    tiny_end = min_date + timedelta(seconds=1)  # far shorter than one 5m candle
+    window = Window(
+        train_start=min_date, train_end=min_date, test_start=min_date, test_end=tiny_end
+    )
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [window])
+
+    # single-window input: median vol is that window's own (degenerate) vol of 0.0,
+    # so 0.0 > 0.0 is False -- deterministically "Low", not just "does not crash".
+    assert labels == ["Sideways/Low"]
+
+
+def test_classify_regimes_raises_on_empty_windows():
+    with pytest.raises(ValueError, match="windows"):
+        classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_regime.py -v`
+Expected: FAIL/ERROR with `ModuleNotFoundError: No module named 'research.regime'` (the
+`regime_report` tests added in Step 5 aren't written yet — only run the four tests above
+for now, e.g. `pytest research/tests/test_regime.py -v -k "classify_regimes"`).
+
+- [ ] **Step 3: Implement `classify_regimes`**
+
+Create `research/regime.py`:
+
+```python
+# research/regime.py
+"""Regime breakdown: labels each walk-forward window's out-of-sample test period by the
+market conditions it actually occurred in (Trend x Volatility), and aggregates a gate's
+window-level results by that label. Purely informational -- never changes
+GateResult.passed. See docs/superpowers/specs/2026-08-24-regime-breakdown-design.md for
+full reasoning, including why this classifier is NOT safe to reuse for a live/production
+regime-switching signal: it ranks each window against the full-sample median of every
+window in this run, including ones chronologically after it -- fine for a one-shot,
+post-hoc report generated after the whole backtest already ran, not causal.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from research.walkforward import Window, WindowResult
+
+
+def classify_regimes(
+    pair: str,
+    timeframe: str,
+    datadir: Path,
+    windows: list[Window],
+    # ponytail: starting default, not empirically derived -- adjust based on real usage
+    # once this runs against real strategies.
+    trend_threshold: float = 0.05,
+) -> list[str]:
+    """Label each window's test period "{Trend}/{Volatility}", e.g. "Bull/High".
+
+    Trend: "Bull" if the test period's total return exceeds `trend_threshold`, "Bear" if
+    below -`trend_threshold`, "Sideways" otherwise.
+
+    Volatility: "High" if this window's realized volatility (std of per-candle pct
+    change) is strictly above the median realized volatility across every window in
+    `windows`, "Low" otherwise (a window sitting exactly on the median is "Low" by
+    construction -- ">", not ">=").
+
+    Self-referential to this run's own windows (no external volatility index needed) --
+    honest about what it is: "more/less volatile than this backtest's other periods," not
+    "objectively high/low."
+
+    A window whose test period has fewer than 2 candles can't compute a return or
+    volatility; it fails closed to total_return=0.0, realized_vol=0.0 (classified
+    "Sideways" on the trend axis by construction, since 0.0 is inside
+    [-trend_threshold, trend_threshold]).
+
+    Returns one label per window, same order as `windows`.
+    """
+    if not windows:
+        raise ValueError("windows must not be empty")
+
+    returns: list[float] = []
+    vols: list[float] = []
+    for window in windows:
+        timerange = TimeRange(
+            "date", "date", int(window.test_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=datadir, timeframe=timeframe, pairs=[pair], timerange=timerange
+        )
+        close = data[pair]["close"]
+        if len(close) < 2:
+            returns.append(0.0)
+            vols.append(0.0)
+            continue
+        returns.append(float(close.iloc[-1] / close.iloc[0] - 1))
+        vols.append(float(close.pct_change().dropna().std()))
+
+    median_vol = float(np.median(vols))
+
+    labels = []
+    for total_return, realized_vol in zip(returns, vols):
+        if total_return > trend_threshold:
+            trend = "Bull"
+        elif total_return < -trend_threshold:
+            trend = "Bear"
+        else:
+            trend = "Sideways"
+        volatility = "High" if realized_vol > median_vol else "Low"
+        labels.append(f"{trend}/{volatility}")
+    return labels
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest research/tests/test_regime.py -v -k "classify_regimes"`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Write the failing tests for `regime_report`**
+
+Append to `research/tests/test_regime.py`:
+
+```python
+_DUMMY_WINDOW = Window(
+    train_start=datetime(2020, 1, 1, tzinfo=UTC),
+    train_end=datetime(2020, 1, 8, tzinfo=UTC),
+    test_start=datetime(2020, 1, 8, tzinfo=UTC),
+    test_end=datetime(2020, 1, 15, tzinfo=UTC),
+)
+
+
+def test_regime_report_aggregates_by_label():
+    wr_a1 = WindowResult(
+        window=_DUMMY_WINDOW, variant_returns={}, best_params={}, train_sharpe=0.0,
+        test_sharpe=1.0, test_n_trades=3, test_returns=[0.01, 0.02, -0.01],
+    )
+    wr_a2 = WindowResult(
+        window=_DUMMY_WINDOW, variant_returns={}, best_params={}, train_sharpe=0.0,
+        test_sharpe=2.0, test_n_trades=2, test_returns=[0.03, 0.04],
+    )
+    wr_b1 = WindowResult(
+        window=_DUMMY_WINDOW, variant_returns={}, best_params={}, train_sharpe=0.0,
+        test_sharpe=-1.0, test_n_trades=5, test_returns=[-0.05, -0.02, 0.01, -0.03, -0.01],
+    )
+
+    report = regime_report([wr_a1, wr_a2, wr_b1], ["Bull/High", "Bull/High", "Bear/Low"])
+
+    assert set(report) == {"Bull/High", "Bear/Low"}
+    assert report["Bull/High"]["n_windows"] == 2
+    assert report["Bull/High"]["n_trades"] == 5
+    assert report["Bull/High"]["mean_test_sharpe"] == pytest.approx(1.5)
+    assert report["Bull/High"]["total_return"] == pytest.approx(0.01 + 0.02 - 0.01 + 0.03 + 0.04)
+    assert report["Bear/Low"]["n_windows"] == 1
+    assert report["Bear/Low"]["n_trades"] == 5
+    assert report["Bear/Low"]["mean_test_sharpe"] == pytest.approx(-1.0)
+    assert report["Bear/Low"]["total_return"] == pytest.approx(-0.05 - 0.02 + 0.01 - 0.03 - 0.01)
+
+
+def test_regime_report_raises_on_mismatched_lengths():
+    wr = WindowResult(
+        window=_DUMMY_WINDOW, variant_returns={}, best_params={}, train_sharpe=0.0,
+        test_sharpe=1.0, test_n_trades=1, test_returns=[0.01],
+    )
+    with pytest.raises(ValueError, match="same length"):
+        regime_report([wr], ["Bull/High", "Bear/Low"])
+```
+
+Add `from datetime import UTC, datetime, timedelta` is already at the top of the file from
+Step 1 — no new import needed for `_DUMMY_WINDOW`.
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_regime.py -v -k "regime_report"`
+Expected: FAIL with `ImportError: cannot import name 'regime_report' from 'research.regime'`
+
+- [ ] **Step 7: Implement `regime_report`**
+
+Append to `research/regime.py`:
+
+```python
+def regime_report(window_results: list[WindowResult], labels: list[str]) -> dict[str, dict]:
+    """Group `window_results` by their parallel `labels` entry and aggregate each group.
+
+    Raises ValueError if len(window_results) != len(labels) -- mismatched parallel lists
+    is a caller-contract violation, not a data problem.
+
+    Returns {label: {"n_windows": int, "n_trades": int, "mean_test_sharpe": float,
+    "total_return": float}}. `total_return` is the plain arithmetic sum of every trade's
+    fractional return across the group's windows -- NOT a geometrically compounded
+    return, a rough same-units aggregate for comparing regime buckets against each
+    other, not a claim about realized account growth.
+
+    WindowResult.test_sharpe is never NaN for a zero-trade window (calculate_sharpe
+    returns the plain sentinel 0), so np.mean over any group is always well-defined --
+    no NaN-guard needed here.
+    """
+    if len(window_results) != len(labels):
+        raise ValueError(
+            f"window_results and labels must be the same length, got "
+            f"{len(window_results)} and {len(labels)}"
+        )
+
+    grouped: dict[str, list[WindowResult]] = defaultdict(list)
+    for wr, label in zip(window_results, labels):
+        grouped[label].append(wr)
+
+    report: dict[str, dict] = {}
+    for label, group in grouped.items():
+        report[label] = {
+            "n_windows": len(group),
+            "n_trades": sum(wr.test_n_trades for wr in group),
+            "mean_test_sharpe": float(np.mean([wr.test_sharpe for wr in group])),
+            "total_return": sum(r for wr in group for r in wr.test_returns),
+        }
+    return report
+```
+
+- [ ] **Step 8: Run all tests in the file to verify they pass**
+
+Run: `pytest research/tests/test_regime.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 9: Lint and format**
+
+Run: `ruff check research/regime.py research/tests/test_regime.py` and
+`ruff format --check research/regime.py research/tests/test_regime.py`
+Expected: no errors (fix with `ruff check --fix` / `ruff format` if needed, then re-run
+the test suite from Step 8 to confirm nothing broke)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add research/regime.py research/tests/test_regime.py
+git commit -m "feat(research): add regime.py -- Trend x Volatility window classification"
+```
+
+---
+
+### Task 2: `research/gate.py` — wire regime breakdown into the promotion gate
+
+**Files:**
+- Modify: `research/gate.py:1-22` (imports), `:25-37` (`GateResult`), `:40-158`
+  (`run_promotion_gate`)
+- Test: `research/tests/test_gate.py`
+
+**Interfaces:**
+- Consumes: `research.regime.classify_regimes`, `research.regime.regime_report` (Task 1).
+  `windows` and `results` are already in scope inside `run_promotion_gate` from the
+  existing walk-forward run (`research/gate.py:77` and `:85`) — no duplicate computation.
+- Produces: `GateResult.regime_breakdown: dict[str, dict] | None`, and
+  `run_promotion_gate(..., include_regime_breakdown: bool = False)` — both consumed by
+  Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `research/tests/test_gate.py`:
+
+```python
+def test_run_promotion_gate_attaches_regime_breakdown_when_requested_and_passes(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Permissive thresholds guarantee a real, unmocked PASS (see the fee-sensitivity
+    # pass test above for the same pattern).
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=0.0,
+        fdr_q=1.0,
+        pbo_threshold=1.0,
+        include_regime_breakdown=True,
+    )
+
+    assert result.passed is True
+    assert result.regime_breakdown is not None
+    assert len(result.regime_breakdown) > 0
+
+
+def test_run_promotion_gate_attaches_regime_breakdown_when_requested_and_fails(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Impossible dsr_threshold guarantees a real FAIL (see the fee-sensitivity skip test
+    # above for the same pattern). Regime breakdown must still be attached -- this is the
+    # test that actually proves the deliberate asymmetry with fee-sensitivity was
+    # implemented, not just described in the spec.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=1.1,
+        include_regime_breakdown=True,
+    )
+
+    assert result.passed is False
+    assert result.regime_breakdown is not None
+    assert len(result.regime_breakdown) > 0
+
+
+def test_run_promotion_gate_omits_regime_breakdown_by_default(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+    )
+
+    assert result.regime_breakdown is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_gate.py -v -k regime_breakdown`
+Expected: FAIL with `TypeError: run_promotion_gate() got an unexpected keyword argument
+'include_regime_breakdown'`
+
+- [ ] **Step 3: Wire `include_regime_breakdown` into `run_promotion_gate` and `GateResult`**
+
+In `research/gate.py`, add the import (alongside the existing `research.*` imports at the
+top of the file):
+
+```python
+from research.regime import classify_regimes, regime_report
+```
+
+Add the new field to `GateResult` (after the existing `fee_sensitivity` field):
+
+```python
+    fee_sensitivity: dict[float, dict] | None = None
+    regime_breakdown: dict[str, dict] | None = None
+```
+
+Add the new parameter to `run_promotion_gate`'s signature (after
+`fee_sensitivity_multipliers`):
+
+```python
+    fee_sensitivity_multipliers: tuple[float, ...] | None = None,
+    include_regime_breakdown: bool = False,
+) -> GateResult:
+```
+
+Inside `run_promotion_gate`, after the existing `fee_report` block (which computes
+`fee_report` conditionally on `passed`) and before the `log_candidate_result` call, add
+the unconditional regime-breakdown block:
+
+```python
+    regime_breakdown = None
+    if include_regime_breakdown:
+        labels = classify_regimes(pairs[0], timeframe, datadir, windows)
+        regime_breakdown = regime_report(results, labels)
+```
+
+Note this block does **not** check `passed` — that is the one deliberate asymmetry with
+the `fee_report` block immediately above it (see Global Constraints). `windows` and
+`results` are already in scope from earlier in this function (`generate_windows(...)` and
+`runner.run(...)`).
+
+Finally, thread it into the `GateResult(...)` construction at the end of the function
+(after the existing `fee_sensitivity=fee_report` line):
+
+```python
+        fee_sensitivity=fee_report,
+        regime_breakdown=regime_breakdown,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest research/tests/test_gate.py -v`
+Expected: PASS (all tests in the file, including the 3 new ones and every pre-existing
+one — confirms no regression)
+
+- [ ] **Step 5: Lint and format**
+
+Run: `ruff check research/gate.py research/tests/test_gate.py` and
+`ruff format --check research/gate.py research/tests/test_gate.py`
+Expected: no errors (fix and re-run Step 4 if needed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add research/gate.py research/tests/test_gate.py
+git commit -m "feat(research): wire regime breakdown into run_promotion_gate (opt-in, runs on pass or fail)"
+```
+
+---
+
+### Task 3: `research/cli.py` — `--regime-breakdown` flag and table output
+
+**Files:**
+- Modify: `research/cli.py:22-43` (arg parser), `:44-83` (dispatch/printing)
+- Test: `research/tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `GateResult.regime_breakdown` (Task 2), `run_promotion_gate(...,
+  include_regime_breakdown=...)` (Task 2).
+- Produces: nothing further downstream — this is the final task in the plan.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `research/tests/test_cli.py`:
+
+```python
+def test_gate_command_prints_regime_breakdown_table_when_present(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2, "n_trades": 14, "mean_test_sharpe": 0.42, "total_return": 0.0012,
+            },
+            "Bear/Low": {
+                "n_windows": 1, "n_trades": 6, "mean_test_sharpe": -1.10, "total_return": -0.0034,
+            },
+        },
+    )
+    mock_gate = mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+            "--regime-breakdown",
+        ]
+    )
+
+    _, kwargs = mock_gate.call_args
+    assert kwargs["include_regime_breakdown"] is True
+
+    captured = capsys.readouterr()
+    assert exit_code == 1  # this GateResult failed -- regime breakdown must print regardless
+    assert "regime breakdown" in captured.out
+    assert "Bull/High" in captured.out
+    assert "Bear/Low" in captured.out
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest research/tests/test_cli.py -v -k regime_breakdown`
+Expected: FAIL with `error: unrecognized arguments: --regime-breakdown` (an `argparse`
+`SystemExit` — Task 2's `GateResult.regime_breakdown` field already exists by this point,
+since Task 2 committed before this task started; the only missing piece here is the CLI
+flag itself)
+
+- [ ] **Step 3: Add the `--regime-breakdown` flag**
+
+In `research/cli.py`, after the existing `--fee-sensitivity` argument definition:
+
+```python
+    gate.add_argument(
+        "--fee-sensitivity",
+        action="store_true",
+        help="Also run a fee-sensitivity stress test if the gate passes (informational)",
+    )
+    gate.add_argument(
+        "--regime-breakdown",
+        action="store_true",
+        help=(
+            "Also compute a regime (Trend x Volatility) breakdown of walk-forward "
+            "results, regardless of pass/fail (informational)"
+        ),
+    )
+```
+
+- [ ] **Step 4: Thread the flag into `run_promotion_gate` and print the table**
+
+In the `run_promotion_gate(...)` call inside `main`, add the new keyword argument (after
+`fee_sensitivity_multipliers=...`):
+
+```python
+            fee_sensitivity_multipliers=DEFAULT_FEE_MULTIPLIERS if args.fee_sensitivity else None,
+            include_regime_breakdown=args.regime_breakdown,
+        )
+```
+
+After the existing `if result.fee_sensitivity:` block, add:
+
+```python
+        if result.regime_breakdown:
+            print("  regime breakdown (informational, not part of PASS/FAIL):")
+            for label, stats in result.regime_breakdown.items():
+                print(
+                    f"    {label:<15} {stats['n_windows']:>2} windows"
+                    f"   {stats['n_trades']:>3} trades"
+                    f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   total return {stats['total_return']:>8.4f}"
+                )
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pytest research/tests/test_cli.py -v`
+Expected: PASS (all tests in the file, including the new one and every pre-existing one)
+
+- [ ] **Step 6: Lint and format**
+
+Run: `ruff check research/cli.py research/tests/test_cli.py` and
+`ruff format --check research/cli.py research/tests/test_cli.py`
+Expected: no errors (fix and re-run Step 5 if needed)
+
+- [ ] **Step 7: Run the full research test suite**
+
+Run: `pytest research/ -v`
+Expected: PASS (every test in `research/tests/`, confirming Tasks 1-3 compose cleanly)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add research/cli.py research/tests/test_cli.py
+git commit -m "feat(research): add --regime-breakdown CLI flag and table output"
+```

--- a/docs/superpowers/plans/2026-08-24-strategy-scoring-and-report.md
+++ b/docs/superpowers/plans/2026-08-24-strategy-scoring-and-report.md
@@ -1,0 +1,570 @@
+# Strategy Scoring & Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Synthesize an already-computed `GateResult` (deflated Sharpe, permutation
+p-value, PBO, optional fee-sensitivity, optional regime-breakdown) into one continuous
+`robustness_score()` and one standardized `strategy_report()` string, replacing
+`research/cli.py`'s ad-hoc print block.
+
+**Architecture:** One new module, `research/scoring.py`, with two pure functions —
+`robustness_score` (a renormalized weighted average) and `strategy_report` (a formatted
+text block, byte-identical in content to what `research/cli.py` currently prints, plus
+one new score line). `research/cli.py` is reduced to one function call.
+
+**Tech Stack:** Python, pytest with real `GateResult` construction (no mocking) — no new
+backtesting, no new data load, no new dependency.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-strategy-scoring-and-report-design.md`
+
+## Global Constraints
+
+- `WEIGHTS = {"deflated_sharpe": 0.35, "significance": 0.25, "pbo_inverse": 0.25,
+  "cost_sensitivity": 0.10, "regime_consistency": 0.05}` — module-level constants in
+  `research/scoring.py`, not a runtime parameter. Do not add a way to override them at
+  call time; this is a deliberate starting default (`ponytail:`-flagged), matching this
+  package's existing pattern for `trend_threshold`/`DEFAULT_FEE_MULTIPLIERS`.
+- `robustness_score(result: GateResult) -> float`: always-present components are
+  `result.deflated_sharpe` directly, `1.0 - result.permutation_p`, and
+  `1.0 - result.pbo`. `cost_sensitivity` is added only when `result.fee_sensitivity` is
+  truthy; `regime_consistency` only when `result.regime_breakdown` is truthy. Final
+  score is `sum(WEIGHTS[k] * v) / sum(WEIGHTS[k])` over whichever components are
+  present — a renormalized weighted average, always in `[0, 1]`.
+- `cost_sensitivity`: `baseline_mult = min(result.fee_sensitivity)`,
+  `stress_mult = max(result.fee_sensitivity)`. If `baseline_mult == stress_mult`:
+  `1.0`. Elif `baseline_dsr <= 0`: `0.0`. Else:
+  `max(0.0, min(1.0, stress_dsr / baseline_dsr))` where `baseline_dsr`/`stress_dsr` are
+  `result.fee_sensitivity[baseline_mult]["deflated_sharpe"]` /
+  `result.fee_sensitivity[stress_mult]["deflated_sharpe"]`.
+- `regime_consistency`: `n_positive / n_total` where `n_total = len(result.regime_breakdown)`
+  and `n_positive` counts buckets with `stats["mean_test_sharpe"] > 0`.
+- **Deliberate, documented limitation (do not "fix"):** the score is only directly
+  comparable between `GateResult`s computed with the *same* set of optional components
+  present, because renormalization shifts the denominator. This was surfaced by an
+  lmchatbot design review and is intentional — see the spec's "Known limitation"
+  paragraph. A reviewer flagging this as a bug should be pointed at that paragraph, not
+  have it "fixed" into fixed-denominator scoring.
+- `strategy_report(result: GateResult, pair: str | None = None) -> str` returns
+  (does not print) text byte-identical in format to `research/cli.py`'s current print
+  block, with one new `"  robustness score  {score:.3f}"` line inserted as the second
+  line (right after the verdict line, before `deflated_sharpe`). When `pair` is `None`,
+  the regime-breakdown header omits the parenthetical pair name entirely (no stray
+  `"(, "`).
+- No new CLI flags. No changes to `run_promotion_gate`'s signature, `GateResult`'s
+  fields, `research/regime.py`, or `research/cost_stress.py` — this plan only adds
+  `research/scoring.py` and reduces `research/cli.py`'s print block to one call.
+- Existing `research/tests/test_cli.py` tests must all continue to pass **unchanged** —
+  they are the regression proof that the `cli.py` refactor preserves exact output.
+
+---
+
+### Task 1: `research/scoring.py` — robustness score and report
+
+**Files:**
+- Create: `research/scoring.py`
+- Test: `research/tests/test_scoring.py`
+
+**Interfaces:**
+- Consumes: `research.gate.GateResult` (existing dataclass — `strategy_id: str, passed:
+  bool, deflated_sharpe: float, permutation_p: float, pbo: float, mean_test_sharpe:
+  float, n_trials: int, reasons: list[str], fee_sensitivity: dict[float, dict] | None =
+  None, regime_breakdown: dict[str, dict] | None = None`, see `research/gate.py:26-39`).
+- Produces: `robustness_score(result: GateResult) -> float` and
+  `strategy_report(result: GateResult, pair: str | None = None) -> str` — both consumed
+  directly by Task 2.
+
+- [ ] **Step 1: Write the failing tests for `robustness_score`**
+
+Create `research/tests/test_scoring.py`:
+
+```python
+# research/tests/test_scoring.py
+import pytest
+
+from research.gate import GateResult
+from research.scoring import WEIGHTS, robustness_score, strategy_report
+
+
+def _core_result(deflated_sharpe=0.90, permutation_p=0.02, pbo=0.15, **kwargs):
+    """A GateResult with only the three always-present statistics populated,
+    unless overridden."""
+    return GateResult(
+        strategy_id="TestStrategy",
+        passed=True,
+        deflated_sharpe=deflated_sharpe,
+        permutation_p=permutation_p,
+        pbo=pbo,
+        mean_test_sharpe=1.1,
+        n_trials=10,
+        reasons=[],
+        **kwargs,
+    )
+
+
+def test_robustness_score_with_only_core_stats():
+    result = _core_result()
+
+    score = robustness_score(result)
+
+    # Independently computed, not calling robustness_score recursively.
+    weighted_sum = (
+        WEIGHTS["deflated_sharpe"] * 0.90
+        + WEIGHTS["significance"] * (1.0 - 0.02)
+        + WEIGHTS["pbo_inverse"] * (1.0 - 0.15)
+    )
+    weight_total = WEIGHTS["deflated_sharpe"] + WEIGHTS["significance"] + WEIGHTS["pbo_inverse"]
+    assert score == pytest.approx(weighted_sum / weight_total)
+    assert score == pytest.approx(0.9088235294117647)
+
+
+def test_robustness_score_includes_cost_sensitivity_when_fee_sensitivity_present():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.8, "deflated_sharpe": 0.90, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.4, "deflated_sharpe": 0.60, "n_windows": 5},
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8833333333333333)
+
+
+def test_robustness_score_includes_regime_consistency_when_regime_breakdown_present():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {"n_windows": 2, "n_trades": 10, "mean_test_sharpe": 0.5, "total_return": 0.01},
+            "Bull/Low": {"n_windows": 1, "n_trades": 5, "mean_test_sharpe": 0.3, "total_return": 0.005},
+            "Bear/Low": {"n_windows": 1, "n_trades": 4, "mean_test_sharpe": 0.1, "total_return": 0.002},
+            "Bear/High": {"n_windows": 1, "n_trades": 3, "mean_test_sharpe": -0.2, "total_return": -0.004},
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.9)
+
+
+def test_robustness_score_with_both_fee_sensitivity_and_regime_breakdown():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.8, "deflated_sharpe": 0.90, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.4, "deflated_sharpe": 0.60, "n_windows": 5},
+        },
+        regime_breakdown={
+            "Bull/High": {"n_windows": 2, "n_trades": 10, "mean_test_sharpe": 0.5, "total_return": 0.01},
+            "Bull/Low": {"n_windows": 1, "n_trades": 5, "mean_test_sharpe": 0.3, "total_return": 0.005},
+            "Bear/Low": {"n_windows": 1, "n_trades": 4, "mean_test_sharpe": 0.1, "total_return": 0.002},
+            "Bear/High": {"n_windows": 1, "n_trades": 3, "mean_test_sharpe": -0.2, "total_return": -0.004},
+        },
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8766666666666667)
+
+
+def test_robustness_score_cost_sensitivity_single_multiplier_is_one():
+    result = _core_result(
+        fee_sensitivity={1.0: {"mean_test_sharpe": 0.5, "deflated_sharpe": 0.5, "n_windows": 5}}
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.9184210526315789)
+
+
+def test_robustness_score_cost_sensitivity_zero_baseline_is_zero():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.0, "deflated_sharpe": 0.0, "n_windows": 5},
+            2.0: {"mean_test_sharpe": 0.1, "deflated_sharpe": 0.3, "n_windows": 5},
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8131578947368421)
+
+
+def test_robustness_score_stays_in_unit_interval():
+    worst = _core_result(deflated_sharpe=0.0, permutation_p=1.0, pbo=1.0)
+    best = _core_result(deflated_sharpe=1.0, permutation_p=0.0, pbo=0.0)
+
+    assert robustness_score(worst) == pytest.approx(0.0)
+    assert robustness_score(best) == pytest.approx(1.0)
+
+
+def test_robustness_score_renormalization_makes_scores_incomparable_across_optional_flags():
+    """Documents a deliberate, spec-approved limitation (not a bug to fix): identical
+    core statistics score differently once an optional component is added, because the
+    weighted-average denominator shifts. See the spec's "Known limitation" paragraph."""
+    without_regime = _core_result(deflated_sharpe=0.7, permutation_p=0.1, pbo=0.2)
+    with_regime = _core_result(
+        deflated_sharpe=0.7,
+        permutation_p=0.1,
+        pbo=0.2,
+        regime_breakdown={
+            "Bull/High": {"n_windows": 3, "n_trades": 20, "mean_test_sharpe": 0.6, "total_return": 0.02},
+        },
+    )
+
+    assert robustness_score(without_regime) == pytest.approx(0.788235294117647)
+    assert robustness_score(with_regime) == pytest.approx(0.8)
+    assert robustness_score(without_regime) != pytest.approx(robustness_score(with_regime))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_scoring.py -v -k "robustness_score"`
+Expected: FAIL/ERROR with `ModuleNotFoundError: No module named 'research.scoring'`
+
+- [ ] **Step 3: Implement `robustness_score`**
+
+Create `research/scoring.py`:
+
+```python
+# research/scoring.py
+"""Strategy scoring and reporting: synthesizes an already-computed GateResult (deflated
+Sharpe, permutation p-value, PBO, and the optional fee-sensitivity/regime-breakdown
+add-ons) into one continuous robustness_score() and one standardized strategy_report()
+string. No new statistics are computed here -- every input is already produced by
+research.gate.run_promotion_gate before either function in this module runs. See
+docs/superpowers/specs/2026-08-24-strategy-scoring-and-report-design.md for the full
+design, including why the score is only directly comparable between GateResults computed
+with the same set of optional components present (a documented, deliberate tradeoff of
+renormalizing over available evidence rather than penalizing runs that skip the
+compute-costly optional fee-sensitivity/regime-breakdown analyses).
+"""
+
+from __future__ import annotations
+
+from research.gate import GateResult
+
+
+# ponytail: starting weights, not empirically derived -- adjust based on real usage once
+# this runs against real strategies. Not a runtime parameter; see the spec for why.
+WEIGHTS = {
+    "deflated_sharpe": 0.35,
+    "significance": 0.25,
+    "pbo_inverse": 0.25,
+    "cost_sensitivity": 0.10,
+    "regime_consistency": 0.05,
+}
+
+
+def robustness_score(result: GateResult) -> float:
+    """Weighted average of GateResult's already-computed statistics, renormalized over
+    whichever components are actually present. Always in [0, 1].
+
+    Always-present components: deflated_sharpe directly, 1 - permutation_p
+    ("significance"), 1 - pbo ("pbo_inverse") -- all three are already probabilities in
+    [0, 1] by construction (see research/statistics.py, research/pbo.py).
+
+    "cost_sensitivity", only when result.fee_sensitivity is present: the fraction of the
+    lowest-tested fee multiplier's deflated Sharpe that survives at the highest-tested
+    multiplier, clipped to [0, 1]. 1.0 (fail open) if only one multiplier was tested --
+    no stress signal to penalize. 0.0 (fail closed) if the baseline deflated Sharpe is
+    non-positive -- the ratio would be meaningless.
+
+    "regime_consistency", only when result.regime_breakdown is present: the fraction of
+    regime buckets with a positive mean_test_sharpe -- does the edge show up broadly, or
+    only in one favorable regime.
+
+    Known limitation, deliberate: scores from GateResults with different optional
+    components present are NOT directly comparable, since renormalization shifts the
+    denominator. Read this as "how robust this candidate looks given the evidence
+    gathered for it," not a universal ranking number.
+    """
+    components: dict[str, float] = {
+        "deflated_sharpe": result.deflated_sharpe,
+        "significance": 1.0 - result.permutation_p,
+        "pbo_inverse": 1.0 - result.pbo,
+    }
+
+    if result.fee_sensitivity:
+        baseline_mult = min(result.fee_sensitivity)
+        stress_mult = max(result.fee_sensitivity)
+        baseline_dsr = result.fee_sensitivity[baseline_mult]["deflated_sharpe"]
+        stress_dsr = result.fee_sensitivity[stress_mult]["deflated_sharpe"]
+        if baseline_mult == stress_mult:
+            cost_sensitivity = 1.0
+        elif baseline_dsr <= 0:
+            cost_sensitivity = 0.0
+        else:
+            cost_sensitivity = max(0.0, min(1.0, stress_dsr / baseline_dsr))
+        components["cost_sensitivity"] = cost_sensitivity
+
+    if result.regime_breakdown:
+        n_total = len(result.regime_breakdown)
+        n_positive = sum(
+            1 for stats in result.regime_breakdown.values() if stats["mean_test_sharpe"] > 0
+        )
+        components["regime_consistency"] = n_positive / n_total
+
+    weighted_sum = sum(WEIGHTS[k] * v for k, v in components.items())
+    weight_total = sum(WEIGHTS[k] for k in components)
+    return weighted_sum / weight_total
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest research/tests/test_scoring.py -v -k "robustness_score"`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Write the failing tests for `strategy_report`**
+
+Append to `research/tests/test_scoring.py`:
+
+```python
+def test_strategy_report_pass_case_shows_verdict_core_stats_and_score():
+    result = _core_result(passed=True, deflated_sharpe=0.97, permutation_p=0.01, pbo=0.1)
+
+    report = strategy_report(result)
+
+    assert "TestStrategy: PASS" in report
+    assert "robustness score" in report
+    assert "deflated_sharpe   0.970" in report
+    assert "permutation p     0.010" in report
+    assert "PBO               0.100" in report
+    assert "mean OOS sharpe   1.100" in report
+    assert "trials (ledger)   10" in report
+
+
+def test_strategy_report_fail_case_shows_reasons():
+    result = GateResult(
+        strategy_id="TestStrategy",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+    )
+
+    report = strategy_report(result)
+
+    assert "TestStrategy: FAIL" in report
+    assert "deflated_sharpe 0.400 below threshold 0.95" in report
+
+
+def test_strategy_report_includes_fee_sensitivity_table_when_present():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.87, "deflated_sharpe": 0.91, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.33, "deflated_sharpe": 0.52, "n_windows": 5},
+        }
+    )
+
+    report = strategy_report(result)
+
+    assert "fee sensitivity" in report
+    assert "baseline" in report
+    assert "1.50x fee" in report
+    assert "slippage" not in report.lower()
+
+
+def test_strategy_report_includes_regime_breakdown_with_pair_name_when_given():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {"n_windows": 2, "n_trades": 14, "mean_test_sharpe": 0.42, "total_return": 0.0012},
+            "Bear/Low": {"n_windows": 1, "n_trades": 6, "mean_test_sharpe": -1.10, "total_return": -0.0034},
+        }
+    )
+
+    report = strategy_report(result, pair="BTC/USDT")
+
+    assert "regime breakdown" in report
+    assert "BTC/USDT" in report
+    assert "Bull/High" in report
+    assert "Bear/Low" in report
+
+
+def test_strategy_report_omits_pair_name_when_not_given():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {"n_windows": 2, "n_trades": 14, "mean_test_sharpe": 0.42, "total_return": 0.0012},
+        }
+    )
+
+    report = strategy_report(result, pair=None)
+
+    assert "regime breakdown" in report
+    assert "Bull/High" in report
+    assert "(, " not in report
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `pytest research/tests/test_scoring.py -v -k "strategy_report"`
+Expected: FAIL with `ImportError: cannot import name 'strategy_report' from 'research.scoring'`
+
+- [ ] **Step 7: Implement `strategy_report`**
+
+Append to `research/scoring.py`:
+
+```python
+def strategy_report(result: GateResult, pair: str | None = None) -> str:
+    """Standardized human-readable report for one GateResult -- verdict, robustness
+    score, the three core statistics, any reasons the gate failed, and the
+    fee-sensitivity / regime-breakdown tables when present. Returns the text (does not
+    print it).
+
+    `pair` names which pair a present regime_breakdown was classified against (the
+    caller's responsibility to supply, since GateResult itself doesn't carry it -- see
+    the spec). When None, the regime-breakdown header omits the parenthetical pair name.
+    """
+    score = robustness_score(result)
+    verdict = "PASS" if result.passed else "FAIL"
+    lines = [
+        f"{result.strategy_id}: {verdict}",
+        f"  robustness score  {score:.3f}",
+        f"  deflated_sharpe   {result.deflated_sharpe:.3f}",
+        f"  permutation p     {result.permutation_p:.3f}",
+        f"  PBO               {result.pbo:.3f}",
+        f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}",
+        f"  trials (ledger)   {result.n_trials}",
+    ]
+    for reason in result.reasons:
+        lines.append(f"  - {reason}")
+
+    if result.fee_sensitivity:
+        lines.append("  fee sensitivity (informational, not part of PASS/FAIL):")
+        for mult, stats in result.fee_sensitivity.items():
+            label = f"{mult:.2f}x fee" + (" (baseline)" if mult == 1.0 else "")
+            lines.append(
+                f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
+                f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
+            )
+
+    if result.regime_breakdown:
+        pair_part = f"{pair}, " if pair else ""
+        lines.append(f"  regime breakdown ({pair_part}informational, not part of PASS/FAIL):")
+        for label, stats in result.regime_breakdown.items():
+            lines.append(
+                f"    {label:<15} {stats['n_windows']:>2} windows"
+                f"   {stats['n_trades']:>3} trades"
+                f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
+                f"   total return {stats['total_return']:>8.4f}"
+            )
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 8: Run all tests in the file to verify they pass**
+
+Run: `pytest research/tests/test_scoring.py -v`
+Expected: PASS (13 tests)
+
+- [ ] **Step 9: Lint and format**
+
+Run: `ruff check research/scoring.py research/tests/test_scoring.py` and
+`ruff format --check research/scoring.py research/tests/test_scoring.py`
+Expected: no errors (fix with `ruff check --fix` / `ruff format` if needed, then re-run
+the test suite from Step 8 to confirm nothing broke)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add research/scoring.py research/tests/test_scoring.py
+git commit -m "feat(research): add scoring.py -- robustness_score and strategy_report"
+```
+
+---
+
+### Task 2: `research/cli.py` — replace print block with `strategy_report`
+
+**Files:**
+- Modify: `research/cli.py:74-103` (the `gate` command's print block)
+- Test: `research/tests/test_cli.py` (no new tests — this task's job is to keep every
+  existing test passing unchanged, proving the refactor preserves output byte-for-byte)
+
+**Interfaces:**
+- Consumes: `research.scoring.strategy_report` (Task 1).
+- Produces: nothing further downstream — this is the final task in the plan.
+
+- [ ] **Step 1: Run the existing tests to confirm the current baseline passes**
+
+Run: `pytest research/tests/test_cli.py -v`
+Expected: PASS (5 tests) — this is the pre-change baseline; Step 3 must not break any of
+these.
+
+- [ ] **Step 2: Add the import**
+
+In `research/cli.py`, add to the existing import block (alongside
+`from research.gate import run_promotion_gate`):
+
+```python
+from research.scoring import strategy_report
+```
+
+- [ ] **Step 3: Replace the print block**
+
+In `research/cli.py`, replace this entire block (currently `research/cli.py:74-103`):
+
+```python
+        verdict = "PASS" if result.passed else "FAIL"
+        print(f"{result.strategy_id}: {verdict}")
+        print(f"  deflated_sharpe   {result.deflated_sharpe:.3f}")
+        print(f"  permutation p     {result.permutation_p:.3f}")
+        print(f"  PBO               {result.pbo:.3f}")
+        print(f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}")
+        print(f"  trials (ledger)   {result.n_trials}")
+        for reason in result.reasons:
+            print(f"  - {reason}")
+        if result.fee_sensitivity:
+            print("  fee sensitivity (informational, not part of PASS/FAIL):")
+            for mult, stats in result.fee_sensitivity.items():
+                label = f"{mult:.2f}x fee" + (" (baseline)" if mult == 1.0 else "")
+                print(
+                    f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
+                )
+        if result.regime_breakdown:
+            print(
+                f"  regime breakdown ({args.pairs.split(',')[0]}, informational, "
+                "not part of PASS/FAIL):"
+            )
+            for label, stats in result.regime_breakdown.items():
+                print(
+                    f"    {label:<15} {stats['n_windows']:>2} windows"
+                    f"   {stats['n_trades']:>3} trades"
+                    f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   total return {stats['total_return']:>8.4f}"
+                )
+        return 0 if result.passed else 1
+```
+
+with:
+
+```python
+        print(strategy_report(result, pair=args.pairs.split(",")[0]))
+        return 0 if result.passed else 1
+```
+
+- [ ] **Step 4: Run the existing tests to confirm nothing broke**
+
+Run: `pytest research/tests/test_cli.py -v`
+Expected: PASS (5 tests) — identical result to Step 1's baseline. If anything fails,
+compare `strategy_report`'s output text against the exact format the removed print block
+produced; the two must match byte-for-byte (this is why Task 1's `strategy_report` was
+written to reproduce that exact format).
+
+- [ ] **Step 5: Lint and format**
+
+Run: `ruff check research/cli.py` and `ruff format --check research/cli.py`
+Expected: no errors (fix and re-run Step 4 if needed)
+
+- [ ] **Step 6: Run the full research suite**
+
+Run: `pytest research/ -v`
+Expected: PASS (every test in `research/tests/`, confirming Tasks 1-2 compose cleanly
+with the rest of the package)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add research/cli.py
+git commit -m "refactor(research): cli.py prints strategy_report() instead of an inline print block"
+```

--- a/docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md
+++ b/docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md
@@ -1,0 +1,305 @@
+# Fee Sensitivity Stress Test — Design
+
+## Context
+
+First sub-project decomposed from `CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md` (§9, cost
+stress testing). The proposal's own MVP list groups this with regime analysis,
+robustness scoring, and reporting — genuinely independent subsystems, decomposed
+per the brainstorming process rather than specced together.
+
+`research/` (ledger, DSR/BH-FDR, PBO, walk-forward runner, promotion gate + CLI) already
+ships and has been proven end-to-end against a real strategy (`EmaTrendFollow`, correctly
+rejected on BTC/USDT). This sub-project adds one more piece of evidence to a candidate
+that already passed the main statistical gate: does its edge survive materially worse
+transaction costs?
+
+## What this is not
+
+**Not a slippage/market-impact model.** freqtrade's backtester has no execution-price
+slippage simulation at all — orders fill at the exact requested price as long as it's
+within the candle's high/low range, only a configurable percentage fee is modeled
+(verified: `FREQTRADE_RESEARCH_ARCHITECTURE.md` §3, `freqtrade/optimize/backtesting.py`).
+A flat fee-rate multiplier is a legitimate cost-sensitivity / margin-of-safety test, but
+it gets slippage's actual structure wrong, not just approximately right — slippage scales
+with order size, book depth, and volatility, not as a fixed percentage of notional
+(cross-checked via lmchatbot, ChatGPT+Gemini, both converged on this distinction
+independently). This sub-project is scoped to **fee sensitivity only**, named
+accordingly everywhere (module, function, CLI flag, report labels) — never "slippage." A
+real execution-shortfall model (moving the simulated fill price based on volatility/
+spread/size) is explicitly deferred as its own future sub-project.
+
+**Not a hard gate criterion.** Runs only on a candidate that has already PASSed the main
+statistical gate (DSR + BH-FDR + PBO). Informational — it doesn't change the PASS/FAIL
+verdict, it adds evidence for a human to weigh. (If experience later shows this should
+become a hard gate, that's a follow-up decision made with real data in hand, not upfront.)
+
+**Not a re-run of the parameter search.** The main gate has already selected the best
+parameters for each walk-forward window (`WindowResult.best_params`). This sub-project
+re-evaluates those *already-chosen* parameters at worse fee levels — it does not
+re-optimize at each fee level (that would be a different, much more expensive experiment,
+and would reopen the multiple-testing question this whole system exists to guard against).
+
+**On `n_trials=1` for the fee-stress DSR (reviewed and deliberately kept, not an
+oversight):** it's tempting to think the fee-stressed Sharpe should inherit the original
+gate's `n_trials`, since the strategy being stress-tested was still chosen via a search.
+That reasoning conflates two different questions. DSR's trial-count corrects for
+selection bias *at the moment a maximum is chosen from N candidates* — that correction
+was already paid once, at the original gate's PASS decision, using the ledger's real
+`family_trial_count`. Fee-stressing doesn't select anything: it applies one deterministic
+transformation (a higher fee) to one already-fixed, already-selected trade sequence, once
+per multiplier, with no comparison across candidates and no new maximum being taken.
+There is no new selection event to correct for, so no new multiplicity penalty accrues —
+using the original `n_trials` here would double-count the same correction rather than
+apply a second, independent one. `n_trials=1` here answers a narrower, different
+question than the original gate's DSR: "is this specific, already-fixed, already-selected
+return series distinguishable from noise at this cost level" — not "was the search that
+found it valid" (that was already settled).
+
+## Architecture
+
+```
+run_promotion_gate() [existing, research/gate.py]
+  │
+  ├─ results = runner.run(windows, param_grid)   [existing — list[WindowResult]]
+  ├─ ... existing DSR / BH-FDR / PBO / ledger logic [unchanged]
+  │
+  └─ if passed and fee_sensitivity_multipliers given:
+         fee_report = cost_stress.fee_sensitivity(
+             config, pairs, timeframe, datadir, results, fee_sensitivity_multipliers
+         )
+         attached to GateResult.fee_sensitivity
+
+cost_stress.fee_sensitivity()  [new, research/cost_stress.py]
+  │  for each multiplier (default 1.0, 1.25, 1.5, 2.0):
+  │    for each WindowResult already in hand:
+  │      runner.evaluate_fixed_params(window, best_params, fee_override=base_fee*multiplier)
+  │    aggregate exactly as run_promotion_gate does (mean Sharpe, concatenated
+│    n_obs) -> deflated_sharpe_ratio(..., n_trials=1) at this fee level
+  └─ returns {multiplier: {mean_test_sharpe, deflated_sharpe, n_windows}}
+
+WalkForwardRunner.evaluate_fixed_params()  [new method, research/walkforward.py]
+  -- extracted from run_window's existing "test phase" (load data, compute indicators
+     for the given fixed params, trim, single backtest call, compute Sharpe/returns) --
+  now reusable with an optional fee override, without re-running the grid search.
+  run_window() itself is unchanged; this is a new method alongside it, not a rewrite.
+```
+
+## Components
+
+**`research/cost_stress.py`** (new file) — one function:
+
+`fee_sensitivity(config, pairs, timeframe, datadir, window_results, multipliers=(1.0, 1.25, 1.5, 2.0), periods_per_year=365) -> dict[float, dict]`
+
+(`periods_per_year` passed straight through from `run_promotion_gate`'s own parameter of
+the same name and default — never a second, independently-specified value.)
+
+Reads the config's effective base fee once (constructing one throwaway `Backtesting`
+instance and reading its resolved `.fee`, mirroring how freqtrade itself resolves fee —
+explicit `config["fee"]` if set, else the exchange's own taker/maker fee). This is the
+exact same fee value the original `run_promotion_gate` call used, since `config` is
+passed through unchanged — the `1.0` multiplier is therefore an exact-reproduction
+control, not a stress level; report labels call it "baseline," not "1.0x stress."
+
+For each multiplier, re-evaluates every `WindowResult`'s already-selected `best_params` on
+that window's test period at `base_fee * multiplier`, via the new
+`WalkForwardRunner.evaluate_fixed_params`. **Aggregation method (exactly mirrors
+`run_promotion_gate`'s own existing aggregation — same functions, same shape, so the
+`1.0`/baseline result reproduces the original gate's `mean_test_sharpe` exactly; its
+`deflated_sharpe` is NOT directly comparable to the gate's own — this module always calls
+`deflated_sharpe_ratio` with `n_trials=1` by design, while the gate's own headline
+`deflated_sharpe` uses the ledger's real `n_trials`, and DSR is monotone non-increasing in
+`n_trials` — see "On `n_trials=1`" above):** concatenate `test_returns` across all windows for `n_obs`; average
+each window's `test_sharpe` for the point Sharpe estimate; feed that point estimate into
+`deflated_sharpe_ratio(mean_sharpe, n_obs=n_obs, n_trials=1, periods_per_year=...)` (same
+`periods_per_year` as the original gate call). This is not a new aggregation convention —
+it is `research/gate.py`'s existing `mean_test_sharpe`/`n_obs`/`deflated_sharpe_ratio`
+call, reused verbatim at each fee level.
+
+**`WalkForwardRunner.evaluate_fixed_params(window, params, fee_override=None) -> WindowResult`**
+(new method on the existing class in `research/walkforward.py`) — the single-params,
+single-window evaluation that `run_window`'s final phase already does once it has settled
+on `best_params`, extracted into its own method so it's callable directly without a grid
+search. It runs BOTH a train-period and a test-period backtest, mirroring `run_window`'s
+own per-variant structure so the two share one implementation rather than drifting apart —
+but only the test-period result (`test_sharpe`, `test_n_trades`, `test_returns`) is
+meaningful to a caller evaluating an already-fixed parameter set. The train-period result
+(`train_sharpe`) exists only because `run_window`'s own final phase needs this method to
+look identical to its grid-search loop's per-variant calls; every current caller
+(`run_window`'s final phase, `cost_stress.fee_sensitivity`) either overwrites or ignores
+it. `fee_override`, when given, builds a config with that fee
+for just this call (never mutates `self.config` — avoids leaking a stress-test fee across
+other calls sharing the same `WalkForwardRunner` instance). Returns a `WindowResult` with
+`variant_returns={}` (an explicit empty dict, not `None` — no grid was searched, so there
+are no variants to report; only `best_params`, `test_sharpe`, `test_n_trades`,
+`test_returns` are meaningful). This is a deliberately **partial** `WindowResult` —
+`cost_stress.py` is documented as its only intended consumer; any future caller that reads
+`variant_returns` off a `WindowResult` must not assume it came from a full grid search
+unless it came from `run_window`. `run_window` itself is refactored to call this new
+method for its own final test-phase step, so the two paths share one implementation
+rather than drifting — this also means `run_window`'s own existing tests double as
+regression coverage for `evaluate_fixed_params`'s core behavior, not just the new tests
+below.
+
+**Invariant this method must uphold (revised after implementation — the original claim
+below was wrong, kept struck through so the correction has context):**
+`fee_override` changes only the fee rate charged in the backtest's own P&L accounting. It
+must never affect ~~indicator computation or signal generation — the same `params` on the
+same `window` must produce the exact same trade entries/exits (same count, same
+timestamps) at every fee level; only each trade's realized `profit_abs` changes~~ *indicator
+computation* — that part still holds (fee never touches `populate_indicators`/
+`populate_entry_trend`). But **trade count and timing are not invariant to fee for
+ROI-exit strategies**, discovered during Task 1's implementation and independently
+verified against real freqtrade source and real fixture data (see the "Deviations from
+this plan" section near the top of
+`docs/superpowers/plans/2026-08-24-fee-sensitivity-stress-test.md` for the durable
+record): `should_exit()` (`freqtrade/strategy/interface.py:1440-1464`) computes
+`current_profit = trade.calc_profit_ratio(...)`, which is fee-adjusted
+(`freqtrade/persistence/trade_model.py:1206-1234`), and compares it against `minimal_roi`
+thresholds — so a higher fee can genuinely delay or prevent an ROI exit, changing *which*
+trades occur, not just their realized P&L. Empirically confirmed on the real
+`UNITTEST/BTC` fixture: 6 trades at `fee=0.0` vs. 2 trades at `fee=0.05`.
+
+This means the fee-sensitivity comparison is **not** a clean like-for-like comparison of
+identical trades at different costs — it's closer to "how does this strategy's realized
+performance change under worse fee assumptions, including any resulting shift in exit
+timing." That's still meaningful evidence (it's still asking "does raising costs hurt this
+candidate"), just a less surgically isolated question than originally specified. Two
+concrete consequences: (1) the trade-set-identity test below is now a documented
+non-invariant, not a guarantee; (2) net P&L is **not** guaranteed monotonic across fee
+levels either — the same mechanism that breaks trade-count invariance also breaks the P&L
+monotonicity claim previously in this section, confirmed empirically on the real fixture
+at a wide fee sweep (0.0 → 0.1): total P&L was *higher* at `fee=0.1` than at `fee=0.05`,
+because fewer/different trades occurred. Neither is asserted as a hard invariant in the
+test suite below.
+
+**`research/gate.py`** (existing file, extended) — `run_promotion_gate` gains one new
+optional parameter, `fee_sensitivity_multipliers: tuple[float, ...] | None = None`
+(default `None` — existing callers and existing tests are unaffected). When set and the
+gate PASSed, calls `cost_stress.fee_sensitivity` using the `results` list already
+computed in this call (no duplicate walk-forward run) and attaches it to a new
+`GateResult.fee_sensitivity: dict | None = None` field.
+
+**`research/cli.py`** (existing file, extended) — `gate` subcommand gains
+`--fee-sensitivity` (flag, default off — opt-in, since it multiplies the already-completed
+walk-forward evaluation's backtest count by `len(multipliers)`, roughly ~4x the work for
+the default 4 multipliers, and is only useful once a candidate has passed). When set,
+threads `fee_sensitivity_multipliers=(1.0, 1.25, 1.5, 2.0)` through to
+`run_promotion_gate`, and if `result.fee_sensitivity` is present, prints a small table:
+
+```
+  fee sensitivity (informational, not part of PASS/FAIL):
+    1.00x fee (baseline)   mean OOS sharpe  0.87   deflated_sharpe 0.91
+    1.25x fee               mean OOS sharpe  0.61   deflated_sharpe 0.74
+    1.50x fee               mean OOS sharpe  0.33   deflated_sharpe 0.52
+    2.00x fee               mean OOS sharpe -0.12   deflated_sharpe 0.08
+```
+
+## Data flow
+
+1. `research gate --strategy X ... --fee-sensitivity` → `cli.main()`
+2. `run_promotion_gate(..., fee_sensitivity_multipliers=(1.0,1.25,1.5,2.0))`
+3. Existing gate logic runs unchanged; `results: list[WindowResult]` already in scope
+4. If `passed`: `cost_stress.fee_sensitivity(config, pairs, timeframe, datadir, results, multipliers)`
+5. Inside: one throwaway `Backtesting(config)` to resolve `base_fee`; then per multiplier,
+   per window, `runner.evaluate_fixed_params(window, window_result.best_params, fee_override)`
+6. Aggregated dict attached to `GateResult.fee_sensitivity`; CLI prints the table
+
+## Error handling
+
+- If `passed` is `False`, fee sensitivity is skipped entirely regardless of the flag
+  (nothing to stress-test — matches the "informational report on passing candidates"
+  decision). `GateResult.fee_sensitivity` stays `None`; the CLI prints nothing extra.
+- `multipliers` must be non-empty and all values `> 0`; `fee_sensitivity` raises
+  `ValueError` on an empty tuple or a non-positive multiplier (mirrors the existing
+  `run_promotion_gate`'s `< 4 windows` `ValueError` pattern — fail loudly on a
+  caller-supplied parameter that can't produce a meaningful result, don't silently
+  return an empty report).
+- `evaluate_fixed_params` reuses `run_window`'s existing data-loading/backtest error
+  behavior unchanged (no new error handling needed there — same freqtrade calls, same
+  failure modes already exercised by the existing `run_window` tests).
+
+## Testing
+
+**Deliberately not tested as a hard invariant: Sharpe monotonically decreasing as fee
+increases.** It's true for a fixed trade set *if* each trade's dollar fee were exactly
+constant, but real per-trade fees scale with that trade's notional value, which varies
+slightly across trades (fill price, position size) — so it's a strong empirical tendency,
+not a mathematical guarantee, and asserting it as exact would risk a flaky test on a
+technically-correct-but-non-monotonic result. Testing the invariants that *are* actually
+guaranteed instead:
+
+- `WalkForwardRunner.evaluate_fixed_params` — three real-execution tests (real
+  `Backtesting`, real fixture data, matching the existing `test_walkforward.py` pattern):
+  1. **Equivalence chain:** for the winning variant of an existing walk-forward window,
+     `run_window`'s own test-phase result, `evaluate_fixed_params(window, best_params,
+     fee_override=None)`, and `evaluate_fixed_params(window, best_params,
+     fee_override=base_fee)` all produce identical `test_sharpe` and `test_returns` —
+     proving the extraction preserved behavior and that `fee_override=None` and
+     `fee_override=base_fee` are truly equivalent.
+  2. **~~Trade-set invariance~~ Fee-override produces a real, measurable result change**
+     (revised — see "Invariant this method must uphold" above): calling
+     `evaluate_fixed_params` on the same window/params at two different fee levels does
+     **not** reliably produce the same `test_n_trades` for ROI-exit strategies — confirmed
+     false on real data, not merely untested. The test instead asserts fee_override
+     produces a measurable difference in the result (Sharpe or trade count) and that P&L
+     moves in the expected direction on average, without asserting trade-count equality or
+     strict cross-level monotonicity as a hard invariant.
+  3. **Config isolation:** `self.config` is byte-for-byte unchanged after a call with
+     `fee_override` set (dict equality before/after) — proving no leakage across calls
+     sharing the same `WalkForwardRunner` instance.
+- `cost_stress.fee_sensitivity` — real end-to-end test reusing the existing
+  `test_walkforward.py` / `test_gate.py` fixture pattern (`StrategyTestV3`, real
+  `UNITTEST/BTC` data): run the existing walk-forward fixture to get real `WindowResult`s,
+  call `fee_sensitivity` with a small multiplier tuple, assert: keys match the multipliers
+  given; the `1.0` (baseline) entry's `mean_test_sharpe`/`deflated_sharpe` exactly match
+  independently recomputing via `evaluate_fixed_params` + the same aggregation by hand in
+  the test. **Cross-fee-level P&L/Sharpe monotonicity is deliberately not asserted as a
+  hard invariant** (revised from the original spec, which called this "a real guarantee" —
+  it isn't; see "Invariant this method must uphold" above, confirmed false by direct
+  empirical measurement at a wide fee sweep on real data). Also a `ValueError` test for
+  empty/non-positive multipliers.
+- `run_promotion_gate` / `cli.py`: extend the existing real end-to-end gate test with one
+  more assertion path — call with `fee_sensitivity_multipliers` set, assert
+  `GateResult.fee_sensitivity` is populated when the gate passes; a second test (can reuse
+  the existing "too few windows" or a canned `FAIL` scenario) confirms it stays `None`
+  when the gate fails, even if multipliers were requested. `test_cli.py` gets one more
+  case: `--fee-sensitivity` flag present, `run_promotion_gate` mocked to return a
+  `GateResult` with `fee_sensitivity` populated, assert the table appears in stdout.
+
+## Open items resolved during brainstorming
+
+- Gate vs. report: **informational report**, not a hard PASS/FAIL criterion (user decision).
+- Slippage: **out of scope**, named "fee sensitivity" throughout, never "slippage" (user
+  decision after lmchatbot cross-check).
+- Multiplier levels: **1.0, 1.25, 1.5, 2.0** (dropped the proposal's 3.0x — lmchatbot's
+  recommended set, "optionally 2.0x" taken as included since it's cheap and informative).
+
+**Spec review round (lmchatbot, ChatGPT draft cross-verified by Gemini — the two
+disagreed with each other on two points, resolved by direct technical judgment rather
+than picking a side by default):**
+- `n_trials=1` for the fee-stress DSR: ChatGPT's draft flagged this as wrong (should
+  inherit the original gate's `n_trials`); Gemini's verify pass corrected it back —
+  confirmed correct as originally specified, reasoning strengthened in "What this is not"
+  above so the question doesn't reopen for a future reader.
+- Monotonic-Sharpe test invariant: ChatGPT's draft flagged it as too strong a claim to
+  assert as exact; Gemini's verify pass defended it as exact. Neither fully right —
+  approximately true for a fixed stake amount, not a strict guarantee. Replaced with
+  invariants that are actually guaranteed (trade-set identity, net-P&L monotonicity,
+  three-way equivalence chain) rather than assuming Sharpe monotonicity.
+- Both providers agreed the DSR aggregation method was underspecified (resolved: reuse
+  `run_promotion_gate`'s existing aggregation verbatim) and that the partial `WindowResult`
+  contract from `evaluate_fixed_params` needed to be explicit (resolved above).
+
+**Post-implementation correction (Task 1, not a review-round finding — discovered by the
+implementer, independently verified by the task reviewer against real freqtrade source and
+real fixture data):** this spec's two strongest "these ARE real guarantees, unlike Sharpe"
+claims — trade-set invariance under `fee_override`, and net-P&L monotonicity across fee
+levels — are both false for ROI-exit strategies. The lmchatbot review round above debated
+whether *Sharpe* monotonicity was safe to assert and correctly concluded no; it did not
+catch that the *replacement* invariants this spec substituted (trade-count identity, P&L
+monotonicity) rest on the same "same trades, only cost differs" assumption, which turned
+out to be the actually-wrong premise. Root cause and empirical confirmation are in
+"Invariant this method must uphold" above. Lesson for future specs in this codebase: a
+confident-sounding "unlike X, this one IS guaranteed" claim still needs the same
+skepticism as the thing it's being contrasted with — being right that one invariant is
+shaky doesn't make the alternative you propose automatically solid.

--- a/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
+++ b/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
@@ -181,6 +181,28 @@ and `Trade.close_date >= paper_trading_started_at`. This session is separate fro
 research ledger's own `session` argument — two independent database files, never the
 same connection.
 
+**Connection hygiene (verified via lmchatbot cross-check as a real, worth-specifying
+concern):** the dry-run database file may belong to a currently-running freqtrade bot
+process that could be writing to it concurrently. This function must not hold that
+connection open longer than the single query needs: open the engine/session, run the
+query, and close/dispose both in a `finally` block (or a context manager) before
+returning — never leave a lingering handle on a file another process owns. Use a bounded
+connection timeout (e.g. `create_engine(url, connect_args={"timeout": 30})`) rather than
+the driver default, so a transient lock from the bot's own write contends gracefully
+instead of hanging indefinitely. This function does not need write access to that
+database — read-only intent should be clear from the code even though `init_db` itself
+doesn't expose a strict read-only mode.
+
+**One normalized instant per call, not two independent clock reads (verified via
+lmchatbot cross-check):** capture `now = datetime.now(UTC)` exactly once at the top of
+this function, and derive `days_elapsed` from that same captured value — never call
+`datetime.now(UTC)` a second time later in the function body, which could let the SQL
+query's implicit "as of" moment drift from the `days_elapsed` arithmetic's own "as of"
+moment by however long the query took to run. Likewise, derive both the tz-aware value
+used for `days_elapsed` arithmetic and the naive-UTC value used in the SQL filter (see
+"Timezone-awareness resolution" below) from the same single normalized
+`paper_trading_started_at` read, not two separate normalizations.
+
 Computes:
 - `days_elapsed = (datetime.now(UTC) - promotion.paper_trading_started_at).days`
 - `n_trades = len(closed_trades)`
@@ -194,6 +216,17 @@ Computes:
   `research/scoring.py`'s `cost_sensitivity` (a baseline-ratio, clipped, fail-closed on
   a non-positive baseline), reusing an established pattern rather than inventing a new
   one for the same kind of question ("how much of a reference Sharpe survived?").
+
+  **Verified via lmchatbot cross-check: this is a coarse heuristic evidence gate, not a
+  statistically rigorous comparison, and the spec says so explicitly rather than implying
+  otherwise.** A `MIN_PAPER_TRADING_DAYS`/`MIN_PAPER_TRADES`-sized paper window is
+  typically far shorter (days to weeks) than the OOS window a candidate was originally
+  evaluated over (often months), so `paper_sharpe` carries materially more estimation
+  noise than `candidate.oos_sharpe` — a real asymmetry inherent to comparing a young
+  sample against a mature one, not a bug this module can fix by picking a different
+  threshold number. `evaluate_paper_trading_health`'s docstring must say this plainly:
+  the returned verdict is a first-pass filter for human judgment, not proof the strategy
+  is fine.
 
 Eligibility logic (not enough evidence vs. failed vs. passed — three distinct outcomes,
 not a single boolean threshold):
@@ -278,10 +311,20 @@ plain SQLAlchemy `DateTime` column — the same pattern `research/ledger.py`'s
 elsewhere in this package. Since SQLite round-tripping through SQLAlchemy's plain
 `DateTime` can silently drop tzinfo, `evaluate_paper_trading_health` normalizes
 defensively on read rather than assuming either behavior:
-`started_at = promotion.paper_trading_started_at; started_at = started_at.replace(tzinfo=UTC) if started_at.tzinfo is None else started_at`
+`started_at_aware = promotion.paper_trading_started_at; started_at_aware = started_at_aware.replace(tzinfo=UTC) if started_at_aware.tzinfo is None else started_at_aware`
 — correct whether or not the round-trip preserved awareness, with no reliance on an
 assumption neither this spec nor a quick source read can settle for SQLAlchemy's SQLite
 dialect in general.
+
+The `Trade` query's `Trade.close_date >= ...` filter compares against freqtrade's
+**raw, naive-UTC** `close_date` column directly (not the `close_date_utc` property,
+which isn't a queryable column) — so the bound value must itself be naive UTC:
+`started_at_naive = started_at_aware.replace(tzinfo=None)`, derived from the same
+`started_at_aware` computed above (see "One normalized instant per call" above — never
+re-derive this independently). Python-side arithmetic (`days_elapsed`, and reading each
+returned `Trade`'s own timestamp) uses the tz-aware `.close_date_utc`/`.open_date_utc`
+properties and the tz-aware `started_at_aware`, consistently on the aware side of the
+boundary; the SQL predicate is the one and only place the naive value is used.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
+++ b/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
@@ -1,0 +1,380 @@
+# Paper-Trading Promotion — Design
+
+## Context
+
+Fourth sub-project from `CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md` (§17, paper-trading
+promotion). `research/gate.py`'s `run_promotion_gate` already covers Backtest →
+Validation → OOS (walk-forward evaluation, DSR/BH-FDR/PBO). This sub-project adds the
+next stage the proposal requires before any strategy reaches LIVE: a tracked
+**Paper-Trading** stage and an explicit, auditable **Live-eligibility** decision — never
+an automatic one.
+
+This is the first `research/` sub-project to read from freqtrade's own trade-persistence
+layer (`freqtrade.persistence.Trade`) rather than only OHLCV price data
+(`history.load_data`, used by `research/walkforward.py` and `research/regime.py`) or
+values `research/gate.py` already computed in-process (`research/scoring.py`,
+`research/cost_stress.py`). Grounded against real freqtrade internals, confirmed before
+writing this spec:
+- `freqtrade/freqtradebot.py:1045` stamps every opened trade with
+  `strategy=self.strategy.get_strategy_name()` — the bot's own normal entry flow, not
+  something a caller sets. Filtering a dry-run database's trades by strategy name is
+  reliable.
+- `freqtrade/constants.py:23`: `DEFAULT_DB_DRYRUN_URL = "sqlite:///tradesv3.dryrun.sqlite"`
+  — freqtrade dry-run and live trades live in **separate database files** (selected by
+  the bot's own `dry_run`/`db_url` config), not distinguished by a per-trade flag. A
+  health evaluator must be pointed at a specific dry-run database file, not guess.
+
+## What this is not
+
+**Not an orchestrator.** This sub-project does not launch, manage, monitor, or configure
+a running freqtrade dry-run process, does not touch exchange connectivity, and does not
+generate freqtrade config files. Starting an actual paper-trading run (`freqtrade trade
+--dry-run ...`) remains a manual, operational step outside this package — this is a
+deployment/ops concern, not a research-package one, the same boundary this session has
+already drawn around backtesting's own compute cost (see `research/cost_stress.py`'s
+"NOT a slippage/market-impact model" and `research/regime.py`'s scope notes). What this
+sub-project DOES do is track that a candidate has entered paper trading, and evaluate
+its health once real dry-run trade data exists.
+
+**Not automatic promotion to LIVE.** The proposal states this explicitly: "No strategy
+should automatically go from BACKTEST to LIVE." Nothing in this module can transition a
+`PromotionRecord` to `LIVE` — only a human, calling `promote_to_live` directly outside
+any automated evaluation path. Automatic transitions exist only for `PAPER_TRADING` (an
+explicit manual call, since starting to paper-trade is itself an operational decision
+this package doesn't make) and `LIVE_ELIGIBLE`/`REJECTED` (the only states the health
+evaluator can drive a candidate into, and even `LIVE_ELIGIBLE` is a recommendation, not
+a live deployment).
+
+**Not a new statistical test.** The health evaluator's degradation check reuses the
+exact clipped-ratio pattern `research/scoring.py`'s `cost_sensitivity` already
+established (fraction of a baseline Sharpe retained, clipped to `[0, 1]`, fail-closed on
+a non-positive baseline) — consistent with this package's existing vocabulary rather
+than inventing a new one.
+
+**Not configurable thresholds.** `MIN_PAPER_TRADING_DAYS`, `MIN_PAPER_TRADES`, and
+`MIN_DEGRADATION_RATIO` are fixed module-level constants, `ponytail:`-flagged starting
+defaults — matching `research/scoring.py`'s `WEIGHTS`, `research/regime.py`'s
+`trend_threshold`, `research/cost_stress.py`'s `DEFAULT_FEE_MULTIPLIERS`. Not a runtime
+parameter until real usage says otherwise.
+
+**Not per-trade-in-progress monitoring.** The health evaluator reads *closed* trades
+only (a trade's outcome isn't known until it closes) — it is a point-in-time snapshot a
+human runs on demand (or a future scheduler could run periodically — out of scope here),
+not a live dashboard.
+
+## Architecture
+
+```
+research/models.py  [extended]
+  PromotionRecord  -- new table, one row per candidate's promotion lifecycle
+
+research/promotion.py  [new]
+  State machine (guarded transitions, ValueError on invalid current state):
+    create_promotion_record(session, candidate_result_id) -> PromotionRecord
+      PASSED_GATE  -- requires the referenced CandidateResult.survived is True
+    start_paper_trading(session, promotion_id, dry_run_db_path, started_at=None) -> PromotionRecord
+      PASSED_GATE -> PAPER_TRADING
+    promote_to_live(session, promotion_id) -> PromotionRecord
+      LIVE_ELIGIBLE -> LIVE   (manual only -- no automated path ever calls this)
+    reject(session, promotion_id, reason) -> PromotionRecord
+      PAPER_TRADING | LIVE_ELIGIBLE -> REJECTED   (manual override, always available)
+
+  Health evaluation (pure computation, no state mutation):
+    evaluate_paper_trading_health(session, promotion_id, dry_run_db_path=None,
+                                   periods_per_year=365) -> dict
+      Reads closed Trade rows from the dry-run database (a SEPARATE sqlite file/session
+      from the research ledger's own `session`), computes days elapsed, trade count,
+      paper Sharpe, and a degradation ratio against the original CandidateResult's
+      oos_sharpe. Returns a verdict dict, does not touch the database.
+
+  Applying an evaluation (the only place PAPER_TRADING can change state automatically):
+    apply_health_evaluation(session, promotion_id, evaluation: dict) -> PromotionRecord
+      PAPER_TRADING -> LIVE_ELIGIBLE   (evaluation["eligible"] is True)
+      PAPER_TRADING -> PAPER_TRADING   (not enough evidence yet -- stays, no state change)
+      PAPER_TRADING -> REJECTED        (enough evidence, but it failed the bar)
+```
+
+## Components
+
+**`research/models.py`** (existing file, extended) — one new table:
+
+```python
+class PromotionRecord(Base):
+    __tablename__ = "promotion_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    candidate_result_id: Mapped[int] = mapped_column(Integer, index=True)
+    state: Mapped[str] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    paper_trading_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    paper_trading_db_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    resolution_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+```
+
+`candidate_result_id` references `CandidateResult.id` (the specific gate-run row being
+promoted — a strategy can have many `CandidateResult` rows across re-runs and parameter
+sets; only one specific passing run is ever the thing under promotion). No SQLAlchemy
+relationship/foreign-key constraint is declared — a plain indexed integer column, queried
+by caller-side join when needed, matching `CandidateResult` itself having no relationships
+to other tables today. `state` stores a `PromotionState` enum's `.value` (a plain string,
+not a SQLAlchemy `Enum` column type) — consistent with how `CandidateResult.survived`
+uses a plain `Boolean` rather than a richer type for a small fixed vocabulary.
+
+**`research/promotion.py`** (new file):
+
+```python
+class PromotionState(str, Enum):
+    PASSED_GATE = "passed_gate"
+    PAPER_TRADING = "paper_trading"
+    LIVE_ELIGIBLE = "live_eligible"
+    LIVE = "live"
+    REJECTED = "rejected"
+```
+
+Module constants (`ponytail:`-flagged starting defaults):
+
+```python
+MIN_PAPER_TRADING_DAYS = 14
+MIN_PAPER_TRADES = 10
+MIN_DEGRADATION_RATIO = 0.5
+```
+
+`create_promotion_record(session: Session, candidate_result_id: int) -> PromotionRecord`
+
+Loads the referenced `CandidateResult` by id (`ValueError` if it doesn't exist — a
+caller-contract violation, not a data problem, matching this package's established
+fail-loudly convention). Raises `ValueError` if `CandidateResult.survived` is not `True`
+— only a candidate that passed the gate can begin a promotion record; this is the one
+enforcement point standing between an arbitrary backtest result and paper trading.
+Creates and returns a new `PromotionRecord` in `PASSED_GATE` state,
+`created_at=datetime.now(UTC)`.
+
+`start_paper_trading(session: Session, promotion_id: int, dry_run_db_path: str,
+started_at: datetime | None = None) -> PromotionRecord`
+
+Loads the `PromotionRecord` by id (`ValueError` if missing). Raises `ValueError` if its
+current state is not `PASSED_GATE` (guards against double-starting or starting a record
+that's already further along). Sets `state = PAPER_TRADING`,
+`paper_trading_db_path = dry_run_db_path`,
+`paper_trading_started_at = started_at or datetime.now(UTC)`. This is the one manual,
+human-initiated step this package requires before any evaluation can run — deliberately
+manual, since actually starting a dry-run bot process is outside this package's scope
+(see "What this is not").
+
+`evaluate_paper_trading_health(session: Session, promotion_id: int, dry_run_db_path:
+str | None = None, periods_per_year: int = 365) -> dict`
+
+Loads the `PromotionRecord` (raises `ValueError` if missing) and requires its state be
+`PAPER_TRADING` (`ValueError` otherwise — evaluating a record that hasn't started paper
+trading, or has already resolved, is a caller error). Loads the referenced
+`CandidateResult` for `oos_sharpe` and `strategy_id`.
+
+`dry_run_db_path` defaults to the record's own stored `paper_trading_db_path` when not
+given — the override parameter exists for tests and for a caller who wants to evaluate
+against a differently-located copy of the same database, not for routine use.
+
+Opens a **fresh, independent** SQLAlchemy engine/session against
+`dry_run_db_path` via freqtrade's own `freqtrade.persistence.init_db` and queries
+`Trade` rows where `Trade.strategy == candidate.strategy_id`, `Trade.is_open is False`,
+and `Trade.close_date >= paper_trading_started_at`. This session is separate from the
+research ledger's own `session` argument — two independent database files, never the
+same connection.
+
+Computes:
+- `days_elapsed = (datetime.now(UTC) - promotion.paper_trading_started_at).days`
+- `n_trades = len(closed_trades)`
+- `paper_sharpe`: via freqtrade's own `freqtrade.data.metrics.calculate_sharpe`, called
+  the same way `research/walkforward.py` already calls it — `calculate_sharpe(trades_df,
+  min_date, max_date, starting_balance)` — built from the queried `Trade` rows'
+  `close_profit_abs`/`open_date`/`close_date` fields (matching how backtest results are
+  scored elsewhere in this package, not a new sentinel/edge-case story to invent).
+- `degradation_ratio`: `max(0.0, min(1.0, paper_sharpe / candidate.oos_sharpe))` if
+  `candidate.oos_sharpe > 0`, else `0.0` — identical shape to
+  `research/scoring.py`'s `cost_sensitivity` (a baseline-ratio, clipped, fail-closed on
+  a non-positive baseline), reusing an established pattern rather than inventing a new
+  one for the same kind of question ("how much of a reference Sharpe survived?").
+
+Eligibility logic (not enough evidence vs. failed vs. passed — three distinct outcomes,
+not a single boolean threshold):
+- If `days_elapsed < MIN_PAPER_TRADING_DAYS` or `n_trades < MIN_PAPER_TRADES`:
+  `eligible = False`, `enough_evidence = False`, reason names which threshold(s) weren't
+  met yet.
+- Elif `degradation_ratio < MIN_DEGRADATION_RATIO`: `eligible = False`,
+  `enough_evidence = True`, reason names the degradation ratio and threshold.
+- Else: `eligible = True`, `enough_evidence = True`.
+
+Returns `{"eligible": bool, "enough_evidence": bool, "days_elapsed": int, "n_trades":
+int, "paper_sharpe": float, "degradation_ratio": float, "reasons": list[str]}` — the
+`enough_evidence` flag is what `apply_health_evaluation` uses to distinguish "stay in
+PAPER_TRADING, ask again later" from "reject now, the evidence is in."
+
+`apply_health_evaluation(session: Session, promotion_id: int, evaluation: dict) ->
+PromotionRecord`
+
+Loads the `PromotionRecord` (raises `ValueError` if missing or not in `PAPER_TRADING`
+state — same guard as the evaluator, since this is meant to be called with that
+function's own output). If `evaluation["eligible"]` is `True`: sets `state =
+LIVE_ELIGIBLE`, `resolved_at = datetime.now(UTC)`, `resolution_reason` summarizing the
+passing metrics. Elif `evaluation["enough_evidence"]` is `True` (eligible is False but
+there's enough data to judge): sets `state = REJECTED`, `resolved_at`,
+`resolution_reason = "; ".join(evaluation["reasons"])`. Else (not enough evidence yet):
+no state change — the record stays `PAPER_TRADING` for a future re-evaluation, and this
+function returns the unchanged record.
+
+`promote_to_live(session: Session, promotion_id: int) -> PromotionRecord`
+
+Loads the `PromotionRecord` (raises `ValueError` if missing). Raises `ValueError` if
+state is not `LIVE_ELIGIBLE`. Sets `state = LIVE`, `resolved_at = datetime.now(UTC)`.
+The only function in this module that produces a `LIVE` state — called only by a human,
+directly, never from `apply_health_evaluation` or any other automated path.
+
+`reject(session: Session, promotion_id: int, reason: str) -> PromotionRecord`
+
+Loads the `PromotionRecord` (raises `ValueError` if missing). Raises `ValueError` if
+current state is not `PAPER_TRADING` or `LIVE_ELIGIBLE` (a manual override available at
+either post-gate stage, not from `PASSED_GATE` before paper trading has even started, and
+not re-callable on an already-resolved record). Sets `state = REJECTED`, `resolved_at`,
+`resolution_reason = reason`.
+
+## Data flow
+
+1. A candidate passes `run_promotion_gate` (existing, unchanged) → its `CandidateResult`
+   row has `survived = True`.
+2. A human calls `create_promotion_record(session, candidate_result.id)` →
+   `PromotionRecord` in `PASSED_GATE`.
+3. A human manually launches a freqtrade dry-run instance for that strategy (outside
+   this package entirely), then calls `start_paper_trading(session, promotion.id,
+   dry_run_db_path)` → `PAPER_TRADING`, recording where that instance's trade data lives.
+4. Periodically (manually, or by a future scheduler — out of scope here), a human or
+   script calls `evaluate_paper_trading_health(session, promotion.id)`, inspects the
+   returned dict, and calls `apply_health_evaluation(session, promotion.id, evaluation)`
+   to act on it → stays `PAPER_TRADING`, moves to `LIVE_ELIGIBLE`, or moves to
+   `REJECTED`.
+5. If `LIVE_ELIGIBLE`: a human, independently of anything this package computes, decides
+   whether to actually deploy live and calls `promote_to_live(session, promotion.id)`.
+
+## Timezone-awareness resolution
+
+This session already hit a real bug in this exact shape earlier (`research/cli.py`'s
+`--start`/`--end` parsing: `Backtesting.backtest()` compares against tz-aware (UTC)
+pandas `Timestamp`s internally, and a naive `datetime` crashes deep inside it). Verified
+directly against freqtrade's source before writing this section, not assumed:
+`freqtrade/persistence/trade_model.py:1758` stores `open_date`/`close_date` as **naive**
+datetimes on the raw ORM column (`default=datetime.now`, no `UTC`), but freqtrade's own
+code never compares those raw columns directly for date arithmetic — it uses the
+`open_date_utc`/`close_date_utc` **properties** (`trade_model.py:536,546`), each just
+`self.open_date.replace(tzinfo=UTC)` / `self.close_date.replace(tzinfo=UTC)`. That is
+the established freqtrade convention this module follows: query the raw
+`Trade.close_date` column in the SQL `WHERE` clause (fine — comparing two naive UTC
+values against each other in SQL is internally consistent, since freqtrade always writes
+naive UTC), but do all **Python-side** date arithmetic (computing `days_elapsed`,
+comparing against `paper_trading_started_at`) using `.close_date_utc`, matching how
+freqtrade's own code does it.
+
+`paper_trading_started_at` itself is written as `datetime.now(UTC)` (tz-aware) into a
+plain SQLAlchemy `DateTime` column — the same pattern `research/ledger.py`'s
+`CandidateResult.run_stamp` already uses (`run_stamp=run_stamp or datetime.now(UTC)`)
+elsewhere in this package. Since SQLite round-tripping through SQLAlchemy's plain
+`DateTime` can silently drop tzinfo, `evaluate_paper_trading_health` normalizes
+defensively on read rather than assuming either behavior:
+`started_at = promotion.paper_trading_started_at; started_at = started_at.replace(tzinfo=UTC) if started_at.tzinfo is None else started_at`
+— correct whether or not the round-trip preserved awareness, with no reliance on an
+assumption neither this spec nor a quick source read can settle for SQLAlchemy's SQLite
+dialect in general.
+
+## Error handling
+
+- Every state-machine function raises `ValueError` on: a missing referenced row (record
+  or candidate), or an invalid current-state-to-target-state transition. No silent
+  no-ops on a caller error — this mirrors `research/regime.py`'s `ValueError` on an
+  empty `windows` list and `research/scoring.py`'s implicit trust in well-formed inputs
+  (a malformed call is a programming error to surface, not paper over).
+- `evaluate_paper_trading_health` degrades gracefully (does not raise) when
+  `n_trades == 0`: `paper_sharpe` is `0` (freqtrade's own `calculate_sharpe` already
+  returns the sentinel `0` for zero trades — verified this session during the
+  regime-breakdown sub-project, `freqtrade/data/metrics.py:466-467`), `degradation_ratio`
+  computed normally from that `0`, and `enough_evidence` will be `False` regardless
+  (since `n_trades < MIN_PAPER_TRADES` is trivially true at 0) — the eligibility logic
+  naturally handles the empty case without a special branch.
+
+## Testing
+
+- `research/tests/test_promotion.py` (new): real SQLAlchemy session construction (an
+  in-memory or `tmp_path` sqlite via `research.db.get_engine`/`get_session`, matching
+  `research/tests/test_gate.py`'s own house style), real `CandidateResult`/
+  `PromotionRecord` rows — no mocking of the state machine itself.
+  1. `create_promotion_record` succeeds for a `survived=True` candidate, starts in
+     `PASSED_GATE`.
+  2. `create_promotion_record` raises `ValueError` for a `survived=False` candidate.
+  3. `create_promotion_record` raises `ValueError` for a nonexistent `candidate_result_id`.
+  4. `start_paper_trading` transitions `PASSED_GATE` → `PAPER_TRADING`, records
+     `paper_trading_db_path`/`paper_trading_started_at` (default `started_at` is
+     approximately "now").
+  5. `start_paper_trading` raises `ValueError` when called on a record already in
+     `PAPER_TRADING` (or any non-`PASSED_GATE` state).
+  6. `promote_to_live` transitions `LIVE_ELIGIBLE` → `LIVE`.
+  7. `promote_to_live` raises `ValueError` from any other state (including
+     `PAPER_TRADING` directly — the point of the whole feature: you cannot skip
+     `LIVE_ELIGIBLE`).
+  8. `reject` transitions `PAPER_TRADING` → `REJECTED` and `LIVE_ELIGIBLE` → `REJECTED`,
+     records the given reason.
+  9. `reject` raises `ValueError` from `PASSED_GATE` (paper trading never started) and
+     from `REJECTED`/`LIVE` (already resolved).
+- `evaluate_paper_trading_health` / `apply_health_evaluation`: real freqtrade `Trade`
+  rows inserted directly into a fresh dry-run-style sqlite database via
+  `freqtrade.persistence.init_db` + direct `Trade(...)` construction (matching how
+  `research/tests/test_regime.py`/`test_scoring.py` construct real dataclasses/rows
+  directly rather than running a full backtest to get them) — not a mocked query result.
+  10. Not-enough-evidence case: fewer than `MIN_PAPER_TRADES` closed trades inserted →
+      `evaluate_paper_trading_health` returns `enough_evidence=False`, `eligible=False`;
+      `apply_health_evaluation` leaves the record in `PAPER_TRADING`.
+  11. Enough evidence, good degradation ratio: enough trades/days inserted with profit
+      values chosen so the computed `paper_sharpe` clears `MIN_DEGRADATION_RATIO` of the
+      candidate's `oos_sharpe` → `eligible=True`; `apply_health_evaluation` transitions
+      to `LIVE_ELIGIBLE`.
+  12. Enough evidence, bad degradation ratio: same trade/day counts but profit values
+      chosen so `paper_sharpe` falls below the threshold → `eligible=False`,
+      `enough_evidence=True`; `apply_health_evaluation` transitions to `REJECTED`.
+  13. Zero-trades case: no trades inserted at all → `evaluate_paper_trading_health`
+      does not raise, returns `n_trades=0`, `paper_sharpe=0`, `enough_evidence=False`.
+  14. `degradation_ratio` edge case: `candidate.oos_sharpe <= 0` → `degradation_ratio`
+      is exactly `0.0` regardless of `paper_sharpe`, mirroring
+      `research/scoring.py`'s `cost_sensitivity` zero-baseline test.
+  15. `evaluate_paper_trading_health`/`apply_health_evaluation` both raise `ValueError`
+      when called on a record not in `PAPER_TRADING` (e.g. still `PASSED_GATE`, or
+      already `LIVE_ELIGIBLE`).
+
+## Open items resolved during brainstorming
+
+- Scope: **state tracker + health evaluator only**, explicitly not orchestration/exchange
+  connectivity/config generation (user-directed scope boundary, matches the pattern this
+  session established for every prior sub-project's "what this is not").
+- Storage: **a new `PromotionRecord` table alongside the existing `candidate_results`
+  table**, referenced by `candidate_result_id` (a plain indexed column, no ORM
+  relationship) rather than folding promotion state onto `CandidateResult` itself, since
+  a candidate's gate-evaluation history and its promotion lifecycle are different
+  concerns with different write patterns (one row per gate run vs. one row per promotion
+  attempt, and a gate-passing candidate might never be promoted at all).
+  **Ruling** (controller decision, not user-specified): kept these separate rather than
+  adding promotion columns to `CandidateResult` directly, to avoid `NULL`-heavy columns
+  on every gate-run row for the (likely common) case where most passing candidates are
+  never promoted to paper trading at all.
+- Degradation metric: **reuses `research/scoring.py`'s exact `cost_sensitivity`
+  clipped-ratio shape** rather than a new formula, for internal consistency across the
+  package (both ask "how much of a reference Sharpe survived a stress condition" — fee
+  stress there, paper-trading reality here).
+  **Ruling**: `MIN_PAPER_TRADING_DAYS=14`, `MIN_PAPER_TRADES=10`,
+  `MIN_DEGRADATION_RATIO=0.5` are starting defaults, not derived from any real paper-
+  trading history (none exists yet in this fork) — explicitly flagged as
+  `ponytail:`-adjust-later constants, same treatment as every other threshold this
+  session has introduced.
+- Eligibility has **three outcomes, not two**: not-enough-evidence (stay), rejected
+  (enough evidence, failed), eligible (enough evidence, passed) — a plain boolean
+  "eligible or not" would conflate "we don't know yet" with "we know it's bad," which
+  would either reject too early (premature judgment on a thin sample) or never resolve
+  (if a caller only checked `eligible` and looped forever without ever reaching
+  `REJECTED`). **Ruling**: this three-way split is load-bearing for
+  `apply_health_evaluation`'s correctness, not an implementation detail — call this out
+  explicitly to the plan's task reviewer so a "simplify to one boolean" suggestion
+  during implementation gets rejected, not accepted.

--- a/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
+++ b/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
@@ -162,8 +162,21 @@ human-initiated step this package requires before any evaluation can run — del
 manual, since actually starting a dry-run bot process is outside this package's scope
 (see "What this is not").
 
-`evaluate_paper_trading_health(session: Session, promotion_id: int, dry_run_db_path:
-str | None = None, periods_per_year: int = 365) -> dict`
+`evaluate_paper_trading_health(session: Session, promotion_id: int, starting_balance:
+float, dry_run_db_path: str | None = None, periods_per_year: int = 365) -> dict`
+
+**`starting_balance` is required, not defaulted or derived (a real gap caught while
+grounding the plan against `calculate_sharpe`'s actual signature, not something the first
+draft of this spec accounted for).** `research/walkforward.py`'s existing
+`calculate_sharpe` calls always pass `self.config["dry_run_wallet"]` — the same
+backtest `config` dict already in scope there. This function has no `config` in scope
+(only a `PromotionRecord` and a `CandidateResult` DB row), and `dry_run_wallet` isn't
+persisted on either — a paper-trading bot's actual configured wallet size lives in that
+bot's own config file, which this package doesn't read. Rather than guess, invent a
+default, or reach into a config file this module has no other reason to touch, the
+caller (a human who knows the paper-trading bot's own configured stake) supplies it
+directly, the same way `research.gate.run_promotion_gate` takes its `config` from the
+caller rather than discovering it.
 
 Loads the `PromotionRecord` (raises `ValueError` if missing) and requires its state be
 `PAPER_TRADING` (`ValueError` otherwise — evaluating a record that hasn't started paper

--- a/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
+++ b/docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md
@@ -206,6 +206,24 @@ instead of hanging indefinitely. This function does not need write access to tha
 database — read-only intent should be clear from the code even though `init_db` itself
 doesn't expose a strict read-only mode.
 
+**`init_db` mutates GLOBAL class-level state on `Trade`, not a scoped per-call
+connection — a real risk this package has already been burned by once this session
+(the `Trade.use_db`/`bt_trades` test-isolation fix, PR #5).** `freqtrade.persistence
+.init_db(db_url)` sets `Trade.session` (a `scoped_session` on the `Trade`/`LocalTrade`
+class itself) as a side effect — it is not a factory returning an independent session
+object. Calling it inside `evaluate_paper_trading_health` therefore redirects `Trade`
+queries for the **entire process**, not just this function call. Concretely: this
+function must fully materialize its query results (`.all()`) and finish everything it
+needs from `Trade.session` before returning, and it must never be called concurrently
+with, or interleaved mid-flight with, any other code in the same process that depends on
+`Trade.session`/`Trade.query` pointing at a different database (a `WalkForwardRunner`/
+`Backtesting` run in the same process being the concrete example — those manage their
+own `Trade`-adjacent state internally). Document this constraint directly in the
+function's docstring, not just here — a future caller reading only the function
+signature has no other way to know. This is a genuine limitation of freqtrade's own
+persistence API, not a design flaw this module can architect around without
+reimplementing freqtrade's ORM setup from scratch, which is out of scope.
+
 **One normalized instant per call, not two independent clock reads (verified via
 lmchatbot cross-check):** capture `now = datetime.now(UTC)` exactly once at the top of
 this function, and derive `days_elapsed` from that same captured value — never call

--- a/docs/superpowers/specs/2026-08-24-regime-breakdown-design.md
+++ b/docs/superpowers/specs/2026-08-24-regime-breakdown-design.md
@@ -1,0 +1,286 @@
+# Regime Breakdown — Design
+
+## Context
+
+Second sub-project decomposed from `CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md` (§5, market
+regimes) — the first was the fee-sensitivity stress test
+(`docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md`, shipped).
+`research/` (ledger, DSR/BH-FDR, PBO, walk-forward runner, promotion gate, fee-sensitivity
+stress test) already ships and has been proven end-to-end against a real strategy
+(`EmaTrendFollow`, correctly rejected on BTC/USDT).
+
+This sub-project attributes a candidate's out-of-sample performance to the market
+conditions each walk-forward window's test period actually occurred in. Unlike
+fee-sensitivity (only meaningful for a candidate that already passed), regime breakdown is
+valuable for a **failed** candidate too — it can distinguish "bad everywhere" from "only
+bad in one kind of market," which is real diagnostic information the plain PASS/FAIL
+verdict throws away.
+
+## What this is not
+
+**Not the proposal's full 7-category taxonomy.** §5 asks for Bull, Bear, Sideways, High
+volatility, Low volatility, Crash, Recovery. This spec ships **two independent axes**
+instead — Trend (Bull/Bear/Sideways) × Volatility (High/Low) — dropping Crash and Recovery
+from the MVP. Trend and volatility are genuinely orthogonal (the proposal's own example
+table lists them as separate rows, not a single enum), so reporting them as two axes is
+more informative than collapsing them into one label, not less. Crash/Recovery need a
+drawdown-magnitude threshold that's harder to calibrate defensibly with only price data
+and no drawdown-history baseline — deferred rather than shipped as an arbitrary guess.
+
+**Not a statistical/unsupervised regime model.** A Hidden Markov Model or Gaussian mixture
+on returns was considered and rejected: more "principled"-sounding, but it's a black box a
+non-expert can't audit, which cuts directly against this whole project's transparency
+goal (§14 of the proposal: "hide complexity, not evidence"). Simple, explicit,
+threshold-based rules — reproducible and auditable by inspection — are what the rest of
+`research/` already does (DSR, BH-FDR, PBO are all closed-form, not fit models).
+
+**Not richer signals (funding rate, BTC dominance).** Classified purely from the traded
+pair's own OHLCV — already downloaded for backtesting, no new data source, no new fetch
+code. A real VIX-style external volatility index doesn't have a crypto equivalent readily
+available; deferred rather than half-built.
+
+**Not a causal/live-safe classifier (verified via lmchatbot cross-check).** The volatility
+axis ranks each window against the **median across every window in the run**, including
+windows chronologically after the one being classified. That's fine for this spec's stated
+use — a one-shot, post-hoc historical report generated after the whole backtest already
+ran, so it can't leak into the trading decisions it's describing (the classifier never
+touches signal generation or fill logic). It is **not** safe to reuse this exact function
+for a live/production regime-switching signal, which would need a trailing, point-in-time
+baseline instead (e.g. a rolling historical volatility window) rather than a full-sample
+median. If a live regime signal is ever wanted, that's a different function, not a new
+call site for this one.
+
+**Not per-trade attribution.** Each walk-forward window's whole test period gets ONE
+regime label, not each individual trade. Finer-grained per-trade tagging would require
+exposing per-trade entry/exit timestamps from `WalkForwardRunner` — a real change to
+code that's already shipped and reviewed twice (Task 1/2 of the fee-sensitivity plan). Per
+the proposal's own example output (a single PASS/FAIL/WEAK per regime row, not per trade),
+window-level granularity is what's actually being asked for.
+
+**Not gated on the gate's PASS/FAIL verdict.** Fee-sensitivity only runs for a passing
+candidate (an already-validated edge's cost margin is what's interesting). Regime
+breakdown deliberately runs regardless of pass/fail — a failed candidate's regime
+breakdown is diagnostic evidence for the next research iteration, not wasted compute.
+
+**Not folded into the promotion decision.** Like fee-sensitivity, this is informational —
+it never changes `GateResult.passed`. The proposal's §5 closing line ("This should
+influence robustness scoring") is future work (a robustness-scoring sub-project doesn't
+exist yet); this spec produces the raw evidence a future scorer could consume, not the
+scorer itself.
+
+**Not Deflated-Sharpe-scored per regime bucket.** Per-regime sample sizes (often 1-3
+windows) are too thin for DSR to say anything meaningful — reporting a DSR per bucket
+would manufacture false precision. Each bucket reports raw `mean_test_sharpe`, `total_return`,
+`n_trades`, `n_windows` — real numbers a human can weigh, explicitly not a statistical
+verdict.
+
+## Architecture
+
+```
+run_promotion_gate() [existing, research/gate.py]
+  │
+  ├─ windows = generate_windows(...)              [existing]
+  ├─ results = runner.run(windows, param_grid)    [existing — list[WindowResult]]
+  ├─ ... existing DSR / BH-FDR / PBO / ledger logic [unchanged]
+  │
+  └─ if include_regime_breakdown:                  (regardless of passed/failed)
+         labels = classify_regimes(pairs[0], timeframe, datadir, windows)
+         regime = regime_report(results, labels)
+         attached to GateResult.regime_breakdown
+
+research/regime.py  [new]
+  classify_regimes(pair, timeframe, datadir, windows, trend_threshold=0.05) -> list[str]
+    -- two-pass: (1) load each window's own OHLCV test-period close series (no
+       Backtesting instance needed -- just history.load_data), compute total
+       return + realized volatility per window; (2) find the median realized
+       volatility ACROSS all windows in this run, classify each window's vol
+       as High/Low relative to that median (self-referential baseline, no
+       external index needed), combine with trend into e.g. "Bull/High".
+       One label per window, same order as `windows`.
+
+  regime_report(window_results, labels) -> dict[str, dict]
+    -- groups window_results by label (parallel list, not a dict key --
+       Window is an unfrozen dataclass, not hashable), aggregates exactly
+       like gate.py/cost_stress.py already do (concatenate test_returns,
+       mean per-window test_sharpe) -- consistent with the established
+       pattern, no new aggregation convention invented.
+```
+
+## Components
+
+**`research/regime.py`** (new file) — two functions:
+
+`classify_regimes(pair: str, timeframe: str, datadir: Path, windows: list[Window], trend_threshold: float = 0.05) -> list[str]`
+
+For each window, builds a `freqtrade.configuration.TimeRange` from that window's own
+`test_start`/`test_end` fields (the same `TimeRange("date", "date", int(ts_start.timestamp()),
+int(ts_end.timestamp()))` construction `research/walkforward.py` already uses), and loads
+that `[test_start, test_end)` close-price series via one `freqtrade.data.history.load_data`
+call per window (no `Backtesting` instance — this needs only price data, not indicators or
+a strategy; no `startup_candles` needed either, since there's no indicator warmup to
+satisfy). One load per window, not a single bulk load re-sliced — simpler, and the number
+of windows in a typical run (single digits to low tens) makes the repeated I/O cheap;
+revisit only if this becomes a measured bottleneck. From the loaded close series, computes:
+- `total_return = close.iloc[-1] / close.iloc[0] - 1`
+- `realized_vol = close.pct_change().dropna().std()`
+
+(Windows within one walk-forward run always share the same `train_days`/`test_days` —
+`generate_windows` takes single scalar values applied to every window it produces — so
+every window's test period is the same duration. The fixed `trend_threshold` is therefore
+being compared against a consistent basis within a run; comparing thresholds across runs
+with different `test_days` is a separate concern this spec doesn't address.)
+
+Trend label: `"Bull"` if `total_return > trend_threshold`, `"Bear"` if
+`total_return < -trend_threshold`, else `"Sideways"`. `trend_threshold` defaults to `0.05`
+(5% total return over the window) — a starting default, not empirically derived; adjust
+based on real usage once this runs against real strategies (`ponytail:`-flagged in code).
+
+Volatility label: computed in a second pass once every window's `realized_vol` is known —
+`"High"` if this window's vol is strictly above the **median** vol across all windows in
+this run, `"Low"` otherwise (a window sitting exactly on the median, or in a tied group
+with the median, is `"Low"` by construction — deliberate, not an unresolved edge case:
+`>` not `>=`, so ties resolve toward `"Low"`). Self-referential to the run's own data (no
+external volatility index needed), which is honest about what it is: "more/less volatile
+than this backtest's other periods," not "objectively high/low." See "Not a causal/live-safe
+classifier" above for why this full-sample median is fine for this report but not for a
+live signal.
+
+Final label is `f"{trend}/{volatility}"`, e.g. `"Bull/High"`, `"Bear/Low"`,
+`"Sideways/High"` — 6 possible combinations. Returns one label per window, in the same
+order as `windows`.
+
+Degenerate input: a window whose test period has fewer than 2 candles (can't compute a
+return or volatility) is fail-closed to `total_return=0.0, realized_vol=0.0` —
+classified `"Sideways"` on the trend axis by construction (`0.0` is inside the
+`[-threshold, threshold]` band) and whatever the vol median comparison yields on the
+volatility axis (deterministic, not a crash).
+
+`regime_report(window_results: list[WindowResult], labels: list[str]) -> dict[str, dict]`
+
+Raises `ValueError` if `len(window_results) != len(labels)` (mismatched parallel lists — a
+caller error, fail loudly). Groups `window_results` by their parallel `labels` entry, and
+for each distinct label reports:
+- `n_windows`: how many windows got this label
+- `n_trades`: total trade count across those windows (`sum(wr.test_n_trades)`)
+- `mean_test_sharpe`: mean of `wr.test_sharpe` across those windows — same aggregation
+  style already used in `gate.py`/`cost_stress.py`, not a new convention
+- `total_return` (named precisely per lmchatbot review — NOT `total_pnl`, which would
+  imply compounded equity/dollar P&L; this is neither): the plain sum of every trade's
+  fractional return across those windows (`sum(r for wr in group for r in wr.test_returns)`,
+  where each `r` is already `profit_abs / dry_run_wallet`, matching how `test_returns` is
+  populated everywhere else in `research/`). An arithmetic sum of fractional returns, not
+  a geometrically compounded return — fine as a rough same-units aggregate for comparing
+  regime buckets against each other, not a claim about realized account growth.
+
+`WindowResult.test_sharpe` is never `NaN` for a zero-trade window — verified against
+`freqtrade/data/metrics.py`'s `calculate_sharpe`, which returns the plain sentinel `0` when
+`len(trades) == 0` (not `NaN`, not a different sentinel). `np.mean` over a group containing
+such a window is therefore always well-defined, no explicit `NaN`-guard needed in
+`regime_report`.
+
+**`research/gate.py`** (existing file, extended) — `run_promotion_gate` gains one new
+optional parameter, `include_regime_breakdown: bool = False` (default off — existing
+callers and existing tests are unaffected). Computed **unconditionally on pass/fail** (the
+one deliberate asymmetry with fee-sensitivity, documented above) using `pairs[0]` as the
+reference pair, `windows` and `results` already in scope from the existing walk-forward
+run — no duplicate work. Attached to a new `GateResult.regime_breakdown: dict[str, dict] |
+None = None` field. Multi-pair regime blending (if `pairs` has more than one entry) is out
+of scope — `pairs[0]` is used as the single reference asset, documented as a scope limit,
+not silently wrong behavior.
+
+**`research/cli.py`** (existing file, extended) — `gate` subcommand gains
+`--regime-breakdown` (flag, default off). When set, threads
+`include_regime_breakdown=True` through to `run_promotion_gate`, and if
+`result.regime_breakdown` is present (always, when the flag was passed — unlike
+fee-sensitivity, this isn't conditional on `passed`), prints a table:
+
+```
+  regime breakdown (informational, not part of PASS/FAIL):
+    Bull/High       2 windows   14 trades   mean sharpe  0.42   total return  0.0012
+    Bear/Low        1 windows    6 trades   mean sharpe -1.10   total return -0.0034
+    Sideways/Low     3 windows   19 trades   mean sharpe -0.05   total return -0.0002
+```
+
+## Data flow
+
+1. `research gate --strategy X ... --regime-breakdown` → `cli.main()`
+2. `run_promotion_gate(..., include_regime_breakdown=True)`
+3. Existing gate logic runs unchanged; `windows`, `results` already in scope
+4. Regardless of `passed`: `labels = classify_regimes(pairs[0], timeframe, datadir, windows)`
+5. Inside `classify_regimes`: one `history.load_data` call per window (price-only, no
+   backtest) to get total return + realized vol; second pass computes the vol median
+   across all windows and finalizes each label
+6. `regime = regime_report(results, labels)` — groups and aggregates
+7. Attached to `GateResult.regime_breakdown`; CLI prints the table if present
+
+## Error handling
+
+- `classify_regimes` raises `ValueError` on an empty `windows` list — nothing to classify,
+  fail loudly rather than return an empty/misleading result (mirrors
+  `run_promotion_gate`'s own `< 4 windows` `ValueError` pattern).
+- `regime_report` raises `ValueError` on mismatched list lengths between `window_results`
+  and `labels` — a caller-contract violation, not a data problem.
+- A degenerate (near-empty) window's price data fails closed to a defined, deterministic
+  label rather than raising or crashing (see "Degenerate input" above) — a single thin
+  window shouldn't abort the whole report.
+
+## Testing
+
+- `classify_regimes`: real execution (real `history.load_data`, real `UNITTEST/BTC`
+  fixture data, matching the existing `research/tests/` pattern):
+  1. **Trend boundary test**: construct windows over known-different price regions of the
+     real fixture (discovered programmatically via the fixture's actual price series, not
+     hand-picked indices — same approach `research/tests/test_walkforward.py` already
+     uses for its own fixtures) and confirm the trend axis assigns `"Bull"` when total
+     return exceeds `trend_threshold`, `"Bear"` when below `-trend_threshold`, `"Sideways"`
+     otherwise — derived from the real computed `total_return`, not hand-calculated.
+  2. **Volatility relative-ranking test**: construct several windows with genuinely
+     different realized volatility (e.g. a flat-price window vs. a sharply oscillating
+     one) and confirm the higher-vol window(s) get `"High"` and the lower-vol window(s)
+     get `"Low"`, relative to the set's own median — not asserting an absolute threshold,
+     since the design deliberately doesn't have one.
+  3. **Degenerate window test**: a window whose test period has 0 or 1 candles gets a
+     deterministic `"Sideways"` trend label, no exception raised.
+  4. **Empty windows list**: raises `ValueError`.
+- `regime_report`: no real backtesting needed — construct `WindowResult` objects directly
+  (plain dataclass construction, real `research.walkforward.WindowResult`/`Window`, not
+  mocks) with known `test_sharpe`/`test_n_trades`/`test_returns` values and known parallel
+  labels, assert the grouped aggregates (`n_windows`, `n_trades`, `mean_test_sharpe`,
+  `total_return`) match hand-computed expected values for a small, fully-specified case.
+  Mismatched-length `ValueError` test.
+- `run_promotion_gate` / `cli.py`: extend the existing real end-to-end gate tests — one
+  assertion path confirming `GateResult.regime_breakdown` is populated when
+  `include_regime_breakdown=True` **and the gate fails** (the one deliberate asymmetry
+  with fee-sensitivity — this is the test that actually proves the asymmetry was
+  implemented, not just described), and populated the same way when it passes.
+  `test_cli.py` gets one more case: `--regime-breakdown` flag present, `run_promotion_gate`
+  mocked to return a `GateResult` with `regime_breakdown` populated, assert the table
+  appears in stdout.
+
+## Open items resolved during brainstorming
+
+- Granularity: **per-window**, not per-trade (user decision — avoids touching already-shipped
+  `WalkForwardRunner`/`WindowResult` structures again).
+- Signal source: **BTC/USDT's own OHLCV only** (user decision — no new data source/fetch code).
+- Category scope: **two axes (Trend × Volatility), not the proposal's 7-category taxonomy**
+  — Crash/Recovery deferred (design decision, presented and approved in chat).
+- Gating: **runs regardless of PASS/FAIL** (design decision, presented and approved in chat)
+  — the one deliberate asymmetry with the fee-sensitivity precedent, called out explicitly
+  everywhere it matters (spec, and to be mirrored in the eventual plan's Global Constraints)
+  so it doesn't read as an inconsistency with the established pattern.
+
+**Spec review round (lmchatbot, Gemini draft cross-verified by ChatGPT).** The draft raised
+eight points; the verify pass corrected several as overstated (raw per-candle `.std()`
+doesn't need annualizing to be a valid volatility measure; a fixed ±5% threshold is fine
+across equal-duration windows, which every window in one run already is by construction;
+"statistically unsound below 6 windows" isn't a real threshold, just "noisier with fewer
+windows"; equal-median handling is a deliberate, already-specified `>`-not-`>=` choice, not
+an unresolved ambiguity). Four real findings survived the cross-check and were applied
+above: (1) `total_pnl` was a misleading name for a plain sum of fractional trade returns —
+renamed `total_return` with an explicit non-compounding disclaimer; (2) the
+`Window`→`TimeRange` translation and the one-load-per-window approach needed to be spelled
+out, not left implicit; (3) the median-relative volatility classifier's non-causal,
+research-only nature needed its own explicit "not" scope item, not just an implied
+limitation; (4) zero-trade `test_sharpe` NaN-safety was unspecified — resolved definitively
+by citing `calculate_sharpe`'s actual `0`-not-`NaN` sentinel behavior (verified against real
+freqtrade source, not assumed).

--- a/docs/superpowers/specs/2026-08-24-strategy-scoring-and-report-design.md
+++ b/docs/superpowers/specs/2026-08-24-strategy-scoring-and-report-design.md
@@ -1,0 +1,275 @@
+# Strategy Scoring & Report — Design
+
+## Context
+
+Third sub-project decomposed from `CRYPTO_STRATEGY_DISCOVERY_PROPOSAL.md` (§14-15, strategy
+scoring and strategy report). The first two were the fee-sensitivity stress test and regime
+breakdown (both shipped). `research/` now produces, per gate run: a PASS/FAIL verdict with
+three thresholded statistics (deflated Sharpe, permutation p-value, PBO), and two optional
+informational dimensions (fee-sensitivity, regime breakdown). This sub-project adds nothing
+new to *compute* — it synthesizes what `GateResult` already carries into (a) one continuous
+robustness score for ranking/comparing candidates, and (b) one standardized human-readable
+report, replacing the ad-hoc print statements currently duplicated inline in `research/cli.py`.
+
+## What this is not
+
+**Not a new statistical test.** Every input to the score is already computed by
+`run_promotion_gate` before this sub-project's code ever runs. No new backtesting, no new
+walk-forward evaluation, no new data load.
+
+**Not the proposal's full component list.** §14 lists OOS performance, OOS consistency,
+drawdown, Sharpe/Sortino, deflated Sharpe, parameter stability, time stability, asset
+stability, regime stability, cost sensitivity, trade count, Monte Carlo risk, profit
+concentration, IS/OOS degradation. Only five of these are ever actually available on a
+`GateResult` today: deflated Sharpe, the permutation test (the proposal's "Monte Carlo
+risk" — `permutation_test` already **is** a sign-flip Monte Carlo test, not a separate
+thing to build), PBO, cost sensitivity (from `fee_sensitivity`, when requested), and regime
+stability (from `regime_breakdown`, when requested). Drawdown, Sortino, parameter/time/asset
+stability, profit concentration, and IS/OOS degradation would all require new fields on
+`WindowResult` or new equity-curve reconstruction that no current code produces — deferred
+rather than half-built from data that doesn't exist yet. `passed` itself is not a
+component — the score is deliberately not a re-derivation of pass/fail (see below).
+
+**Not a replacement for the PASS/FAIL verdict.** `GateResult.passed` and `reasons` are
+untouched — the score is a supplementary, continuous signal (particularly useful for
+comparing several FAILED candidates to see which is closest, or ranking several PASSED
+ones), not a second gate. A strategy that fails the gate can still have a computed score;
+the report shows both, never lets one substitute for the other.
+
+**Not a new CLI flag.** The report is not conditional — it's what `research gate` already
+prints, reorganized into one reusable function instead of ten scattered `print()` calls.
+`--fee-sensitivity` and `--regime-breakdown` keep gating whether those *sections* of the
+report have content, exactly as today.
+
+**Not configurable weights.** The score's five component weights are fixed module-level
+constants, not a runtime parameter — matches this package's established pattern for
+similar starting defaults (`trend_threshold` in `research/regime.py`,
+`DEFAULT_FEE_MULTIPLIERS` in `research/cost_stress.py`): a `ponytail:`-flagged starting
+point, adjustable in code once this runs against real strategies, not prematurely
+generalized into a config object nobody has asked to tune yet.
+
+## Architecture
+
+```
+research/scoring.py  [new]
+  robustness_score(result: GateResult) -> float
+    -- weighted average of whichever components GateResult actually has populated,
+       renormalized over the weights actually used. Always in [0, 1].
+
+  strategy_report(result: GateResult, pair: str | None = None) -> str
+    -- the exact text research/cli.py currently prints, unchanged in content, now built
+       as one string instead of ad-hoc print() calls, plus one new line embedding
+       robustness_score(result).
+
+research/cli.py  [modified]
+  gate command's print block replaced with print(strategy_report(result, pair=...))
+  -- no new flags, no behavior change to what gets shown or the exit code.
+```
+
+## Components
+
+**`research/scoring.py`** (new file):
+
+```python
+WEIGHTS = {
+    "deflated_sharpe": 0.35,
+    "significance": 0.25,       # 1 - permutation_p
+    "pbo_inverse": 0.25,        # 1 - pbo
+    "cost_sensitivity": 0.10,   # only when result.fee_sensitivity is present
+    "regime_consistency": 0.05, # only when result.regime_breakdown is present
+}
+```
+
+`robustness_score(result: GateResult) -> float`
+
+Every one of `deflated_sharpe`, `permutation_p`, and `pbo` is already a probability in
+`[0, 1]` by construction (`deflated_sharpe_ratio` returns `norm.cdf(...)`;
+`permutation_test` returns a fraction of matching permutations; `probability_of_backtest_
+overfitting` returns a probability) — no rescaling needed, just `1 - x` for the two where
+lower is better (`permutation_p`, `pbo`).
+
+Always-present components:
+- `"deflated_sharpe"`: `result.deflated_sharpe` directly.
+- `"significance"`: `1.0 - result.permutation_p`.
+- `"pbo_inverse"`: `1.0 - result.pbo`.
+
+`"cost_sensitivity"`, only when `result.fee_sensitivity` is truthy: let
+`baseline_mult = min(result.fee_sensitivity)`, `stress_mult = max(result.fee_sensitivity)`
+(the lowest and highest multiplier actually tested — not hardcoded to `1.0`, since a caller
+could in principle pass `fee_sensitivity` computed with custom multipliers that don't
+include `1.0`). Let `baseline_dsr = result.fee_sensitivity[baseline_mult]["deflated_sharpe"]`,
+`stress_dsr = result.fee_sensitivity[stress_mult]["deflated_sharpe"]`.
+- If `baseline_mult == stress_mult` (only one multiplier was tested — no stress signal
+  either way): component = `1.0` (fail open, not closed — there's genuinely no
+  information to penalize on).
+- Elif `baseline_dsr <= 0`: component = `0.0` (fail closed — dividing by a non-positive
+  baseline is meaningless, and an already-zero-or-negative baseline deflated Sharpe is
+  the worst case regardless of how stress compares to it).
+- Else: component = `max(0.0, min(1.0, stress_dsr / baseline_dsr))` — how much of the
+  baseline's statistical edge survives at the worst tested fee level, clipped to `[0, 1]`
+  (a `stress_dsr` that's *higher* than baseline, e.g. from a genuinely noisy small sample,
+  should not push the component above `1.0` and give an unearned bonus).
+
+`"regime_consistency"`, only when `result.regime_breakdown` is truthy:
+`n_positive = sum(1 for stats in result.regime_breakdown.values() if stats["mean_test_sharpe"] > 0)`,
+`n_total = len(result.regime_breakdown)`, component = `n_positive / n_total` — the fraction
+of regime buckets where the strategy was net-positive on average, not just one favorable
+bucket carrying the whole result.
+
+Final score: `sum(WEIGHTS[k] * v for k, v in components.items()) / sum(WEIGHTS[k] for k in
+components)` — a weighted average renormalized over whichever components are actually
+present. Always in `[0, 1]`: every component value is itself in `[0, 1]`, and a weighted
+average of values in `[0, 1]` stays in `[0, 1]`. The denominator is never zero — the three
+always-present components alone sum to `0.85` of weight.
+
+**Known limitation, deliberate (verified via lmchatbot cross-check): scores are only
+directly comparable between `GateResult`s computed with the *same* set of optional
+components present.** Renormalizing over available weight means an identical underlying
+performance profile scores differently depending on whether `fee_sensitivity`/
+`regime_breakdown` were requested for that run — e.g. adding a strong
+`regime_consistency` value shifts the denominator from `0.85` to `0.90`, changing the
+result even though the three core statistics didn't move. This is a real property of
+the design, not an oversight: the alternative (a fixed `1.0` denominator that treats a
+missing optional component as `0`) would instead punish every ordinary run that never
+requested the optional, compute-costly fee-sensitivity/regime-breakdown analyses,
+capping their maximum achievable score below what a more expensively-evaluated
+candidate could reach for reasons having nothing to do with actual strategy quality —
+worse than the chosen tradeoff, since both `fee_sensitivity` and `regime_breakdown` stay
+opt-in specifically to avoid forcing extra backtesting nobody asked for (see "Not a new
+CLI flag" above). Read `robustness_score` as "how robust this candidate looks *given the
+evidence gathered for it*," not a universal ranking number — a future batch-ranking tool
+built on top of this (see §16's non-expert workflow) should compare only
+same-configuration runs, or surface which optional components fed into each score
+alongside the number. `strategy_report`'s printed sections already make this visible:
+which of the fee-sensitivity/regime-breakdown blocks appear tells a reader which
+components the accompanying score used.
+
+`strategy_report(result: GateResult, pair: str | None = None) -> str`
+
+Builds and returns (does not print) the exact text `research/cli.py`'s `gate` command
+prints today, verbatim in content and format, plus one new line for the robustness score.
+Reusing the current format exactly means every existing `research/tests/test_cli.py`
+assertion on printed substrings (`"PASS"`, `"FAIL"`, `"fee sensitivity"`, `"baseline"`,
+`"1.50x fee"`, `"regime breakdown"`, `"Bull/High"`, `"Bear/Low"`, `"slippage" not in
+...lower()`) continues to pass unchanged once `cli.py` is switched to print this
+function's return value — this sub-project is a pure refactor-plus-one-line-addition at
+the CLI layer, not a format change.
+
+```
+{strategy_id}: {PASS|FAIL}
+  robustness score  {score:.3f}
+  deflated_sharpe   {deflated_sharpe:.3f}
+  permutation p     {permutation_p:.3f}
+  PBO               {pbo:.3f}
+  mean OOS sharpe   {mean_test_sharpe:.3f}
+  trials (ledger)   {n_trials}
+  - {reason}                                    [one line per entry in reasons]
+  fee sensitivity (informational, not part of PASS/FAIL):     [only if fee_sensitivity truthy]
+    {mult:.2f}x fee{" (baseline)" if mult == 1.0 else ""}   mean OOS sharpe {..:>6.2f}   deflated_sharpe (n_trials=1) {..:.3f}
+  regime breakdown ({pair}, informational, not part of PASS/FAIL):   [only if regime_breakdown truthy; omit "({pair}, " -> "(" when pair is None]
+    {label:<15} {n_windows:>2} windows   {n_trades:>3} trades   mean sharpe {mean_test_sharpe:>6.2f}   total return {total_return:>8.4f}
+```
+
+The `robustness score` line's placement (second line, right after the verdict) is
+deliberate: it is the one number meant to be read alongside PASS/FAIL, not buried after
+the individual statistics that already justify the verdict on their own.
+
+`pair` is optional because `strategy_report` operates on a `GateResult` alone — it has no
+way to know which pair was classified for a `regime_breakdown` unless the caller tells it
+(the CLI knows, from `args.pairs`; a caller scoring several already-computed `GateResult`s
+programmatically, e.g. for a ranking table, may not always have it handy). When `pair` is
+`None`, the regime-breakdown header line simply omits the parenthetical pair name rather
+than raising or guessing.
+
+**`research/cli.py`** (existing file, modified): the `gate` command's block of ~12
+individual `print()` calls (verdict through the regime-breakdown table) is replaced with:
+
+```python
+from research.scoring import strategy_report
+...
+print(strategy_report(result, pair=args.pairs.split(",")[0]))
+```
+
+No new argparse flags. `return 0 if result.passed else 1` is unchanged and stays after
+this line, in the same position.
+
+## Data flow
+
+1. `run_promotion_gate(...)` (unchanged) produces a `GateResult`.
+2. `research gate` CLI command calls `strategy_report(result, pair=args.pairs.split(",")[0])`.
+3. Inside `strategy_report`: calls `robustness_score(result)` once, embeds it, then builds
+   the rest of the text from `result`'s existing fields exactly as `cli.py` does today.
+4. `print()`s the returned string; exit code logic is unchanged.
+
+A caller other than the CLI (e.g. a future batch-ranking script iterating over several
+`GateResult`s from the ledger) can call `robustness_score` directly without going through
+`strategy_report` at all — the two functions are independently useful, not coupled.
+
+## Error handling
+
+- `robustness_score` never raises on a well-formed `GateResult` — every branch above is
+  total (covers `fee_sensitivity`/`regime_breakdown` present-and-absent, and the two
+  cost-sensitivity edge cases explicitly). A malformed `GateResult` (e.g.
+  `permutation_p` outside `[0, 1]`) is a caller-contract violation from `run_promotion_
+  gate` itself, which is not this sub-project's concern to re-validate — `GateResult`'s
+  fields are already trusted throughout the rest of `research/`.
+- `strategy_report` never raises — it only formats fields already present on a
+  well-formed `GateResult`, the same fields `cli.py` already formats today without
+  guards.
+
+## Testing
+
+- `research/tests/test_scoring.py` (new): real `GateResult` construction (no mocking),
+  matching this package's established house style.
+  1. Only the three always-present components (no `fee_sensitivity`/`regime_breakdown`):
+     assert the result equals an independently-computed weighted average using the same
+     `WEIGHTS` constants (imported, not hardcoded decimal literals in the test) but a
+     fresh, separately-written arithmetic expression — not calling `robustness_score`
+     recursively.
+  2. With `fee_sensitivity` added (two multipliers, deflated Sharpe genuinely lower at
+     the higher one): assert the result equals an independently-computed weighted
+     average over all four weights actually used (`deflated_sharpe`, `significance`,
+     `pbo_inverse`, `cost_sensitivity`), renormalized over their sum (`0.95`) — an exact
+     value, not a directional claim, computed the same way as case 1.
+  3. With `regime_breakdown` added (a mix of positive- and negative-mean-Sharpe buckets):
+     assert the result equals an independently-computed weighted average over the four
+     weights actually used (`deflated_sharpe`, `significance`, `pbo_inverse`,
+     `regime_consistency`), renormalized over their sum (`0.90`) — same exact-value
+     approach.
+  4. Both `fee_sensitivity` and `regime_breakdown` present together: assert the result
+     equals an independently-computed weighted average over all five weights,
+     renormalized over the full `1.0` denominator.
+  5. Cost-sensitivity edge case: `fee_sensitivity` with a single multiplier key →
+     component is exactly `1.0`.
+  6. Cost-sensitivity edge case: baseline (`min` multiplier) `deflated_sharpe` is `0.0` →
+     component is exactly `0.0`.
+  7. Sanity bound: construct several varied `GateResult`s (including a deliberately bad
+     one — `deflated_sharpe=0.0, permutation_p=1.0, pbo=1.0`) and assert every score is
+     in `[0.0, 1.0]`.
+  8. Documents the known renormalization limitation as real, intentional behavior (not a
+     regression to "fix" later): two `GateResult`s with identical `deflated_sharpe`/
+     `permutation_p`/`pbo`, one with a `regime_breakdown` added whose buckets are all
+     positive (`regime_consistency = 1.0`), assert the two scores are NOT equal —
+     confirms the documented tradeoff is real and the test suite would catch anyone
+     "fixing" it into fixed-denominator scoring without an explicit spec change.
+- `research/tests/test_scoring.py` also covers `strategy_report`:
+  9. PASS case, no fee/regime: assert `"PASS"`, the formatted `deflated_sharpe`/
+     `permutation p`/`PBO`/`mean OOS sharpe`/`trials (ledger)` lines, and a
+     `"robustness score"` line with a numeric value, all appear in the returned string.
+  10. FAIL case with `reasons`: assert `"FAIL"` and every reason string appear.
+  11. `fee_sensitivity` present: assert `"fee sensitivity"`, `"baseline"`, a
+      `"1.50x fee"`-style label, and that `"slippage"` never appears (case-insensitive) —
+      the same three assertions `test_cli.py`'s existing fee-sensitivity test makes today,
+      now made directly against `strategy_report`'s return value.
+  12. `regime_breakdown` present with `pair="BTC/USDT"`: assert `"regime breakdown"`,
+      `"BTC/USDT"`, and both regime labels appear.
+  13. `regime_breakdown` present with `pair=None`: assert `"regime breakdown"` and the
+      regime labels still appear, and the string does not contain a stray `"(, "` or
+      similar malformed parenthetical from a missing pair name.
+- `research/tests/test_cli.py` (existing file): **no test changes required** — every
+  existing assertion (verdict text, exit codes, fee-sensitivity substrings,
+  regime-breakdown substrings and the `include_regime_breakdown` kwarg check) continues
+  to pass once `cli.py`'s print block is replaced with `print(strategy_report(result,
+  pair=...))`, because `strategy_report`'s format is byte-identical to the text those
+  tests already check for. Re-running the existing suite after the `cli.py` change is
+  itself the regression proof that this refactor didn't alter any user-visible output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,9 @@ extend-ignore = [
   "DTZ005",  # Use timezone-aware datetime objects
   "DTZ", # Use timezone-aware datetime objects
   ]
+"research/tests/**.py" = [
+  "S101",  # allow assert in tests
+  ]
 
 "freqtrade/templates/**.py" = [
   "RUF100",  # Allow unused noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,10 @@ extend-ignore = [
   "S101",  # allow assert in tests
   ]
 
+"user_data/strategies/tests/**.py" = [
+  "S101",  # allow assert in tests
+  ]
+
 "freqtrade/templates/**.py" = [
   "RUF100",  # Allow unused noqa
 ]

--- a/research/cli.py
+++ b/research/cli.py
@@ -1,0 +1,71 @@
+# research/cli.py
+"""Command-line entry point for the research package: `python -m research.cli gate
+...` runs the promotion gate for a strategy and prints its verdict."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from freqtrade.configuration import Configuration
+from research.gate import run_promotion_gate
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI args and dispatch to the requested subcommand. Currently only
+    `gate` is implemented: it loads the freqtrade config, runs
+    `run_promotion_gate`, prints the verdict and supporting statistics, and
+    returns exit code 0 on pass or 1 on fail (for use in CI/scripts)."""
+    parser = argparse.ArgumentParser(prog="research", description="Freqtrade research gate")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gate = sub.add_parser("gate", help="Run the promotion gate for a strategy")
+    gate.add_argument("--strategy", required=True)
+    gate.add_argument("--config", required=True, help="Path to a freqtrade config.json")
+    gate.add_argument(
+        "--pairs", required=True, help="Comma-separated pairs, e.g. BTC/USDT,ETH/USDT"
+    )
+    gate.add_argument("--timeframe", required=True)
+    gate.add_argument("--start", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--end", required=True, help="YYYY-MM-DD")
+    gate.add_argument("--train-days", type=int, required=True)
+    gate.add_argument("--test-days", type=int, required=True)
+    gate.add_argument("--param-grid", required=True, help="JSON list of param dicts")
+    gate.add_argument("--db-path", default="user_data/research.sqlite")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "gate":
+        ft_config = Configuration.from_files([args.config])
+        ft_config["strategy"] = args.strategy
+        result = run_promotion_gate(
+            config=ft_config,
+            strategy_id=args.strategy,
+            pairs=args.pairs.split(","),
+            timeframe=args.timeframe,
+            datadir=Path(ft_config["datadir"]),
+            start=datetime.fromisoformat(args.start),
+            end=datetime.fromisoformat(args.end),
+            train_days=args.train_days,
+            test_days=args.test_days,
+            param_grid=json.loads(args.param_grid),
+            db_path=args.db_path,
+        )
+        verdict = "PASS" if result.passed else "FAIL"
+        print(f"{result.strategy_id}: {verdict}")
+        print(f"  deflated_sharpe   {result.deflated_sharpe:.3f}")
+        print(f"  permutation p     {result.permutation_p:.3f}")
+        print(f"  PBO               {result.pbo:.3f}")
+        print(f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}")
+        print(f"  trials (ledger)   {result.n_trials}")
+        for reason in result.reasons:
+            print(f"  - {reason}")
+        return 0 if result.passed else 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/cli.py
+++ b/research/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from freqtrade.configuration import Configuration
 from research.cost_stress import DEFAULT_FEE_MULTIPLIERS
 from research.gate import run_promotion_gate
+from research.scoring import strategy_report
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -71,35 +72,7 @@ def main(argv: list[str] | None = None) -> int:
             fee_sensitivity_multipliers=DEFAULT_FEE_MULTIPLIERS if args.fee_sensitivity else None,
             include_regime_breakdown=args.regime_breakdown,
         )
-        verdict = "PASS" if result.passed else "FAIL"
-        print(f"{result.strategy_id}: {verdict}")
-        print(f"  deflated_sharpe   {result.deflated_sharpe:.3f}")
-        print(f"  permutation p     {result.permutation_p:.3f}")
-        print(f"  PBO               {result.pbo:.3f}")
-        print(f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}")
-        print(f"  trials (ledger)   {result.n_trials}")
-        for reason in result.reasons:
-            print(f"  - {reason}")
-        if result.fee_sensitivity:
-            print("  fee sensitivity (informational, not part of PASS/FAIL):")
-            for mult, stats in result.fee_sensitivity.items():
-                label = f"{mult:.2f}x fee" + (" (baseline)" if mult == 1.0 else "")
-                print(
-                    f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
-                    f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
-                )
-        if result.regime_breakdown:
-            print(
-                f"  regime breakdown ({args.pairs.split(',')[0]}, informational, "
-                "not part of PASS/FAIL):"
-            )
-            for label, stats in result.regime_breakdown.items():
-                print(
-                    f"    {label:<15} {stats['n_windows']:>2} windows"
-                    f"   {stats['n_trades']:>3} trades"
-                    f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
-                    f"   total return {stats['total_return']:>8.4f}"
-                )
+        print(strategy_report(result, pair=args.pairs.split(",")[0]))
         return 0 if result.passed else 1
 
     return 1

--- a/research/cli.py
+++ b/research/cli.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from freqtrade.configuration import Configuration
+from research.cost_stress import DEFAULT_FEE_MULTIPLIERS
 from research.gate import run_promotion_gate
 
 
@@ -34,6 +35,11 @@ def main(argv: list[str] | None = None) -> int:
     gate.add_argument("--test-days", type=int, required=True)
     gate.add_argument("--param-grid", required=True, help="JSON list of param dicts")
     gate.add_argument("--db-path", default="user_data/research.sqlite")
+    gate.add_argument(
+        "--fee-sensitivity",
+        action="store_true",
+        help="Also run a fee-sensitivity stress test if the gate passes (informational)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -54,6 +60,7 @@ def main(argv: list[str] | None = None) -> int:
             test_days=args.test_days,
             param_grid=json.loads(args.param_grid),
             db_path=args.db_path,
+            fee_sensitivity_multipliers=DEFAULT_FEE_MULTIPLIERS if args.fee_sensitivity else None,
         )
         verdict = "PASS" if result.passed else "FAIL"
         print(f"{result.strategy_id}: {verdict}")
@@ -64,6 +71,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  trials (ledger)   {result.n_trials}")
         for reason in result.reasons:
             print(f"  - {reason}")
+        if result.fee_sensitivity:
+            print("  fee sensitivity (informational, not part of PASS/FAIL):")
+            for mult, stats in result.fee_sensitivity.items():
+                label = f"{mult:.2f}x fee" + (" (baseline)" if mult == 1.0 else "")
+                print(
+                    f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
+                )
         return 0 if result.passed else 1
 
     return 1

--- a/research/cli.py
+++ b/research/cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from freqtrade.configuration import Configuration
@@ -46,8 +46,10 @@ def main(argv: list[str] | None = None) -> int:
             pairs=args.pairs.split(","),
             timeframe=args.timeframe,
             datadir=Path(ft_config["datadir"]),
-            start=datetime.fromisoformat(args.start),
-            end=datetime.fromisoformat(args.end),
+            # freqtrade's Backtesting.backtest() compares against tz-aware (UTC) pandas
+            # Timestamps internally -- a naive datetime here crashes deep inside it.
+            start=datetime.fromisoformat(args.start).replace(tzinfo=UTC),
+            end=datetime.fromisoformat(args.end).replace(tzinfo=UTC),
             train_days=args.train_days,
             test_days=args.test_days,
             param_grid=json.loads(args.param_grid),

--- a/research/cli.py
+++ b/research/cli.py
@@ -40,6 +40,14 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Also run a fee-sensitivity stress test if the gate passes (informational)",
     )
+    gate.add_argument(
+        "--regime-breakdown",
+        action="store_true",
+        help=(
+            "Also compute a regime (Trend x Volatility) breakdown of walk-forward "
+            "results, regardless of pass/fail (informational)"
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -61,6 +69,7 @@ def main(argv: list[str] | None = None) -> int:
             param_grid=json.loads(args.param_grid),
             db_path=args.db_path,
             fee_sensitivity_multipliers=DEFAULT_FEE_MULTIPLIERS if args.fee_sensitivity else None,
+            include_regime_breakdown=args.regime_breakdown,
         )
         verdict = "PASS" if result.passed else "FAIL"
         print(f"{result.strategy_id}: {verdict}")
@@ -78,6 +87,18 @@ def main(argv: list[str] | None = None) -> int:
                 print(
                     f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
                     f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
+                )
+        if result.regime_breakdown:
+            print(
+                f"  regime breakdown ({args.pairs.split(',')[0]}, informational, "
+                "not part of PASS/FAIL):"
+            )
+            for label, stats in result.regime_breakdown.items():
+                print(
+                    f"    {label:<15} {stats['n_windows']:>2} windows"
+                    f"   {stats['n_trades']:>3} trades"
+                    f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
+                    f"   total return {stats['total_return']:>8.4f}"
                 )
         return 0 if result.passed else 1
 

--- a/research/cost_stress.py
+++ b/research/cost_stress.py
@@ -1,0 +1,84 @@
+# research/cost_stress.py
+"""Fee-sensitivity stress test: re-evaluates a promotion gate candidate's
+already-selected walk-forward parameters at progressively higher (worse)
+transaction fee assumptions, to see whether its edge is a thin margin over
+baseline costs or survives materially worse ones. Informational only --
+never changes a gate's PASS/FAIL verdict.
+
+This is NOT a slippage/market-impact model -- freqtrade's backtester has no
+execution-price slippage simulation at all (orders fill at the exact
+requested price). A flat fee-rate multiplier is a legitimate cost-sensitivity
+/ margin-of-safety test, but it gets slippage's actual structure wrong (which
+scales with order size/liquidity/volatility, not as a fixed percentage), so
+it is named and reported as "fee sensitivity" throughout, never "slippage".
+See docs/superpowers/specs/2026-08-24-fee-sensitivity-stress-test-design.md
+for the full reasoning, including why n_trials=1 is correct here (no new
+selection happens at any fee level, so no new multiple-testing penalty
+applies -- the original gate's trial count already paid for that once).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.optimize.backtesting import Backtesting
+from research.statistics import deflated_sharpe_ratio
+from research.walkforward import WalkForwardRunner, WindowResult
+
+
+DEFAULT_FEE_MULTIPLIERS = (1.0, 1.25, 1.5, 2.0)
+
+
+def fee_sensitivity(
+    config: dict,
+    pairs: list[str],
+    timeframe: str,
+    datadir: Path,
+    window_results: list[WindowResult],
+    multipliers: tuple[float, ...] = DEFAULT_FEE_MULTIPLIERS,
+    periods_per_year: int = 365,
+) -> dict[float, dict]:
+    """Re-evaluate every `WindowResult`'s already-selected `best_params` at
+    each fee multiplier (`base_fee * multiplier`), aggregating exactly as
+    `research.gate.run_promotion_gate` does: mean per-window test Sharpe fed
+    into `deflated_sharpe_ratio` with `n_obs` = total concatenated
+    `test_returns` and `n_trials=1`.
+
+    `base_fee` is read once from a throwaway `Backtesting(config)` instance's
+    resolved `.fee` -- the exact same fee the original gate run used, since
+    `config` is passed through unchanged. The `1.0` multiplier therefore
+    reproduces the original gate's own fee exactly (a control, not a stress
+    level).
+
+    Returns `{multiplier: {"mean_test_sharpe": float, "deflated_sharpe":
+    float, "n_windows": int}}`, one entry per multiplier given.
+    """
+    if not multipliers or any(m <= 0 for m in multipliers):
+        raise ValueError("multipliers must be non-empty and all values > 0")
+
+    base_fee = Backtesting(config).fee
+    runner = WalkForwardRunner(config, pairs, timeframe, datadir)
+
+    report: dict[float, dict] = {}
+    for multiplier in multipliers:
+        fee = base_fee * multiplier
+        results = [
+            runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=fee)
+            for wr in window_results
+        ]
+        all_test_returns = [r for res in results for r in res.test_returns]
+        mean_test_sharpe = float(np.mean([res.test_sharpe for res in results]))
+        deflated = deflated_sharpe_ratio(
+            mean_test_sharpe,
+            n_obs=len(all_test_returns),
+            n_trials=1,
+            periods_per_year=periods_per_year,
+        )
+        report[multiplier] = {
+            "mean_test_sharpe": mean_test_sharpe,
+            "deflated_sharpe": deflated,
+            "n_windows": len(results),
+        }
+    return report

--- a/research/db.py
+++ b/research/db.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from research.models import Base
+
+
+DEFAULT_DB_PATH = "user_data/research.sqlite"
+
+
+def get_engine(db_path: str = DEFAULT_DB_PATH) -> Engine:
+    if db_path != ":memory:":
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def get_session(engine: Engine) -> Session:
+    return Session(engine)

--- a/research/gate.py
+++ b/research/gate.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import numpy as np
 
+from research.cost_stress import fee_sensitivity
 from research.db import get_engine, get_session
 from research.ledger import family_of, family_trial_count, log_candidate_result
 from research.pbo import probability_of_backtest_overfitting
@@ -33,6 +34,7 @@ class GateResult:
     mean_test_sharpe: float
     n_trials: int
     reasons: list[str]
+    fee_sensitivity: dict[float, dict] | None = None
 
 
 def run_promotion_gate(
@@ -51,6 +53,7 @@ def run_promotion_gate(
     fdr_q: float = 0.05,
     pbo_threshold: float = 0.5,
     periods_per_year: int = 365,
+    fee_sensitivity_multipliers: tuple[float, ...] | None = None,
 ) -> GateResult:
     """Run walk-forward evaluation for `strategy_id` and decide whether it is
     statistically fit to promote, logging the outcome to the candidate ledger.
@@ -112,6 +115,18 @@ def run_promotion_gate(
         reasons.append(f"PBO {pbo_result['pbo']:.3f} above threshold {pbo_threshold}")
     passed = not reasons
 
+    fee_report = None
+    if passed and fee_sensitivity_multipliers is not None:
+        fee_report = fee_sensitivity(
+            config,
+            pairs,
+            timeframe,
+            datadir,
+            results,
+            multipliers=fee_sensitivity_multipliers,
+            periods_per_year=periods_per_year,
+        )
+
     log_candidate_result(
         session,
         strategy_id=strategy_id,
@@ -139,4 +154,5 @@ def run_promotion_gate(
         mean_test_sharpe=mean_test_sharpe,
         n_trials=n_trials,
         reasons=reasons,
+        fee_sensitivity=fee_report,
     )

--- a/research/gate.py
+++ b/research/gate.py
@@ -1,0 +1,142 @@
+# research/gate.py
+"""Promotion gate: the final go/no-go check a strategy must pass before it is
+trusted, built on top of walk-forward evaluation (`research.walkforward`) and
+the statistical tests in `research.statistics`/`research.pbo`. Ties those
+pieces together, logs the outcome to the candidate ledger (`research.ledger`),
+and returns a single pass/fail verdict with the reasons for it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from research.db import get_engine, get_session
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.pbo import probability_of_backtest_overfitting
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+from research.walkforward import WalkForwardRunner, generate_windows
+
+
+@dataclass
+class GateResult:
+    """Verdict and supporting statistics from one `run_promotion_gate` call."""
+
+    strategy_id: str
+    passed: bool
+    deflated_sharpe: float
+    permutation_p: float
+    pbo: float
+    mean_test_sharpe: float
+    n_trials: int
+    reasons: list[str]
+
+
+def run_promotion_gate(
+    config: dict,
+    strategy_id: str,
+    pairs: list[str],
+    timeframe: str,
+    datadir: Path,
+    start: datetime,
+    end: datetime,
+    train_days: int,
+    test_days: int,
+    param_grid: list[dict],
+    db_path: str = "user_data/research.sqlite",
+    dsr_threshold: float = 0.95,
+    fdr_q: float = 0.05,
+    pbo_threshold: float = 0.5,
+    periods_per_year: int = 365,
+) -> GateResult:
+    """Run walk-forward evaluation for `strategy_id` and decide whether it is
+    statistically fit to promote, logging the outcome to the candidate ledger.
+
+    Requires at least 4 walk-forward windows (raises `ValueError` otherwise) --
+    fewer windows leave the OOS statistics (DSR, permutation test, PBO) too
+    thin to be meaningful, so it is better to fail loudly than to gate on noise.
+
+    Trial count and ledger writes follow a strict count-then-write order:
+    `family_trial_count` reads the ledger's accumulated trial history for this
+    strategy's family BEFORE this run's own row is written, so the deflated
+    Sharpe ratio never deflates against trials this run hasn't finished yet
+    (which would be circular) and never omits trials prior runs already spent.
+    The candidate row is logged regardless of pass/fail, so the ledger stays a
+    complete trial history for future DSR calculations.
+
+    A strategy passes only if it clears all three checks: deflated Sharpe >=
+    `dsr_threshold`, the permutation-test p-value survives Benjamini-Hochberg
+    FDR control at `fdr_q`, and PBO <= `pbo_threshold`.
+    """
+    windows = generate_windows(start, end, train_days, test_days)
+    if len(windows) < 4:
+        raise ValueError(
+            f"Need at least 4 walk-forward windows for a meaningful gate, got "
+            f"{len(windows)}. Widen start/end or shrink train_days/test_days."
+        )
+
+    runner = WalkForwardRunner(config, pairs, timeframe, datadir)
+    results = runner.run(windows, param_grid)
+
+    all_test_returns = [r for wr in results for r in wr.test_returns]
+    n_obs = len(all_test_returns)
+    mean_test_sharpe = float(np.mean([wr.test_sharpe for wr in results]))
+
+    variant_keys = sorted({k for wr in results for k in wr.variant_returns})
+    variant_matrix = np.array([[wr.variant_returns[key] for wr in results] for key in variant_keys])
+    pbo_result = probability_of_backtest_overfitting(variant_matrix)
+
+    engine = get_engine(db_path)
+    session = get_session(engine)
+    family = family_of(strategy_id)
+    this_run_trials = len(param_grid) * len(windows)
+    # count-then-write: read ledger history BEFORE writing this run's own row, so a
+    # run never deflates its own significance test against trials it hasn't finished.
+    n_trials = family_trial_count(session, family, declared=this_run_trials)
+
+    deflated = deflated_sharpe_ratio(
+        mean_test_sharpe, n_obs=n_obs, n_trials=n_trials, periods_per_year=periods_per_year
+    )
+    perm_p = permutation_test(mean_test_sharpe, np.array(all_test_returns))
+    survived_bh = benjamini_hochberg([perm_p], q=fdr_q)[0]
+
+    reasons: list[str] = []
+    if deflated < dsr_threshold:
+        reasons.append(f"deflated_sharpe {deflated:.3f} below threshold {dsr_threshold}")
+    if not survived_bh:
+        reasons.append(f"permutation p-value {perm_p:.3f} fails BH-FDR at q={fdr_q}")
+    if pbo_result["pbo"] > pbo_threshold:
+        reasons.append(f"PBO {pbo_result['pbo']:.3f} above threshold {pbo_threshold}")
+    passed = not reasons
+
+    log_candidate_result(
+        session,
+        strategy_id=strategy_id,
+        params={"grid": param_grid},
+        universe=",".join(pairs),
+        timeframe=timeframe,
+        discovery_start=start.isoformat(),
+        discovery_end=end.isoformat(),
+        n_trials_this_run=this_run_trials,
+        is_sharpe=float(np.mean([wr.train_sharpe for wr in results])),
+        oos_sharpe=mean_test_sharpe,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        survived=passed,
+    )
+    session.commit()
+
+    return GateResult(
+        strategy_id=strategy_id,
+        passed=passed,
+        deflated_sharpe=deflated,
+        permutation_p=perm_p,
+        pbo=pbo_result["pbo"],
+        mean_test_sharpe=mean_test_sharpe,
+        n_trials=n_trials,
+        reasons=reasons,
+    )

--- a/research/gate.py
+++ b/research/gate.py
@@ -18,6 +18,7 @@ from research.cost_stress import fee_sensitivity
 from research.db import get_engine, get_session
 from research.ledger import family_of, family_trial_count, log_candidate_result
 from research.pbo import probability_of_backtest_overfitting
+from research.regime import classify_regimes, regime_report
 from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
 from research.walkforward import WalkForwardRunner, generate_windows
 
@@ -35,6 +36,7 @@ class GateResult:
     n_trials: int
     reasons: list[str]
     fee_sensitivity: dict[float, dict] | None = None
+    regime_breakdown: dict[str, dict] | None = None
 
 
 def run_promotion_gate(
@@ -54,6 +56,7 @@ def run_promotion_gate(
     pbo_threshold: float = 0.5,
     periods_per_year: int = 365,
     fee_sensitivity_multipliers: tuple[float, ...] | None = None,
+    include_regime_breakdown: bool = False,
 ) -> GateResult:
     """Run walk-forward evaluation for `strategy_id` and decide whether it is
     statistically fit to promote, logging the outcome to the candidate ledger.
@@ -73,6 +76,9 @@ def run_promotion_gate(
     A strategy passes only if it clears all three checks: deflated Sharpe >=
     `dsr_threshold`, the permutation-test p-value survives Benjamini-Hochberg
     FDR control at `fdr_q`, and PBO <= `pbo_threshold`.
+
+    `include_regime_breakdown` classifies using only `pairs[0]` as the reference pair --
+    multi-pair blending is out of scope for this feature.
     """
     windows = generate_windows(start, end, train_days, test_days)
     if len(windows) < 4:
@@ -145,6 +151,11 @@ def run_promotion_gate(
     )
     session.commit()
 
+    regime_breakdown = None
+    if include_regime_breakdown:
+        labels = classify_regimes(pairs[0], timeframe, datadir, windows)
+        regime_breakdown = regime_report(results, labels)
+
     return GateResult(
         strategy_id=strategy_id,
         passed=passed,
@@ -155,4 +166,5 @@ def run_promotion_gate(
         n_trials=n_trials,
         reasons=reasons,
         fee_sensitivity=fee_report,
+        regime_breakdown=regime_breakdown,
     )

--- a/research/ledger.py
+++ b/research/ledger.py
@@ -1,0 +1,78 @@
+import json
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from research.models import CandidateResult
+
+
+# Strategy-name -> family aliasing. Grow this table as strategy variants are added —
+# related parameter sweeps must share a family so trial counts compound correctly.
+_FAMILY_ALIASES: dict[str, str] = {
+    "ema_cross_v3": "trend_following",
+}
+
+
+def family_of(strategy_id: str) -> str:
+    return _FAMILY_ALIASES.get(strategy_id, strategy_id)
+
+
+def log_candidate_result(
+    session: Session,
+    *,
+    strategy_id: str,
+    params: dict,
+    universe: str,
+    timeframe: str,
+    discovery_start: str,
+    discovery_end: str,
+    n_trials_this_run: int,
+    is_sharpe: float,
+    oos_sharpe: float,
+    deflated_sharpe: float,
+    permutation_p: float,
+    pbo: float,
+    survived: bool,
+    validation_start: str | None = None,
+    validation_end: str | None = None,
+    oos_start: str | None = None,
+    oos_end: str | None = None,
+    evidence: dict | None = None,
+    run_stamp: datetime | None = None,
+) -> CandidateResult:
+    row = CandidateResult(
+        run_stamp=run_stamp or datetime.now(UTC),
+        strategy_id=strategy_id,
+        strategy_family=family_of(strategy_id),
+        params_json=json.dumps(params, sort_keys=True),
+        universe=universe,
+        timeframe=timeframe,
+        discovery_start=discovery_start,
+        discovery_end=discovery_end,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        oos_start=oos_start,
+        oos_end=oos_end,
+        n_trials_this_run=n_trials_this_run,
+        is_sharpe=is_sharpe,
+        oos_sharpe=oos_sharpe,
+        deflated_sharpe=deflated_sharpe,
+        permutation_p=permutation_p,
+        pbo=pbo,
+        survived=survived,
+        evidence_json=json.dumps(evidence or {}),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def family_trial_count(session: Session, family: str, declared: int = 0) -> int:
+    """The number of trials to deflate against: whichever is larger between the
+    ledger's accumulated row count for this family and a caller-declared count.
+    Call this BEFORE writing the current run's own row (count-then-write) so a run
+    never deflates against trials it hasn't finished yet."""
+    ledger_count = (
+        session.query(CandidateResult).filter(CandidateResult.strategy_family == family).count()
+    )
+    return max(ledger_count, declared)

--- a/research/models.py
+++ b/research/models.py
@@ -35,3 +35,21 @@ class CandidateResult(Base):
     pbo: Mapped[float] = mapped_column(Float)
     survived: Mapped[bool] = mapped_column(Boolean)
     evidence_json: Mapped[str] = mapped_column(String, default="{}")
+
+
+class PromotionRecord(Base):
+    """One row per promotion attempt for a specific passing CandidateResult -- tracks
+    the Paper-Trading -> Live-eligibility lifecycle. A candidate can have many
+    CandidateResult rows (re-runs, parameter sweeps); only specific passing runs ever
+    get a PromotionRecord, and most never do."""
+
+    __tablename__ = "promotion_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    candidate_result_id: Mapped[int] = mapped_column(Integer, index=True)
+    state: Mapped[str] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    paper_trading_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    paper_trading_db_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    resolution_reason: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/research/models.py
+++ b/research/models.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class CandidateResult(Base):
+    """One row per (research run, strategy, parameter-set) — survivors AND losers
+    both get logged, so `family_trial_count` reflects the real search history."""
+
+    __tablename__ = "candidate_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_stamp: Mapped[datetime] = mapped_column(DateTime)
+    strategy_id: Mapped[str] = mapped_column(String(120))
+    strategy_family: Mapped[str] = mapped_column(String(120), index=True)
+    params_json: Mapped[str] = mapped_column(String)
+    universe: Mapped[str] = mapped_column(String(200))
+    timeframe: Mapped[str] = mapped_column(String(10))
+    discovery_start: Mapped[str] = mapped_column(String(20))
+    discovery_end: Mapped[str] = mapped_column(String(20))
+    validation_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    validation_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_start: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    oos_end: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    n_trials_this_run: Mapped[int] = mapped_column(Integer)
+    is_sharpe: Mapped[float] = mapped_column(Float)
+    oos_sharpe: Mapped[float] = mapped_column(Float)
+    deflated_sharpe: Mapped[float] = mapped_column(Float)
+    permutation_p: Mapped[float] = mapped_column(Float)
+    pbo: Mapped[float] = mapped_column(Float)
+    survived: Mapped[bool] = mapped_column(Boolean)
+    evidence_json: Mapped[str] = mapped_column(String, default="{}")

--- a/research/pbo.py
+++ b/research/pbo.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+
+
+def choose_n_splits(n_periods: int, max_splits: int = 16) -> int:
+    """Largest even number <= max_splits that evenly divides n_periods, so CSCV's
+    IS/OOS blocks are equal-sized. Falls back to 2 if nothing else divides evenly."""
+    for s in range(min(max_splits, n_periods), 1, -1):
+        if s % 2 == 0 and n_periods % s == 0:
+            return s
+    return 2
+
+
+def probability_of_backtest_overfitting(
+    returns_matrix: np.ndarray, n_splits: int | None = None
+) -> dict:
+    """Combinatorially Symmetric Cross-Validation (Bailey, Borwein, Lopez de Prado,
+    Zhu 2014). Splits the n_periods columns into n_splits contiguous blocks, and for
+    every way of picking half the blocks as in-sample: finds the variant with the best
+    in-sample Sharpe, then checks how that same variant ranks out-of-sample. PBO is the
+    fraction of splits where the in-sample winner ranked in the OOS-worse half — logit
+    of the OOS relative rank <= 0.
+    """
+    returns_matrix = np.asarray(returns_matrix, dtype=float)
+    if returns_matrix.ndim != 2:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    n_variants, n_periods = returns_matrix.shape
+    if n_variants < 2 or n_periods < 4:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    s = n_splits or choose_n_splits(n_periods)
+    if s < 2 or n_periods % s != 0:
+        return {"pbo": 1.0, "n_splits": 0, "n_combinations": 0, "logits": []}
+
+    blocks = np.array_split(returns_matrix, s, axis=1)
+    logits: list[float] = []
+
+    for is_block_idx in itertools.combinations(range(s), s // 2):
+        oos_block_idx = [i for i in range(s) if i not in is_block_idx]
+        is_returns = np.concatenate([blocks[i] for i in is_block_idx], axis=1)
+        oos_returns = np.concatenate([blocks[i] for i in oos_block_idx], axis=1)
+
+        is_sharpe = is_returns.mean(axis=1) / (is_returns.std(axis=1) + 1e-12)
+        oos_sharpe = oos_returns.mean(axis=1) / (oos_returns.std(axis=1) + 1e-12)
+
+        best_variant = int(np.argmax(is_sharpe))
+        # relative rank of the IS-best variant's OOS performance, in (0, 1)
+        rank = int((oos_sharpe < oos_sharpe[best_variant]).sum()) + 1
+        omega = rank / (n_variants + 1)
+        omega = min(max(omega, 1e-6), 1 - 1e-6)
+        logits.append(float(np.log(omega / (1 - omega))))
+
+    pbo = float(np.mean([1.0 if lg <= 0 else 0.0 for lg in logits]))
+    return {"pbo": pbo, "n_splits": s, "n_combinations": len(logits), "logits": logits}

--- a/research/promotion.py
+++ b/research/promotion.py
@@ -137,7 +137,6 @@ def evaluate_paper_trading_health(
     promotion_id: int,
     starting_balance: float,
     dry_run_db_path: str | None = None,
-    periods_per_year: int = 365,
 ) -> dict:
     """Pure evaluation (no state mutation) of a PAPER_TRADING record's real dry-run
     trade history. Returns a verdict dict; call apply_health_evaluation with the result

--- a/research/promotion.py
+++ b/research/promotion.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import cast
 
 import pandas as pd
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from freqtrade.data.metrics import calculate_sharpe
@@ -157,6 +159,11 @@ def evaluate_paper_trading_health(
     shorter than the OOS window a candidate was originally evaluated over, so
     paper_sharpe carries materially more estimation noise than the OOS baseline it's
     compared against. Treat this as a first-pass filter for human judgment, not proof.
+
+    Known limitation: the spec's bounded-connection-timeout requirement is not
+    implemented -- init_db()'s plain string-URL signature has no way to pass
+    connect_args, and bypassing init_db to construct the engine directly is out of
+    scope here.
     """
     record = _load_promotion_record(session, promotion_id)
     if record.state != PromotionState.PAPER_TRADING.value:
@@ -187,15 +194,27 @@ def evaluate_paper_trading_health(
     days_elapsed = (now - started_at_aware).days
 
     init_db(f"sqlite:///{db_path}")
-    closed_trades = (
-        Trade.session.query(Trade)
-        .filter(
-            Trade.strategy == candidate.strategy_id,
-            Trade.is_open.is_(False),
-            Trade.close_date >= started_at_naive,
+    try:
+        closed_trades = (
+            Trade.session.query(Trade)
+            .filter(
+                Trade.strategy == candidate.strategy_id,
+                Trade.is_open.is_(False),
+                Trade.close_date >= started_at_naive,
+            )
+            .all()
         )
-        .all()
-    )
+    finally:
+        # Connection hygiene: the dry-run database file may belong to a currently
+        # running freqtrade bot process writing to it concurrently -- never leave a
+        # lingering handle on it. Release the scoped session and dispose its engine
+        # before returning, regardless of whether the query above succeeded.
+        # init_db() always binds Trade.session via sessionmaker(bind=engine) with a
+        # real Engine (see freqtrade/persistence/models.py's init_db) -- get_bind()'s
+        # broader Engine | Connection return type is never a Connection here.
+        engine = cast(Engine, Trade.session.get_bind())
+        Trade.session.remove()
+        engine.dispose()
     n_trades = len(closed_trades)
 
     if n_trades > 0:
@@ -252,6 +271,12 @@ def apply_health_evaluation(
         raise ValueError(
             f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
             f"{PromotionState.PAPER_TRADING.value!r} -- cannot apply a health evaluation."
+        )
+    if evaluation["eligible"] and not evaluation["enough_evidence"]:
+        raise ValueError(
+            "evaluation is internally inconsistent: eligible=True requires "
+            "enough_evidence=True -- this should only be produced by "
+            "evaluate_paper_trading_health()."
         )
     if evaluation["eligible"]:
         record.state = PromotionState.LIVE_ELIGIBLE.value

--- a/research/promotion.py
+++ b/research/promotion.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from enum import StrEnum
 
+import pandas as pd
 from sqlalchemy.orm import Session
 
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.persistence import Trade, init_db
 from research.models import CandidateResult, PromotionRecord
 
 
@@ -117,5 +120,151 @@ def reject(session: Session, promotion_id: int, reason: str) -> PromotionRecord:
     record.state = PromotionState.REJECTED.value
     record.resolved_at = datetime.now(UTC)
     record.resolution_reason = reason
+    session.flush()
+    return record
+
+
+# ponytail: starting defaults, not derived from any real paper-trading history (none
+# exists yet in this fork) -- adjust based on real usage once this runs against real
+# strategies.
+MIN_PAPER_TRADING_DAYS = 14
+MIN_PAPER_TRADES = 10
+MIN_DEGRADATION_RATIO = 0.5
+
+
+def evaluate_paper_trading_health(
+    session: Session,
+    promotion_id: int,
+    starting_balance: float,
+    dry_run_db_path: str | None = None,
+    periods_per_year: int = 365,
+) -> dict:
+    """Pure evaluation (no state mutation) of a PAPER_TRADING record's real dry-run
+    trade history. Returns a verdict dict; call apply_health_evaluation with the result
+    to actually transition state.
+
+    `starting_balance` is required -- the paper-trading bot's own configured wallet
+    size, which this function has no other way to discover (see the spec for why
+    run_promotion_gate's config isn't available here).
+
+    IMPORTANT: freqtrade.persistence.init_db() sets Trade.session as GLOBAL class-level
+    state, not a scoped per-call connection. This function fully materializes its query
+    results before returning and must never be called concurrently with, or interleaved
+    with, other in-process code relying on Trade.session pointing at a different
+    database (e.g. a WalkForwardRunner/Backtesting run in the same process).
+
+    Known limitation: the returned degradation_ratio is a coarse heuristic, not a
+    statistically rigorous comparison -- a paper-trading window is typically far
+    shorter than the OOS window a candidate was originally evaluated over, so
+    paper_sharpe carries materially more estimation noise than the OOS baseline it's
+    compared against. Treat this as a first-pass filter for human judgment, not proof.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PAPER_TRADING.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PAPER_TRADING.value!r} -- cannot evaluate health."
+        )
+    candidate = session.get(CandidateResult, record.candidate_result_id)
+    if candidate is None:
+        raise ValueError(f"No CandidateResult with id {record.candidate_result_id}")
+
+    db_path = dry_run_db_path or record.paper_trading_db_path
+
+    now = datetime.now(UTC)
+    started_at_aware = record.paper_trading_started_at
+    if started_at_aware is None:
+        # Unreachable in practice: start_paper_trading() always sets this before a
+        # record can reach PAPER_TRADING state. Narrows the nullable-in-schema type
+        # for mypy and fails loudly rather than silently if that invariant ever breaks.
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is PAPER_TRADING but has no "
+            "paper_trading_started_at -- this should be impossible."
+        )
+    if started_at_aware.tzinfo is None:
+        started_at_aware = started_at_aware.replace(tzinfo=UTC)
+    started_at_naive = started_at_aware.replace(tzinfo=None)
+
+    days_elapsed = (now - started_at_aware).days
+
+    init_db(f"sqlite:///{db_path}")
+    closed_trades = (
+        Trade.session.query(Trade)
+        .filter(
+            Trade.strategy == candidate.strategy_id,
+            Trade.is_open.is_(False),
+            Trade.close_date >= started_at_naive,
+        )
+        .all()
+    )
+    n_trades = len(closed_trades)
+
+    if n_trades > 0:
+        trades_df = pd.DataFrame({"profit_abs": [t.close_profit_abs for t in closed_trades]})
+        paper_sharpe = calculate_sharpe(trades_df, started_at_aware, now, starting_balance)
+    else:
+        paper_sharpe = 0
+
+    if candidate.oos_sharpe > 0:
+        degradation_ratio = max(0.0, min(1.0, paper_sharpe / candidate.oos_sharpe))
+    else:
+        degradation_ratio = 0.0
+
+    reasons: list[str] = []
+    enough_evidence = days_elapsed >= MIN_PAPER_TRADING_DAYS and n_trades >= MIN_PAPER_TRADES
+    if not enough_evidence:
+        eligible = False
+        if days_elapsed < MIN_PAPER_TRADING_DAYS:
+            reasons.append(f"only {days_elapsed} days elapsed, need >= {MIN_PAPER_TRADING_DAYS}")
+        if n_trades < MIN_PAPER_TRADES:
+            reasons.append(f"only {n_trades} trades, need >= {MIN_PAPER_TRADES}")
+    elif degradation_ratio < MIN_DEGRADATION_RATIO:
+        eligible = False
+        reasons.append(
+            f"degradation_ratio {degradation_ratio:.3f} below threshold {MIN_DEGRADATION_RATIO}"
+        )
+    else:
+        eligible = True
+
+    return {
+        "eligible": eligible,
+        "enough_evidence": enough_evidence,
+        "days_elapsed": days_elapsed,
+        "n_trades": n_trades,
+        "paper_sharpe": paper_sharpe,
+        "degradation_ratio": degradation_ratio,
+        "reasons": reasons,
+    }
+
+
+def apply_health_evaluation(
+    session: Session, promotion_id: int, evaluation: dict
+) -> PromotionRecord:
+    """Apply an evaluate_paper_trading_health() result to the state machine.
+
+    PAPER_TRADING -> LIVE_ELIGIBLE if eligible; PAPER_TRADING -> REJECTED if there's
+    enough evidence but it failed the bar; otherwise no state change (stays
+    PAPER_TRADING for a future re-evaluation).
+
+    Raises ValueError if the record doesn't exist or isn't currently PAPER_TRADING.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PAPER_TRADING.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PAPER_TRADING.value!r} -- cannot apply a health evaluation."
+        )
+    if evaluation["eligible"]:
+        record.state = PromotionState.LIVE_ELIGIBLE.value
+        record.resolved_at = datetime.now(UTC)
+        record.resolution_reason = (
+            f"paper_sharpe={evaluation['paper_sharpe']:.3f}, "
+            f"degradation_ratio={evaluation['degradation_ratio']:.3f}, "
+            f"n_trades={evaluation['n_trades']}, days_elapsed={evaluation['days_elapsed']}"
+        )
+    elif evaluation["enough_evidence"]:
+        record.state = PromotionState.REJECTED.value
+        record.resolved_at = datetime.now(UTC)
+        record.resolution_reason = "; ".join(evaluation["reasons"])
     session.flush()
     return record

--- a/research/promotion.py
+++ b/research/promotion.py
@@ -1,0 +1,121 @@
+# research/promotion.py
+"""Paper-trading promotion tracker: a state machine tracking a gate-passing candidate's
+lifecycle from PASSED_GATE through PAPER_TRADING to a LIVE_ELIGIBLE recommendation or a
+REJECTED verdict. LIVE is reachable only via a direct, manual promote_to_live() call --
+never from any automated evaluation path (see evaluate_paper_trading_health /
+apply_health_evaluation, added in Task 2 of this module's plan). See
+docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md for the full design.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from sqlalchemy.orm import Session
+
+from research.models import CandidateResult, PromotionRecord
+
+
+class PromotionState(StrEnum):
+    PASSED_GATE = "passed_gate"
+    PAPER_TRADING = "paper_trading"
+    LIVE_ELIGIBLE = "live_eligible"
+    LIVE = "live"
+    REJECTED = "rejected"
+
+
+def _load_promotion_record(session: Session, promotion_id: int) -> PromotionRecord:
+    record = session.get(PromotionRecord, promotion_id)
+    if record is None:
+        raise ValueError(f"No PromotionRecord with id {promotion_id}")
+    return record
+
+
+def create_promotion_record(session: Session, candidate_result_id: int) -> PromotionRecord:
+    """Start a new promotion lifecycle for a candidate that already passed the gate.
+
+    Raises ValueError if candidate_result_id doesn't exist, or if that candidate's
+    CandidateResult.survived is not True -- only a passing gate result may be promoted.
+    """
+    candidate = session.get(CandidateResult, candidate_result_id)
+    if candidate is None:
+        raise ValueError(f"No CandidateResult with id {candidate_result_id}")
+    if not candidate.survived:
+        raise ValueError(
+            f"CandidateResult {candidate_result_id} did not pass the gate "
+            "(survived=False) -- only a passing candidate may be promoted."
+        )
+    record = PromotionRecord(
+        candidate_result_id=candidate_result_id,
+        state=PromotionState.PASSED_GATE.value,
+        created_at=datetime.now(UTC),
+    )
+    session.add(record)
+    session.flush()
+    return record
+
+
+def start_paper_trading(
+    session: Session,
+    promotion_id: int,
+    dry_run_db_path: str,
+    started_at: datetime | None = None,
+) -> PromotionRecord:
+    """Transition PASSED_GATE -> PAPER_TRADING.
+
+    Raises ValueError if the record doesn't exist or isn't currently PASSED_GATE.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.PASSED_GATE.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.PASSED_GATE.value!r} -- cannot start paper trading."
+        )
+    record.state = PromotionState.PAPER_TRADING.value
+    record.paper_trading_db_path = dry_run_db_path
+    record.paper_trading_started_at = started_at or datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def promote_to_live(session: Session, promotion_id: int) -> PromotionRecord:
+    """Transition LIVE_ELIGIBLE -> LIVE. The only function in this module that can
+    produce a LIVE state -- called only by a human, directly, never from
+    apply_health_evaluation or any other automated path.
+
+    Raises ValueError if the record doesn't exist or isn't currently LIVE_ELIGIBLE.
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state != PromotionState.LIVE_ELIGIBLE.value:
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r}, not "
+            f"{PromotionState.LIVE_ELIGIBLE.value!r} -- cannot promote to live."
+        )
+    record.state = PromotionState.LIVE.value
+    record.resolved_at = datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def reject(session: Session, promotion_id: int, reason: str) -> PromotionRecord:
+    """Manually transition PAPER_TRADING or LIVE_ELIGIBLE -> REJECTED.
+
+    Raises ValueError if the record doesn't exist, is currently PASSED_GATE (paper
+    trading never started), or is already resolved (REJECTED/LIVE).
+    """
+    record = _load_promotion_record(session, promotion_id)
+    if record.state not in (
+        PromotionState.PAPER_TRADING.value,
+        PromotionState.LIVE_ELIGIBLE.value,
+    ):
+        raise ValueError(
+            f"PromotionRecord {promotion_id} is in state {record.state!r} -- "
+            f"reject() only applies from {PromotionState.PAPER_TRADING.value!r} or "
+            f"{PromotionState.LIVE_ELIGIBLE.value!r}."
+        )
+    record.state = PromotionState.REJECTED.value
+    record.resolved_at = datetime.now(UTC)
+    record.resolution_reason = reason
+    session.flush()
+    return record

--- a/research/regime.py
+++ b/research/regime.py
@@ -1,0 +1,140 @@
+# research/regime.py
+"""Regime breakdown: labels each walk-forward window's out-of-sample test period by the
+market conditions it actually occurred in (Trend x Volatility), and aggregates a gate's
+window-level results by that label. Purely informational -- never changes
+GateResult.passed. See docs/superpowers/specs/2026-08-24-regime-breakdown-design.md for
+full reasoning, including why this classifier is NOT safe to reuse for a live/production
+regime-switching signal: it ranks each window against the full-sample median of every
+window in this run, including ones chronologically after it -- fine for a one-shot,
+post-hoc report generated after the whole backtest already ran, not causal.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from research.walkforward import Window, WindowResult
+
+
+def classify_regimes(
+    pair: str,
+    timeframe: str,
+    datadir: Path,
+    windows: list[Window],
+    # ponytail: starting default, not empirically derived -- adjust based on real usage
+    # once this runs against real strategies.
+    trend_threshold: float = 0.05,
+) -> list[str]:
+    """Label each window's test period "{Trend}/{Volatility}", e.g. "Bull/High".
+
+    Trend: "Bull" if the test period's total return exceeds `trend_threshold`, "Bear" if
+    below -`trend_threshold`, "Sideways" otherwise.
+
+    Volatility: "High" if this window's realized volatility (std of per-candle pct
+    change) is strictly above the median realized volatility across every window in
+    `windows`, "Low" otherwise (a window sitting exactly on the median is "Low" by
+    construction -- ">", not ">=").
+
+    Self-referential to this run's own windows (no external volatility index needed) --
+    honest about what it is: "more/less volatile than this backtest's other periods," not
+    "objectively high/low."
+
+    A window whose test period has fewer than 2 candles can't compute a return or
+    volatility; it fails closed to total_return=0.0, realized_vol=0.0 (classified
+    "Sideways" on the trend axis by construction, since 0.0 is inside
+    [-trend_threshold, trend_threshold]).
+
+    Returns one label per window, same order as `windows`.
+    """
+    if not windows:
+        raise ValueError("windows must not be empty")
+
+    returns: list[float] = []
+    vols: list[float] = []
+    for window in windows:
+        timerange = TimeRange(
+            "date", "date", int(window.test_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=datadir, timeframe=timeframe, pairs=[pair], timerange=timerange
+        )
+        # freqtrade's history.load_data only inserts a pair into the returned dict when
+        # the loaded frame is non-empty -- a window whose test period contains zero
+        # candles leaves `pair` absent entirely, so guard before indexing rather than
+        # let a KeyError bypass the `len(close) < 2` fail-closed path below.
+        close = data[pair]["close"] if pair in data else pd.Series(dtype=float)
+        if len(close) < 2:
+            returns.append(0.0)
+            vols.append(0.0)
+            continue
+        returns.append(float(close.iloc[-1] / close.iloc[0] - 1))
+        pct_changes = close.pct_change().dropna()
+        # A single pct-change value (i.e. exactly 2 candles) has an undefined sample std
+        # (pandas' default ddof=1 divides by n-1=0, producing NaN) -- fail closed to 0.0
+        # rather than let a NaN silently poison np.median(vols) for the whole run.
+        vols.append(float(pct_changes.std()) if len(pct_changes) >= 2 else 0.0)
+
+    median_vol = float(np.median(vols))
+
+    labels = []
+    for total_return, realized_vol in zip(returns, vols, strict=True):
+        if total_return > trend_threshold:
+            trend = "Bull"
+        elif total_return < -trend_threshold:
+            trend = "Bear"
+        else:
+            trend = "Sideways"
+        volatility = "High" if realized_vol > median_vol else "Low"
+        labels.append(f"{trend}/{volatility}")
+    return labels
+
+
+def regime_report(window_results: list[WindowResult], labels: list[str]) -> dict[str, dict]:
+    """Group `window_results` by their parallel `labels` entry and aggregate each group.
+
+    Raises ValueError if len(window_results) != len(labels) -- mismatched parallel lists
+    is a caller-contract violation, not a data problem.
+
+    Returns {label: {"n_windows": int, "n_trades": int, "mean_test_sharpe": float,
+    "total_return": float}}. `total_return` is the plain arithmetic sum of every trade's
+    fractional return across the group's windows -- NOT a geometrically compounded
+    return, a rough same-units aggregate for comparing regime buckets against each
+    other, not a claim about realized account growth.
+
+    WindowResult.test_sharpe is never NaN for a zero-trade window (calculate_sharpe
+    returns the plain sentinel 0), so np.mean over any group is always well-defined --
+    no NaN-guard needed here.
+
+    Caution when reading `mean_test_sharpe`: freqtrade's `calculate_sharpe` returns a
+    sentinel of -100.0 whenever a window's return standard deviation is zero -- notably
+    true for any window with exactly one trade. That sentinel is diluted across many
+    windows in the gate's overall mean_test_sharpe, but a regime bucket here often
+    contains only 1-3 windows, so a single thin-window's undefined-variance sentinel can
+    dominate the bucket's mean and look like a real (very bad) market finding when it is
+    actually a sentinel artifact.
+    """
+    if len(window_results) != len(labels):
+        raise ValueError(
+            f"window_results and labels must be the same length, got "
+            f"{len(window_results)} and {len(labels)}"
+        )
+
+    grouped: dict[str, list[WindowResult]] = defaultdict(list)
+    for wr, label in zip(window_results, labels, strict=True):
+        grouped[label].append(wr)
+
+    report: dict[str, dict] = {}
+    for label, group in grouped.items():
+        report[label] = {
+            "n_windows": len(group),
+            "n_trades": sum(wr.test_n_trades for wr in group),
+            "mean_test_sharpe": float(np.mean([wr.test_sharpe for wr in group])),
+            "total_return": float(sum(r for wr in group for r in wr.test_returns)),
+        }
+    return report

--- a/research/scoring.py
+++ b/research/scoring.py
@@ -1,0 +1,128 @@
+# research/scoring.py
+"""Strategy scoring and reporting: synthesizes an already-computed GateResult (deflated
+Sharpe, permutation p-value, PBO, and the optional fee-sensitivity/regime-breakdown
+add-ons) into one continuous robustness_score() and one standardized strategy_report()
+string. No new statistics are computed here -- every input is already produced by
+research.gate.run_promotion_gate before either function in this module runs. See
+docs/superpowers/specs/2026-08-24-strategy-scoring-and-report-design.md for the full
+design, including why the score is only directly comparable between GateResults computed
+with the same set of optional components present (a documented, deliberate tradeoff of
+renormalizing over available evidence rather than penalizing runs that skip the
+compute-costly optional fee-sensitivity/regime-breakdown analyses).
+"""
+
+from __future__ import annotations
+
+from research.gate import GateResult
+
+
+# ponytail: starting weights, not empirically derived -- adjust based on real usage once
+# this runs against real strategies. Not a runtime parameter; see the spec for why.
+WEIGHTS = {
+    "deflated_sharpe": 0.35,
+    "significance": 0.25,
+    "pbo_inverse": 0.25,
+    "cost_sensitivity": 0.10,
+    "regime_consistency": 0.05,
+}
+
+
+def robustness_score(result: GateResult) -> float:
+    """Weighted average of GateResult's already-computed statistics, renormalized over
+    whichever components are actually present. Always in [0, 1].
+
+    Always-present components: deflated_sharpe directly, 1 - permutation_p
+    ("significance"), 1 - pbo ("pbo_inverse") -- all three are already probabilities in
+    [0, 1] by construction (see research/statistics.py, research/pbo.py).
+
+    "cost_sensitivity", only when result.fee_sensitivity is present: the fraction of the
+    lowest-tested fee multiplier's deflated Sharpe that survives at the highest-tested
+    multiplier, clipped to [0, 1]. 1.0 (fail open) if only one multiplier was tested --
+    no stress signal to penalize. 0.0 (fail closed) if the baseline deflated Sharpe is
+    non-positive -- the ratio would be meaningless.
+
+    "regime_consistency", only when result.regime_breakdown is present: the fraction of
+    regime buckets with a positive mean_test_sharpe -- does the edge show up broadly, or
+    only in one favorable regime.
+
+    Known limitation, deliberate: scores from GateResults with different optional
+    components present are NOT directly comparable, since renormalization shifts the
+    denominator. Read this as "how robust this candidate looks given the evidence
+    gathered for it," not a universal ranking number.
+    """
+    components: dict[str, float] = {
+        "deflated_sharpe": result.deflated_sharpe,
+        "significance": 1.0 - result.permutation_p,
+        "pbo_inverse": 1.0 - result.pbo,
+    }
+
+    if result.fee_sensitivity:
+        baseline_mult = min(result.fee_sensitivity)
+        stress_mult = max(result.fee_sensitivity)
+        baseline_dsr = result.fee_sensitivity[baseline_mult]["deflated_sharpe"]
+        stress_dsr = result.fee_sensitivity[stress_mult]["deflated_sharpe"]
+        if baseline_mult == stress_mult:
+            cost_sensitivity = 1.0
+        elif baseline_dsr <= 0:
+            cost_sensitivity = 0.0
+        else:
+            cost_sensitivity = max(0.0, min(1.0, stress_dsr / baseline_dsr))
+        components["cost_sensitivity"] = cost_sensitivity
+
+    if result.regime_breakdown:
+        n_total = len(result.regime_breakdown)
+        n_positive = sum(
+            1 for stats in result.regime_breakdown.values() if stats["mean_test_sharpe"] > 0
+        )
+        components["regime_consistency"] = n_positive / n_total
+
+    weighted_sum = sum(WEIGHTS[k] * v for k, v in components.items())
+    weight_total = sum(WEIGHTS[k] for k in components)
+    return weighted_sum / weight_total
+
+
+def strategy_report(result: GateResult, pair: str | None = None) -> str:
+    """Standardized human-readable report for one GateResult -- verdict, robustness
+    score, the three core statistics, any reasons the gate failed, and the
+    fee-sensitivity / regime-breakdown tables when present. Returns the text (does not
+    print it).
+
+    `pair` names which pair a present regime_breakdown was classified against (the
+    caller's responsibility to supply, since GateResult itself doesn't carry it -- see
+    the spec). When None, the regime-breakdown header omits the parenthetical pair name.
+    """
+    score = robustness_score(result)
+    verdict = "PASS" if result.passed else "FAIL"
+    lines = [
+        f"{result.strategy_id}: {verdict}",
+        f"  robustness score  {score:.3f}",
+        f"  deflated_sharpe   {result.deflated_sharpe:.3f}",
+        f"  permutation p     {result.permutation_p:.3f}",
+        f"  PBO               {result.pbo:.3f}",
+        f"  mean OOS sharpe   {result.mean_test_sharpe:.3f}",
+        f"  trials (ledger)   {result.n_trials}",
+    ]
+    for reason in result.reasons:
+        lines.append(f"  - {reason}")
+
+    if result.fee_sensitivity:
+        lines.append("  fee sensitivity (informational, not part of PASS/FAIL):")
+        for mult, stats in result.fee_sensitivity.items():
+            label = f"{mult:.2f}x fee" + (" (baseline)" if mult == 1.0 else "")
+            lines.append(
+                f"    {label:<22} mean OOS sharpe {stats['mean_test_sharpe']:>6.2f}"
+                f"   deflated_sharpe (n_trials=1) {stats['deflated_sharpe']:.3f}"
+            )
+
+    if result.regime_breakdown:
+        pair_part = f"{pair}, " if pair else ""
+        lines.append(f"  regime breakdown ({pair_part}informational, not part of PASS/FAIL):")
+        for label, stats in result.regime_breakdown.items():
+            lines.append(
+                f"    {label:<15} {stats['n_windows']:>2} windows"
+                f"   {stats['n_trades']:>3} trades"
+                f"   mean sharpe {stats['mean_test_sharpe']:>6.2f}"
+                f"   total return {stats['total_return']:>8.4f}"
+            )
+
+    return "\n".join(lines)

--- a/research/statistics.py
+++ b/research/statistics.py
@@ -1,0 +1,162 @@
+"""
+Statistical functions for validating trading strategies before promotion.
+
+Ported and adapted from `C:\\dev\\MarketMind\\backend\\backtest\\enhanced\\statistics.py`
+(lines 14-104 for `benjamini_hochberg`/`permutation_test`, lines 168-228 for
+`deflated_sharpe_ratio`; see FREQTRADE_RESEARCH_ARCHITECTURE.md §15). Two adaptations from
+the source were applied: the hand-rolled normal CDF/PPF helpers (used there to avoid a new
+dependency) are replaced with `scipy.stats.norm`, since SciPy is already a freqtrade
+dependency; and the default `periods_per_year` is 365 rather than 252, since crypto trades
+every calendar day rather than only equities trading days.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from scipy.stats import norm
+
+
+_EULER_MASCHERONI = 0.5772156649015329
+
+
+def benjamini_hochberg(p_values: list[float], q: float = 0.05) -> list[bool]:
+    """Benjamini-Hochberg step-up FDR control over a batch of p-values.
+
+    Returns a reject mask aligned with the INPUT order: True where the null is rejected
+    (a discovery), such that the expected false-discovery rate among rejections is <= q.
+
+    This is the batch-level multiple-testing control the funnel needs. A naive "keep
+    p < q" cut passes ~q*N candidates from a pure-noise batch by construction; BH passes
+    ~0, because it raises the bar with the number of comparisons. Step-up: find the largest
+    rank k (1-indexed, ascending p) with p_(k) <= (k/m)*q, then reject EVERY candidate at
+    rank <= k -- including ones that fail their own critical value but sit below the cutoff.
+    """
+    m = len(p_values)
+    if m == 0:
+        return []
+    order = sorted(range(m), key=lambda i: p_values[i])  # ascending p, original indices
+    max_k = 0
+    for rank, idx in enumerate(order, start=1):
+        if p_values[idx] <= (rank / m) * q:
+            max_k = rank  # largest passing rank so far (step-up keeps the last one)
+    reject = [False] * m
+    for rank, idx in enumerate(order, start=1):
+        if rank <= max_k:
+            reject[idx] = True
+    return reject
+
+
+def permutation_test(
+    observed_stat: float,
+    returns: np.ndarray,
+    n_permutations: int = 1000,
+    seed: int | None = None,
+) -> float:
+    """Sign-flip randomization test for the significance of an observed statistic.
+
+    Null hypothesis: the returns carry no directional edge -- the *sign* of each return
+    is arbitrary. Each iteration randomly flips the sign of every return and recomputes
+    the null statistic (mean/std, in the same units as `observed_stat`), building a null
+    distribution; the p-value is the fraction of null statistics that match or beat the
+    observed one.
+
+    NOTE: shuffling the *order* of the returns (as an earlier, buggy version did) is
+    meaningless -- mean/std is order-invariant, so every reordering yields the same
+    statistic and the p-value would be floating-point noise (~1.0 even for a strongly
+    trending series). Randomizing signs is what actually tests whether the observed drift
+    is distinguishable from chance.
+
+    Args:
+        observed_stat: The statistic computed on the real (unpermuted) returns, e.g.
+            `returns.mean() / returns.std()`. Compared directly against each permutation's
+            null statistic, so it must be in the same units (no implicit annualization is
+            applied here).
+        returns: Array of periodic returns.
+        n_permutations: Number of sign-flip resamples.
+        seed: Optional seed for reproducibility.
+
+    Returns:
+        p-value in [0, 1]: the fraction of null statistics >= observed_stat.
+    """
+    r = np.asarray(returns, dtype=float)
+    if len(r) < 2:
+        return 1.0
+
+    std_r = np.std(r, ddof=1)
+    if std_r == 0:
+        return 1.0
+
+    rng = np.random.default_rng(seed)
+    ge, counted = 0, 0
+    for _ in range(n_permutations):
+        flipped = r * rng.choice((-1.0, 1.0), size=len(r))
+        s = np.std(flipped, ddof=1)
+        if s == 0:
+            continue
+        null_stat = np.mean(flipped) / s
+        counted += 1
+        if null_stat >= observed_stat:
+            ge += 1
+
+    return 1.0 if counted == 0 else ge / counted
+
+
+def deflated_sharpe_ratio(
+    sharpe_ratio: float,
+    n_obs: int,
+    n_trials: int = 1,
+    skewness: float = 0.0,
+    kurtosis: float = 3.0,
+    periods_per_year: int = 365,
+) -> float:
+    """Bailey-Lopez de Prado (2014) Deflated Sharpe Ratio. Returns a PROBABILITY in [0, 1].
+
+        DSR = Phi[ ((SR - SR*) * sqrt(n-1)) / sqrt(1 - g3*SR + ((g4-1)/4)*SR^2) ]
+
+    i.e. the probability the observed Sharpe beats the benchmark SR*, given the returns'
+    non-normality and how many trials were searched. At n_trials=1 there is no multiple
+    testing, SR* = 0, and this reduces to the Probabilistic Sharpe Ratio against zero.
+
+    Args:
+        sharpe_ratio: ANNUALIZED Sharpe. De-annualized internally: the formula needs SR
+            and n at the same frequency, and n counts per-period observations.
+        n_obs: Number of return observations. Without this term, a 6-trade and a
+            10,000-trade backtest would deflate identically -- a DSR that can't tell them
+            apart is just a sign test wearing a rigor costume.
+        n_trials: Parameter combinations searched.
+        skewness / kurtosis: Standardized 3rd/4th moments of the returns (g3, g4).
+        periods_per_year: Annualization factor used to recover the per-period SR. Default
+            365 (crypto trades every calendar day, unlike equities' 252 trading days).
+
+    Returns:
+        Probability in [0, 1]. Fails CLOSED to 0.0 on degenerate input (n_obs < 2,
+        non-finite SR, non-positive variance term) -- no data is not a coin flip.
+    """
+    if not math.isfinite(sharpe_ratio) or n_obs is None or n_obs < 2:
+        return 0.0
+
+    # Per-period SR: n counts per-period observations, so SR must match their frequency.
+    sr = float(sharpe_ratio) / math.sqrt(periods_per_year)
+
+    # V[SR] -- the variance of the Sharpe estimator under non-normality. Used both to
+    # scale SR* and (via its square root) as this estimator's own standard error.
+    variance_term = 1.0 - skewness * sr + (kurtosis - 1.0) / 4.0 * sr**2
+    if not math.isfinite(variance_term) or variance_term <= 0:
+        return 0.0  # fail closed rather than take a root of a negative number
+
+    # SR*: expected MAXIMUM Sharpe under the null across n_trials independent trials.
+    # n_trials=1 -> no search -> SR* = 0 (norm.ppf(1 - 1/1) is -inf and must not leak in).
+    sr_star = 0.0
+    if n_trials > 1:
+        v_sr = math.sqrt(variance_term / (n_obs - 1))
+        g = _EULER_MASCHERONI
+        sr_star = v_sr * (
+            (1 - g) * norm.ppf(1 - 1.0 / n_trials) + g * norm.ppf(1 - 1.0 / (n_trials * math.e))
+        )
+
+    z = ((sr - sr_star) * math.sqrt(n_obs - 1)) / math.sqrt(variance_term)
+    if not math.isfinite(z):
+        return 0.0
+    return float(norm.cdf(z))

--- a/research/tests/test_cli.py
+++ b/research/tests/test_cli.py
@@ -1,0 +1,92 @@
+from research.cli import main
+from research.gate import GateResult
+
+
+def test_gate_command_prints_verdict_and_returns_pass_exit_code(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT,ETH/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS" in captured.out
+
+
+def test_gate_command_returns_nonzero_exit_code_on_fail(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "FAIL" in captured.out

--- a/research/tests/test_cli.py
+++ b/research/tests/test_cli.py
@@ -196,3 +196,68 @@ def test_gate_command_prints_fee_sensitivity_table_when_present(mocker, capsys):
     assert "baseline" in captured.out
     assert "1.50x fee" in captured.out
     assert "slippage" not in captured.out.lower()
+
+
+def test_gate_command_prints_regime_breakdown_table_when_present(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2,
+                "n_trades": 14,
+                "mean_test_sharpe": 0.42,
+                "total_return": 0.0012,
+            },
+            "Bear/Low": {
+                "n_windows": 1,
+                "n_trades": 6,
+                "mean_test_sharpe": -1.10,
+                "total_return": -0.0034,
+            },
+        },
+    )
+    mock_gate = mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+            "--regime-breakdown",
+        ]
+    )
+
+    _, kwargs = mock_gate.call_args
+    assert kwargs["include_regime_breakdown"] is True
+
+    captured = capsys.readouterr()
+    assert exit_code == 1  # this GateResult failed -- regime breakdown must print regardless
+    assert "regime breakdown" in captured.out
+    assert "Bull/High" in captured.out
+    assert "Bear/Low" in captured.out

--- a/research/tests/test_cli.py
+++ b/research/tests/test_cli.py
@@ -1,5 +1,58 @@
+from datetime import UTC
+
 from research.cli import main
 from research.gate import GateResult
+
+
+def test_gate_command_parses_start_and_end_as_utc_aware_datetimes(mocker, capsys):
+    """Regression test: freqtrade's Backtesting.backtest() internally compares
+    against tz-aware (UTC) pandas Timestamps. A naive datetime passed as
+    start_date/end_date crashes deep inside freqtrade with
+    "can't compare offset-naive and offset-aware datetimes" -- caught only when
+    running against real data, since research/tests' own fixtures always derive
+    start/end from an already tz-aware loaded dataframe."""
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+    )
+    mock_gate = mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+        ]
+    )
+
+    _, kwargs = mock_gate.call_args
+    assert kwargs["start"].utcoffset() == UTC.utcoffset(None)
+    assert kwargs["end"].utcoffset() == UTC.utcoffset(None)
 
 
 def test_gate_command_prints_verdict_and_returns_pass_exit_code(mocker, capsys):

--- a/research/tests/test_cli.py
+++ b/research/tests/test_cli.py
@@ -143,3 +143,56 @@ def test_gate_command_returns_nonzero_exit_code_on_fail(mocker, capsys):
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "FAIL" in captured.out
+
+
+def test_gate_command_prints_fee_sensitivity_table_when_present(mocker, capsys):
+    canned = GateResult(
+        strategy_id="StrategyTestV3",
+        passed=True,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        mean_test_sharpe=1.2,
+        n_trials=12,
+        reasons=[],
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.87, "deflated_sharpe": 0.91, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.33, "deflated_sharpe": 0.52, "n_windows": 5},
+        },
+    )
+    mocker.patch("research.cli.run_promotion_gate", return_value=canned)
+    mocker.patch(
+        "research.cli.Configuration.from_files", return_value={"datadir": "user_data/data"}
+    )
+
+    exit_code = main(
+        [
+            "gate",
+            "--strategy",
+            "StrategyTestV3",
+            "--config",
+            "config.json",
+            "--pairs",
+            "BTC/USDT",
+            "--timeframe",
+            "1h",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-06-01",
+            "--train-days",
+            "60",
+            "--test-days",
+            "20",
+            "--param-grid",
+            '[{"buy_rsi": 30}]',
+            "--fee-sensitivity",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "fee sensitivity" in captured.out
+    assert "baseline" in captured.out
+    assert "1.50x fee" in captured.out
+    assert "slippage" not in captured.out.lower()

--- a/research/tests/test_cost_stress.py
+++ b/research/tests/test_cost_stress.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+from freqtrade.optimize.backtesting import Backtesting
+from research.cost_stress import fee_sensitivity
+from research.statistics import deflated_sharpe_ratio
+from research.walkforward import WalkForwardRunner, generate_windows
+from tests.conftest import get_default_conf, patch_exchange
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def _patch(mocker):
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+
+def _window_results(conf):
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+    windows = generate_windows(min_date, max_date, train_days, test_days)
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    return runner, runner.run(windows, [{"buy_rsi": 25}, {"buy_rsi": 35}])
+
+
+def test_fee_sensitivity_reports_one_entry_per_multiplier(mocker):
+    conf = _conf()
+    _patch(mocker)
+    _runner, results = _window_results(conf)
+
+    report = fee_sensitivity(
+        conf,
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        window_results=results,
+        multipliers=(1.0, 1.5),
+    )
+
+    assert set(report) == {1.0, 1.5}
+    for stats in report.values():
+        assert isinstance(stats["mean_test_sharpe"], float)
+        assert 0.0 <= stats["deflated_sharpe"] <= 1.0
+        assert stats["n_windows"] == len(results)
+
+
+def test_fee_sensitivity_baseline_matches_direct_recomputation(mocker):
+    conf = _conf()
+    _patch(mocker)
+    runner, results = _window_results(conf)
+
+    report = fee_sensitivity(
+        conf,
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        window_results=results,
+        multipliers=(1.0,),
+    )
+
+    base_fee = Backtesting(conf).fee
+    direct = [
+        runner.evaluate_fixed_params(wr.window, wr.best_params, fee_override=base_fee)
+        for wr in results
+    ]
+    expected_mean_sharpe = float(np.mean([r.test_sharpe for r in direct]))
+    expected_n_obs = sum(len(r.test_returns) for r in direct)
+    expected_deflated = deflated_sharpe_ratio(
+        expected_mean_sharpe, n_obs=expected_n_obs, n_trials=1, periods_per_year=365
+    )
+
+    assert report[1.0]["mean_test_sharpe"] == pytest.approx(expected_mean_sharpe)
+    assert report[1.0]["deflated_sharpe"] == pytest.approx(expected_deflated)
+
+
+def test_fee_sensitivity_raises_on_empty_or_non_positive_multipliers(mocker):
+    conf = _conf()
+    _patch(mocker)
+    _runner, results = _window_results(conf)
+
+    with pytest.raises(ValueError, match="multipliers"):
+        fee_sensitivity(
+            conf,
+            pairs=["UNITTEST/BTC"],
+            timeframe="5m",
+            datadir=TESTDATADIR,
+            window_results=results,
+            multipliers=(),
+        )
+    with pytest.raises(ValueError, match="multipliers"):
+        fee_sensitivity(
+            conf,
+            pairs=["UNITTEST/BTC"],
+            timeframe="5m",
+            datadir=TESTDATADIR,
+            window_results=results,
+            multipliers=(0.0,),
+        )

--- a/research/tests/test_gate.py
+++ b/research/tests/test_gate.py
@@ -150,3 +150,97 @@ def test_run_promotion_gate_skips_fee_sensitivity_when_it_fails(mocker, tmp_path
 
     assert result.passed is False
     assert result.fee_sensitivity is None
+
+
+def test_run_promotion_gate_attaches_regime_breakdown_when_requested_and_passes(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Permissive thresholds guarantee a real, unmocked PASS (see the fee-sensitivity
+    # pass test above for the same pattern).
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=0.0,
+        fdr_q=1.0,
+        pbo_threshold=1.0,
+        include_regime_breakdown=True,
+    )
+
+    assert result.passed is True
+    assert result.regime_breakdown is not None
+    assert len(result.regime_breakdown) > 0
+
+
+def test_run_promotion_gate_attaches_regime_breakdown_when_requested_and_fails(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Impossible dsr_threshold guarantees a real FAIL (see the fee-sensitivity skip test
+    # above for the same pattern). Regime breakdown must still be attached -- this is the
+    # test that actually proves the deliberate asymmetry with fee-sensitivity was
+    # implemented, not just described in the spec.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=1.1,
+        include_regime_breakdown=True,
+    )
+
+    assert result.passed is False
+    assert result.regime_breakdown is not None
+    assert len(result.regime_breakdown) > 0
+
+
+def test_run_promotion_gate_omits_regime_breakdown_by_default(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+    )
+
+    assert result.regime_breakdown is None

--- a/research/tests/test_gate.py
+++ b/research/tests/test_gate.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+from research.db import get_engine, get_session
+from research.gate import run_promotion_gate
+from research.models import CandidateResult
+from tests.conftest import get_default_conf, patch_exchange
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def _patch(mocker):
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+
+def test_run_promotion_gate_raises_with_too_few_windows(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+
+    with pytest.raises(ValueError, match="walk-forward windows"):
+        run_promotion_gate(
+            config=conf,
+            strategy_id="StrategyTestV3",
+            pairs=["UNITTEST/BTC"],
+            timeframe="5m",
+            datadir=TESTDATADIR,
+            start=min_date,
+            end=max_date,
+            train_days=3650,  # deliberately far larger than the available data span
+            test_days=3650,
+            param_grid=[{"buy_rsi": 30}],
+            db_path=str(tmp_path / "research.sqlite"),
+        )
+
+
+def test_run_promotion_gate_returns_result_and_writes_ledger_row(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+    db_path = str(tmp_path / "research.sqlite")
+
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=db_path,
+    )
+
+    assert result.strategy_id == "StrategyTestV3"
+    assert isinstance(result.passed, bool)
+    assert 0.0 <= result.deflated_sharpe <= 1.0
+    assert 0.0 <= result.permutation_p <= 1.0
+    assert 0.0 <= result.pbo <= 1.0
+    assert result.n_trials >= 1
+
+    session = get_session(get_engine(db_path))
+    assert session.query(CandidateResult).filter_by(strategy_id="StrategyTestV3").count() == 1

--- a/research/tests/test_gate.py
+++ b/research/tests/test_gate.py
@@ -85,3 +85,68 @@ def test_run_promotion_gate_returns_result_and_writes_ledger_row(mocker, tmp_pat
 
     session = get_session(get_engine(db_path))
     assert session.query(CandidateResult).filter_by(strategy_id="StrategyTestV3").count() == 1
+
+
+def test_run_promotion_gate_attaches_fee_sensitivity_when_it_passes(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Permissive thresholds guarantee a real, unmocked PASS on the small fixture dataset
+    # (any run with at least one trade clears them) without mocking the statistics --
+    # deterministic real-execution test, not a forced/mocked pass.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=0.0,
+        fdr_q=1.0,
+        pbo_threshold=1.0,
+        fee_sensitivity_multipliers=(1.0, 1.5),
+    )
+
+    assert result.passed is True
+    assert result.fee_sensitivity is not None
+    assert set(result.fee_sensitivity) == {1.0, 1.5}
+
+
+def test_run_promotion_gate_skips_fee_sensitivity_when_it_fails(mocker, tmp_path):
+    conf = _conf()
+    _patch(mocker)
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    total_days = max(8, (max_date - min_date).days)
+    train_days = max(1, total_days // 8)
+    test_days = max(1, total_days // 16)
+
+    # Impossible dsr_threshold guarantees a real FAIL, regardless of the actual result.
+    result = run_promotion_gate(
+        config=conf,
+        strategy_id="StrategyTestV3",
+        pairs=["UNITTEST/BTC"],
+        timeframe="5m",
+        datadir=TESTDATADIR,
+        start=min_date,
+        end=max_date,
+        train_days=train_days,
+        test_days=test_days,
+        param_grid=[{"buy_rsi": 25}, {"buy_rsi": 35}],
+        db_path=str(tmp_path / "research.sqlite"),
+        dsr_threshold=1.1,
+        fee_sensitivity_multipliers=(1.0, 1.5),
+    )
+
+    assert result.passed is False
+    assert result.fee_sensitivity is None

--- a/research/tests/test_ledger.py
+++ b/research/tests/test_ledger.py
@@ -1,0 +1,89 @@
+"""Test suite for research ledger module."""
+
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from research.ledger import family_of, family_trial_count, log_candidate_result
+from research.models import Base, CandidateResult
+
+
+def _memory_session() -> Session:
+    """Create an in-memory SQLite session for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_log_candidate_result_round_trips() -> None:
+    """Test that log_candidate_result stores and retrieves data correctly."""
+    session = _memory_session()
+    row = log_candidate_result(
+        session,
+        strategy_id="ema_cross_v3",
+        params={"buy_rsi": 30},
+        universe="BTC/USDT",
+        timeframe="1h",
+        discovery_start="2020-01-01",
+        discovery_end="2024-12-31",
+        n_trials_this_run=48,
+        is_sharpe=1.2,
+        oos_sharpe=0.8,
+        deflated_sharpe=0.6,
+        permutation_p=0.03,
+        pbo=0.2,
+        survived=True,
+    )
+    session.commit()
+
+    fetched = session.query(CandidateResult).filter_by(id=row.id).one()
+    assert fetched.strategy_id == "ema_cross_v3"
+    assert fetched.strategy_family == "trend_following"
+    assert fetched.params_json == '{"buy_rsi": 30}'
+    assert fetched.survived is True
+
+
+def test_family_of_maps_known_alias_and_falls_back_to_strategy_id() -> None:
+    """Test family_of mapping and fallback behavior."""
+    assert family_of("ema_cross_v3") == "trend_following"
+    assert family_of("some_unmapped_strategy") == "some_unmapped_strategy"
+
+
+def test_family_trial_count_prefers_ledger_count_when_higher_than_declared() -> None:
+    """Test that family_trial_count uses the larger of ledger and declared counts."""
+    session = _memory_session()
+    for i in range(5):
+        log_candidate_result(
+            session,
+            strategy_id="ema_cross_v3",
+            params={"buy_rsi": i},
+            universe="BTC/USDT",
+            timeframe="1h",
+            discovery_start="2020-01-01",
+            discovery_end="2024-12-31",
+            n_trials_this_run=1,
+            is_sharpe=0.1,
+            oos_sharpe=0.0,
+            deflated_sharpe=0.0,
+            permutation_p=1.0,
+            pbo=1.0,
+            survived=False,
+        )
+    session.commit()
+
+    assert family_trial_count(session, "trend_following") == 5
+    assert family_trial_count(session, "trend_following", declared=2) == 5
+    assert family_trial_count(session, "trend_following", declared=10) == 10
+
+
+def test_get_engine_creates_sqlite_file_and_tables(tmp_path: Path) -> None:
+    """Test that get_engine creates database file and initializes tables."""
+    from research.db import get_engine, get_session
+
+    db_path = tmp_path / "research.sqlite"
+    engine = get_engine(str(db_path))
+    session = get_session(engine)
+
+    assert db_path.exists()
+    assert session.query(CandidateResult).count() == 0

--- a/research/tests/test_pbo.py
+++ b/research/tests/test_pbo.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from research.pbo import choose_n_splits, probability_of_backtest_overfitting
+
+
+class TestChooseNSplits:
+    def test_returns_an_even_divisor_of_n_periods(self):
+        n_periods = 16
+        s = choose_n_splits(n_periods)
+        assert s % 2 == 0
+        assert n_periods % s == 0
+
+    def test_never_exceeds_max_splits(self):
+        assert choose_n_splits(100, max_splits=8) <= 8
+
+
+class TestProbabilityOfBacktestOverfitting:
+    def test_bounded_in_unit_interval(self):
+        rng = np.random.default_rng(3)
+        matrix = rng.normal(0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert 0.0 <= result["pbo"] <= 1.0
+
+    def test_low_when_one_variant_dominates_every_period(self):
+        """Variant 0 has a real, consistent edge (positive mean, low noise) in every
+        period; the others are pure noise. Picking the best-in-sample variant should
+        reliably also do well out-of-sample -> low overfitting probability."""
+        rng = np.random.default_rng(11)
+        n_variants, n_periods = 5, 16
+        matrix = rng.normal(0.0, 0.01, size=(n_variants, n_periods))
+        matrix[0] = rng.normal(0.05, 0.005, size=n_periods)
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] < 0.3
+
+    def test_near_coin_flip_when_all_variants_are_pure_noise(self):
+        """No variant has a real edge -> which one looks best in-sample is arbitrary
+        and should NOT reliably predict out-of-sample rank. PBO should be high."""
+        rng = np.random.default_rng(6)
+        matrix = rng.normal(0.0, 0.01, size=(6, 16))
+        result = probability_of_backtest_overfitting(matrix)
+        assert result["pbo"] > 0.35
+
+    def test_degenerate_input_fails_closed(self):
+        result = probability_of_backtest_overfitting(np.zeros((1, 2)))
+        assert result["pbo"] == 1.0

--- a/research/tests/test_promotion.py
+++ b/research/tests/test_promotion.py
@@ -345,3 +345,50 @@ def test_apply_health_evaluation_raises_when_not_in_paper_trading(tmp_path):
 
     with pytest.raises(ValueError, match="cannot apply a health evaluation"):
         apply_health_evaluation(session, record.id, canned_evaluation)
+
+
+def test_apply_health_evaluation_raises_when_eligible_without_enough_evidence(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+    inconsistent_evaluation = {
+        "eligible": True,
+        "enough_evidence": False,
+        "days_elapsed": 3,
+        "n_trades": 1,
+        "paper_sharpe": 1.5,
+        "degradation_ratio": 0.9,
+        "reasons": [],
+    }
+
+    with pytest.raises(ValueError, match="internally inconsistent"):
+        apply_health_evaluation(session, record.id, inconsistent_evaluation)
+
+
+def test_full_promotion_chain_from_passed_gate_through_live(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    assert record.state == PromotionState.PASSED_GATE.value
+
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    dry_run_db_path = tmp_path / "dryrun_full_chain.sqlite"
+    start_paper_trading(session, record.id, str(dry_run_db_path), started_at)
+    assert record.state == PromotionState.PAPER_TRADING.value
+
+    _insert_dry_run_trades(
+        dry_run_db_path,
+        "TestStrategy",
+        started_at,
+        [8, 6, 7, 9, 5, 8, 6, 7, 9, 5],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.LIVE_ELIGIBLE.value
+
+    live = promote_to_live(session, record.id)
+    assert live.state == PromotionState.LIVE.value
+    assert live.resolved_at is not None

--- a/research/tests/test_promotion.py
+++ b/research/tests/test_promotion.py
@@ -1,0 +1,147 @@
+# research/tests/test_promotion.py
+from datetime import UTC, datetime
+
+import pytest
+
+from research.db import get_engine, get_session
+from research.models import CandidateResult
+from research.promotion import (
+    PromotionState,
+    create_promotion_record,
+    promote_to_live,
+    reject,
+    start_paper_trading,
+)
+
+
+def _session(tmp_path):
+    engine = get_engine(str(tmp_path / "research.sqlite"))
+    return get_session(engine)
+
+
+def _candidate(session, survived=True, oos_sharpe=1.5):
+    candidate = CandidateResult(
+        run_stamp=datetime.now(UTC),
+        strategy_id="TestStrategy",
+        strategy_family="TestStrategy",
+        params_json="{}",
+        universe="BTC/USDT",
+        timeframe="1h",
+        discovery_start="2024-01-01",
+        discovery_end="2024-06-01",
+        n_trials_this_run=1,
+        is_sharpe=1.0,
+        oos_sharpe=oos_sharpe,
+        deflated_sharpe=0.97,
+        permutation_p=0.01,
+        pbo=0.1,
+        survived=survived,
+        evidence_json="{}",
+    )
+    session.add(candidate)
+    session.flush()
+    return candidate
+
+
+def test_create_promotion_record_succeeds_for_a_passing_candidate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, survived=True)
+
+    record = create_promotion_record(session, candidate.id)
+
+    assert record.state == PromotionState.PASSED_GATE.value
+    assert record.candidate_result_id == candidate.id
+
+
+def test_create_promotion_record_raises_for_a_failing_candidate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, survived=False)
+
+    with pytest.raises(ValueError, match="did not pass the gate"):
+        create_promotion_record(session, candidate.id)
+
+
+def test_create_promotion_record_raises_for_a_nonexistent_candidate(tmp_path):
+    session = _session(tmp_path)
+
+    with pytest.raises(ValueError, match="No CandidateResult"):
+        create_promotion_record(session, 999)
+
+
+def test_start_paper_trading_transitions_passed_gate_to_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    before = datetime.now(UTC)
+
+    updated = start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    assert updated.state == PromotionState.PAPER_TRADING.value
+    assert updated.paper_trading_db_path == "tradesv3.dryrun.sqlite"
+    assert updated.paper_trading_started_at.replace(tzinfo=UTC) >= before
+
+
+def test_start_paper_trading_raises_when_not_in_passed_gate(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    with pytest.raises(ValueError, match="cannot start paper trading"):
+        start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+
+def test_promote_to_live_transitions_live_eligible_to_live(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+    record.state = PromotionState.LIVE_ELIGIBLE.value
+    session.flush()
+
+    updated = promote_to_live(session, record.id)
+
+    assert updated.state == PromotionState.LIVE.value
+    assert updated.resolved_at is not None
+
+
+def test_promote_to_live_raises_from_paper_trading_directly(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "tradesv3.dryrun.sqlite")
+
+    with pytest.raises(ValueError, match="cannot promote to live"):
+        promote_to_live(session, record.id)
+
+
+def test_reject_transitions_paper_trading_and_live_eligible_to_rejected(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+
+    record_a = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record_a.id, "a.sqlite")
+    rejected_a = reject(session, record_a.id, "degraded in paper trading")
+    assert rejected_a.state == PromotionState.REJECTED.value
+    assert rejected_a.resolution_reason == "degraded in paper trading"
+
+    record_b = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record_b.id, "b.sqlite")
+    record_b.state = PromotionState.LIVE_ELIGIBLE.value
+    session.flush()
+    rejected_b = reject(session, record_b.id, "manual override")
+    assert rejected_b.state == PromotionState.REJECTED.value
+
+
+def test_reject_raises_from_passed_gate_and_already_resolved_states(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+
+    with pytest.raises(ValueError, match=r"reject\(\) only applies"):
+        reject(session, record.id, "too early")
+
+    start_paper_trading(session, record.id, "a.sqlite")
+    reject(session, record.id, "first rejection")
+    with pytest.raises(ValueError, match=r"reject\(\) only applies"):
+        reject(session, record.id, "second rejection")

--- a/research/tests/test_promotion.py
+++ b/research/tests/test_promotion.py
@@ -145,3 +145,22 @@ def test_reject_raises_from_passed_gate_and_already_resolved_states(tmp_path):
     reject(session, record.id, "first rejection")
     with pytest.raises(ValueError, match=r"reject\(\) only applies"):
         reject(session, record.id, "second rejection")
+
+
+def test_transitions_raise_from_live(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    start_paper_trading(session, record.id, "a.sqlite")
+    record.state = PromotionState.LIVE_ELIGIBLE.value
+    session.flush()
+    promote_to_live(session, record.id)
+
+    with pytest.raises(ValueError):
+        start_paper_trading(session, record.id, "b.sqlite")
+
+    with pytest.raises(ValueError):
+        promote_to_live(session, record.id)
+
+    with pytest.raises(ValueError):
+        reject(session, record.id, "too late")

--- a/research/tests/test_promotion.py
+++ b/research/tests/test_promotion.py
@@ -1,13 +1,16 @@
 # research/tests/test_promotion.py
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from freqtrade.persistence import Trade, init_db
 from research.db import get_engine, get_session
 from research.models import CandidateResult
 from research.promotion import (
     PromotionState,
+    apply_health_evaluation,
     create_promotion_record,
+    evaluate_paper_trading_health,
     promote_to_live,
     reject,
     start_paper_trading,
@@ -164,3 +167,181 @@ def test_transitions_raise_from_live(tmp_path):
 
     with pytest.raises(ValueError):
         reject(session, record.id, "too late")
+
+
+@pytest.fixture(autouse=True)
+def _reset_trade_session_after_evaluation_tests():
+    """evaluate_paper_trading_health() calls freqtrade's own init_db(), which sets
+    Trade.session as GLOBAL class-level state (see the plan's Global Constraints for
+    why) -- reset it to a fresh in-memory DB after every test in this file so no later
+    test (in this file or elsewhere in the same pytest-xdist worker) can see
+    Trade.session still pointed at one of this file's throwaway dry-run databases."""
+    yield
+    init_db("sqlite://")
+
+
+def _insert_dry_run_trades(dry_run_db_path, strategy_id, started_at, profits_abs):
+    """Directly construct and insert closed Trade rows into a fresh dry-run-style
+    sqlite database -- one trade per entry in profits_abs, spaced evenly across the
+    period from started_at to now, matching how research/tests/test_regime.py and
+    test_scoring.py construct real rows directly rather than running a full backtest."""
+    init_db(f"sqlite:///{dry_run_db_path}")
+    now = datetime.now(UTC).replace(tzinfo=None)
+    started_naive = started_at.replace(tzinfo=None) if started_at.tzinfo else started_at
+    span = now - started_naive
+    step = span / max(1, len(profits_abs))
+    for i, profit in enumerate(profits_abs):
+        open_dt = started_naive + step * i
+        close_dt = open_dt + timedelta(minutes=30)
+        trade = Trade(
+            pair="BTC/USDT",
+            strategy=strategy_id,
+            exchange="binance",
+            is_open=False,
+            open_date=open_dt,
+            close_date=close_dt,
+            close_profit_abs=float(profit),
+            stake_amount=100.0,
+            amount=1.0,
+            open_rate=100.0,
+            close_rate=100.0 + float(profit) / 100.0,
+            fee_open=0.001,
+            fee_close=0.001,
+        )
+        Trade.session.add(trade)
+    Trade.session.flush()
+    Trade.session.commit()
+    init_db("sqlite://")  # release this function's own Trade.session redirect immediately
+
+
+def test_evaluate_paper_trading_health_not_enough_evidence_when_too_few_trades(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_thin.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_thin.sqlite", "TestStrategy", started_at, [8, 6, 7]
+    )  # only 3 trades, MIN_PAPER_TRADES is 10
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is False
+    assert evaluation["eligible"] is False
+    assert evaluation["n_trades"] == 3
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.PAPER_TRADING.value
+
+
+def test_evaluate_paper_trading_health_eligible_when_degradation_ratio_clears_bar(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_good.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_good.sqlite",
+        "TestStrategy",
+        started_at,
+        [8, 6, 7, 9, 5, 8, 6, 7, 9, 5],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is True
+    assert evaluation["n_trades"] == 10
+    assert evaluation["paper_sharpe"] == pytest.approx(67.54628043053148)
+    assert evaluation["degradation_ratio"] == pytest.approx(1.0)
+    assert evaluation["eligible"] is True
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.LIVE_ELIGIBLE.value
+    assert updated.resolved_at is not None
+
+
+def test_evaluate_paper_trading_health_rejected_when_degradation_ratio_fails_bar(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_bad.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_bad.sqlite",
+        "TestStrategy",
+        started_at,
+        [-3, 2, -4, 1, -2, 3, -5, 2, -3, 1],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["enough_evidence"] is True
+    assert evaluation["paper_sharpe"] == pytest.approx(-3.9705208944418664)
+    assert evaluation["degradation_ratio"] == pytest.approx(0.0)
+    assert evaluation["eligible"] is False
+
+    updated = apply_health_evaluation(session, record.id, evaluation)
+    assert updated.state == PromotionState.REJECTED.value
+    assert updated.resolution_reason is not None
+
+
+def test_evaluate_paper_trading_health_zero_trades_does_not_raise(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=2.0)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=1)
+    dry_run_path = tmp_path / "dryrun_empty.sqlite"
+    start_paper_trading(session, record.id, str(dry_run_path), started_at)
+    init_db(f"sqlite:///{dry_run_path}")  # create the (empty) schema, no trades inserted
+    init_db("sqlite://")
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["n_trades"] == 0
+    assert evaluation["paper_sharpe"] == 0
+    assert evaluation["enough_evidence"] is False
+
+
+def test_evaluate_paper_trading_health_non_positive_oos_sharpe_is_zero_degradation(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session, oos_sharpe=-0.5)
+    record = create_promotion_record(session, candidate.id)
+    started_at = datetime.now(UTC) - timedelta(days=14)
+    start_paper_trading(session, record.id, str(tmp_path / "dryrun_neg.sqlite"), started_at)
+    _insert_dry_run_trades(
+        tmp_path / "dryrun_neg.sqlite",
+        "TestStrategy",
+        started_at,
+        [8, 6, 7, 9, 5, 8, 6, 7, 9, 5],
+    )
+
+    evaluation = evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+    assert evaluation["degradation_ratio"] == 0.0
+
+
+def test_evaluate_paper_trading_health_raises_when_not_in_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+
+    with pytest.raises(ValueError, match="cannot evaluate health"):
+        evaluate_paper_trading_health(session, record.id, starting_balance=1000.0)
+
+
+def test_apply_health_evaluation_raises_when_not_in_paper_trading(tmp_path):
+    session = _session(tmp_path)
+    candidate = _candidate(session)
+    record = create_promotion_record(session, candidate.id)
+    canned_evaluation = {
+        "eligible": True,
+        "enough_evidence": True,
+        "days_elapsed": 30,
+        "n_trades": 20,
+        "paper_sharpe": 1.5,
+        "degradation_ratio": 0.9,
+        "reasons": [],
+    }
+
+    with pytest.raises(ValueError, match="cannot apply a health evaluation"):
+        apply_health_evaluation(session, record.id, canned_evaluation)

--- a/research/tests/test_regime.py
+++ b/research/tests/test_regime.py
@@ -1,0 +1,246 @@
+# research/tests/test_regime.py
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from research.regime import classify_regimes, regime_report
+from research.walkforward import Window, WindowResult
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+PAIR = "UNITTEST/BTC"
+TIMEFRAME = "5m"
+
+
+def _split_into_n_windows(min_date, max_date, n):
+    """N equal-duration, contiguous windows spanning [min_date, max_date). Only
+    test_start/test_end matter to classify_regimes, so train_start/train_end are set
+    equal to test_start -- unused, but Window requires all four fields."""
+    step = (max_date - min_date) / n
+    windows = []
+    for i in range(n):
+        test_start = min_date + step * i
+        test_end = min_date + step * (i + 1)
+        windows.append(
+            Window(
+                train_start=test_start,
+                train_end=test_start,
+                test_start=test_start,
+                test_end=test_end,
+            )
+        )
+    return windows
+
+
+def _real_return_and_vol(pair, timeframe, datadir, window):
+    """Independently recompute a window's total_return/realized_vol via a fresh
+    history.load_data call -- a separate execution path from classify_regimes' own
+    internals, used to derive the expected label from real data rather than a
+    hand-picked one."""
+    timerange = TimeRange(
+        "date", "date", int(window.test_start.timestamp()), int(window.test_end.timestamp())
+    )
+    data = history.load_data(
+        datadir=datadir, timeframe=timeframe, pairs=[pair], timerange=timerange
+    )
+    close = data[pair]["close"]
+    if len(close) < 2:
+        return 0.0, 0.0
+    return float(close.iloc[-1] / close.iloc[0] - 1), float(close.pct_change().dropna().std())
+
+
+def test_classify_regimes_trend_axis_matches_threshold_on_real_data():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, max_date = get_timerange(full_data)
+    windows = _split_into_n_windows(min_date, max_date, n=5)
+    trend_threshold = 0.05
+
+    labels = classify_regimes(
+        PAIR, TIMEFRAME, TESTDATADIR, windows, trend_threshold=trend_threshold
+    )
+
+    assert len(labels) == len(windows)
+    for window, label in zip(windows, labels, strict=True):
+        total_return, _ = _real_return_and_vol(PAIR, TIMEFRAME, TESTDATADIR, window)
+        if total_return > trend_threshold:
+            expected_trend = "Bull"
+        elif total_return < -trend_threshold:
+            expected_trend = "Bear"
+        else:
+            expected_trend = "Sideways"
+        assert label.split("/")[0] == expected_trend
+
+
+def test_classify_regimes_volatility_axis_ranks_relative_to_median_on_real_data():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, max_date = get_timerange(full_data)
+    windows = _split_into_n_windows(min_date, max_date, n=5)
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, windows)
+
+    vols = [_real_return_and_vol(PAIR, TIMEFRAME, TESTDATADIR, w)[1] for w in windows]
+    median_vol = float(np.median(vols))
+    for vol, label in zip(vols, labels, strict=True):
+        expected_volatility = "High" if vol > median_vol else "Low"
+        assert label.split("/")[1] == expected_volatility
+
+
+def test_classify_regimes_degenerate_window_is_sideways_and_does_not_raise():
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, _ = get_timerange(full_data)
+    tiny_end = min_date + timedelta(seconds=1)  # far shorter than one 5m candle
+    window = Window(
+        train_start=min_date, train_end=min_date, test_start=min_date, test_end=tiny_end
+    )
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [window])
+
+    # single-window input: median vol is that window's own (degenerate) vol of 0.0,
+    # so 0.0 > 0.0 is False -- deterministically "Low", not just "does not crash".
+    assert labels == ["Sideways/Low"]
+
+
+def test_classify_regimes_zero_candle_window_is_sideways_and_does_not_raise():
+    """Regression test: a window whose test period loads ZERO candles (distinct from
+    the 1-candle degenerate case above). freqtrade's history.load_data only inserts a
+    pair into its returned dict when the loaded frame is non-empty, so a window placed
+    entirely after the fixture data's max_date loads no candles at all and `pair` is
+    absent from the dict -- indexing into it unguarded raises KeyError before the
+    `len(close) < 2` fail-closed check ever runs.
+    """
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    _, max_date = get_timerange(full_data)
+    window = Window(
+        train_start=max_date,
+        train_end=max_date,
+        test_start=max_date + timedelta(days=1),
+        test_end=max_date + timedelta(days=2),
+    )
+
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [window])
+
+    # single-window input: median vol is that window's own (degenerate) vol of 0.0,
+    # so 0.0 > 0.0 is False -- deterministically "Low", same as the 1-candle case.
+    assert labels == ["Sideways/Low"]
+
+
+def test_classify_regimes_raises_on_empty_windows():
+    with pytest.raises(ValueError, match="windows"):
+        classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [])
+
+
+def test_classify_regimes_handles_exactly_2_candle_window_without_nan_poisoning():
+    """Regression test: exactly 2 candles produce 1 pct_change, which has undefined
+    sample std (NaN with ddof=1). This NaN must not poison np.median(vols) for the
+    entire call.
+    """
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe=TIMEFRAME, pairs=[PAIR])
+    min_date, max_date = get_timerange(full_data)
+
+    # Create a window that spans exactly 2 candles:
+    # history.load_data's timerange is inclusive on both ends, so to get exactly 2 candles
+    # (at t=0 and t=5min), test_end must be < t=10min. Using t=5min+1sec ensures exactly 2.
+    two_candle_window = Window(
+        train_start=min_date,
+        train_end=min_date,
+        test_start=min_date,
+        test_end=min_date + timedelta(minutes=5, seconds=1),  # spans exactly 2 candles
+    )
+
+    # Also create a normal multi-candle window to check it's not affected
+    # This spans from after the 2-candle window to the end
+    normal_window = Window(
+        train_start=min_date + timedelta(minutes=5, seconds=1),
+        train_end=min_date + timedelta(minutes=5, seconds=1),
+        test_start=min_date + timedelta(minutes=5, seconds=1),
+        test_end=max_date,
+    )
+
+    # Classify both windows together
+    labels = classify_regimes(PAIR, TIMEFRAME, TESTDATADIR, [two_candle_window, normal_window])
+
+    # 2-candle window should have "Low" volatility (fail-closed)
+    assert labels[0].endswith("/Low"), f"2-candle window volatility should be Low, got {labels[0]}"
+
+    # The normal window must NOT be forced to "Low" by a poisoned NaN median.
+    # With vols = [0.0, v] for v > 0, np.median gives median_vol = v/2 (not 0.0 --
+    # np.median averages the two middle values of an even-length list). The real-vol
+    # window's v > v/2 is True -> "High"; the degenerate window's 0.0 > v/2 is False ->
+    # "Low".
+    # The buggy code (unguarded .std() on 1 pct_change = NaN) forces labels[1] to
+    # "Low", while the fixed code correctly labels it "High".
+    assert labels[1].endswith("/High"), (
+        f"Normal window should be High volatility (not NaN-poisoned), got {labels[1]}"
+    )
+
+    # Verify no exception was raised
+    assert len(labels) == 2
+
+
+_DUMMY_WINDOW = Window(
+    train_start=datetime(2020, 1, 1, tzinfo=UTC),
+    train_end=datetime(2020, 1, 8, tzinfo=UTC),
+    test_start=datetime(2020, 1, 8, tzinfo=UTC),
+    test_end=datetime(2020, 1, 15, tzinfo=UTC),
+)
+
+
+def test_regime_report_aggregates_by_label():
+    wr_a1 = WindowResult(
+        window=_DUMMY_WINDOW,
+        variant_returns={},
+        best_params={},
+        train_sharpe=0.0,
+        test_sharpe=1.0,
+        test_n_trades=3,
+        test_returns=[0.01, 0.02, -0.01],
+    )
+    wr_a2 = WindowResult(
+        window=_DUMMY_WINDOW,
+        variant_returns={},
+        best_params={},
+        train_sharpe=0.0,
+        test_sharpe=2.0,
+        test_n_trades=2,
+        test_returns=[0.03, 0.04],
+    )
+    wr_b1 = WindowResult(
+        window=_DUMMY_WINDOW,
+        variant_returns={},
+        best_params={},
+        train_sharpe=0.0,
+        test_sharpe=-1.0,
+        test_n_trades=5,
+        test_returns=[-0.05, -0.02, 0.01, -0.03, -0.01],
+    )
+
+    report = regime_report([wr_a1, wr_a2, wr_b1], ["Bull/High", "Bull/High", "Bear/Low"])
+
+    assert set(report) == {"Bull/High", "Bear/Low"}
+    assert report["Bull/High"]["n_windows"] == 2
+    assert report["Bull/High"]["n_trades"] == 5
+    assert report["Bull/High"]["mean_test_sharpe"] == pytest.approx(1.5)
+    assert report["Bull/High"]["total_return"] == pytest.approx(0.01 + 0.02 - 0.01 + 0.03 + 0.04)
+    assert report["Bear/Low"]["n_windows"] == 1
+    assert report["Bear/Low"]["n_trades"] == 5
+    assert report["Bear/Low"]["mean_test_sharpe"] == pytest.approx(-1.0)
+    assert report["Bear/Low"]["total_return"] == pytest.approx(-0.05 - 0.02 + 0.01 - 0.03 - 0.01)
+
+
+def test_regime_report_raises_on_mismatched_lengths():
+    wr = WindowResult(
+        window=_DUMMY_WINDOW,
+        variant_returns={},
+        best_params={},
+        train_sharpe=0.0,
+        test_sharpe=1.0,
+        test_n_trades=1,
+        test_returns=[0.01],
+    )
+    with pytest.raises(ValueError, match="same length"):
+        regime_report([wr], ["Bull/High", "Bear/Low"])

--- a/research/tests/test_scoring.py
+++ b/research/tests/test_scoring.py
@@ -1,0 +1,272 @@
+# research/tests/test_scoring.py
+import pytest
+
+from research.gate import GateResult
+from research.scoring import WEIGHTS, robustness_score, strategy_report
+
+
+def _core_result(deflated_sharpe=0.90, permutation_p=0.02, pbo=0.15, passed=True, **kwargs):
+    """A GateResult with only the three always-present statistics populated,
+    unless overridden."""
+    return GateResult(
+        strategy_id="TestStrategy",
+        passed=passed,
+        deflated_sharpe=deflated_sharpe,
+        permutation_p=permutation_p,
+        pbo=pbo,
+        mean_test_sharpe=1.1,
+        n_trials=10,
+        reasons=[],
+        **kwargs,
+    )
+
+
+def test_robustness_score_with_only_core_stats():
+    result = _core_result()
+
+    score = robustness_score(result)
+
+    # Independently computed, not calling robustness_score recursively.
+    weighted_sum = (
+        WEIGHTS["deflated_sharpe"] * 0.90
+        + WEIGHTS["significance"] * (1.0 - 0.02)
+        + WEIGHTS["pbo_inverse"] * (1.0 - 0.15)
+    )
+    weight_total = WEIGHTS["deflated_sharpe"] + WEIGHTS["significance"] + WEIGHTS["pbo_inverse"]
+    assert score == pytest.approx(weighted_sum / weight_total)
+    assert score == pytest.approx(0.9088235294117647)
+
+
+def test_robustness_score_includes_cost_sensitivity_when_fee_sensitivity_present():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.8, "deflated_sharpe": 0.90, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.4, "deflated_sharpe": 0.60, "n_windows": 5},
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8833333333333333)
+
+
+def test_robustness_score_includes_regime_consistency_when_regime_breakdown_present():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2,
+                "n_trades": 10,
+                "mean_test_sharpe": 0.5,
+                "total_return": 0.01,
+            },
+            "Bull/Low": {
+                "n_windows": 1,
+                "n_trades": 5,
+                "mean_test_sharpe": 0.3,
+                "total_return": 0.005,
+            },
+            "Bear/Low": {
+                "n_windows": 1,
+                "n_trades": 4,
+                "mean_test_sharpe": 0.1,
+                "total_return": 0.002,
+            },
+            "Bear/High": {
+                "n_windows": 1,
+                "n_trades": 3,
+                "mean_test_sharpe": -0.2,
+                "total_return": -0.004,
+            },
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.9)
+
+
+def test_robustness_score_with_both_fee_sensitivity_and_regime_breakdown():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.8, "deflated_sharpe": 0.90, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.4, "deflated_sharpe": 0.60, "n_windows": 5},
+        },
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2,
+                "n_trades": 10,
+                "mean_test_sharpe": 0.5,
+                "total_return": 0.01,
+            },
+            "Bull/Low": {
+                "n_windows": 1,
+                "n_trades": 5,
+                "mean_test_sharpe": 0.3,
+                "total_return": 0.005,
+            },
+            "Bear/Low": {
+                "n_windows": 1,
+                "n_trades": 4,
+                "mean_test_sharpe": 0.1,
+                "total_return": 0.002,
+            },
+            "Bear/High": {
+                "n_windows": 1,
+                "n_trades": 3,
+                "mean_test_sharpe": -0.2,
+                "total_return": -0.004,
+            },
+        },
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8766666666666667)
+
+
+def test_robustness_score_cost_sensitivity_single_multiplier_is_one():
+    result = _core_result(
+        fee_sensitivity={1.0: {"mean_test_sharpe": 0.5, "deflated_sharpe": 0.5, "n_windows": 5}}
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.9184210526315789)
+
+
+def test_robustness_score_cost_sensitivity_zero_baseline_is_zero():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.0, "deflated_sharpe": 0.0, "n_windows": 5},
+            2.0: {"mean_test_sharpe": 0.1, "deflated_sharpe": 0.3, "n_windows": 5},
+        }
+    )
+
+    score = robustness_score(result)
+
+    assert score == pytest.approx(0.8131578947368421)
+
+
+def test_robustness_score_stays_in_unit_interval():
+    worst = _core_result(deflated_sharpe=0.0, permutation_p=1.0, pbo=1.0)
+    best = _core_result(deflated_sharpe=1.0, permutation_p=0.0, pbo=0.0)
+
+    assert robustness_score(worst) == pytest.approx(0.0)
+    assert robustness_score(best) == pytest.approx(1.0)
+
+
+def test_robustness_score_renormalization_makes_scores_incomparable_across_optional_flags():
+    """Documents a deliberate, spec-approved limitation (not a bug to fix): identical
+    core statistics score differently once an optional component is added, because the
+    weighted-average denominator shifts. See the spec's "Known limitation" paragraph."""
+    without_regime = _core_result(deflated_sharpe=0.7, permutation_p=0.1, pbo=0.2)
+    with_regime = _core_result(
+        deflated_sharpe=0.7,
+        permutation_p=0.1,
+        pbo=0.2,
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 3,
+                "n_trades": 20,
+                "mean_test_sharpe": 0.6,
+                "total_return": 0.02,
+            },
+        },
+    )
+
+    assert robustness_score(without_regime) == pytest.approx(0.788235294117647)
+    assert robustness_score(with_regime) == pytest.approx(0.8)
+    assert robustness_score(without_regime) != pytest.approx(robustness_score(with_regime))
+
+
+def test_strategy_report_pass_case_shows_verdict_core_stats_and_score():
+    result = _core_result(passed=True, deflated_sharpe=0.97, permutation_p=0.01, pbo=0.1)
+
+    report = strategy_report(result)
+
+    assert "TestStrategy: PASS" in report
+    assert "robustness score" in report
+    assert "deflated_sharpe   0.970" in report
+    assert "permutation p     0.010" in report
+    assert "PBO               0.100" in report
+    assert "mean OOS sharpe   1.100" in report
+    assert "trials (ledger)   10" in report
+
+
+def test_strategy_report_fail_case_shows_reasons():
+    result = GateResult(
+        strategy_id="TestStrategy",
+        passed=False,
+        deflated_sharpe=0.4,
+        permutation_p=0.3,
+        pbo=0.7,
+        mean_test_sharpe=0.1,
+        n_trials=12,
+        reasons=["deflated_sharpe 0.400 below threshold 0.95"],
+    )
+
+    report = strategy_report(result)
+
+    assert "TestStrategy: FAIL" in report
+    assert "deflated_sharpe 0.400 below threshold 0.95" in report
+
+
+def test_strategy_report_includes_fee_sensitivity_table_when_present():
+    result = _core_result(
+        fee_sensitivity={
+            1.0: {"mean_test_sharpe": 0.87, "deflated_sharpe": 0.91, "n_windows": 5},
+            1.5: {"mean_test_sharpe": 0.33, "deflated_sharpe": 0.52, "n_windows": 5},
+        }
+    )
+
+    report = strategy_report(result)
+
+    assert "fee sensitivity" in report
+    assert "baseline" in report
+    assert "1.50x fee" in report
+    assert "slippage" not in report.lower()
+
+
+def test_strategy_report_includes_regime_breakdown_with_pair_name_when_given():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2,
+                "n_trades": 14,
+                "mean_test_sharpe": 0.42,
+                "total_return": 0.0012,
+            },
+            "Bear/Low": {
+                "n_windows": 1,
+                "n_trades": 6,
+                "mean_test_sharpe": -1.10,
+                "total_return": -0.0034,
+            },
+        }
+    )
+
+    report = strategy_report(result, pair="BTC/USDT")
+
+    assert "regime breakdown" in report
+    assert "BTC/USDT" in report
+    assert "Bull/High" in report
+    assert "Bear/Low" in report
+
+
+def test_strategy_report_omits_pair_name_when_not_given():
+    result = _core_result(
+        regime_breakdown={
+            "Bull/High": {
+                "n_windows": 2,
+                "n_trades": 14,
+                "mean_test_sharpe": 0.42,
+                "total_return": 0.0012,
+            },
+        }
+    )
+
+    report = strategy_report(result, pair=None)
+
+    assert "regime breakdown" in report
+    assert "Bull/High" in report
+    assert "(, " not in report

--- a/research/tests/test_statistics.py
+++ b/research/tests/test_statistics.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from research.statistics import benjamini_hochberg, deflated_sharpe_ratio, permutation_test
+
+
+class TestDeflatedSharpeRatio:
+    def test_returns_zero_on_degenerate_n_obs(self):
+        assert deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=1, n_trials=10) == 0.0
+
+    def test_bounded_in_unit_interval(self):
+        for sharpe in (-3.0, -0.5, 0.0, 0.5, 1.5, 3.0):
+            for n_obs in (10, 100, 1000):
+                for n_trials in (1, 10, 1000):
+                    result = deflated_sharpe_ratio(sharpe, n_obs, n_trials)
+                    assert 0.0 <= result <= 1.0, (sharpe, n_obs, n_trials, result)
+
+    def test_more_trials_never_increases_the_score(self):
+        """Regression test for the exact bug this project's spec (§16, lesson 1) flags:
+        a DSR with no real trial-count term would score n_trials=1 and n_trials=1000
+        identically. Holding sharpe and n_obs fixed, searching harder must not look
+        MORE convincing."""
+        few_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1)
+        many_trials = deflated_sharpe_ratio(sharpe_ratio=2.0, n_obs=500, n_trials=1000)
+        assert many_trials <= few_trials
+
+    def test_more_observations_never_decreases_the_score(self):
+        """Regression test for the same lesson from the other axis: a 6-trade and a
+        10,000-trade backtest must not deflate identically."""
+        few_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=20, n_trials=50)
+        many_obs = deflated_sharpe_ratio(sharpe_ratio=1.0, n_obs=5000, n_trials=50)
+        assert many_obs >= few_obs
+
+
+class TestBenjaminiHochberg:
+    def test_matches_hand_worked_example(self):
+        # sorted ascending already; thresholds are (rank/m)*q = 0.01,0.02,0.03,0.04,0.05
+        p_values = [0.01, 0.02, 0.03, 0.04, 0.5]
+        result = benjamini_hochberg(p_values, q=0.05)
+        assert result == [True, True, True, True, False]
+
+    def test_empty_input_returns_empty_output(self):
+        assert benjamini_hochberg([], q=0.05) == []
+
+    def test_all_p_values_above_q_rejects_nothing(self):
+        assert benjamini_hochberg([0.9, 0.8, 0.99], q=0.05) == [False, False, False]
+
+
+class TestPermutationTest:
+    def test_p_value_in_unit_interval(self):
+        rng = np.random.default_rng(1)
+        returns = rng.normal(0, 0.01, 40)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=200, seed=1)
+        assert 0.0 <= p <= 1.0
+
+    def test_low_p_value_for_a_strong_consistent_positive_edge(self):
+        """All-positive, low-noise returns: virtually every sign-flip permutation
+        produces a worse Sharpe than the unflipped (real) series, since flipping any
+        positive return can only hurt the mean. p must be small."""
+        rng = np.random.default_rng(42)
+        returns = 0.02 + rng.normal(0, 0.001, 30)
+        observed = float(returns.mean() / returns.std())
+        p = permutation_test(observed, returns, n_permutations=2000, seed=42)
+        assert p < 0.05
+
+    def test_seeded_calls_are_reproducible(self):
+        rng = np.random.default_rng(7)
+        returns = rng.normal(0.001, 0.02, 50)
+        observed = float(returns.mean() / returns.std())
+        p1 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        p2 = permutation_test(observed, returns, n_permutations=500, seed=123)
+        assert p1 == p2

--- a/research/tests/test_walkforward.py
+++ b/research/tests/test_walkforward.py
@@ -1,0 +1,67 @@
+# research/tests/test_walkforward.py
+from datetime import timedelta
+from pathlib import Path
+
+from freqtrade.data import history
+from freqtrade.data.history import get_timerange
+from freqtrade.enums import RunMode
+from research.walkforward import WalkForwardRunner, Window, variant_key
+from tests.conftest import get_default_conf, patch_exchange
+
+
+TESTDATADIR = Path(__file__).resolve().parents[2] / "tests" / "testdata"
+EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+def _conf():
+    conf = get_default_conf(TESTDATADIR)
+    conf["runmode"] = RunMode.BACKTEST
+    conf["max_open_trades"] = 10
+    conf["use_exit_signal"] = False
+    return conf
+
+
+def test_run_window_selects_best_train_params_and_reports_oos_result(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    param_grid = [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    result = runner.run_window(window, param_grid)
+
+    assert result.best_params in param_grid
+    assert set(result.variant_returns) == {variant_key(p) for p in param_grid}
+    assert isinstance(result.train_sharpe, float)
+    assert isinstance(result.test_sharpe, float)
+    assert isinstance(result.test_returns, list)
+    assert result.test_n_trades == len(result.test_returns)
+
+
+def test_generate_windows_are_contiguous_and_non_overlapping():
+    from datetime import UTC, datetime
+
+    from research.walkforward import generate_windows
+
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    end = datetime(2020, 3, 1, tzinfo=UTC)
+    windows = generate_windows(start, end, train_days=20, test_days=10)
+
+    assert len(windows) > 0
+    for w in windows:
+        assert w.train_end == w.test_start
+        assert w.test_end <= end
+    from itertools import pairwise
+
+    for a, b in pairwise(windows):
+        assert b.test_start == a.test_end

--- a/research/tests/test_walkforward.py
+++ b/research/tests/test_walkforward.py
@@ -1,4 +1,5 @@
 # research/tests/test_walkforward.py
+import copy
 from datetime import timedelta
 from pathlib import Path
 
@@ -65,3 +66,112 @@ def test_generate_windows_are_contiguous_and_non_overlapping():
 
     for a, b in pairwise(windows):
         assert b.test_start == a.test_end
+
+
+def test_evaluate_fixed_params_matches_run_window_for_the_winning_variant(mocker):
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    param_grid = [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    run_window_result = runner.run_window(window, param_grid)
+
+    direct_result = runner.evaluate_fixed_params(window, run_window_result.best_params)
+
+    assert direct_result.test_sharpe == run_window_result.test_sharpe
+    assert direct_result.test_returns == run_window_result.test_returns
+    assert direct_result.test_n_trades == run_window_result.test_n_trades
+    assert direct_result.variant_returns == {}
+
+    # fee_override=None and fee_override=<the config's own base fee> must be equivalent --
+    # they resolve to the same fee, just via a different code path.
+    from freqtrade.optimize.backtesting import Backtesting
+
+    base_fee = Backtesting(conf).fee
+    override_result = runner.evaluate_fixed_params(
+        window, run_window_result.best_params, fee_override=base_fee
+    )
+    assert override_result.test_sharpe == run_window_result.test_sharpe
+    assert override_result.test_returns == run_window_result.test_returns
+
+
+def test_evaluate_fixed_params_fee_override_changes_results(mocker):
+    """Fee overrides affect backtest results (P&L and/or trade count), not just realized profit.
+
+    IMPORTANT: Different fees can produce different trade counts even with identical entry signals.
+    Mechanism: freqtrade's should_exit() checks ROI profit thresholds via calc_profit_ratio(),
+    which factors in the fee. A higher fee reduces net profit, potentially delaying ROI exits and
+    preventing subsequent trades on the same pair (no parallel stacking by default). This is real,
+    verified freqtrade behavior for strategies using minimal_roi (which this fixture does, with
+    use_exit_signal=False). This is not a bug or a loosened test — it's an immutable property
+    of how freqtrade's exit timing interacts with fees.
+    """
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    params = {"buy_rsi": 25}
+
+    config_before = copy.deepcopy(runner.config)
+    cheap = runner.evaluate_fixed_params(window, params, fee_override=0.0)
+    expensive = runner.evaluate_fixed_params(window, params, fee_override=0.05)
+
+    # self.config must never be mutated by a fee_override call.
+    assert runner.config == config_before
+
+    # Fee override produces measurable result differences (Sharpe, trade count, or both).
+    assert (
+        cheap.test_sharpe != expensive.test_sharpe or cheap.test_n_trades != expensive.test_n_trades
+    )
+
+
+def test_run_window_still_works_after_the_refactor(mocker):
+    """Regression coverage: run_window's own pre-existing test already covers this,
+    but this direct check makes the refactor's intent explicit -- run_window's final
+    phase now delegates to evaluate_fixed_params rather than duplicating it."""
+    conf = _conf()
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_min_pair_stake_amount", return_value=0.00001)
+    mocker.patch(f"{EXMS}.get_max_pair_stake_amount", return_value=float("inf"))
+    mocker.patch(f"{EXMS}.get_pair_base_currency", lambda _, x: x.split("/")[0])
+
+    full_data = history.load_data(datadir=TESTDATADIR, timeframe="5m", pairs=["UNITTEST/BTC"])
+    min_date, max_date = get_timerange(full_data)
+    train_days = max(1, int((max_date - min_date).days * 0.7))
+    train_end = min_date + timedelta(days=train_days)
+    window = Window(
+        train_start=min_date, train_end=train_end, test_start=train_end, test_end=max_date
+    )
+
+    runner = WalkForwardRunner(conf, pairs=["UNITTEST/BTC"], timeframe="5m", datadir=TESTDATADIR)
+    result = runner.run_window(window, [{"buy_rsi": 25}, {"buy_rsi": 35}])
+
+    assert result.best_params in [{"buy_rsi": 25}, {"buy_rsi": 35}]
+    assert set(result.variant_returns) == {
+        variant_key({"buy_rsi": 25}),
+        variant_key({"buy_rsi": 35}),
+    }
+    assert isinstance(result.train_sharpe, float)
+    assert isinstance(result.test_sharpe, float)

--- a/research/walkforward.py
+++ b/research/walkforward.py
@@ -32,7 +32,13 @@ class WindowResult:
     """Outcome of running one `Window` through `WalkForwardRunner.run_window`:
     the train-period Sharpe of every param variant (`variant_returns`, keyed by
     `variant_key`, feeding `research.pbo`), the train-selected best params, and
-    the resulting out-of-sample (test-period) performance."""
+    the resulting out-of-sample (test-period) performance.
+
+    `evaluate_fixed_params` also returns a `WindowResult`, but a deliberately
+    partial one: no grid was searched, so `variant_returns` is always `{}` on
+    that path. `research.cost_stress` is the only intended consumer of that
+    partial form -- don't assume `variant_returns` reflects a real grid search
+    unless the `WindowResult` came from `run_window`."""
 
     window: Window
     variant_returns: dict[str, float]
@@ -82,10 +88,82 @@ class WalkForwardRunner:
         self.timeframe = timeframe
         self.datadir = datadir
 
+    def evaluate_fixed_params(
+        self, window: Window, params: dict, fee_override: float | None = None
+    ) -> WindowResult:
+        """Backtest a single, already-chosen `params` on `window` -- no grid
+        search. Used directly by `research.cost_stress.fee_sensitivity` to
+        re-evaluate an already-selected candidate at a different fee level,
+        and by `run_window` (below) for its own final test-phase step -- both
+        paths share this one implementation rather than drifting apart.
+
+        `fee_override`, when given, is used ONLY for this call's `Backtesting`
+        instance -- `self.config` is never mutated, so a stress-test fee can
+        never leak into other calls sharing this `WalkForwardRunner`.
+
+        Returns a `WindowResult` with `variant_returns={}` (no grid was
+        searched) and `train_sharpe` reflecting only `params`' own
+        train-period Sharpe (not a selection among alternatives).
+        """
+        cfg = (
+            {**deepcopy(self.config), "fee": fee_override}
+            if fee_override is not None
+            else self.config
+        )
+        backtesting = Backtesting(cfg)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        for name, value in params.items():
+            getattr(backtesting.strategy, name).value = value
+        processed = backtesting.strategy.advise_all_indicators(data)
+        processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+        train_result = backtesting.backtest(
+            processed=deepcopy(processed),
+            start_date=window.train_start,
+            end_date=window.train_end,
+        )
+        train_trades = train_result["results"]
+        train_sharpe = calculate_sharpe(
+            train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+        )
+
+        test_result = backtesting.backtest(
+            processed=deepcopy(processed),
+            start_date=window.test_start,
+            end_date=window.test_end,
+        )
+        test_trades = test_result["results"]
+        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
+        test_sharpe = calculate_sharpe(
+            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
+        )
+
+        return WindowResult(
+            window=window,
+            variant_returns={},
+            best_params=params,
+            train_sharpe=train_sharpe,
+            test_sharpe=test_sharpe,
+            test_n_trades=len(test_trades),
+            test_returns=test_returns,
+        )
+
     def run_window(self, window: Window, param_grid: list[dict]) -> WindowResult:
         """Backtest every variant in `param_grid` on `window`'s train period,
-        pick the highest-train-Sharpe variant, then backtest ONLY that variant
-        on the test period.
+        pick the highest-train-Sharpe variant, then evaluate ONLY that variant
+        on the test period via `evaluate_fixed_params`.
 
         This ordering is the load-bearing invariant: parameter selection is
         strictly train-only. Test-period data is never touched until after
@@ -120,7 +198,6 @@ class WalkForwardRunner:
         variant_returns: dict[str, float] = {}
         best_sharpe = -np.inf
         best_params: dict | None = None
-        best_processed: dict | None = None
 
         for params in param_grid:
             for name, value in params.items():
@@ -160,34 +237,29 @@ class WalkForwardRunner:
             )
 
             if sharpe > best_sharpe:
-                best_sharpe, best_params, best_processed = sharpe, params, processed
+                best_sharpe, best_params = sharpe, params
 
-        if best_params is None or best_processed is None:
+        if best_params is None:
             raise RuntimeError(
                 "no param variant produced a result"
             )  # unreachable: param_grid non-empty
-        for name, value in best_params.items():
-            getattr(backtesting.strategy, name).value = value
-        test_result = backtesting.backtest(
-            processed=deepcopy(best_processed),
-            start_date=window.test_start,
-            end_date=window.test_end,
-        )
-        test_trades = test_result["results"]
-        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
-        test_sharpe = calculate_sharpe(
-            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
-        )
 
-        return WindowResult(
-            window=window,
-            variant_returns=variant_returns,
-            best_params=best_params,
-            train_sharpe=best_sharpe,
-            test_sharpe=test_sharpe,
-            test_n_trades=len(test_trades),
-            test_returns=test_returns,
-        )
+        # ponytail: this recomputes data + indicators for the winning variant a
+        # second time (evaluate_fixed_params does its own history.load_data +
+        # advise_all_indicators call) rather than reusing the grid loop's
+        # already-computed `processed` dataframe for that variant, AND
+        # evaluate_fixed_params also runs a train-period backtest whose result
+        # (train_sharpe) is discarded immediately below (overwritten with the
+        # grid search's own best_sharpe) -- so the actual duplicate cost here
+        # is data + indicators + one full (train-period) backtest, not just
+        # data + indicators. Trades a small, deterministic amount of duplicate
+        # work for one shared, single-tested code path between run_window and
+        # evaluate_fixed_params (see the fee-sensitivity design doc) --
+        # revisit only if this becomes a measured bottleneck.
+        result = self.evaluate_fixed_params(window, best_params)
+        result.variant_returns = variant_returns
+        result.train_sharpe = best_sharpe
+        return result
 
     def run(self, windows: list[Window], param_grid: list[dict]) -> list[WindowResult]:
         """Run `run_window` over every window in sequence and collect results."""

--- a/research/walkforward.py
+++ b/research/walkforward.py
@@ -1,0 +1,194 @@
+# research/walkforward.py
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+
+from freqtrade.configuration import TimeRange
+from freqtrade.data import history
+from freqtrade.data.converter import trim_dataframes
+from freqtrade.data.metrics import calculate_sharpe
+from freqtrade.optimize.backtesting import Backtesting
+
+
+@dataclass
+class Window:
+    """One walk-forward train/test period. `test_start` always equals
+    `train_end`; see `generate_windows` for how consecutive windows relate."""
+
+    train_start: datetime
+    train_end: datetime
+    test_start: datetime
+    test_end: datetime
+
+
+@dataclass
+class WindowResult:
+    """Outcome of running one `Window` through `WalkForwardRunner.run_window`:
+    the train-period Sharpe of every param variant (`variant_returns`, keyed by
+    `variant_key`, feeding `research.pbo`), the train-selected best params, and
+    the resulting out-of-sample (test-period) performance."""
+
+    window: Window
+    variant_returns: dict[str, float]
+    best_params: dict
+    train_sharpe: float
+    test_sharpe: float
+    test_n_trades: int
+    test_returns: list[float]
+
+
+def variant_key(params: dict) -> str:
+    """Canonical, order-independent string key for a param-variant dict, used
+    to identify the same variant across windows (e.g. in `variant_returns`)."""
+    return json.dumps(params, sort_keys=True)
+
+
+def generate_windows(
+    start: datetime, end: datetime, train_days: int, test_days: int
+) -> list[Window]:
+    """Rolling, contiguous windows: each window's test period starts exactly
+    where its train period ends, and test periods are gapless across windows
+    (the next window's test period starts exactly where the previous
+    window's test period ended). Cursor advances by test_days each step, so
+    every day in [start, end) is covered by at most one window's OOS test
+    period, maximizing out-of-sample statistical power for Task 5's
+    DSR/permutation-test/PBO evaluation."""
+    windows: list[Window] = []
+    cursor = start
+    while True:
+        train_end = cursor + timedelta(days=train_days)
+        test_end = train_end + timedelta(days=test_days)
+        if test_end > end:
+            break
+        windows.append(Window(cursor, train_end, train_end, test_end))
+        cursor = cursor + timedelta(days=test_days)
+    return windows
+
+
+class WalkForwardRunner:
+    """Runs a strategy through freqtrade's `Backtesting` engine across a series
+    of walk-forward windows, selecting the best param variant on each window's
+    train period and evaluating it on that window's held-out test period."""
+
+    def __init__(self, config: dict, pairs: list[str], timeframe: str, datadir: Path):
+        self.config = config
+        self.pairs = pairs
+        self.timeframe = timeframe
+        self.datadir = datadir
+
+    def run_window(self, window: Window, param_grid: list[dict]) -> WindowResult:
+        """Backtest every variant in `param_grid` on `window`'s train period,
+        pick the highest-train-Sharpe variant, then backtest ONLY that variant
+        on the test period.
+
+        This ordering is the load-bearing invariant: parameter selection is
+        strictly train-only. Test-period data is never touched until after
+        `best_params` is fixed, so no parameter choice can be informed by data
+        it will later be scored against -- the test-period Sharpe this returns
+        is a genuine out-of-sample estimate, not a look-ahead-contaminated one.
+
+        Indicators are (re)computed per param variant over the full
+        [train_start, test_end] span before either backtest call (freqtrade's
+        own convention), which is safe for backward-looking, row-local
+        indicators but can leak test-period information into train-period
+        selection for non-causal or DataFrame-wide-normalized indicators --
+        see the inline note below.
+        """
+        backtesting = Backtesting(self.config)
+        backtesting._set_strategy(backtesting.strategylist[0])
+
+        timerange = TimeRange(
+            "date", "date", int(window.train_start.timestamp()), int(window.test_end.timestamp())
+        )
+        data = history.load_data(
+            datadir=self.datadir,
+            timeframe=self.timeframe,
+            pairs=self.pairs,
+            timerange=timerange,
+            startup_candles=backtesting.required_startup,
+        )
+
+        if not param_grid:
+            raise ValueError("param_grid must not be empty")
+
+        variant_returns: dict[str, float] = {}
+        best_sharpe = -np.inf
+        best_params: dict | None = None
+        best_processed: dict | None = None
+
+        for params in param_grid:
+            for name, value in params.items():
+                getattr(backtesting.strategy, name).value = value
+
+            # ponytail: indicators are (re)computed per param variant over
+            # [train_start, test_end], per freqtrade's own convention (§3 of the
+            # architecture doc). Safe for backward-looking, row-local indicators
+            # (this strategy's RSI); two families of indicator would leak
+            # test-period information into the train-period parameter selection
+            # done below even though they're "backward-looking" in the naive
+            # sense: (1) a non-causal indicator (centered rolling, .shift(-n)),
+            # and (2) any indicator normalized against a DataFrame-wide
+            # statistic (global z-score, min/max scaling, global percentile
+            # rank) computed over the whole [train_start, test_end] span, since
+            # that statistic itself is contaminated by test-period rows. Run
+            # freqtrade's lookahead-analysis (and audit for global
+            # normalization) on any strategy before trusting this runner's
+            # results for it.
+            processed = backtesting.strategy.advise_all_indicators(data)
+            processed = trim_dataframes(processed, timerange, backtesting.required_startup)
+
+            train_result = backtesting.backtest(
+                processed=deepcopy(processed),
+                start_date=window.train_start,
+                end_date=window.train_end,
+            )
+            train_trades = train_result["results"]
+            sharpe = calculate_sharpe(
+                train_trades, window.train_start, window.train_end, self.config["dry_run_wallet"]
+            )
+            key = variant_key(params)
+            variant_returns[key] = (
+                float((train_trades["profit_abs"] / self.config["dry_run_wallet"]).mean())
+                if len(train_trades)
+                else 0.0
+            )
+
+            if sharpe > best_sharpe:
+                best_sharpe, best_params, best_processed = sharpe, params, processed
+
+        if best_params is None or best_processed is None:
+            raise RuntimeError(
+                "no param variant produced a result"
+            )  # unreachable: param_grid non-empty
+        for name, value in best_params.items():
+            getattr(backtesting.strategy, name).value = value
+        test_result = backtesting.backtest(
+            processed=deepcopy(best_processed),
+            start_date=window.test_start,
+            end_date=window.test_end,
+        )
+        test_trades = test_result["results"]
+        test_returns = (test_trades["profit_abs"] / self.config["dry_run_wallet"]).tolist()
+        test_sharpe = calculate_sharpe(
+            test_trades, window.test_start, window.test_end, self.config["dry_run_wallet"]
+        )
+
+        return WindowResult(
+            window=window,
+            variant_returns=variant_returns,
+            best_params=best_params,
+            train_sharpe=best_sharpe,
+            test_sharpe=test_sharpe,
+            test_n_trades=len(test_trades),
+            test_returns=test_returns,
+        )
+
+    def run(self, windows: list[Window], param_grid: list[dict]) -> list[WindowResult]:
+        """Run `run_window` over every window in sequence and collect results."""
+        return [self.run_window(w, param_grid) for w in windows]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from freqtrade.data.converter import ohlcv_to_dataframe, trades_list_to_df
 from freqtrade.enums import CandleType, MarginMode, SignalDirection, TradingMode
 from freqtrade.exchange import Exchange, timeframe_to_minutes, timeframe_to_seconds
 from freqtrade.freqtradebot import FreqtradeBot
-from freqtrade.persistence import LocalTrade, Order, Trade, init_db
+from freqtrade.persistence import LocalTrade, Order, Trade, enable_database_use, init_db
 from freqtrade.persistence.custom_data import _CustomData
 from freqtrade.resolvers import ExchangeResolver
 from freqtrade.system import set_mp_start_method
@@ -46,6 +46,10 @@ from tests.conftest_trades_usdt import (
 )
 
 
+# pytester spawns isolated sub-runs; used by test_use_db_flag_leak.py to test fixture
+# behavior across a test boundary, which can't be observed within a single test body.
+pytest_plugins = ["pytester"]
+
 logging.getLogger("").setLevel(logging.INFO)
 
 
@@ -55,6 +59,25 @@ np.seterr(all="raise")
 CURRENT_TEST_STRATEGY = "StrategyTestV3"
 TRADE_SIDES = ("long", "short")
 EXMS = "freqtrade.exchange.exchange.Exchange"
+
+
+@pytest.fixture(autouse=True)
+def reset_use_db_flags():
+    """
+    Several tests toggle Trade.use_db (and PairLocks/CustomDataWrapper's use_db) with a
+    bare assignment instead of the exception-safe FtNoDBContext, and/or add to
+    LocalTrade.bt_trades & friends without a guaranteed matching Trade.reset_trades().
+    If the test raises before resetting either one, the state -- class attributes, not
+    per-test state -- stays dirty for every later test sharing this pytest-xdist worker
+    process: a disabled use_db flag silently routes queries to the shared
+    LocalTrade.trades list instead of each test's own per-test DB, and leftover
+    bt_trades bleed stale trades into unrelated tests. This runs unconditionally after
+    every test (pytest guarantees generator-fixture teardown runs even when the test
+    body raised) to guard against both leaks regardless of which test causes them.
+    """
+    yield
+    enable_database_use()
+    Trade.reset_trades()
 
 
 def pytest_addoption(parser):

--- a/tests/persistence/test_use_db_flag_leak.py
+++ b/tests/persistence/test_use_db_flag_leak.py
@@ -1,0 +1,70 @@
+"""
+Regression test for a leaked-global-state bug: several tests toggle
+``Trade.use_db = False`` (and friends) with a bare assignment instead of the
+exception-safe ``FtNoDBContext``. If anything between the ``False`` and the
+matching ``= True`` raises, the flag is never restored -- and because
+``Trade.use_db`` is a class attribute, not a per-test fixture, it stays
+``False`` for every later test that shares the same pytest-xdist worker
+process. That single leaked flag was the root cause of dozens of unrelated
+CI failures (``Trade.get_trades() not supported in backtesting mode``, empty
+query results, stale trades from other tests) once CI started running with
+the project's real ``--random-order -n auto`` recipe.
+
+This uses pytest's own ``pytester`` fixture to spawn an isolated sub-run
+that imports the real ``reset_use_db_flags`` autouse fixture from
+``tests/conftest.py``, because the property under test -- "state leaked by
+a failing test does not survive into the next test in the same process" --
+can only be observed across a test boundary, not within a single test body.
+"""
+
+
+def test_reset_use_db_flags_fixture_prevents_the_leak(pytester):
+    pytester.makepyfile(
+        test_leak="""
+            # Importing this registers the autouse fixture in this module.
+            from tests.conftest import reset_use_db_flags  # noqa: F401
+
+            from freqtrade.persistence import Trade
+
+            def test_a_disables_use_db_then_fails():
+                Trade.use_db = False
+                assert False, "simulates a test that fails before resetting the flag"
+
+            def test_b_expects_use_db_enabled():
+                assert Trade.use_db is True
+        """
+    )
+
+    result = pytester.runpytest()
+
+    # test_a still fails as designed; test_b must see a properly reset flag,
+    # not the False left behind by test_a.
+    result.assert_outcomes(failed=1, passed=1)
+
+
+def test_reset_use_db_flags_fixture_also_clears_backtest_trade_state(pytester):
+    """
+    Sibling leak: LocalTrade.bt_trades / bt_trades_open / bt_trades_open_pp /
+    bt_open_open_trade_count / bt_total_profit are the same kind of class-level
+    mutable state as Trade.use_db, only cleared by an explicit (and equally
+    unguarded) Trade.reset_trades() call in a handful of tests.
+    """
+    pytester.makepyfile(
+        test_leak="""
+            # Importing this registers the autouse fixture in this module.
+            from tests.conftest import reset_use_db_flags  # noqa: F401
+
+            from freqtrade.persistence import LocalTrade
+
+            def test_a_adds_a_backtest_trade_then_fails():
+                LocalTrade.bt_trades.append(object())
+                assert False, "simulates a test that fails before resetting bt state"
+
+            def test_b_expects_clean_backtest_trade_state():
+                assert LocalTrade.bt_trades == []
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(failed=1, passed=1)

--- a/user_data/strategies/EmaTrendFollow.py
+++ b/user_data/strategies/EmaTrendFollow.py
@@ -1,0 +1,67 @@
+"""EMA crossover trend-following strategy, filtered by a long-term trend regime EMA.
+
+Research hypothesis, not an assumed edge -- BTC/USDT, 1h, meant to be run through the
+research/ package's statistical validation gate (walk-forward + Deflated Sharpe Ratio +
+Benjamini-Hochberg FDR + Probability of Backtest Overfitting) before ever touching paper
+money. Designed and cross-checked with ChatGPT/Gemini via lmchatbot; see conversation for
+the full design rationale.
+
+Entry:  ema_fast crosses above ema_slow AND close is above ema_trend (trend regime filter)
+Exit:   ema_fast crosses below ema_slow (no trend filter on exit)
+
+The EMA period Parameters below use optimize=False and are read via .value directly inside
+populate_indicators() -- this is deliberately NOT meant for freqtrade's own native hyperopt
+(which expects a different, .range-based access pattern for that use case). Parameter
+search for this strategy is owned by the external research/ package
+(research/walkforward.py's WalkForwardRunner), which re-instantiates indicators fresh for
+each grid point by setting `.value` directly and recomputing -- exactly the access pattern
+used here.
+"""
+
+import talib.abstract as ta
+from pandas import DataFrame
+from technical import qtpylib
+
+from freqtrade.strategy import IntParameter, IStrategy
+
+
+class EmaTrendFollow(IStrategy):
+    INTERFACE_VERSION = 3
+
+    timeframe = "1h"
+
+    # ROI disabled -- let the crossover exit and stoploss handle position exits, so the
+    # backtest measures the strategy's raw signal edge rather than a hardcoded profit target.
+    minimal_roi = {}
+
+    # Fixed risk-control constant for this first experiment (not a tuned/gridded parameter
+    # yet) -- there is no literature-canonical stoploss for BTC 1h; -8% is a loose guardrail.
+    stoploss = -0.08
+
+    # EMA(200) needs 200 candles of history before its value is meaningful.
+    startup_candle_count = 200
+
+    ema_fast = IntParameter(5, 20, default=12, space="buy", optimize=False)
+    ema_slow = IntParameter(20, 50, default=26, space="buy", optimize=False)
+    ema_trend = IntParameter(100, 300, default=200, space="buy", optimize=False)
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe["ema_fast"] = ta.EMA(dataframe, timeperiod=self.ema_fast.value)
+        dataframe["ema_slow"] = ta.EMA(dataframe, timeperiod=self.ema_slow.value)
+        dataframe["ema_trend"] = ta.EMA(dataframe, timeperiod=self.ema_trend.value)
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            qtpylib.crossed_above(dataframe["ema_fast"], dataframe["ema_slow"])
+            & (dataframe["close"] > dataframe["ema_trend"]),
+            "enter_long",
+        ] = 1
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            qtpylib.crossed_below(dataframe["ema_fast"], dataframe["ema_slow"]),
+            "exit_long",
+        ] = 1
+        return dataframe

--- a/user_data/strategies/tests/test_ema_trend_follow.py
+++ b/user_data/strategies/tests/test_ema_trend_follow.py
@@ -1,0 +1,107 @@
+"""TDD tests for EmaTrendFollow, run directly against real indicator computation.
+
+Expected signal locations are derived programmatically from the strategy's own computed
+EMA columns (never hand-calculated), then compared row-for-row against the strategy's
+actual enter_long/exit_long columns. Each fixture also asserts it actually exercises the
+case it claims to (a nonzero count of crossings) so a passing test can't be vacuous.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from EmaTrendFollow import EmaTrendFollow
+
+
+def _levels_to_df(levels: list[float]) -> pd.DataFrame:
+    n = len(levels)
+    dates = pd.date_range(start="2020-01-01", periods=n, freq="1h", tz="UTC")
+    close = pd.Series(levels, dtype=float)
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "open": close,
+            "high": close + 0.01,
+            "low": close - 0.01,
+            "close": close,
+            "volume": 1000.0,
+        }
+    )
+
+
+def _flat(level: float, n: int) -> list[float]:
+    return [level] * n
+
+
+def _ramp(start: float, end: float, n: int) -> list[float]:
+    step = (end - start) / n
+    return [start + step * i for i in range(1, n + 1)]
+
+
+def _run_strategy(levels: list[float]) -> pd.DataFrame:
+    strategy = EmaTrendFollow({"stake_currency": "USDT", "strategy": "EmaTrendFollow"})
+    dataframe = _levels_to_df(levels)
+    metadata = {"pair": "BTC/USDT"}
+    dataframe = strategy.populate_indicators(dataframe, metadata)
+    dataframe = strategy.populate_entry_trend(dataframe, metadata)
+    dataframe = strategy.populate_exit_trend(dataframe, metadata)
+    # populate_entry_trend/populate_exit_trend only set 1 where a signal fires (matching
+    # freqtrade's own strategy convention, see StrategyTestV3) -- everywhere else is NaN,
+    # which freqtrade's own `dataframe["enter_long"] == 1` checks treat identically to 0
+    # ("no signal"). Normalize to int(0/1) here so the test can compare directly.
+    for col in ("enter_long", "exit_long"):
+        dataframe[col] = dataframe[col].fillna(0).astype(int)
+    return dataframe
+
+
+def _expected_cross_up(df: pd.DataFrame) -> pd.Series:
+    fast, slow = df["ema_fast"], df["ema_slow"]
+    return (fast > slow) & (fast.shift(1) <= slow.shift(1))
+
+
+def _expected_cross_down(df: pd.DataFrame) -> pd.Series:
+    fast, slow = df["ema_fast"], df["ema_slow"]
+    return (fast < slow) & (fast.shift(1) >= slow.shift(1))
+
+
+def test_enters_on_ema_crossover_above_trend_filter_and_exits_on_reverse_crossover():
+    # Long flat warmup so EMA200 fully settles at 100, then a sustained rally (fast EMA
+    # crosses above slow EMA while price is already above the barely-moved EMA200), then
+    # a symmetric decline back down (fast EMA crosses back below slow EMA).
+    levels = _flat(100.0, 250) + _ramp(100.0, 180.0, 40) + _ramp(180.0, 100.0, 40)
+    df = _run_strategy(levels)
+
+    expected_up = _expected_cross_up(df)
+    expected_down = _expected_cross_down(df)
+    expected_entry = expected_up & (df["close"] > df["ema_trend"])
+
+    assert expected_up.sum() >= 1, "fixture must contain at least one bullish EMA crossover"
+    assert expected_down.sum() >= 1, "fixture must contain at least one bearish EMA crossover"
+
+    assert (df["enter_long"] == expected_entry.astype(int)).all()
+    assert (df["exit_long"] == expected_down.astype(int)).all()
+    assert df["enter_long"].sum() >= 1
+    assert df["exit_long"].sum() >= 1
+
+
+def test_crossover_below_trend_filter_does_not_enter():
+    # High flat warmup (EMA200 settles at 300), a long decline, then a modest local
+    # bounce -- enough to flip the fast/slow EMA crossover, but EMA200 (barely moved from
+    # 300 over this short a decline) stays far above the bounce's price level.
+    levels = _flat(300.0, 250) + _ramp(300.0, 120.0, 60) + _ramp(120.0, 220.0, 40)
+    df = _run_strategy(levels)
+
+    expected_up = _expected_cross_up(df)
+    expected_entry = expected_up & (df["close"] > df["ema_trend"])
+
+    assert expected_up.sum() >= 1, "fixture must contain a bullish EMA crossover to be blocked"
+    assert (df.loc[expected_up, "close"] <= df.loc[expected_up, "ema_trend"]).all(), (
+        "fixture must place the crossover below the trend filter to test blocking"
+    )
+
+    assert (df["enter_long"] == expected_entry.astype(int)).all()
+    assert df["enter_long"].sum() == 0


### PR DESCRIPTION
## Summary

Adds a paper-trading promotion tracker for the research/validation package: a state
machine that carries a gate-passing candidate from `PASSED_GATE` through
`PAPER_TRADING` to a `LIVE_ELIGIBLE` recommendation or a `REJECTED` verdict, plus a
health evaluator that reads real freqtrade dry-run trade data to make that call.

**`LIVE` is a terminal state reachable only via a direct, manual `promote_to_live()`
call — never automatically.** This is the single safety-critical invariant of the
whole feature and was independently verified end-to-end (tracing every state
assignment in the file) by two separate final reviewers.

## What's here

- `research/models.py`: new `PromotionRecord` table.
- `research/promotion.py`: `create_promotion_record`, `start_paper_trading`,
  `promote_to_live`, `reject` (Task 1 state machine), plus
  `evaluate_paper_trading_health` / `apply_health_evaluation` (Task 2 — reads real
  closed `Trade` rows from a dry-run SQLite DB via freqtrade's own `calculate_sharpe`,
  computes a degradation ratio against the candidate's original OOS Sharpe).
- `research/tests/test_promotion.py`: 20 tests, real DB/dataclass construction
  throughout, no mocking of core logic.
- `docs/superpowers/specs/2026-08-24-paper-trading-promotion-design.md` and
  `docs/superpowers/plans/2026-08-24-paper-trading-promotion.md`: the design spec and
  implementation plan this was built from.
- `FIELD-NOTES.md` (new for this repo): documents a real, confirmed-in-practice trap
  — freqtrade's `init_db()` sets `Trade.session` as global class-level state, not a
  per-call scoped session. The same bug class PR #5 already fixed once for a different
  pair of `Trade`-class globals.

## Process

Built via subagent-driven-development: fresh implementer per task, a task-scoped
review (Sonnet task reviewer + lmchatbot cross-check) and one fix round each, then a
final whole-branch review (Sonnet + lmchatbot) that specifically re-verified the LIVE
invariant across both tasks combined and independently re-derived both hand-verified
Sharpe test values from freqtrade's real `calculate_sharpe` formula.

The final review caught two real issues neither task-level review had (both were
checking against the plan's own code, not the spec directly):
- A spec-mandated connection-hygiene gap: `evaluate_paper_trading_health` wasn't
  disposing its dry-run DB engine/session after querying it. Fixed with a
  `try`/`finally`, verified against freqtrade's real `init_db` internals rather than
  guessed.
- `apply_health_evaluation` trusted `eligible=True` without cross-checking
  `enough_evidence` — added a guard immediately before the human-gated LIVE step,
  plus a regression test and one full end-to-end integration test
  (`PASSED_GATE → … → LIVE`, real functions only, no manual state injection).

Both fixes were independently re-reviewed and confirmed correct. 80/80 tests passing,
all pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)