### PR TITLE
fix: guard against zero amount in calculate_fee_rate

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -2587,7 +2587,7 @@ class Exchange:
         # Calculate fee based on order details
         if fee_curr == self.get_pair_base_currency(symbol):
             # Base currency - divide by amount
-            return round(fee_cost / amount, 8)
+            return round(fee_cost / amount, 8) if amount else None
         elif fee_curr == self.get_pair_quote_currency(symbol):
             # Quote currency - divide by cost
             return round(fee_cost / cost, 8) if cost else None

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -5383,6 +5383,37 @@ def test_extract_cost_curr_rate(mocker, default_conf, order, expected) -> None:
             None,
             None,
         ),
+        # Zero amount - fee reported, filled amount missing (see #5842)
+        (
+            {
+                "symbol": "ETH/BTC",
+                "amount": 0.0,
+                "cost": 0.0,
+                "fee": {"currency": "ETH", "cost": 0.005, "rate": None},
+            },
+            None,
+            None,
+        ),
+        (
+            {
+                "symbol": "ETH/BTC",
+                "amount": 0.0,
+                "cost": 0.0,
+                "fee": {"currency": "BTC", "cost": 0.005, "rate": None},
+            },
+            None,
+            None,
+        ),
+        (
+            {
+                "symbol": "ETH/BTC",
+                "amount": 0.0,
+                "cost": 0.0,
+                "fee": {"currency": "NEO", "cost": 0.005, "rate": None},
+            },
+            None,
+            None,
+        ),
         # Invalid pair combination - POINT/BTC is not a pair
         (
             {


### PR DESCRIPTION
## Summary

Guard the base-currency branch of `calculate_fee_rate` against a zero amount, so a fee lookup on an order with no filled amount returns `None` instead of raising `ZeroDivisionError`.

Solve the issue: no open issue, found by reading. Related history in #5842.

## Quick changelog

- `Exchange.calculate_fee_rate` returns `None` instead of dividing by zero when the fee is charged in the base currency and the amount is 0.
- Three test cases added to the existing `test_calculate_fee_rate` parametrization, covering all three currency branches with `amount=0`.

## What's new?

`calculate_fee_rate` has three branches and only two of them guard their denominator:

```python
if fee_curr == self.get_pair_base_currency(symbol):
    return round(fee_cost / amount, 8)                   # no guard
elif fee_curr == self.get_pair_quote_currency(symbol):
    return round(fee_cost / cost, 8) if cost else None   # guarded
else:
    if not cost:
        return None                                      # guarded
```

`ZeroDivisionError` is neither `TemporaryError` nor `OperationalException`, and the only handler on the way up is `except DependencyException` in `handle_order_fee`, so it propagates through `process()` and the worker and ends the bot with "Fatal exception!".

Two call sites can pass a zero amount. `get_real_amount` passes `order_obj.safe_filled`, which is `0.0` whenever `filled` is `None`, and `fee_detection_from_trades` passes `exectrade["amount"]` straight from `fetch_my_trades`. The upstream guard `check_order_canceled_empty` tests `order.get("filled") == 0.0`, so an order reporting `filled: None` rather than `0.0` passes that check and reaches the division as `0.0`.

This crash class was reported before, in #5842 on OKEx. That was fixed in d99eaccb5 by moving the `check_order_canceled_empty` call ahead of `get_real_amount`, which closed the reported path at the caller. The division itself was never guarded, so it still raises for any input that reaches it with `amount == 0`.

The fix matches the guard already used one line below it. The new tests sit alongside the existing `#3431` zero-cost cases, which cover the same three branches with a zero cost but a non-zero amount.

Being explicit about what I did and did not verify: the missing guard and the crash are reproducible directly against `calculate_fee_rate`, and the added test fails on develop with `ZeroDivisionError: float division by zero` at exchange.py:2590. The specific live trigger, an order carrying a base-currency fee with `filled` reported as `None`, is inferred from the ccxt response-shape pattern in `#13532` rather than observed on a live exchange. I have not reproduced an actual bot exit from this. The asymmetry between the three branches stands on its own regardless.

`tests/exchange` is green: 1792 passed, 18 skipped. `ruff check`, `ruff format` and `mypy` clean.

Disclosure since the template asks: I used an AI agent for the source reading and to build the test cases, and verified the crash, the fix and the test results myself.

**edit by maintainer** Remove _absolutely wrong_ link ot random issues by marking them as code.
