### PR TITLE
fix(freqai): harden historic-predictions tz handling and metadata load

### DIFF
--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -355,8 +355,15 @@ class FreqaiDataDrawer:
         hist_preds = self.historic_predictions[pair].copy()
 
         # ensure both dataframes have the same date format so they can be merged
+        # (historic predictions reloaded from disk can be tz-naive while the
+        # live dataframe date is tz-aware, or vice versa - normalize to UTC only
+        # in that mixed case, since pandas refuses to compare or merge mixed
+        # tz-aware/tz-naive frames)
         new_pred["date_pred"] = pd.to_datetime(new_pred["date_pred"])
         hist_preds["date_pred"] = pd.to_datetime(hist_preds["date_pred"])
+        if (new_pred["date_pred"].dt.tz is None) != (hist_preds["date_pred"].dt.tz is None):
+            new_pred["date_pred"] = pd.to_datetime(new_pred["date_pred"], utc=True)
+            hist_preds["date_pred"] = pd.to_datetime(hist_preds["date_pred"], utc=True)
 
         # Find the closest common date between new_pred and historic predictions
         # and cut off the new_pred dataframe at that date
@@ -684,7 +691,7 @@ class FreqaiDataDrawer:
             dk.model_filename = self.pair_dict[coin]["model_filename"]
             dk.data_path = Path(self.pair_dict[coin]["data_path"])
 
-        if coin in self.meta_data_dictionary:
+        if coin in self.meta_data_dictionary and METADATA in self.meta_data_dictionary[coin]:
             dk.data = self.meta_data_dictionary[coin][METADATA]
             dk.feature_pipeline = self.meta_data_dictionary[coin][FEATURE_PIPELINE]
             dk.label_pipeline = self.meta_data_dictionary[coin][LABEL_PIPELINE]

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -968,6 +968,16 @@ class IFreqaiModel(ABC):
             set(saved_dataframe.columns).intersection(dk.return_dataframe.columns)
         )
         dk.return_dataframe = dk.return_dataframe.drop(columns=list(columns_to_drop))
+        # saved predictions reloaded from disk can be tz-naive while the strategy
+        # dataframe date is tz-aware (or vice versa) - normalize both to UTC only
+        # in that mixed case (pandas refuses mixed tz-aware/tz-naive merges).
+        saved_tz = pd.to_datetime(saved_dataframe["date_pred"]).dt.tz
+        df_tz = pd.to_datetime(dk.return_dataframe["date"]).dt.tz
+        if (saved_tz is None) != (df_tz is None):
+            saved_dataframe["date_pred"] = pd.to_datetime(
+                saved_dataframe["date_pred"], utc=True
+            )
+            dk.return_dataframe["date"] = pd.to_datetime(dk.return_dataframe["date"], utc=True)
         dk.return_dataframe = pd.merge(
             dk.return_dataframe, saved_dataframe, how="left", left_on="date", right_on="date_pred"
         )


### PR DESCRIPTION
## Problem
Live-restarting a FreqAI bot after historic predictions were reloaded from disk can crash with:
- `TypeError: Invalid comparison between dtype=datetime64[ns, UTC] and Timestamp` in `set_initial_historic_predictions`
- `ValueError` on merging tz-aware `date_pred` against a tz-naive strategy `date` in `start_backtesting_from_historic_predictions`
- `KeyError: METADATA` in `load_data` when the in-memory metadata entry exists but lacks METADATA

The on-disk repair path (`_ensure_date_pred_dtype`, utc=True) and the in-memory/live paths disagreed on tz-awareness, so any restart mixing the two blew up.

## Fix
- `data_drawer.set_initial_historic_predictions`: normalize both sides to UTC only in the mixed tz-aware/tz-naive case; identical-tz frames keep existing behavior.
- `freqai_interface.start_backtesting_from_historic_predictions`: same mixed-tz normalization before the merge back into the strategy dataframe.
- `data_drawer.load_data`: fall back to disk when the cached metadata entry lacks METADATA instead of raising KeyError.

## Tests
- `tests/freqai/test_freqai_datadrawer.py`: 19 passed (previously 17 passed, 2 failed on unmodified develop: `test_set_initial_return_values_gap`, `test_set_initial_return_values_shifted_index`).
- `tests/freqai/test_freqai_backtesting.py`: 6 passed.
- `tests/freqai/test_freqai_interface.py`: 30 passed / 9 failed - identical to unmodified develop baseline (pre-existing RL/state-info failures, unrelated).