### PR TITLE
fix: take exit_lock when reloading a trade from the exchange

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1013,11 +1013,12 @@ class RPC:
         Handler for reload_trade_from_exchange.
         Reloads a trade from it's orders, should manual interaction have happened.
         """
-        trade = Trade.get_trades(trade_filter=[Trade.id == trade_id]).first()
-        if not trade:
-            raise RPCException(f"Could not find trade with id {trade_id}.")
+        with self._freqtrade._exit_lock:
+            trade = Trade.get_trades(trade_filter=[Trade.id == trade_id]).first()
+            if not trade:
+                raise RPCException(f"Could not find trade with id {trade_id}.")
 
-        self._freqtrade.handle_onexchange_order(trade)
+            self._freqtrade.handle_onexchange_order(trade)
         return {"status": "Reloaded from orders from exchange"}
 
     def __exec_force_exit(

--- a/tests/rpc/test_rpc.py
+++ b/tests/rpc/test_rpc.py
@@ -377,6 +377,32 @@ def test_rpc_trade_history(mocker, default_conf, markets, fee, is_short):
     assert trades["trades"][0]["pair"] == "XRP/BTC"
 
 
+def test_rpc_reload_trade_from_exchange(mocker, default_conf, fee) -> None:
+    freqtradebot = get_patched_freqtradebot(mocker, default_conf)
+    rpc = RPC(freqtradebot)
+
+    with pytest.raises(RPCException, match=r"Could not find trade with id 1\."):
+        rpc._rpc_reload_trade_from_exchange(1)
+
+    create_mock_trades(fee)
+
+    # handle_onexchange_order mutates the trade (and may delete it), so it must run
+    # under the same lock the main loop holds while calling it from exit_positions().
+    lock_states = []
+
+    def _record_lock_state(trade):
+        lock_states.append(freqtradebot._exit_lock.locked())
+        return False
+
+    mocker.patch.object(freqtradebot, "handle_onexchange_order", side_effect=_record_lock_state)
+
+    assert rpc._rpc_reload_trade_from_exchange(1) == {
+        "status": "Reloaded from orders from exchange"
+    }
+    assert lock_states == [True]
+    assert not freqtradebot._exit_lock.locked()
+
+
 @pytest.mark.parametrize("is_short", [True, False])
 def test_rpc_delete_trade(mocker, default_conf, fee, markets, caplog, is_short):
     mocker.patch("freqtrade.rpc.telegram.Telegram", MagicMock())


### PR DESCRIPTION
## Summary

Take `_exit_lock` in `_rpc_reload_trade_from_exchange`, so the RPC path into `handle_onexchange_order` is serialized against the main trading loop the same way every other trade-mutating RPC handler already is.

Solve the issue: no open issue, found by reading.

## Quick changelog

- `RPC._rpc_reload_trade_from_exchange` now runs under `self._freqtrade._exit_lock`.
- Test added asserting the lock is held while `handle_onexchange_order` runs, and released afterwards.

## What's new?

`_rpc_reload_trade_from_exchange` calls `self._freqtrade.handle_onexchange_order(trade)` without taking `_exit_lock`. Every other trade-mutating handler in `rpc.py` takes it:

| handler | takes `_exit_lock` |
|---|---|
| `_rpc_force_exit` | yes |
| `_rpc_force_entry` | yes |
| `_rpc_cancel_open_order` | yes |
| `_rpc_delete` | yes |
| `_rpc_reload_trade_from_exchange` | no |

The main loop's own call to the same function is lock-protected: `exit_positions()` calls `handle_onexchange_order` and is invoked from `process()` inside `with self._exit_lock:`. So the codebase already treats this function as requiring the lock, and the RPC path is the one place that doesn't.

What the function does while unsynchronized: it appends `Order` rows, calls `update_trade_state`, `Trade.commit()` and `Trade.session.refresh(trade)`, adjusts `trade.amount`, calls `cancel_stoploss_on_exchange`, and in the fully-cancelled-entry case calls `trade.delete()`.

Both entry points run off the main thread. `POST /api/v1/trades/{tradeid}/reload` (`api_trading.py`) runs on a uvicorn worker thread, and Telegram's `/reload_trade` runs on the `FTTelegram` thread created in `telegram.py`. Sessions are `scoped_session(..., scopefunc=get_request_or_thread_id)` with `autoflush=False`, so the two threads hold separate sessions over the same rows. That makes this a concurrent read-modify-write across sessions rather than a shared-ORM-object problem, which is the shape `_exit_lock` exists to prevent.

To be plain about the evidence: I have not demonstrated a concrete lost update or a corrupted trade in a running bot. The argument here is architectural consistency, backed by reading the locking convention in `rpc.py`, the main loop's own lock-protected call site, and the per-thread session mechanism in `persistence/models.py`. I did not reproduce an incident, and I am not claiming one.

`_exit_lock` is a plain non-reentrant `Lock`, so it is worth noting the call tree under `handle_onexchange_order` does not re-acquire it. If it did, the existing main-loop call from `exit_positions()` would already deadlock.

The test asserts the lock state observed from inside `handle_onexchange_order`, so it fails on develop with `assert [False] == [True]` and passes with the change. `tests/rpc` is green (297 passed) and `tests/freqtradebot` is green (391 passed). `ruff check`, `ruff format` and `mypy` clean.

Disclosure since the template asks: I used an AI agent for the source reading and to build the test, and verified the locking behaviour, the fix and the test results myself.
