### PR TITLE
Check exchange time and warn on time deviations

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -301,6 +301,8 @@ class Exchange:
             # Initial markets load
             self.reload_markets(True, load_leverage_tiers=False)
             self.validate_config(self._config)
+            if self._config["runmode"] in TRADE_MODES:
+                self.check_time_offset()
 
         if self.trading_mode != TradingMode.SPOT and load_leverage_tiers:
             self.fill_leverage_tiers()
@@ -499,6 +501,36 @@ class Exchange:
         .api will be available at this point.
         Must be overridden in child methods if required.
         """
+
+    def check_time_offset(self) -> None:
+        """
+        Compare the exchange time to the local system time.
+        An out-of-sync clock causes authentication failures on most exchanges, and can cause odd
+        sync issues with freqtrade.
+        """
+        if not self.exchange_has("fetchTime"):
+            logger.debug(f"{self.name} does not support fetchTime, skipping time offset check.")
+            return
+        try:
+            before = dt_ts()
+            exchange_time = self._api.fetch_time()
+            # Use the middle of the request to compensate for the request duration.
+            offset = (before + dt_ts()) // 2 - exchange_time
+        except ccxt.BaseError as e:
+            logger.debug(
+                f"Could not fetch exchange time due to {e.__class__.__name__}. Message: {e}"
+            )
+            return
+
+        # Maximum tolerated deviation between exchange and local time before warning the user.
+        if abs(offset) > 1500:
+            logger.warning(
+                f"Your system time deviates by {offset / 1000:.1f}s from the time of "
+                f"{self.name}. This can cause failing requests - please synchronize your "
+                "system clock (e.g. via NTP)."
+            )
+        else:
+            logger.info(f"Time offset to {self.name} is {offset}ms.")
 
     def _log_exchange_response(self, endpoint: str, response, *, add_info=None) -> None:
         """Log exchange responses"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,6 +222,7 @@ def patch_exchange(
 ) -> None:
     mocker.patch(f"{EXMS}.validate_config", MagicMock())
     mocker.patch(f"{EXMS}.validate_timeframes", MagicMock())
+    mocker.patch(f"{EXMS}.check_time_offset", MagicMock())
     mocker.patch(f"{EXMS}.id", PropertyMock(return_value=exchange))
     mocker.patch(f"{EXMS}.name", PropertyMock(return_value=exchange.title()))
     mocker.patch(f"{EXMS}.precisionMode", PropertyMock(return_value=2))

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -3,6 +3,7 @@ import logging
 import re
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from random import randint
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
@@ -410,6 +411,35 @@ def test_validate_demo_trading(default_conf_usdt, mocker, caplog):
     ex_bybit = get_patched_exchange(mocker, default_conf_usdt, exchange="bybit")
     ex_bybit.validate_demo_trading(default_conf_usdt["exchange"])
     assert log_has_re(msg, caplog)
+
+
+def test_check_time_offset(default_conf, mocker, caplog, time_machine):
+    # patch_exchange mocks this method away - keep a reference to the real implementation.
+    check_time_offset_orig = Exchange.check_time_offset
+    time_machine.move_to("2024-01-01 10:00:00 +00:00", tick=False)
+    api_mock = MagicMock()
+    api_mock.fetch_time = MagicMock(return_value=dt_ts())
+    mocker.patch(f"{EXMS}.exchange_has", return_value=False)
+    exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    check_time_offset = partial(check_time_offset_orig, exchange)
+
+    # Exchange without fetchTime support - no call is made.
+    check_time_offset()
+    assert api_mock.fetch_time.call_count == 0
+
+    mocker.patch(f"{EXMS}.exchange_has", return_value=True)
+    check_time_offset()
+    assert api_mock.fetch_time.call_count == 1
+    assert log_has("Time offset to Binance is 0ms.", caplog)
+
+    # Local time is 5s ahead of the exchange.
+    api_mock.fetch_time = MagicMock(return_value=dt_ts() - 5000)
+    check_time_offset()
+    assert log_has_re(r"Your system time deviates by 5.0s from the time of Binance\..*", caplog)
+
+    # Failing to fetch the time is not fatal.
+    api_mock.fetch_time = MagicMock(side_effect=ccxt.BaseError("DeadBeef"))
+    check_time_offset()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

Time alignment is important for freqtrade's correct functioning - though we don't check for it and warn in cases of missmatches.
This will adress this for most exchanges by issuing a warning.

the current "allowed" offset is 1.5s - which is pretty high - but i fear that having this lower will cause tons of false positives if the system is prone to clock-screw and ntp isn't setup to run every other minute.

## Quick changelog

- Add warning if local time deviates from exchange time
- add info showing the offset (this may be reduced to debug later).

## 

Testing: 
on a systemd linux system (make sure nothign else on the system depends on accurate time during the test)

``` bash
# disble NTP daemon
sudo timedatectl set-ntp false
sudo date -s '-30 seconds'

# ... run tests by starting freqtrade in trade mode

# Reenable ntp
sudo timedatectl set-ntp true
```
can be "pretty" eaisly


_AI used for tests and review._