### PR TITLE
docs: fix missing verb in CONTRIBUTING.md AI section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Few pointers for contributions:
 ### AI Assisted Contributions
 
 - If you're using AI for your PR, please both mention it in the PR description and do a thorough review of the generated code yourself.  
-The final responsibility for the code with the PR author, not with the AI, which also means that commits must be linked to your (human) account, not some generic AI account.
+The final responsibility for the code lies with the PR author, not with the AI, which also means that commits must be linked to your (human) account, not some generic AI account.
 - **Never let an LLM speak for you** - all comments, issues and PR descriptions should be written in your own words, reflecting your own understanding.
 - **Never let an LLM think for you** - only submit contributions you fully understand and can explain.
 


### PR DESCRIPTION
## Summary
Small grammar fix in the "AI Assisted Contributions" section of CONTRIBUTING.md — the sentence was missing its main verb.

Before: "The final responsibility for the code with the PR author, ..."
After: "The final responsibility for the code lies with the PR author, ..."

## AI disclosure
Per this repo's own CONTRIBUTING.md guidance: this fix was identified and drafted with AI assistance (Claude), and I reviewed the change myself before submitting. This is my first contribution to open source.

## Test plan
- Docs-only change, no code/behavior affected.