### PR TITLE
docs: note how much open interest history each exchange serves

### DIFF
--- a/docs/data-download.md
+++ b/docs/data-download.md
@@ -103,8 +103,9 @@ The resulting dataframe has three columns:
     Check which of the two columns actually carries data for your exchange and pairs before relying on it in a strategy.
 
 !!! Note "Limited history"
-    Exchanges keep far less open interest history than candle history - Binance for example only serves the last 30 days.
+    Exchanges keep far less open interest history than candle history, and how far back they go differs between them by orders of magnitude - Binance for example only serves the last 30 days, while Bybit serves several years of the same series, going back close to the instrument's listing date.
     Downloads reaching further back will silently return no data for the missing period.
+    If you plan to backtest over a longer period, check the available depth before deciding which exchange to download open interest from - it may not be the one you intend to trade on.
 
 Exchanges that don't provide open interest history reject the download with an explicit error, and a running bot whose strategy requests open interest on such an exchange refuses to start.
 


### PR DESCRIPTION
The existing note gives Binance's 30 day limit as the example, which reads as if that were typical. Depth differs between exchanges by orders of magnitude: Bybit serves open interest back to close to the instrument's listing date - for BTC/USDT:USDT that is several years of hourly data, against Binance's 30 days.

That difference decides whether a backtest can cover more than one market regime, so it is worth checking before picking which exchange to download open interest from - which need not be the exchange you trade on.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
