### PR TITLE
Add open interest data candletype

### DIFF
--- a/docs/commands/convert-data.md
+++ b/docs/commands/convert-data.md
@@ -7,7 +7,7 @@ usage: freqtrade convert-data [-h] [-v] [--no-color] [--logfile FILE] [-V]
                               [--erase] [--exchange EXCHANGE]
                               [-t TIMEFRAMES [TIMEFRAMES ...]]
                               [--trading-mode {spot,margin,futures}]
-                              [--candle-types {spot,futures,mark,index,premiumIndex,funding_rate} [{spot,futures,mark,index,premiumIndex,funding_rate} ...]]
+                              [--candle-types {spot,futures,mark,index,premiumIndex,funding_rate,open_interest} [{spot,futures,mark,index,premiumIndex,funding_rate,open_interest} ...]]
 
 options:
   -h, --help            show this help message and exit
@@ -26,7 +26,7 @@ options:
                         list. Default: `1m 5m`.
   --trading-mode, --tradingmode {spot,margin,futures}
                         Select Trading mode
-  --candle-types {spot,futures,mark,index,premiumIndex,funding_rate} [{spot,futures,mark,index,premiumIndex,funding_rate} ...]
+  --candle-types {spot,futures,mark,index,premiumIndex,funding_rate,open_interest} [{spot,futures,mark,index,premiumIndex,funding_rate,open_interest} ...]
                         Select candle type to convert. Defaults to all
                         available types.
 

--- a/docs/commands/download-data.md
+++ b/docs/commands/download-data.md
@@ -11,7 +11,7 @@ usage: freqtrade download-data [-h] [-v] [--no-color] [--logfile FILE] [-V]
                                [--data-format-ohlcv {json,jsongz,feather,parquet}]
                                [--data-format-trades {json,jsongz,feather,parquet}]
                                [--trading-mode {spot,margin,futures}]
-                               [--candle-types {spot,futures,mark,index,premiumIndex,funding_rate} [{spot,futures,mark,index,premiumIndex,funding_rate} ...]]
+                               [--candle-types {spot,futures,mark,index,premiumIndex,funding_rate,open_interest} [{spot,futures,mark,index,premiumIndex,funding_rate,open_interest} ...]]
                                [--prepend]
 
 options:
@@ -53,7 +53,7 @@ options:
                         `feather`).
   --trading-mode, --tradingmode {spot,margin,futures}
                         Select Trading mode
-  --candle-types {spot,futures,mark,index,premiumIndex,funding_rate} [{spot,futures,mark,index,premiumIndex,funding_rate} ...]
+  --candle-types {spot,futures,mark,index,premiumIndex,funding_rate,open_interest} [{spot,futures,mark,index,premiumIndex,funding_rate,open_interest} ...]
                         Select candle type to download. Defaults to the
                         necessary candles for the selected trading mode (e.g.
                         'spot' or ('futures', 'funding_rate' and 'mark') for

--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -62,6 +62,7 @@ freqtrade download-data --exchange binance --pairs ".*/USDT"
 * To use exchange, timeframe and list of pairs as defined in your configuration file, use the `-c/--config` option. With this, the script uses the whitelist defined in the config as the list of currency pairs to download data for and does not require the pairs.json file. You can combine `-c/--config` with most other options.
 * When downloading futures data (`--trading-mode futures` or a configuration specifying futures mode), freqtrade will automatically download the necessary candle types (e.g. `mark` and `funding_rate` candles) unless specified otherwise via `--candle-types`.
 * Funding rate data is stored with a `date` and a `funding_rate` column - unlike the other candle types, which use the regular OHLCV columns. Data downloaded with an older version is read transparently and rewritten in the current layout the next time it's stored, so no manual migration is needed.
+* Open interest data is not downloaded by default - request it explicitly with `--candle-types open_interest`. It is stored with a `date`, an `open_interest_amount` and an `open_interest_value` column, and is only available for futures markets on exchanges that support it.
 
 ??? Note "Permission denied errors"
     If your configuration directory `user_data` was made by docker, you may get the following error:
@@ -75,6 +76,37 @@ freqtrade download-data --exchange binance --pairs ".*/USDT"
     ```
     sudo chown -R $UID:$GID user_data
     ```
+
+### Open interest data
+
+Open interest - the total number of outstanding derivative contracts - is available for futures markets on exchanges that support it (e.g. Binance, Bybit, Gate, OKX).
+It is not part of the default download, as it's not needed to run a bot - so it has to be downloaded explicitly with `--candle-types open_interest`.
+
+``` bash
+freqtrade download-data --exchange binance --pairs BTC/USDT:USDT --timeframes 1h --trading-mode futures --candle-types open_interest
+```
+
+Unlike funding rates - which are always downloaded at the exchange's funding rate timeframe - open interest is downloaded for the timeframes you pass via `--timeframes`.
+Which timeframes an exchange offers for open interest varies, and is usually a smaller set than for regular candles.
+
+The resulting dataframe has three columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `date` | Candle start date |
+| `open_interest_amount` | Open interest denominated in the base currency |
+| `open_interest_value` | Open interest denominated in the quote currency |
+
+!!! Warning "Not every exchange reports both columns"
+    Exchanges report open interest in the base currency, the quote currency, or both - and which one can depend on the market type.
+    Bybit for example only reports `open_interest_amount` on linear markets, leaving `open_interest_value` as `NaN` for the whole dataframe.
+    Check which of the two columns actually carries data for your exchange and pairs before relying on it in a strategy.
+
+!!! Note "Limited history"
+    Exchanges keep far less open interest history than candle history - Binance for example only serves the last 30 days.
+    Downloads reaching further back will silently return no data for the missing period.
+
+Exchanges that don't provide open interest history reject the download with an explicit error, and a running bot whose strategy requests open interest on such an exchange refuses to start.
 
 ### Download additional data before the current timerange
 

--- a/docs/strategy-customization.md
+++ b/docs/strategy-customization.md
@@ -624,7 +624,9 @@ When hyperopting, use of the hyperoptable parameter `.value` attribute is not su
             None or '' (the default) resolves to the trading mode's candle type.
             Attention: Availability for non-spot/futures candle-types across exchanges may vary.
             funding_rate candles only contain the "funding_rate" column (open for historic reasons)
-            All other columns will be missing from this dataframe.
+            open_interest candles only contain the "open_interest_amount" and
+            "open_interest_value" columns.
+            All other columns will be missing from these dataframes.
         :param cache: Cache populated indicators in dry/live mode while the latest informative candle
                     remains unchanged. Entries expire after two effective informative timeframes
                     without an update. Disable for methods that use external state, have side effects,
@@ -1016,6 +1018,37 @@ Use `ffill=False` to keep the timestamps without funding empty (absolutely neces
     Funding rates used to be treated as regular candles, with the rate in `open` and `high`, `low`, `close` and `volume` all set to 0.
     `open` is still available as an alias of `funding_rate`, but the unused columns are gone.
     Please switch to `funding_rate` - the `open` alias is deprecated and will be removed in a future version.
+
+### Open Interest
+
+Historic open interest is available for futures markets on exchanges that support it, and has to be downloaded explicitly
+(see [open interest data](data-download.md#open-interest-data)).
+The dataframe contains a `date`, an `open_interest_amount` (base currency) and an `open_interest_value` (quote currency) column:
+
+``` python
+open_interest = self.dp.get_pair_dataframe(
+    pair=metadata['pair'], timeframe='1h', candle_type="open_interest"
+)
+dataframe['open_interest'] = open_interest['open_interest_amount']
+```
+
+The same works via the [informative decorator](#informative-pairs-decorator-informative), which merges the data onto your dataframe for you:
+
+``` python
+@informative('1h', candle_type='open_interest')
+def populate_indicators_oi_1h(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    dataframe['oi_change'] = dataframe['open_interest_amount'].pct_change()
+    return dataframe
+```
+
+!!! Warning "Check which column carries data"
+    Exchanges report open interest in the base currency, the quote currency, or both.
+    Bybit for example leaves `open_interest_value` as `NaN` on linear markets.
+    Both columns are always present - an all-`NaN` column means the exchange doesn't report that side, not that the download failed.
+
+!!! Note "Exchange support is checked on startup"
+    Not every exchange provides open interest history.
+    If your strategy requests a candle type the exchange cannot serve - via `@informative` or via [`informative_pairs()`](#get-data-for-non-tradeable-pairs) - the bot refuses to start, rather than running your strategy against a permanently empty dataframe.
 
 ### Send Notification
 

--- a/freqtrade/candle_columns.py
+++ b/freqtrade/candle_columns.py
@@ -3,7 +3,7 @@ Per-CandleType column schemas for stored candle data.
 
 Not every candle type is a candle. Funding rates for example carry exactly one value
 per timestamp, so storing them in the full OHLCV shape wastes four columns per row and
-gives them names that don't describe their content.
+gives them names that don't describe their content. Open interest carries two.
 
 This module is the single authority for "which columns does this candle type have".
 It is deliberately dependency-free (no pandas) so that `freqtrade.constants` can
@@ -15,6 +15,10 @@ from freqtrade.enums import CandleType
 
 OHLCV_COLUMNS = ["date", "open", "high", "low", "close", "volume"]
 _FUNDING_RATE_COLUMNS = ["date", "funding_rate"]
+# Open interest is reported in the base currency ("amount") and the quote currency ("value").
+# Which of the two an exchange fills depends on the exchange and the market - e.g. Bybit reports
+# only "amount" on linear markets - so either column can legitimately be all-NaN.
+_OPEN_INTEREST_COLUMNS = ["date", "open_interest_amount", "open_interest_value"]
 
 _OHLCV_AGG = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "max"}
 
@@ -22,18 +26,19 @@ _OHLCV_AGG = {"open": "first", "high": "max", "low": "min", "close": "last", "vo
 # Every entry must start with "date" - it is mandatory for all candle types.
 _CANDLE_TYPE_COLUMNS: dict[str, list[str]] = {
     CandleType.FUNDING_RATE: _FUNDING_RATE_COLUMNS,
+    CandleType.OPEN_INTEREST: _OPEN_INTEREST_COLUMNS,
 }
 
 # Funding rates used to be stored as OHLCV candles, with the rate in "open".
 # Old files are read through this mapping, and "open" is kept as an in-memory alias so
 # existing strategies keep working - it is not written back to disk.
-# This is the only alias there is: every other candle type stores the full OHLCV set.
+# This is the only alias there is - candle types added since are stored under their own names.
 FUNDING_RATE_LEGACY_RENAME = {"open": "funding_rate"}
 
 # Every column that can legitimately hold candle data. Used to keep such columns out of
 # dtype downcasting.
 ALL_CANDLE_VALUE_COLUMNS: frozenset[str] = frozenset(
-    {"open", "high", "low", "close", "volume", "funding_rate"}
+    {*OHLCV_COLUMNS[1:], *_FUNDING_RATE_COLUMNS[1:], *_OPEN_INTEREST_COLUMNS[1:]}
 )
 
 

--- a/freqtrade/enums/candletype.py
+++ b/freqtrade/enums/candletype.py
@@ -12,6 +12,7 @@ class CandleType(StrEnum):
 
     # TODO: Could take up less memory if these weren't a CandleType
     FUNDING_RATE = "funding_rate"
+    OPEN_INTEREST = "open_interest"
     # BORROW_RATE = "borrow_rate"  # * unimplemented
 
     @staticmethod

--- a/freqtrade/exchange/binance.py
+++ b/freqtrade/exchange/binance.py
@@ -54,6 +54,7 @@ class Binance(Exchange):
     _ft_has_futures: FtHas = {
         "ohlcv_candle_limit": 499,
         "funding_fee_candle_limit": 1000,
+        "open_interest_candle_limit": 500,
         "stoploss_order_types": {"limit": "stop", "market": "stop_market"},
         "stoploss_blocks_assets": False,  # Stoploss orders do not block assets
         "stoploss_query_requires_stop_flag": True,

--- a/freqtrade/exchange/bybit.py
+++ b/freqtrade/exchange/bybit.py
@@ -42,6 +42,7 @@ class Bybit(Exchange):
     _ft_has_futures: FtHas = {
         "ohlcv_has_history": True,
         "funding_fee_candle_limit": 200,
+        "open_interest_candle_limit": 200,
         "stoploss_on_exchange": True,
         "stoploss_order_types": {"limit": "limit", "market": "market"},
         "stoploss_blocks_assets": False,

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -527,6 +527,8 @@ class Exchange:
         fallback_val = self._ft_has.get("ohlcv_candle_limit", ccxt_val)
         if candle_type == CandleType.FUNDING_RATE:
             fallback_val = self._ft_has.get("funding_fee_candle_limit", fallback_val)
+        elif candle_type == CandleType.OPEN_INTEREST:
+            fallback_val = self._ft_has.get("open_interest_candle_limit", fallback_val)
         return int(
             self._ft_has.get("ohlcv_candle_limit_per_timeframe", {}).get(
                 timeframe, str(fallback_val)
@@ -3012,20 +3014,26 @@ class Exchange:
                 timeframe, candle_type=candle_type, since_ms=since_ms
             )
 
-            if candle_type != CandleType.FUNDING_RATE:
-                if candle_type and candle_type not in (CandleType.SPOT, CandleType.FUTURES):
-                    self.verify_candle_type_support(candle_type)
-                    params.update({"price": str(candle_type)})
-                data = await self._api_async.fetch_ohlcv(
-                    pair, timeframe=timeframe, since=since_ms, limit=candle_limit, params=params
-                )
-            else:
-                # Funding rate
+            if candle_type == CandleType.FUNDING_RATE:
                 data = await self._fetch_funding_rate_history(
                     pair=pair,
                     timeframe=timeframe,
                     limit=candle_limit,
                     since_ms=since_ms,
+                )
+            elif candle_type == CandleType.OPEN_INTEREST:
+                data = await self._fetch_open_interest_history(
+                    pair=pair,
+                    timeframe=timeframe,
+                    limit=candle_limit,
+                    since_ms=since_ms,
+                )
+            else:
+                if candle_type and candle_type not in (CandleType.SPOT, CandleType.FUTURES):
+                    self.verify_candle_type_support(candle_type)
+                    params.update({"price": str(candle_type)})
+                data = await self._api_async.fetch_ohlcv(
+                    pair, timeframe=timeframe, since=since_ms, limit=candle_limit, params=params
                 )
             # Some exchanges sort OHLCV in ASC order and others in DESC.
             # Only sort if necessary to save computing time
@@ -3080,26 +3088,38 @@ class Exchange:
         data = [[x["timestamp"], x["fundingRate"]] for x in data]
         return data
 
+    async def _fetch_open_interest_history(
+        self,
+        pair: str,
+        timeframe: str,
+        limit: int,
+        since_ms: int | None = None,
+    ) -> list[list]:
+        """
+        Fetch open interest history - used to selectively override this by subclasses.
+        """
+        data = await self._api_async.fetch_open_interest_history(
+            pair, timeframe, since=since_ms, limit=limit
+        )
+        data_res = [[x["timestamp"], x["openInterestAmount"], x["openInterestValue"]] for x in data]
+        return data_res
+
     def check_candle_type_support(self, candle_type: CandleType) -> bool:
         """
         Check that the exchange supports the given candle type.
         :param candle_type: CandleType to verify
         :return: True if supported, False otherwise
         """
-        if candle_type == CandleType.FUNDING_RATE:
-            if not self.exchange_has("fetchFundingRateHistory"):
-                return False
-        elif candle_type not in (CandleType.SPOT, CandleType.FUTURES):
-            mapping = {
-                CandleType.MARK: "fetchMarkOHLCV",
-                CandleType.INDEX: "fetchIndexOHLCV",
-                CandleType.PREMIUMINDEX: "fetchPremiumIndexOHLCV",
-                CandleType.FUNDING_RATE: "fetchFundingRateHistory",
-            }
-            _method = mapping.get(candle_type, "fetchOHLCV")
-            if not self.exchange_has(_method):
-                return False
-        return True
+        if candle_type in (CandleType.SPOT, CandleType.FUTURES):
+            return True
+        mapping = {
+            CandleType.MARK: "fetchMarkOHLCV",
+            CandleType.INDEX: "fetchIndexOHLCV",
+            CandleType.PREMIUMINDEX: "fetchPremiumIndexOHLCV",
+            CandleType.FUNDING_RATE: "fetchFundingRateHistory",
+            CandleType.OPEN_INTEREST: "fetchOpenInterestHistory",
+        }
+        return self.exchange_has(mapping.get(candle_type, "fetchOHLCV"))
 
     def verify_candle_type_support(self, candle_type: CandleType) -> None:
         """

--- a/freqtrade/exchange/exchange_types.py
+++ b/freqtrade/exchange/exchange_types.py
@@ -55,6 +55,7 @@ class FtHas(TypedDict, total=False):
     mark_ohlcv_timeframe: str
     funding_fee_timeframe: str
     funding_fee_candle_limit: int
+    open_interest_candle_limit: int
     floor_leverage: bool
     uses_leverage_tiers: bool
     needs_trading_fees: bool

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -32,6 +32,7 @@ from freqtrade.exceptions import (
     ExchangeError,
     InsufficientFundsError,
     InvalidOrderException,
+    OperationalException,
     PricingError,
 )
 from freqtrade.exchange import (
@@ -178,6 +179,10 @@ class FreqtradeBot(LoggingMixin):
             # Initialize protections AFTER bot start - otherwise parameters are not loaded.
             self.protections = ProtectionManager(self.config, self.strategy.protections)
 
+            # AFTER bot_start and the initial pairlist refresh - informative_pairs() is a user
+            # callback that may rely on either.
+            self.validate_informative_candle_types()
+
             def log_took_too_long(duration: float, time_limit: float):
                 logger.warning(
                     f"Strategy analysis took {duration:.2f}s, more than 25% of the timeframe "
@@ -253,6 +258,28 @@ class FreqtradeBot(LoggingMixin):
         self.startup_update_open_orders()
         self.update_all_liquidation_prices()
         self.update_funding_fees()
+
+    def validate_informative_candle_types(self) -> None:
+        """
+        Verify the exchange can deliver every candle type the strategy asks for.
+
+        Leaves a gap on dynamic informative_pairs calls - where the candle type is not
+        part of the initial request.
+        :raises OperationalException: if the exchange doesn't support a requested candle type
+        """
+        unsupported = sorted(
+            {
+                candle_type
+                for _, _, candle_type in self.strategy.gather_informative_pairs()
+                if not self.exchange.check_candle_type_support(candle_type)
+            }
+        )
+        if unsupported:
+            raise OperationalException(
+                f"Strategy {self.strategy.get_strategy_name()} requests informative data of type "
+                f"{', '.join(unsupported)}, which {self.exchange.name} does not provide. "
+                f"Please remove the affected informative pairs from your strategy."
+            )
 
     def process(self) -> None:
         """

--- a/freqtrade/strategy/informative_decorator.py
+++ b/freqtrade/strategy/informative_decorator.py
@@ -4,7 +4,7 @@ from time import monotonic
 from typing import Any, NoReturn
 
 from cachetools import TLRUCache
-from pandas import DataFrame
+from pandas import DataFrame, isna
 
 from freqtrade.candle_columns import get_candle_columns
 from freqtrade.enums import CandleType
@@ -108,7 +108,9 @@ def informative(
         None or '' (the default) resolves to the trading mode's candle type.
         Attention: Availability for non-spot/futures candle-types across exchanges may vary.
            funding_rate candles only contain the "funding_rate" column (open for historic reasons)
-           All other columns will be missing from this dataframe.
+           open_interest candles only contain the "open_interest_amount" and
+           "open_interest_value" columns.
+           All other columns will be missing from these dataframes.
     :param cache: Cache populated indicators in dry/live mode while the latest informative candle
                   remains unchanged. Entries expire after two effective informative timeframes
                   without an update. Disable for methods that use external state, have side effects,
@@ -153,14 +155,19 @@ def _format_pair_name(config, pair: str, market: dict[str, Any] | None = None) -
     ).upper()
 
 
+# NaN never compares equal to itself, so a NaN anywhere in the fingerprint would make every
+# lookup a miss. Some candle types have legitimately empty columns - open interest is reported
+# in the base currency, the quote currency, or both, depending on exchange and market - so a
+# permanently NaN column must not silently disable the cache.
+_MISSING = object()
+
+
 def _informative_dataframe_fingerprint(
     dataframe: DataFrame, candle_type: CandleType | None
 ) -> tuple[Any, ...]:
     last_candle = dataframe.iloc[-1]
-    return (
-        len(dataframe),
-        *(last_candle[column] for column in get_candle_columns(candle_type)),
-    )
+    values = (last_candle[column] for column in get_candle_columns(candle_type))
+    return (len(dataframe), *(_MISSING if isna(value) else value for value in values))
 
 
 def _raise_reserved_column_name() -> NoReturn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 dependencies = [
   # from requirements.txt
-  "ccxt>=4.5.4",
+  "ccxt>=4.5.76",
   "SQLAlchemy>=2.0.6",
   "python-telegram-bot>=20.1",
   "humanize>=4.0.0",

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -192,7 +192,9 @@ def test_datahandler_funding_rate_legacy_load_formats(testdatadir, datahandler):
 
 
 @pytest.mark.parametrize("datahandler", ["feather", "parquet"])
-@pytest.mark.parametrize("candle_type", [CandleType.SPOT, CandleType.FUNDING_RATE])
+@pytest.mark.parametrize(
+    "candle_type", [CandleType.SPOT, CandleType.FUNDING_RATE, CandleType.OPEN_INTEREST]
+)
 @pytest.mark.parametrize("typed", [True, False])
 def test_datahandler_ohlcv_load_empty_file(tmp_path, datahandler, candle_type, typed):
     """An empty stored file must load as an empty dataframe, not raise.
@@ -219,6 +221,39 @@ def test_datahandler_ohlcv_load_empty_file(tmp_path, datahandler, candle_type, t
     loaded = dh.ohlcv_load("XRP/USDT:USDT", "1h", candle_type, warn_no_data=False)
     assert loaded.empty
     assert list(loaded.columns) == get_candle_columns(candle_type)
+
+
+@pytest.mark.parametrize("datahandler", AVAILABLE_DATAHANDLERS)
+def test_datahandler_open_interest_roundtrip(tmp_path, datahandler):
+    """Open interest survives a store/load cycle with one side missing.
+
+    Bybit reports only the base amount on linear markets, so an all-NaN
+    open_interest_value column must round-trip as NaN - not as 0, and not as an error.
+    """
+    (tmp_path / "futures").mkdir()
+    dh = get_datahandler(tmp_path, datahandler)
+    raw = [
+        [1630454400000, 108721.214, None],
+        [1630458000000, 109261.55, None],
+        [1630461600000, 107807.866, None],
+    ]
+    df = ohlcv_to_dataframe(
+        raw,
+        "1h",
+        "XRP/USDT:USDT",
+        fill_missing=False,
+        drop_incomplete=False,
+        candle_type=CandleType.OPEN_INTEREST,
+    )
+    dh.ohlcv_store("XRP/USDT:USDT", "1h", df, CandleType.OPEN_INTEREST)
+
+    loaded = dh.ohlcv_load("XRP/USDT:USDT", "1h", CandleType.OPEN_INTEREST, fill_missing=False)
+    assert list(loaded.columns) == ["date", "open_interest_amount", "open_interest_value"]
+    assert len(loaded) == 3
+    assert loaded["open_interest_amount"].tolist() == [108721.214, 109261.55, 107807.866]
+    assert loaded["open_interest_value"].isna().all()
+    assert loaded["open_interest_value"].dtype == "float64"
+    assert_frame_equal(loaded, df)
 
 
 def test_datahandler_ohlcv_get_available_data(testdatadir):

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -619,6 +619,44 @@ def test_refresh_backtest_ohlcv_data(
         assert parallel_mock.call_count == 0
         assert dl_mock.call_count == 3  # 2 timeframes premiumIndex + 1x funding_rate
 
+        # Open interest is opt-in and downloaded for the timeframes the user asked for
+        dl_mock.reset_mock()
+        refresh_backtest_ohlcv_data(
+            exchange=ex,
+            pairs=[
+                "ETH/BTC",
+            ],
+            timeframes=["5m", "1h"],
+            datadir=testdatadir,
+            timerange=timerange,
+            erase=False,
+            trading_mode=trademode,
+            no_parallel_download=True,
+            candle_types=["open_interest"],
+        )
+        assert parallel_mock.call_count == 0
+        assert dl_mock.call_count == 2  # 2 timeframes open_interest
+        assert [c[1]["candle_type"] for c in dl_mock.call_args_list] == [
+            CandleType.OPEN_INTEREST,
+            CandleType.OPEN_INTEREST,
+        ]
+
+        # ... and is not part of the default futures download
+        dl_mock.reset_mock()
+        refresh_backtest_ohlcv_data(
+            exchange=ex,
+            pairs=[
+                "ETH/BTC",
+            ],
+            timeframes=["5m"],
+            datadir=testdatadir,
+            timerange=timerange,
+            erase=False,
+            trading_mode=trademode,
+            no_parallel_download=True,
+        )
+        assert CandleType.OPEN_INTEREST not in [c[1]["candle_type"] for c in dl_mock.call_args_list]
+
 
 def test_download_data_no_markets(mocker, default_conf, caplog, testdatadir):
     dl_mock = mocker.patch(

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -12,6 +12,7 @@ from numpy import nan
 from pandas import DataFrame, to_datetime
 
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS
+from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.enums import CandleType, MarginMode, RunMode, TradingMode
 from freqtrade.exceptions import (
     ConfigurationError,
@@ -3186,6 +3187,96 @@ async def test__fetch_funding_rate_history(default_conf, mocker):
     exchange = get_patched_exchange(mocker, default_conf, api_mock)
     res = await exchange._fetch_funding_rate_history("XRP/USDT:USDT", "1h", limit=2)
     assert res == [[1630454400000, -0.000008], [1630458000000, -0.000004]]
+
+
+async def test__fetch_open_interest_history_missing_side(default_conf, mocker):
+
+    api_mock = MagicMock()
+    # kinda unrealistic, usually one column is None for all entries.
+    api_mock.fetch_open_interest_history = AsyncMock(
+        return_value=[
+            {
+                "timestamp": 1630454400000,
+                "openInterestAmount": 50114.633,
+                "openInterestValue": None,
+            },
+            {
+                "timestamp": 1630458000000,
+                "openInterestAmount": None,
+                "openInterestValue": 8502979793.293565,
+            },
+            {
+                "timestamp": 1630461600000,
+                "openInterestAmount": 50114.555,
+                "openInterestValue": 8502979793.12354,
+            },
+        ]
+    )
+    exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    res = await exchange._fetch_open_interest_history("XRP/USDT:USDT", "1h", limit=2)
+    assert res == [
+        [1630454400000, 50114.633, None],
+        [1630458000000, None, 8502979793.293565],
+        [1630461600000, 50114.555, 8502979793.12354],
+    ]
+
+    # ... and reach the dataframe as NaN, without disturbing the dtype
+    df = ohlcv_to_dataframe(
+        res,
+        "1h",
+        "XRP/USDT:USDT",
+        fill_missing=False,
+        drop_incomplete=False,
+        candle_type=CandleType.OPEN_INTEREST,
+    )
+    assert list(df.columns) == ["date", "open_interest_amount", "open_interest_value"]
+    assert df["open_interest_amount"].dtype == "float64"
+    assert df["open_interest_value"].dtype == "float64"
+    assert df["open_interest_value"].isna().tolist() == [True, False, False]
+    assert df["open_interest_amount"].isna().tolist() == [False, True, False]
+
+
+def test_refresh_latest_ohlcv_open_interest(mocker, default_conf_usdt) -> None:
+    """Open interest goes through its own endpoint and keeps its own columns."""
+    ohlcv = generate_test_data_raw("1h", 24, "2025-01-02 12:00:00+00:00")
+    oi_data = [
+        {"timestamp": x[0], "openInterestAmount": x[1], "openInterestValue": x[4]} for x in ohlcv
+    ]
+
+    exchange = get_patched_exchange(mocker, default_conf_usdt)
+    exchange._api_async.fetch_ohlcv = AsyncMock(return_value=ohlcv)
+    exchange._api_async.fetch_open_interest_history = AsyncMock(return_value=oi_data)
+
+    pair_tf = ("XRP/USDT:USDT", "1h", CandleType.OPEN_INTEREST)
+    res = exchange.refresh_latest_ohlcv([pair_tf], cache=True)
+
+    assert exchange._api_async.fetch_ohlcv.call_count == 0
+    df = res[pair_tf]
+    assert list(df.columns) == ["date", "open_interest_amount", "open_interest_value"]
+    # Unlike funding rates, open interest gets no "open" alias - it is a new candle type
+    assert "open" not in df.columns
+    # The last record is the still-updating period and is dropped as incomplete
+    assert len(df) == len(ohlcv) - 1
+
+    # Second refresh goes through the concat/clean cache-merge path
+    second = exchange.refresh_latest_ohlcv([pair_tf], cache=True)[pair_tf]
+    assert list(second.columns) == list(df.columns)
+    assert len(second) == len(df)
+
+
+@pytest.mark.parametrize("exchange_name", [e for e in EXCHANGES if e not in ["okx"]])
+def test_ohlcv_candle_limit_open_interest(default_conf, mocker, exchange_name):
+    default_conf["trading_mode"] = "futures"
+    default_conf["margin_mode"] = "isolated"
+    exchange = get_patched_exchange(mocker, default_conf, exchange=exchange_name)
+    expected = exchange._ft_has.get("open_interest_candle_limit", None)
+    limit = exchange.ohlcv_candle_limit("1h", CandleType.OPEN_INTEREST)
+    if expected is None:
+        assert limit == exchange.ohlcv_candle_limit("1h", CandleType.FUTURES)
+    else:
+        assert limit == expected
+        # The lower limit must not leak into regular candle downloads
+        assert exchange.ohlcv_candle_limit("1h", CandleType.FUTURES) != limit
 
 
 @pytest.mark.parametrize("exchange_name", EXCHANGES)
@@ -6966,6 +7057,7 @@ def test_verify_candle_type_support(default_conf, mocker):
             "fetchFundingRateHistory": True,
             "fetchIndexOHLCV": True,
             "fetchMarkOHLCV": True,
+            "fetchOpenInterestHistory": True,
             "fetchPremiumIndexOHLCV": False,
         }
     )
@@ -6975,6 +7067,7 @@ def test_verify_candle_type_support(default_conf, mocker):
     exchange.verify_candle_type_support("futures")
     exchange.verify_candle_type_support(CandleType.FUTURES)
     exchange.verify_candle_type_support(CandleType.FUNDING_RATE)
+    exchange.verify_candle_type_support(CandleType.OPEN_INTEREST)
     exchange.verify_candle_type_support(CandleType.SPOT)
     exchange.verify_candle_type_support(CandleType.MARK)
 
@@ -6991,11 +7084,13 @@ def test_verify_candle_type_support(default_conf, mocker):
             "fetchFundingRateHistory": False,
             "fetchIndexOHLCV": False,
             "fetchMarkOHLCV": False,
+            "fetchOpenInterestHistory": False,
             "fetchPremiumIndexOHLCV": True,
         }
     )
     for candle_type in [
         CandleType.FUNDING_RATE,
+        CandleType.OPEN_INTEREST,
         CandleType.INDEX,
         CandleType.MARK,
     ]:

--- a/tests/exchange_online/conftest.py
+++ b/tests/exchange_online/conftest.py
@@ -22,6 +22,7 @@ class TestExchangeOnlineSetup(TypedDict):
     futures_pair: str | None
     candle_count_futures: int | None
     hasQuoteVolumeFutures: bool | None
+    open_interest_history_days: int | None
     leverage_tiers_public: bool
     leverage_in_spot_market: bool
     trades_lookback_hours: int
@@ -48,6 +49,8 @@ EXCHANGES: dict[str, TestExchangeOnlineSetup] = {
         "futures_pair": "BTC/USDT:USDT",
         "candle_count_futures": 499,
         "hasQuoteVolumeFutures": True,
+        # Binance rejects "startTime" older than 30 days for open interest history.
+        "open_interest_history_days": 30,
         "leverage_tiers_public": False,
         "leverage_in_spot_market": False,
         "trades_lookback_hours": 4,
@@ -353,6 +356,8 @@ EXCHANGES: dict[str, TestExchangeOnlineSetup] = {
         "futures_pair": "BTC/USDT:USDT",
         "candle_count_futures": 1999,
         "hasQuoteVolumeFutures": True,
+        # gate rejects a "from" older than 180 days ("from time exceeds 180-day limit").
+        "open_interest_history_days": 179,
         "leverage_tiers_public": True,
         "leverage_in_spot_market": True,
         "sample_order": [
@@ -471,6 +476,8 @@ EXCHANGES: dict[str, TestExchangeOnlineSetup] = {
         "futures": True,
         "futures_pair": "BTC/USDT:USDT",
         "hasQuoteVolumeFutures": False,
+        # okx raises "Illegal time range" beyond 30 days of open interest history.
+        "open_interest_history_days": 30,
         "leverage_tiers_public": True,
         "leverage_in_spot_market": True,
         "private_methods": ["fetch_accounts"],
@@ -484,6 +491,9 @@ EXCHANGES: dict[str, TestExchangeOnlineSetup] = {
         "candle_count": 1000,
         "futures_pair": "BTC/USDT:USDT",
         "futures": True,
+        # Bybit serves well over 2 years of open interest history - capped here to keep the
+        # runtime of this test in check, 200 candles per call add up quickly.
+        "open_interest_history_days": 180,
         "orderbook_max_entries": 50,
         "leverage_tiers_public": True,
         "leverage_in_spot_market": True,

--- a/tests/exchange_online/test_ccxt_compat.py
+++ b/tests/exchange_online/test_ccxt_compat.py
@@ -10,7 +10,11 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from freqtrade.enums import CandleType
-from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
+from freqtrade.exchange import (
+    timeframe_to_minutes,
+    timeframe_to_prev_date,
+    timeframe_to_resample_freq,
+)
 from freqtrade.exchange.exchange import Exchange, timeframe_to_msecs
 from freqtrade.util import dt_floor_day, dt_now, dt_ts
 from tests.exchange_online.conftest import EXCHANGE_FIXTURE_TYPE
@@ -366,6 +370,37 @@ class TestCCXTExchange:
             timeframe=timeframe,
             candle_type=candle_type,
         )
+
+    def test_ccxt_fetch_open_interest_history(self, exchange_futures: EXCHANGE_FIXTURE_TYPE):
+        exchange, exchange_name, exchange_params = exchange_futures
+
+        if not exchange.check_candle_type_support(CandleType.OPEN_INTEREST):
+            pytest.skip(f"{exchange_name} does not support open interest history")
+
+        pair = exchange_params.get("futures_pair", exchange_params["pair"])
+        timeframe = exchange_params["timeframe"]
+        pair_tf = (pair, timeframe, CandleType.OPEN_INTEREST)
+        # Open interest history is short-lived - Binance only serves the last 30 days.
+        since = dt_ts(dt_now() - timedelta(days=2))
+
+        res = exchange.refresh_latest_ohlcv([pair_tf], since_ms=since, drop_incomplete=False)
+        oi = res[pair_tf]
+
+        assert list(oi.columns) == ["date", "open_interest_amount", "open_interest_value"]
+        assert len(oi) > 0
+        # Exchanges report open interest in base currency, quote currency, or both -
+        # but at least one of the two has to carry data.
+        assert not (
+            oi["open_interest_amount"].isna().all() and oi["open_interest_value"].isna().all()
+        ), f"{exchange_name} returned no open interest values at all"
+
+        # The most recent candle must be recent - the series is not allowed to be stale
+        assert oi.iloc[-1]["date"] >= timeframe_to_prev_date(
+            timeframe, dt_now() - timedelta(hours=6)
+        )
+        # Dates are aligned to the timeframe and strictly increasing
+        assert oi["date"].is_monotonic_increasing
+        assert (oi["date"] == oi["date"].dt.floor(timeframe_to_resample_freq(timeframe))).all()
 
     def test_ccxt_fetch_funding_rate_history(self, exchange_futures: EXCHANGE_FIXTURE_TYPE):
         exchange, _, exchange_params = exchange_futures

--- a/tests/exchange_online/test_ccxt_compat.py
+++ b/tests/exchange_online/test_ccxt_compat.py
@@ -377,13 +377,22 @@ class TestCCXTExchange:
         if not exchange.check_candle_type_support(CandleType.OPEN_INTEREST):
             pytest.skip(f"{exchange_name} does not support open interest history")
 
+        # Open interest history is short-lived, and how far back it goes differs
+        # per exchange - hence the per-exchange setting instead of one global value.
+        # Setting it to None disables the test for that exchange.
+        history_days = exchange_params.get("open_interest_history_days", 30)
+        if not history_days:
+            pytest.skip(f"No open interest history depth configured for {exchange_name}")
+
         pair = exchange_params.get("futures_pair", exchange_params["pair"])
         timeframe = exchange_params["timeframe"]
+        tf_delta = timedelta(minutes=timeframe_to_minutes(timeframe))
         pair_tf = (pair, timeframe, CandleType.OPEN_INTEREST)
-        # Open interest history is short-lived - Binance only serves the last 30 days.
-        since = dt_ts(dt_now() - timedelta(days=2))
+        since_date = timeframe_to_prev_date(timeframe, dt_now() - timedelta(days=history_days))
 
-        res = exchange.refresh_latest_ohlcv([pair_tf], since_ms=since, drop_incomplete=False)
+        res = exchange.refresh_latest_ohlcv(
+            [pair_tf], since_ms=dt_ts(since_date), drop_incomplete=False
+        )
         oi = res[pair_tf]
 
         assert list(oi.columns) == ["date", "open_interest_amount", "open_interest_value"]
@@ -394,13 +403,26 @@ class TestCCXTExchange:
             oi["open_interest_amount"].isna().all() and oi["open_interest_value"].isna().all()
         ), f"{exchange_name} returned no open interest values at all"
 
-        # The most recent candle must be recent - the series is not allowed to be stale
-        assert oi.iloc[-1]["date"] >= timeframe_to_prev_date(
-            timeframe, dt_now() - timedelta(hours=6)
-        )
         # Dates are aligned to the timeframe and strictly increasing
         assert oi["date"].is_monotonic_increasing
         assert (oi["date"] == oi["date"].dt.floor(timeframe_to_resample_freq(timeframe))).all()
+
+        # History must start at the requested date - exchanges may skip the very first candle.
+        assert oi.iloc[0]["date"] <= since_date + tf_delta, (
+            f"{exchange_name} open interest history starts at {oi.iloc[0]['date']}, "
+            f"expected {since_date}"
+        )
+        # ... and must reach up to now. Open interest usually lags OHLCV by one candle.
+        last_date = timeframe_to_prev_date(timeframe, dt_now())
+        assert oi.iloc[-1]["date"] >= last_date - 3 * tf_delta, (
+            f"{exchange_name} open interest history is stale - last candle {oi.iloc[-1]['date']}"
+        )
+        # The full range must be covered, not just the last call. Assume 90% uptime,
+        # in line with the other candle history tests.
+        expected_candles = (last_date - since_date) // tf_delta
+        assert len(oi) >= expected_candles * 0.9, (
+            f"{exchange_name} returned {len(oi)} of ~{expected_candles} open interest candles"
+        )
 
     def test_ccxt_fetch_funding_rate_history(self, exchange_futures: EXCHANGE_FIXTURE_TYPE):
         exchange, _, exchange_params = exchange_futures

--- a/tests/freqtradebot/test_freqtradebot.py
+++ b/tests/freqtradebot/test_freqtradebot.py
@@ -166,6 +166,69 @@ def test_order_dict(default_conf_usdt, mocker, runmode, caplog) -> None:
     assert not log_has_re(r".*stoploss_on_exchange .* dry-run", caplog)
 
 
+def test_validate_informative_candle_types(default_conf_usdt, mocker) -> None:
+
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    freqtrade = get_patched_freqtradebot(mocker, default_conf_usdt)
+
+    mocker.patch.object(
+        freqtrade.strategy,
+        "gather_informative_pairs",
+        return_value=[
+            ("XRP/USDT", "1h", CandleType.SPOT),
+            ("XRP/USDT:USDT", "1h", CandleType.OPEN_INTEREST),
+        ],
+    )
+    # Supported by the exchange - no complaints
+    mocker.patch(f"{EXMS}.check_candle_type_support", return_value=True)
+    freqtrade.validate_informative_candle_types()
+
+    mocker.patch(
+        f"{EXMS}.check_candle_type_support",
+        side_effect=lambda ct: ct != CandleType.OPEN_INTEREST,
+    )
+    with pytest.raises(
+        OperationalException,
+        match=r"requests informative data of type open_interest, which .* does not provide",
+    ):
+        freqtrade.validate_informative_candle_types()
+
+    # Each unsupported type is reported once, even across many pairs
+    mocker.patch.object(
+        freqtrade.strategy,
+        "gather_informative_pairs",
+        return_value=[
+            ("XRP/USDT:USDT", "1h", CandleType.OPEN_INTEREST),
+            ("BTC/USDT:USDT", "4h", CandleType.OPEN_INTEREST),
+            ("BTC/USDT:USDT", "1h", CandleType.FUNDING_RATE),
+        ],
+    )
+    mocker.patch(f"{EXMS}.check_candle_type_support", return_value=False)
+    with pytest.raises(
+        OperationalException, match=r"type funding_rate, open_interest, which .* does not provide"
+    ):
+        freqtrade.validate_informative_candle_types()
+
+
+def test_validate_informative_candle_types_on_init(default_conf_usdt, mocker) -> None:
+    """The check has to run during startup, not only when called directly."""
+    patch_RPCManager(mocker)
+    patch_exchange(mocker)
+    mocker.patch(f"{EXMS}.get_fee", return_value=0.0025)
+    mocker.patch(
+        "freqtrade.strategy.interface.IStrategy.gather_informative_pairs",
+        return_value=[("XRP/USDT:USDT", "1h", CandleType.OPEN_INTEREST)],
+    )
+    mocker.patch(f"{EXMS}.check_candle_type_support", return_value=False)
+
+    with pytest.raises(
+        OperationalException,
+        match=r"requests informative data of type open_interest, which .* does not provide",
+    ):
+        FreqtradeBot(default_conf_usdt)
+
+
 def test_get_trade_stake_amount(default_conf_usdt, mocker) -> None:
     patch_RPCManager(mocker)
     patch_exchange(mocker)

--- a/tests/strategy/strats/informative_decorator_strategy_cache.py
+++ b/tests/strategy/strats/informative_decorator_strategy_cache.py
@@ -47,6 +47,14 @@ class InformativeDecoratorCacheTest(IStrategy):
 
         return dataframe
 
+    @informative(
+        "1h", "ADA/USDT:USDT", "{column}_{base}_{timeframe}_OI", candle_type="open_interest"
+    )
+    def populate_indicators_open_interest(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        self.informative_counter[metadata["pair"], metadata["timeframe"]] += 1
+
+        return dataframe
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
         return dataframe

--- a/tests/strategy/test_strategy_helpers.py
+++ b/tests/strategy/test_strategy_helpers.py
@@ -8,7 +8,11 @@ from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import CandleType, RunMode
 from freqtrade.resolvers.strategy_resolver import StrategyResolver
 from freqtrade.strategy import merge_informative_pair, stoploss_from_absolute, stoploss_from_open
-from freqtrade.strategy.informative_decorator import InformativeCache, InformativeCacheKey
+from freqtrade.strategy.informative_decorator import (
+    InformativeCache,
+    InformativeCacheKey,
+    _informative_dataframe_fingerprint,
+)
 from tests.conftest import generate_test_data, get_patched_exchange
 
 
@@ -529,13 +533,40 @@ def test_analyze_expires_informative_cache(mocker, default_conf_usdt):
     assert cache == {}
 
 
+def test_informative_dataframe_fingerprint_nan():
+    """A permanently empty column must not turn every cache lookup into a miss."""
+    dates = pd.date_range("2026-01-01", periods=3, freq="1h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open_interest_amount": [1.0, 2.0, 3.0],
+            "open_interest_value": np.nan,
+        }
+    )
+    ct = CandleType.OPEN_INTEREST
+    assert _informative_dataframe_fingerprint(df, ct) == _informative_dataframe_fingerprint(df, ct)
+
+    # Real changes are still detected - in either column, and in either direction
+    changed_amount = df.assign(open_interest_amount=[1.0, 2.0, 4.0])
+    assert _informative_dataframe_fingerprint(df, ct) != _informative_dataframe_fingerprint(
+        changed_amount, ct
+    )
+    filled_value = df.assign(open_interest_value=[np.nan, np.nan, 5.0])
+    assert _informative_dataframe_fingerprint(df, ct) != _informative_dataframe_fingerprint(
+        filled_value, ct
+    )
+    assert _informative_dataframe_fingerprint(filled_value, ct) != (
+        _informative_dataframe_fingerprint(df, ct)
+    )
+
+
 @pytest.mark.parametrize(
     "runmode, expected",
     [
-        (RunMode.DRY_RUN, [2, 2, 2, 1, 2, 1, 4, 2, 1, 1]),
-        (RunMode.LIVE, [2, 2, 2, 1, 2, 1, 4, 2, 1, 1]),
-        (RunMode.BACKTEST, [2, 4, 2, 2, 2, 2, 4, 8, 2, 4]),
-        (RunMode.HYPEROPT, [2, 4, 2, 2, 2, 2, 4, 8, 2, 4]),
+        (RunMode.DRY_RUN, [2, 2, 2, 1, 2, 1, 4, 2, 1, 1, 1, 1]),
+        (RunMode.LIVE, [2, 2, 2, 1, 2, 1, 4, 2, 1, 1, 1, 1]),
+        (RunMode.BACKTEST, [2, 4, 2, 2, 2, 2, 4, 8, 2, 4, 2, 4]),
+        (RunMode.HYPEROPT, [2, 4, 2, 2, 2, 2, 4, 8, 2, 4, 2, 4]),
     ],
 )
 def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expected):
@@ -553,6 +584,15 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
             "open": test_data_1h["open"],
         }
     )
+    # Open interest has two value columns - and Bybit-style exchanges leave one of them
+    # permanently NaN, which must not defeat the cache.
+    test_data_1h_open_interest = pd.DataFrame(
+        {
+            "date": test_data_1h["date"],
+            "open_interest_amount": test_data_1h["open"],
+            "open_interest_value": np.nan,
+        }
+    )
     data = {
         ("XRP/USDT", "5m", candle_def): test_data_5m,
         ("XRP/USDT", "30m", candle_def): test_data_30m,
@@ -563,6 +603,7 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
         ("ETH/USDT", "1h", candle_def): test_data_1h,
         ("ETH/USDT", "30m", candle_def): test_data_30m,
         ("ETH/USDT:USDT", "1h", CandleType.FUNDING_RATE): test_data_1h_funding,
+        ("ADA/USDT:USDT", "1h", CandleType.OPEN_INTEREST): test_data_1h_open_interest,
     }
     default_conf_usdt["strategy"] = "InformativeDecoratorCacheTest"
     strategy = StrategyResolver.load_strategy(default_conf_usdt)
@@ -571,7 +612,7 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
     strategy.dp = DataProvider({}, exchange, None)
     mocker.patch.object(strategy.dp, "current_whitelist", return_value=["XRP/USDT", "LTC/USDT"])
 
-    assert len(strategy._ft_informative) == 6  # Equal to number of decorators used
+    assert len(strategy._ft_informative) == 7  # Equal to number of decorators used
 
     def test_historic_ohlcv(pair, timeframe, candle_type):
         return data.get(
@@ -588,8 +629,9 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
     )
     # Number of distinct timeframes seen per pair
     timeframes_per_pair = Counter(pair for pair, _ in strategy.informative_counter)
-    # Each whitelist pair, plus the fixed ETH/USDT and BTC/USDT (funding rate) pairs
-    assert len(timeframes_per_pair) == 4
+    # Each whitelist pair, plus the fixed ETH/USDT, ETH/USDT:USDT (funding rate)
+    # and ADA/USDT:USDT (open interest) pairs
+    assert len(timeframes_per_pair) == 5
     assert timeframes_per_pair["XRP/USDT"] == 2  # 2 informative timeframes
     assert timeframes_per_pair["LTC/USDT"] == 2  # 2 informative timeframes
     assert timeframes_per_pair["ETH/USDT"] == 2  # 2 informative timeframes
@@ -605,6 +647,8 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
     )  # called twice, once for each informative function
     # Funding rate informative - cached like any other, despite its different columns
     assert strategy.informative_counter["ETH/USDT:USDT", "1h"] == expected[8]
+    # Open interest informative - one of its two columns is permanently NaN
+    assert strategy.informative_counter["ADA/USDT:USDT", "1h"] == expected[10]
 
     # Trigger populate indicators again, to see the effect of cache
     _ = strategy.advise_all_indicators(
@@ -617,3 +661,5 @@ def test_informative_decorator_cache(mocker, default_conf_usdt, runmode, expecte
     assert strategy.informative_counter["ETH/USDT", "1h"] == expected[6]
     assert strategy.informative_counter["ETH/USDT", "30m"] == expected[7]
     assert strategy.informative_counter["ETH/USDT:USDT", "1h"] == expected[9]
+    # A permanently NaN column must not turn every cache lookup into a miss
+    assert strategy.informative_counter["ADA/USDT:USDT", "1h"] == expected[11]

--- a/tests/test_candle_columns.py
+++ b/tests/test_candle_columns.py
@@ -27,11 +27,13 @@ def test_default_dataframe_columns_reexport():
         (CandleType.INDEX, OHLCV_COLUMNS),
         (CandleType.PREMIUMINDEX, OHLCV_COLUMNS),
         (CandleType.FUNDING_RATE, ["date", "funding_rate"]),
+        (CandleType.OPEN_INTEREST, ["date", "open_interest_amount", "open_interest_value"]),
         # DataProvider and informative pairs pass plain strings / None for spot
         ("", OHLCV_COLUMNS),
         (None, OHLCV_COLUMNS),
         ("mark", OHLCV_COLUMNS),
         ("funding_rate", ["date", "funding_rate"]),
+        ("open_interest", ["date", "open_interest_amount", "open_interest_value"]),
     ],
 )
 def test_get_candle_columns(candle_type, expected):
@@ -50,6 +52,10 @@ def test_get_candle_dtypes():
         "volume": "float",
     }
     assert get_candle_dtypes(CandleType.FUNDING_RATE) == {"funding_rate": "float"}
+    assert get_candle_dtypes(CandleType.OPEN_INTEREST) == {
+        "open_interest_amount": "float",
+        "open_interest_value": "float",
+    }
     # date is never cast
     assert "date" not in get_candle_dtypes(CandleType.SPOT)
 
@@ -63,6 +69,10 @@ def test_get_candle_agg_dict():
         "volume": "max",
     }
     assert get_candle_agg_dict(CandleType.FUNDING_RATE) == {"funding_rate": "first"}
+    assert get_candle_agg_dict(CandleType.OPEN_INTEREST) == {
+        "open_interest_amount": "first",
+        "open_interest_value": "first",
+    }
     # Callers must not be able to mutate the shared default
     get_candle_agg_dict(CandleType.SPOT)["open"] = "last"
     assert get_candle_agg_dict(CandleType.SPOT)["open"] == "first"
@@ -74,6 +84,7 @@ def test_candle_type_is_ohlcv():
     assert candle_type_is_ohlcv("")
     assert candle_type_is_ohlcv(None)
     assert not candle_type_is_ohlcv(CandleType.FUNDING_RATE)
+    assert not candle_type_is_ohlcv(CandleType.OPEN_INTEREST)
 
 
 def test_all_candle_value_columns():
@@ -84,5 +95,7 @@ def test_all_candle_value_columns():
         "close",
         "volume",
         "funding_rate",
+        "open_interest_amount",
+        "open_interest_value",
     }
     assert "date" not in ALL_CANDLE_VALUE_COLUMNS


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Add open interest rate as additional candle type.
It's going to have the columns `open_interest_amount` and `open_interest_value` - which one is filled will depend on the exchange (both, only one, not available).

Startup checks verify the availability of the candletype and stop if they're not available.

side note: this requires ccxt 4.5.76 or higher - otherwise downloads will fail due to upstream bugs.

Closes #12956

## Quick changelog

- Add open-interest data as candletype
- add startup check for candletype support
