### PR TITLE
fix: reject non-ASCII digits in timerange input

### DIFF
--- a/freqtrade/configuration/timerange.py
+++ b/freqtrade/configuration/timerange.py
@@ -165,7 +165,7 @@ class TimeRange:
         if not text:
             return 0
         for rex, fmt in _TIMERANGE_FORMATS:
-            if not re.fullmatch(rex, text):
+            if not re.fullmatch(rex, text, flags=re.ASCII):
                 continue
             if fmt is None:
                 # Epoch - in seconds (10 digits) or milliseconds (13 digits)

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -76,6 +76,11 @@ def test_parse_timerange_minutes():
     assert TimeRange("date", "date", 1274486400, 1438214400) == timerange
     assert timerange.timerange_str == "20100522-20150730"
 
+    # Start and stop may be identical
+    timerange = TimeRange.parse_timerange("20240101T1200-20240101T1200")
+    assert TimeRange("date", "date", 1704110400, 1704110400) == timerange
+    assert timerange.startts == timerange.stopts
+
     with pytest.raises(
         OperationalException, match=r"Start date is after stop date for timerange.*"
     ):
@@ -152,6 +157,15 @@ def test_parse_timerange_mixed_formats(timerange, expected, expected_str):
         "20100532T1030-",
         "20100522 1030-",
         "20100522T10:30-",
+        "20150201T1030 ",
+        " 20150201",
+        "20150201\n",
+        "12345678901",
+        "123456789012",
+        "٢٠١٥٠١٠١",
+        "２０１５۰۱۰۱",  # noqa: RUF001
+        "٢٠١٥0101-",  # noqa: RUF001
+        "١٢٣١٠٠٦٥٠٥-",
     ],
 )
 def test_parse_timerange_invalid(timerange):


### PR DESCRIPTION
## Summary

Timerange input written with non-ASCII decimal digits was silently accepted and parsed into a wrong timestamp instead of raising a configuration error.

Solve the issue: no dedicated issue; found while reviewing the timerange parsing rework in #13478

## Quick changelog

- Restrict the timerange part regex matching to ASCII digits (`re.ASCII` flag on the single `re.fullmatch` call site)
- Add regression cases to `test_parse_timerange_invalid`: whitespace variants, 11- and 12-digit epochs, Arabic-Indic and fullwidth digit inputs
- Document existing acceptance of equal start/stop with a test case

## What's new?

`\d` in Python matches any Unicode decimal digit, and `int()` accepts those digits as well, so the epoch branch of `_parse_timerange_part` happily converted e.g. an Arabic-Indic digit string into a nonsense epoch timestamp:

```
TimeRange.parse_timerange("١٢٣١٠٠٦٥٠٥-")
# pre-fix: TimeRange(20090103T181505-)  (silent wrong parse)
```

Mixed-script dates were also affected: `"٢٠١٥0101-"` (Arabic year, ASCII rest) silently parsed to 2015-01-01 before this change. Purely non-ASCII dates already failed by accident because `strptime` rejects them, but only after the regex had matched.

With `re.ASCII` on the one match call that all five format patterns flow through, every malformed or foreign-digit range now raises `OperationalException` like other invalid input. Valid ASCII formats are untouched; all previously documented forms parse identically.

The whitespace, 11/12-digit-epoch and single-script Unicode date cases already raised before this patch - they are added to pin that behavior so it does not regress when the parser is touched again. The two mixed-script / epoch-form Unicode cases are the ones that actually fail without the fix (verified by reverting the source hunk and running the file: exactly those two fail).

### Test plan

```
pytest tests/test_timerange.py -q --no-header
34 passed in 3.45s

pytest tests/test_timerange.py tests/test_arguments.py -q --no-header
60 passed in 10.63s

pytest tests/test_configuration.py -q --no-header
74 passed in 12.52s

ruff check freqtrade/configuration/timerange.py tests/test_timerange.py
All checks passed!

ruff format --check freqtrade/configuration/timerange.py tests/test_timerange.py
2 files already formatted

mypy freqtrade/configuration
Success: no issues found in 12 source files
```

### AI assistance disclosure

This PR was developed with the help of an AI coding tool working under my direction. I reviewed every line of the diff myself, ran all commands above, and verified the new cases fail against the unpatched parser.
