### PR TITLE
fix: clamp ohlcv refresh time for exchanges omitting empty candles

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -523,6 +523,8 @@ If your account is required to use an operatorId, you can set it in the configur
 
 Bitvavo expects the `operatorId` to be an integer.
 
+Bitvavo does not return candles for intervals without trades. To avoid re-requesting the same data on every loop iteration for inactive pairs, freqtrade treats such pairs as refreshed up to the last closed candle. Updates for pairs without recent trades can therefore be delayed by up to one candle.
+
 ## All exchanges
 
 Should you experience constant errors with Nonce (like `InvalidNonce`), it is best to regenerate the API keys. Resetting Nonce is difficult and it's usually easier to regenerate the API keys.

--- a/freqtrade/exchange/bitvavo.py
+++ b/freqtrade/exchange/bitvavo.py
@@ -21,4 +21,5 @@ class Bitvavo(Exchange):
 
     _ft_has: FtHas = {
         "ohlcv_candle_limit": 1440,
+        "ohlcv_skip_empty_candles": True,
     }

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -140,6 +140,7 @@ class Exchange:
         "ohlcv_has_history": True,  # Some exchanges (Kraken) don't provide history via ohlcv
         "ohlcv_partial_candle": True,
         "ohlcv_require_since": False,
+        "ohlcv_skip_empty_candles": False,  # Some exchanges omit empty candles
         "download_data_parallel_quick": True,
         "always_require_api_keys": False,  # purge API keys for Dry-run. Must default to false.
         # Check https://github.com/ccxt/ccxt/issues/10767 for removal of ohlcv_volume_currency
@@ -265,6 +266,7 @@ class Exchange:
 
         # Assign this directly for easy access
         self._ohlcv_partial_candle = self._ft_has["ohlcv_partial_candle"]
+        self._ohlcv_skip_empty = self._ft_has["ohlcv_skip_empty_candles"]
 
         # Initialize ccxt objects
         ccxt_config = self._ccxt_config
@@ -2847,7 +2849,15 @@ class Exchange:
         # keeping last candle time as last refreshed time of the pair
         if ticks and cache:
             idx = -2 if drop_incomplete and len(ticks) > 1 else -1
-            self._pairs_last_refresh_time[(pair, timeframe, c_type)] = ticks[idx][0]
+            last_refresh = ticks[idx][0]
+            if self._ohlcv_skip_empty:
+                # Exchanges omitting empty candles return stale ticks for inactive pairs -
+                # clamp to the last elapsed candle, otherwise it's re-fetched every iteration.
+                last_refresh = max(
+                    last_refresh,
+                    dt_ts(timeframe_to_prev_date(timeframe)) - timeframe_to_msecs(timeframe),
+                )
+            self._pairs_last_refresh_time[(pair, timeframe, c_type)] = last_refresh
         has_cache = cache and (pair, timeframe, c_type) in self._klines
         # in case of existing cache, fill_missing happens after concatenation
         ohlcv_df = ohlcv_to_dataframe(

--- a/freqtrade/exchange/exchange_types.py
+++ b/freqtrade/exchange/exchange_types.py
@@ -27,6 +27,7 @@ class FtHas(TypedDict, total=False):
     ohlcv_has_history: bool
     ohlcv_partial_candle: bool
     ohlcv_require_since: bool
+    ohlcv_skip_empty_candles: bool
     ohlcv_volume_currency: str
     ohlcv_candle_limit_per_timeframe: dict[str, int]
     always_require_api_keys: bool

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3033,6 +3033,35 @@ def test_refresh_latest_ohlcv_cache(mocker, default_conf, candle_type, time_mach
     assert res[pair2].at[0, "open"]
 
 
+@pytest.mark.parametrize("skip_empty", [True, False])
+def test_refresh_latest_ohlcv_stale_candles(
+    mocker, default_conf_usdt, time_machine, skip_empty
+) -> None:
+    # Exchange that omits empty candles: the response ends long before "now".
+    # With ohlcv_skip_empty_candles the pair must be marked refreshed up to the last
+    # closed candle, so no re-fetch happens within the same candle interval.
+    now = datetime(2024, 1, 15, 12, 5, 0, tzinfo=UTC)
+    time_machine.move_to(now)
+    ohlcv = generate_test_data_raw("5m", 3, "2024-01-15 11:20")
+    expected_last_closed = dt_ts(timeframe_to_prev_date("5m")) - timeframe_to_msecs("5m")
+
+    exchange = get_patched_exchange(mocker, default_conf_usdt)
+    exchange._set_startup_candle_count(default_conf_usdt)
+    exchange._ohlcv_skip_empty = skip_empty
+    exchange._api_async.fetch_ohlcv = AsyncMock(return_value=ohlcv)
+    pair = ("BTC/USDT", "5m", CandleType.SPOT)
+
+    exchange.refresh_latest_ohlcv([pair])
+    exchange.refresh_latest_ohlcv([pair])
+
+    expected_calls = 1 if skip_empty else 2
+    assert exchange._api_async.fetch_ohlcv.call_count == expected_calls
+    if skip_empty:
+        assert exchange._pairs_last_refresh_time[pair] == expected_last_closed
+    else:
+        assert exchange._pairs_last_refresh_time[pair] == ohlcv[-2][0]
+
+
 def test_refresh_ohlcv_with_cache(mocker, default_conf, time_machine) -> None:
     start = datetime(2021, 8, 1, 0, 0, 0, 0, tzinfo=UTC)
     ohlcv = generate_test_data_raw("1h", 100, start.strftime("%Y-%m-%d"))


### PR DESCRIPTION
## Summary

Exchanges that do not return candles for intervals without trades (Bitvavo, and possibly others) left pairs with no recent trades stuck in a re-fetch loop: one candle-history REST call on every bot iteration. This PR adds an exchange flag that treats such a stale response as refreshed up to the last closed candle.

Solve the issue: #13479

## Quick changelog

- Add `ohlcv_skip_empty_candles` ft_has flag (default `false`), enabled for Bitvavo
- When set, clamp the stored ohlcv refresh time to the open time of the last fully elapsed candle
- Document the behavior (and the possible one-candle delay for inactive pairs) in the Bitvavo section of docs/exchanges.md

## What's new?

For pairs with no recent trades, an exchange like Bitvavo answers the ohlcv request with candles that end long before "now". `_process_ohlcv_df` stored the last tick timestamp as the pair's refresh time, so it never advanced, `_now_is_time_to_refresh` stayed true on every iteration, and each bot loop issued another candle-history call. The reporter measured roughly 650 requests per minute across 72 stuck combinations with a 119-pair whitelist, enough to trigger Bitvavo IP bans during volatile periods.

With the flag set, the stored refresh time is clamped to the open of the last fully elapsed candle (`floor(now) - timeframe`). A stale response therefore marks the pair as refreshed until the next candle boundary, and requests drop to once per interval. For exchanges whose responses already contain fresh candles the clamp computes the same value the code stored before, so behavior there is unchanged; this is why the flag defaults to false and only Bitvavo enables it.

Deliberately not done: no change to which data ends up in the dataframe cache, no change to backtesting or download-data paths (they use `cache=False` and never touch this bookkeeping), and no automatic detection of omitting exchanges - enabling the flag per exchange module follows the existing `_ft_has` convention.

Trade-off worth stating plainly: if an affected pair starts trading again mid-interval, its new candles are picked up at the next boundary instead of within seconds. Updates for such pairs can be delayed by up to one candle.

### Test plan

New regression test `test_refresh_latest_ohlcv_stale_candles` in tests/exchange/test_exchange.py, parametrized over the flag:

- With `skip_empty=True`, two consecutive `refresh_latest_ohlcv` calls within one candle issue exactly one fetch, and the stored time equals the clamped value.
- With `skip_empty=False`, behavior matches the previous code exactly (two fetches, raw timestamp stored).

Verified the test fails against the unpatched source for `skip_empty=True` (stash the exchange.py change, run, restore).

```
pytest tests/exchange/test_exchange.py tests/data/test_history.py
1470 passed, 18 skipped in 50.59s

ruff check freqtrade/exchange/exchange.py freqtrade/exchange/bitvavo.py freqtrade/exchange/exchange_types.py tests/exchange/test_exchange.py
All checks passed!

mypy freqtrade
Success: no issues found in 332 source files
```

### AI assistance disclosure

This PR was developed with the help of an AI coding tool working under my direction. I reviewed the diff line by line, ran every command above myself, verified the regression test fails before the fix, and take full responsibility for the content.
